### PR TITLE
fby3.5: cl: Add ADC sensor reading

### DIFF
--- a/meta-facebook/yv35-cl/src/main.c
+++ b/meta-facebook/yv35-cl/src/main.c
@@ -15,13 +15,16 @@
 #include "ipmi.h"
 #include "kcs.h"
 
+void device_init(){
+  adc_init();
+}
+
 void main(void)
 {
   printk("Hello yv35 cl\n");
 
   util_init_timer();
   util_init_I2C();
-  util_spi_init();
 
   gpio_init();
   sensor_init();
@@ -29,19 +32,6 @@ void main(void)
   ipmi_init();
   kcs_init();
   usb_dev_init();
-
-  ipmi_msg msg;
-  while(0) {
-    msg.data_len = 3;
-    msg.InF_source = Self_IFs;
-    msg.InF_target = BMC_IPMB_IFs;
-    msg.netfn = NETFN_OEM_1S_REQ;
-    msg.cmd = CMD_OEM_GET_GPIO;
-
-    msg.data[0] = 0x9c;
-    msg.data[1] = 0x9c;
-    msg.data[2] = 0x0;
-    ipmb_read(&msg, 0);
-k_msleep(5);
-  }
+  device_init();
 }
+

--- a/meta-facebook/yv35-cl/src/platform/plat_gpio.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_gpio.h
@@ -206,6 +206,6 @@ enum _GPIO_NUMS_ { name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_g
 extern enum _GPIO_NUMS_ GPIO_NUMS;
 #undef gpio_name_to_num
 
-const char * const gpio_name[];
+extern const char * const gpio_name[];
 
 #endif

--- a/meta-facebook/yv35-cl/src/sensor/dev/adc.c
+++ b/meta-facebook/yv35-cl/src/sensor/dev/adc.c
@@ -1,0 +1,117 @@
+#include <stdio.h>
+#include "sensor.h"
+#include "sensor_def.h"
+#include "pal.h"
+#include "plat_gpio.h"
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <drivers/adc.h>
+
+#define ADC_CHAN_NUM 8
+#define ADC_NUM 2
+#define BUFFER_SIZE 1
+
+#if DT_NODE_EXISTS(DT_NODELABEL(adc0))
+#define DEV_ADC0
+#endif
+#if DT_NODE_EXISTS(DT_NODELABEL(adc1))
+#define DEV_ADC1
+#endif
+
+#define ADC_RESOLUTION      10
+#define ADC_CALIBRATE      0
+#define ADC_GAIN        ADC_GAIN_1
+#define ADC_REFERENCE       ADC_REF_INTERNAL
+#define ADC_ACQUISITION_TIME    ADC_ACQ_TIME_DEFAULT
+
+static struct device *dev_adc[ADC_NUM];
+static int16_t sample_buffer[BUFFER_SIZE];
+int32_t adc_vref;
+
+struct adc_channel_cfg channel_cfg = {
+  .gain = ADC_GAIN,
+  .reference = ADC_REFERENCE,
+  .acquisition_time = ADC_ACQUISITION_TIME,
+  .channel_id = 0,
+  .differential = 0,
+};
+
+struct adc_sequence sequence = {
+  .channels    = 0,
+  .buffer      = sample_buffer,
+  .buffer_size = sizeof(sample_buffer),
+  .resolution  = ADC_RESOLUTION,
+  .calibrate   = ADC_CALIBRATE,
+};
+
+enum{
+  adc0,
+  adc1,
+};
+
+void init_adc_dev(void) {
+#ifdef DEV_ADC0
+  dev_adc[adc0] = device_get_binding("ADC0");
+#endif
+#ifdef DEV_ADC1
+  dev_adc[adc1] = device_get_binding("ADC1");
+#endif
+}
+
+bool adc_init(){
+  init_adc_dev();
+  if (! ( device_is_ready(dev_adc[0]) && device_is_ready(dev_adc[1]) ) ){
+    printk("ADC device not found\n");
+    return false;
+  }
+  for (uint8_t i = 0; i < ADC_NUM; i++) {
+    channel_cfg.channel_id = i;
+    adc_channel_setup(dev_adc[i], &channel_cfg);
+    sequence.channels |= BIT(i);
+  }
+  return true;
+}
+
+static bool adc_read_mv(uint32_t index, uint32_t channel, int *adc_val){
+  int err;
+  adc_vref = adc_get_ref(dev_adc[index]);
+  sequence.channels = BIT(channel);
+  channel_cfg.channel_id = channel;
+  adc_channel_setup(dev_adc[index], &channel_cfg) ;
+  err = adc_read(dev_adc[index], &sequence);
+  if (err != 0){
+    printk("ADC reading failed with error %d.\n", err);
+    return false;
+  }
+  int32_t raw_value = sample_buffer[0];
+  if ( adc_vref > 0 ){
+    *adc_val = raw_value;
+    adc_raw_to_millivolts( adc_get_ref(dev_adc[index]), ADC_GAIN, ADC_RESOLUTION, adc_val);
+    return true;
+  }
+  return false;
+}
+bool pal_adc_read(uint8_t sensor_num, int *reading) {
+  uint8_t snrcfg_sensor_num = SnrNum_SnrCfg_map[sensor_num];
+  uint8_t chip = sensor_config[snrcfg_sensor_num].port / ADC_CHAN_NUM;
+  uint8_t number = sensor_config[snrcfg_sensor_num].port % ADC_CHAN_NUM;
+  int val = 1;
+  int ret = adc_read_mv(chip, number, &val);
+  if ( ret ){
+    if( sensor_num == SENSOR_NUM_VOL_BAT3V) {
+      gpio_set(A_P3V_BAT_SCALED_EN_R, GPIO_HIGH);
+      osDelay(1);
+      adc_read_mv(chip, number, &val);
+      val = val * sensor_config[snrcfg_sensor_num].arg0 / sensor_config[snrcfg_sensor_num].arg1;
+      gpio_set(A_P3V_BAT_SCALED_EN_R, GPIO_LOW);
+    }else{
+      val = val * sensor_config[snrcfg_sensor_num].arg0 / sensor_config[snrcfg_sensor_num].arg1;
+		}
+    *reading = (cal_MBR(sensor_num, val) / 1000) & 0xFF;
+    sensor_config[snrcfg_sensor_num].cache = *reading;
+    sensor_config[snrcfg_sensor_num].cache_status = SNR_READ_SUCCESS;
+    return true;
+  }else{
+    return false;
+  }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:
- Add ADC init and voltage reading function.

known issue:
- GPIO initial fail making GPIO status set fail.
- Battery voltage require GPIO status controlling to get correct voltage.

Test plan:
-Build code: Pass
-Sensor read: Pass
Test gpio direction initial setting pass , sensor P3V_BAT voltage is correct.

Log:
P12V_STBY Vol                (0x20) :   12.54       | (ok)
P3V_BAT Vol                  (0x21) :    0.61       | (ok)
P3V3_STBY Vol                (0x22) :    3.33       | (ok)
P1V8_STBY Vol                (0x24) :    1.80       | (ok)
P1V05_PCH Vol                (0x23) :    1.06       | (ok)