### PR TITLE
[Y35/CL]Added get device id command.

### DIFF
--- a/common/ipmi/ipmi_def.h
+++ b/common/ipmi/ipmi_def.h
@@ -1,0 +1,23 @@
+#ifndef IPMI_DEF_H
+#define IPMI_DEF_H
+
+#define DEVICE_ID 0x00
+#define DEVICE_REVISION 0x80
+#define FIRMWARE_REVISION_1 0x00
+#define FIRMWARE_REVISION_2 0x00
+#define IPMI_VERSION 0x02
+#define ADDITIONAL_DEVICE_SUPPORT 0xBF
+#define WW_IANA_ID 0x009c9c
+#define PRODUCT_ID 0x0000
+#define AUXILIARY_FW_REVISION 0x00000000
+#define GET_TEST_RESULT 0
+
+// firmware update interface
+enum {
+  BIOS_UPDATE,
+  CPLD_UPDATE,
+  BIC_UPDATE,
+  UPDATE_EN = 0x80,
+};
+
+#endif

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -92,10 +92,23 @@ void pal_APP_GET_DEVICE_ID(ipmi_msg *msg)
 		return;
 	}
 
-	msg->data[0] = 0xab;
-	msg->data[1] = 0xcd;
-	msg->data_len = 2;
-	msg->completion_code = CC_SUCCESS;
+  msg->data[0] = DEVICE_ID;
+  msg->data[1] = DEVICE_REVISION;
+  msg->data[2] = FIRMWARE_REVISION_1;
+  msg->data[3] = FIRMWARE_REVISION_2;
+  msg->data[4] = IPMI_VERSION;
+  msg->data[5] = ADDITIONAL_DEVICE_SUPPORT;
+  msg->data[6] = (WW_IANA_ID & 0xFF);
+  msg->data[7] = (WW_IANA_ID >> 8) & 0xFF;
+  msg->data[8] = (WW_IANA_ID >> 16) & 0xFF;
+  msg->data[9] = (PRODUCT_ID & 0xFF);
+  msg->data[10] = (PRODUCT_ID >> 8) & 0xFF;
+  msg->data[11] = (AUXILIARY_FW_REVISION >> 24) & 0xFF;
+  msg->data[12] = (AUXILIARY_FW_REVISION >> 16) & 0xFF;
+  msg->data[13] = (AUXILIARY_FW_REVISION >> 8) & 0xFF;
+  msg->data[14] = (AUXILIARY_FW_REVISION & 0xFF);
+  msg->data_len = 15;
+  msg->completion_code = CC_SUCCESS;
 
 	return;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:
- Impletmented get device id command.

Test plan:
-Build code: Pass
root@bmc-oob:~# bic-util slot4 0x18 0x1
00 80 01 01 02 BF 9C 9C 00 00 00 00 00 00 00