### PR TITLE
fby3.5: cl: Added set DC and postcode system status

### DIFF
--- a/meta-facebook/yv35-cl/src/main.c
+++ b/meta-facebook/yv35-cl/src/main.c
@@ -15,6 +15,7 @@
 #include "ipmi_def.h"
 #include "ipmi.h"
 #include "kcs.h"
+#include "plat_func.h"
 
 void device_init() {
   adc_init();
@@ -24,6 +25,8 @@ void device_init() {
 void set_sys_status() {
   gpio_set(FM_SPI_PCH_MASTER_SEL_R, GPIO_LOW);
   gpio_set(BIC_READY, GPIO_HIGH);
+  set_DC_status();
+  set_post_status();
 }
 
 void main(void)

--- a/meta-facebook/yv35-cl/src/platform/plat_func.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_func.h
@@ -8,6 +8,8 @@ void ISR_slp3();
 void ISR_DC_on();
 void ISR_post_complete();
 
+void set_DC_status();
 bool get_DC_status();
+void set_post_status();
 bool get_post_status();
 #endif


### PR DESCRIPTION
Summary:
- Added set DC and postcode status while Bic init.

Test plan:
-Build code: Pass
-Set system status: Pass

Log:
Power on
[00:00:0*** Booting Zephyr OS build 8ac09a4e6cd6  ***
Hello, wellcome to yv35 craterlake POC 2
ipmi_init
set dc status 1
set is_post_complete 1

Power off
[00:00:0*** Booting Zephyr OS build 8ac09a4e6cd6  ***
Hello, wellcome to yv35 craterlake POC 2
ipmi_init
set dc status 0
set is_post_complete 0
