### PR TITLE
fby3.5: cl: Added BIC warm reboot

### DIFF
--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -179,6 +179,19 @@ void pal_APP_GET_DEVICE_ID(ipmi_msg *msg)
 	return;
 }
 
+void pal_APP_WARM_RESET(ipmi_msg *msg)
+{
+  if (msg->data_len != 0) {
+    msg->completion_code = CC_INVALID_LENGTH;
+    return;
+  }
+
+  submit_bic_warm_reset();
+
+  msg->completion_code = CC_SUCCESS;
+  return;
+}
+
 void pal_APP_GET_SELFTEST_RESULTS(ipmi_msg *msg) {
   if (msg->data_len != 0) {
     msg->completion_code = CC_INVALID_LENGTH;


### PR DESCRIPTION
Summary:
- Added IPMI APP warm reboot command.

Test plan:
[Build code] Pass
[Warm reboot] Pass
Send IPMI warm reboot command and check BIC console printing initial message.

Log:
BMC console:
root@bmc-oob:~# bic-util slot2 0x18 0x3

root@bmc-oob:~#

BIC console:
uart:~$
uart:~$ ⚌>)⚌⚌[00:00:00.001,000] <inf> usb_dc_aspeed: select ep[0x81] as IN endpoint
[00:00:00.001,000] <inf> usb_dc_aspeed: select ep[0x82] as IN endpoint
[00:00:00.001,000] <wrn> usb_dc_aspeed: pre-selected ep[0x1] as IN endpoint
[00:00:00.001,000] <wrn> usb_dc_aspeed: pre-selected ep[0x2] as IN endpoint
[00:00:00*** Booting Zephyr OS build 8ac09a4e6cd6  ***
Hello, wellcome to yv35 craterlake POC 2
ipmi_init
.001,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint
[00:00:00.067,000] <inf> kcs_aspeed: KCS3: addr=0xca2, idr=0x2c, odr=0x38, str=0x44

[00:00:00.068,000] <err> spi_nor_multi_dev: SFDP magic 00000000 invalid
[00:00:00.068,000] <err> spi_nor_multi_dev: SFDP read failed: -22
[00:00:00.068,000] <err> spi_nor_multi_dev: SFDP magic 00000000 invalid
[00:00:00.068,000] <err> spi_nor_multi_dev: SFDP read failed: -22
[00:00:00.068,000] <err> spi_nor_multi_dev: SFDP magic 00000000 invalid
[00:00:00.068,000] <err> spi_nor_multi_dev: SFDP read failed: -22
[00:00:00.068,000] <inf> spi_aspeed: Flash data is monotonous, skip calibration.
[00:00:00.068,000] <err> spi_nor_multi_dev: SFDP magic 00000000 invalid
[00:00:00.068,000] <err> spi_nor_multi_dev: SFDP read failed: -22

uart:~$ [00:00:00.647,000] <inf> usb_cdc_acm: Device configured
[00:00:00.647,000] <inf> usb_cdc_acm: Device configured
uart:~$
