### PR TITLE
fby35: cl: Fixed GPIO direction and status control

### DIFF
--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -586,7 +586,11 @@ void pal_OEM_GET_SET_GPIO(ipmi_msg *msg) {
       if(msg->data_len != 3) {
         break;
       }
-      gpio_conf(gpio_num, msg->data[2]);
+      if (msg->data[2]) {
+        gpio_conf(gpio_num, GPIO_OUTPUT);
+      } else {
+        gpio_conf(gpio_num, GPIO_INPUT);
+      }
       msg->data[0] = gpio_num;
       msg->data[1] = msg->data[2]; 
       completion_code = CC_SUCCESS;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:
- Checked all GPIO setting to input and not able to control output status
- According to chip vendor suggestion, should set gpio direction to input instead of gpio direction output and status high.

Fix:
- Fixed gpio config setting arvg, avoiding setting missing.
- Modified open drain GPIO status controlling. Setting GPIO direction to input as GPIO setting status high. Setting GPIO direction to output and status high as GPIO setting status low.
- Only set push pull GPIO direction during GPIO status initial. Open drain GPIO direction will be set during GPIO status initial.

Test plan:
-Build code: Pass
-GPIO control: Pass

Log:
Tested open drain and push pull GPIO control through IPMI command
root@bmc-oob:~# bic-util slot2 --get_gpio | grep HSC_SET
7 HSC_SET_EN_R: 0
root@bmc-oob:~# bic-util slot2 --set_gpio 7 1
slot 2: setting [7]HSC_SET_EN_R to 1
root@bmc-oob:~# bic-util slot2 --get_gpio | grep HSC_SET
7 HSC_SET_EN_R: 1
root@bmc-oob:~# bic-util slot2 --set_gpio 7 0
slot 2: setting [7]HSC_SET_EN_R to 0
root@bmc-oob:~# bic-util slot2 --get_gpio | grep HSC_SET
7 HSC_SET_EN_R: 0
root@bmc-oob:~# bic-util slot2 --set_gpio 9 0
slot 2: setting [9]RST_USB_HUB_N_R to 0
root@bmc-oob:~# bic-util slot2 --get_gpio | grep USB
9 RST_USB_HUB_N_R: 0
root@bmc-oob:~# bic-util slot2 --set_gpio 9 1
slot 2: setting [9]RST_USB_HUB_N_R to 1
root@bmc-oob:~# bic-util slot2 --get_gpio | grep USB
9 RST_USB_HUB_N_R: 1