### PR TITLE
SDK: v00.01.01: I2C patch for transmission stability fix

### DIFF
--- a/fix_patch/read_me
+++ b/fix_patch/read_me
@@ -1,0 +1,5 @@
+  This file is for driver hot fix before Aspeed new tag is released.
+
+  To make sure application is competitive with driver from Aspeed SDK,
+  please patch drivers in zephyrproject/zephyr/ with git patch
+  correspoding to revision in yaml file.

--- a/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0001-drivers-i2c-update-cache-control.patch
+++ b/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0001-drivers-i2c-update-cache-control.patch
@@ -1,0 +1,90 @@
+From e6239809c9b4d8b6696411833979e320306d748c Mon Sep 17 00:00:00 2001
+From: tommy-huang <tommy_huang@aspeedtech.com>
+Date: Wed, 22 Sep 2021 16:52:09 +0800
+Subject: [PATCH] drivers: i2c: update cache control
+
+Add cache invalid when the i2c received first offset.
+Add i2c test loop count into CI test.
+
+Signed-off-by: tommy-huang <tommy_huang@aspeedtech.com>
+Change-Id: I9db391779186e392f06a8566126a46a00d0633ec
+---
+ drivers/i2c/i2c_aspeed.c       | 15 ++++++++++++---
+ tests/boards/ast1030/src/i2c.c | 11 ++++++-----
+ 2 files changed, 18 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/i2c/i2c_aspeed.c b/drivers/i2c/i2c_aspeed.c
+index dea8234d9c..eba10e5fe0 100644
+--- a/drivers/i2c/i2c_aspeed.c
++++ b/drivers/i2c/i2c_aspeed.c
+@@ -861,6 +861,13 @@ static int i2c_aspeed_transfer(const struct device *dev, struct i2c_msg *msgs,
+ 		return -ETIMEDOUT;
+ 	}
+ 
++	if (msgs->flags & I2C_MSG_READ) {
++		if (config->mode == DMA_MODE) {
++			cache_data_range(&(msgs->buf)
++			, msgs->len, K_CACHE_INVD);
++		}
++	}
++
+ 	LOG_DBG(" end %d\n", data->cmd_err);
+ 
+ 	return data->cmd_err;
+@@ -1279,11 +1286,11 @@ int aspeed_i2c_slave_irq(const struct device *dev)
+ 				slave_rx_len =
+ 				AST_I2C_GET_RX_DMA_LEN(sys_read32(i2c_base + AST_I2CS_DMA_LEN_STS));
+ 				/*aspeed_cache_invalid_data*/
++				cache_data_range((&data->slave_dma_buf[i])
++				, slave_rx_len, K_CACHE_INVD);
+ 				for (i = 0; i < slave_rx_len; i++) {
+ 				/*LOG_DBG(data->dev, "[%02x]", data->slave_dma_buf[i]);*/
+ 					if (slave_cb->write_received) {
+-						cache_data_range((&data->slave_dma_buf[i])
+-						, 0, K_CACHE_INVD);
+ 						slave_cb->write_received(data->slave_cfg
+ 						, data->slave_dma_buf[i]);
+ 					}
+@@ -1345,6 +1352,8 @@ int aspeed_i2c_slave_irq(const struct device *dev)
+ 				AST_I2C_GET_RX_DMA_LEN(sys_read32(i2c_base + AST_I2CS_DMA_LEN_STS));
+ 
+ 				for (i = 0; i < slave_rx_len; i++) {
++					cache_data_range((&data->slave_dma_buf[i])
++					, 1, K_CACHE_INVD);
+ 					LOG_DBG("rx [%02x]", data->slave_dma_buf[i]);
+ 					if (slave_cb->write_received) {
+ 						slave_cb->write_received(data->slave_cfg
+@@ -1471,7 +1480,7 @@ int aspeed_i2c_slave_irq(const struct device *dev)
+ 					slave_cb->read_processed(data->slave_cfg
+ 					, &data->slave_dma_buf[0]);
+ 				}
+-				LOG_DBG("tx : [%02x]", data->slave_dma_buf[0]);
++				LOG_DBG("rx : [%02x]", data->slave_dma_buf[0]);
+ 				sys_write32(0, i2c_base + AST_I2CS_DMA_LEN_STS);
+ 				sys_write32(AST_I2CS_SET_TX_DMA_LEN(1)
+ 				, i2c_base + AST_I2CS_DMA_LEN);
+diff --git a/tests/boards/ast1030/src/i2c.c b/tests/boards/ast1030/src/i2c.c
+index 38ca2adf20..cb578ee8e9 100644
+--- a/tests/boards/ast1030/src/i2c.c
++++ b/tests/boards/ast1030/src/i2c.c
+@@ -208,11 +208,12 @@ int test_i2c(int count, enum aspeed_test_type type)
+ {
+ 	printk("%s, count: %d, type: %d\n", __func__, count, type);
+ 
+-	printk("I2C slave EEPROM\n");
+-	test_i2c_slave_EEPROM();
+-
+-	printk("I2C slave IPMB\n");
+-	test_i2c_slave_IPMB();
++	for (int i = 0; i < count; i++) {
++		printk("I2C slave EEPROM\n");
++		test_i2c_slave_EEPROM();
+ 
++		printk("I2C slave IPMB\n");
++		test_i2c_slave_IPMB();
++	}
+ 	return ast_ztest_result();
+ }
+-- 
+2.17.1
+

--- a/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0002-drivers-i2c-add-mutex-to-avoid-re-entry.patch
+++ b/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0002-drivers-i2c-add-mutex-to-avoid-re-entry.patch
@@ -1,0 +1,72 @@
+From 612157039e8add6445f179c4e652cf2219308e4b Mon Sep 17 00:00:00 2001
+From: tommy-huang <tommy_huang@aspeedtech.com>
+Date: Thu, 30 Sep 2021 14:42:17 +0800
+Subject: [PATCH] drivers: i2c: add mutex to avoid re-entry
+
+Add mutux lock / unlock protect for api re-entry
+
+Signed-off-by: tommy-huang <tommy_huang@aspeedtech.com>
+Change-Id: Ia4459acfe8fcd382875aa5dfb64c7f9fac8dd6d1
+---
+ drivers/i2c/i2c_aspeed.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/i2c/i2c_aspeed.c b/drivers/i2c/i2c_aspeed.c
+index eba10e5fe0..ff29f250b1 100644
+--- a/drivers/i2c/i2c_aspeed.c
++++ b/drivers/i2c/i2c_aspeed.c
+@@ -301,6 +301,7 @@ struct i2c_aspeed_config {
+ 
+ struct i2c_aspeed_data {
+ 	struct k_sem sync_sem;
++	struct k_mutex trans_mutex;
+ 
+ 	int alert_enable;
+ 
+@@ -546,6 +547,7 @@ static uint32_t i2c_aspeed_select_clock(const struct device *dev)
+ 
+ /*Default maximum time we allow for an I2C transfer (unit:ms)*/
+ #define I2C_TRANS_TIMEOUT K_MSEC(100)
++#define I2C_ENTRY_TIMEOUT K_MSEC(200)
+ 
+ static int i2c_wait_completion(const struct device *dev)
+ {
+@@ -831,12 +833,18 @@ static int i2c_aspeed_transfer(const struct device *dev, struct i2c_msg *msgs,
+ 		return 0;
+ 	}
+ 
++	/* mutex lock for api re-entry */
++	if (k_mutex_lock(&(data->trans_mutex), I2C_ENTRY_TIMEOUT) != 0) {
++		return -ETIMEDOUT;
++	}
++
+ 	/*If bus is busy in a single master environment, attempt recovery.*/
+ 	if (!config->multi_master &&
+ 	(sys_read32(i2c_base + AST_I2CC_STS_AND_BUFF) & AST_I2CC_BUS_BUSY_STS)) {
+ 		int ret;
+ 		ret = aspeed_new_i2c_recover_bus(dev);
+ 		if (ret) {
++			k_mutex_unlock(&data->trans_mutex);
+ 			return ret;
+ 		}
+ 	}
+@@ -858,6 +866,7 @@ static int i2c_aspeed_transfer(const struct device *dev, struct i2c_msg *msgs,
+ 		    (sys_read32(i2c_base + AST_I2CC_STS_AND_BUFF) & AST_I2CC_BUS_BUSY_STS)) {
+ 			aspeed_new_i2c_recover_bus(dev);
+ 		}
++		k_mutex_unlock(&data->trans_mutex);
+ 		return -ETIMEDOUT;
+ 	}
+ 
+@@ -869,6 +878,8 @@ static int i2c_aspeed_transfer(const struct device *dev, struct i2c_msg *msgs,
+ 	}
+ 
+ 	LOG_DBG(" end %d\n", data->cmd_err);
++	/* mutex unlock */
++	k_mutex_unlock(&data->trans_mutex);
+ 
+ 	return data->cmd_err;
+ 
+-- 
+2.17.1
+

--- a/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0003-drivers-i2c-fix-the-buffer-mode.patch
+++ b/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0003-drivers-i2c-fix-the-buffer-mode.patch
@@ -1,0 +1,146 @@
+From 91e7ea5a954170833527f786673424da537ff168 Mon Sep 17 00:00:00 2001
+From: tommy-huang <tommy_huang@aspeedtech.com>
+Date: Tue, 5 Oct 2021 14:12:05 +0800
+Subject: [PATCH] drivers: i2c: fix the buffer mode
+
+Fix the transfer fail under i2c buffer mode.
+
+Signed-off-by: tommy-huang <tommy_huang@aspeedtech.com>
+Change-Id: I552e4b9cdee9fbdc79cfcfc0763e7217e5a56054
+---
+ drivers/i2c/i2c_aspeed.c | 40 ++++++++++++++++++++++++++++------------
+ 1 file changed, 28 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/i2c/i2c_aspeed.c b/drivers/i2c/i2c_aspeed.c
+index ff29f250b1..c6179fd167 100644
+--- a/drivers/i2c/i2c_aspeed.c
++++ b/drivers/i2c/i2c_aspeed.c
+@@ -23,6 +23,7 @@ LOG_MODULE_REGISTER(i2c_aspeed);
+ #define I2C_SLAVE_BUF_SIZE      256
+ 
+ #define I2C_BUF_SIZE            0x20
++#define I2C_BUF_BASE            0xC00
+ 
+ /***************************************************************************/
+ #define ASPEED_I2CG_ISR                         0x00
+@@ -783,6 +784,7 @@ static void aspeed_new_i2c_do_start(const struct device *dev)
+ 				}
+ 				xfer_len = msg->len;
+ 			}
++
+ 			if (xfer_len) {
+ 				cmd |= AST_I2CM_TX_BUFF_EN | AST_I2CM_TX_CMD;
+ 				sys_write32(AST_I2CC_SET_TX_BUF_LEN(xfer_len), i2c_base + AST_I2CC_BUFF_CTRL);
+@@ -870,6 +872,7 @@ static int i2c_aspeed_transfer(const struct device *dev, struct i2c_msg *msgs,
+ 		return -ETIMEDOUT;
+ 	}
+ 
++	/* cache flush for read buffer */
+ 	if (msgs->flags & I2C_MSG_READ) {
+ 		if (config->mode == DMA_MODE) {
+ 			cache_data_range(&(msgs->buf)
+@@ -878,11 +881,11 @@ static int i2c_aspeed_transfer(const struct device *dev, struct i2c_msg *msgs,
+ 	}
+ 
+ 	LOG_DBG(" end %d\n", data->cmd_err);
++
+ 	/* mutex unlock */
+ 	k_mutex_unlock(&data->trans_mutex);
+ 
+ 	return data->cmd_err;
+-
+ }
+ 
+ static int aspeed_i2c_is_irq_error(uint32_t irq_status)
+@@ -1309,12 +1312,12 @@ int aspeed_i2c_slave_irq(const struct device *dev)
+ 				sys_write32(AST_I2CS_SET_RX_DMA_LEN(I2C_SLAVE_BUF_SIZE)
+ 				, i2c_base + AST_I2CS_DMA_LEN);
+ 			} else if (config->mode == BUFF_MODE) {
++				LOG_DBG("Slave_Buff");
+ 				cmd |= AST_I2CS_RX_BUFF_EN;
+ 				slave_rx_len =
+ 				AST_I2CC_GET_RX_BUF_LEN(sys_read32(i2c_base + AST_I2CC_BUFF_CTRL));
+-				for (i = 0; i < slave_rx_len; i++) {
+-					/* LOG_DBG("[%02x]", value); */
+-					if (slave_cb->write_received) {
++				if (slave_cb->write_received) {
++					for (i = 0; i < slave_rx_len ; i++) {
+ 						slave_cb->write_received(data->slave_cfg
+ 						, sys_read8(config->buf_base + i));
+ 					}
+@@ -1358,6 +1361,7 @@ int aspeed_i2c_slave_irq(const struct device *dev)
+ 
+ 			cmd = AST_I2CS_ACTIVE_ALL | AST_I2CS_PKT_MODE_EN;
+ 			if (config->mode == DMA_MODE) {
++
+ 				cmd |= AST_I2CS_TX_DMA_EN;
+ 				slave_rx_len =
+ 				AST_I2C_GET_RX_DMA_LEN(sys_read32(i2c_base + AST_I2CS_DMA_LEN_STS));
+@@ -1383,22 +1387,27 @@ int aspeed_i2c_slave_irq(const struct device *dev)
+ 				sys_write32(AST_I2CS_SET_TX_DMA_LEN(slave_rx_len)
+ 				, i2c_base + AST_I2CS_DMA_LEN);
+ 			} else if (config->mode == BUFF_MODE) {
++
+ 				cmd |= AST_I2CS_TX_BUFF_EN;
+ 				slave_rx_len =
+ 				AST_I2CC_GET_RX_BUF_LEN(sys_read32(i2c_base + AST_I2CC_BUFF_CTRL));
+ 				for (i = 0; i < slave_rx_len; i++) {
+ 					if (slave_cb->write_received) {
+ 						slave_cb->write_received(data->slave_cfg
+-						, sys_read8(config->buf_base + i));
++						, (sys_read32(config->buf_base + i) & 0xFF));
+ 					}
+-				}
+-				if (slave_cb->read_requested) {
+-					slave_cb->read_requested(data->slave_cfg, &value);
++
++					if (slave_cb->read_requested) {
++						slave_cb->read_requested(data->slave_cfg, &value);
++					}
++
++					sys_write32(value, config->buf_base);
++
++					sys_write32(AST_I2CC_SET_TX_BUF_LEN(1)
++					, i2c_base + AST_I2CC_BUFF_CTRL);
++
+ 				}
+ 
+-				sys_write8(value, config->buf_base);
+-				sys_write32(AST_I2CC_SET_TX_BUF_LEN(1)
+-				, i2c_base + AST_I2CC_BUFF_CTRL);
+ 			} else {
+ 				cmd &= ~AST_I2CS_PKT_MODE_EN;
+ 				cmd |= AST_I2CS_TX_CMD;
+@@ -1501,7 +1510,7 @@ int aspeed_i2c_slave_irq(const struct device *dev)
+ 					slave_cb->read_processed(data->slave_cfg, &value);
+ 				}
+ 				LOG_DBG("tx: [%02x]\n", value);
+-				sys_write8(value, config->buf_base);
++				sys_write32(value, config->buf_base);
+ 				sys_write32(AST_I2CC_SET_TX_BUF_LEN(1)
+ 				, i2c_base + AST_I2CC_BUFF_CTRL);
+ 			} else {
+@@ -1635,6 +1644,8 @@ static int i2c_aspeed_init(const struct device *dev)
+ 	struct i2c_aspeed_config *config = DEV_CFG(dev);
+ 	struct i2c_aspeed_data *data = DEV_DATA(dev);
+ 	uint32_t i2c_base = DEV_BASE(dev);
++	uint32_t i2c_count = ((i2c_base & 0xFFFF) / 0x80) - 1;
++	uint32_t i2c_base_offset = I2C_BUF_BASE + (i2c_count * 0x20);
+ 	uint32_t bitrate_cfg;
+ 	int error;
+ 
+@@ -1649,6 +1660,11 @@ static int i2c_aspeed_init(const struct device *dev)
+ 
+ 	config->multi_master = 0;
+ 	config->mode = DMA_MODE;
++
++	/* buffer mode base and size */
++	config->buf_base = config->global_reg + i2c_base_offset;
++	config->buf_size = I2C_BUF_SIZE;
++
+ 	clock_control_get_rate(config->clock_dev, config->clk_id, &config->clk_src);
+ 	LOG_DBG("clk src %d, div mode %d, multi-master %d, xfer mode %d\n",
+ 		config->clk_src, config->clk_div_mode, config->multi_master, config->mode);
+-- 
+2.17.1
+

--- a/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0004-drivers-i2c-connect-the-virtual-slave-into-byte-mode.patch
+++ b/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0004-drivers-i2c-connect-the-virtual-slave-into-byte-mode.patch
@@ -1,0 +1,116 @@
+From 2504a0c52f1ac40b945975955eb8396f92d55576 Mon Sep 17 00:00:00 2001
+From: tommy-huang <tommy_huang@aspeedtech.com>
+Date: Tue, 5 Oct 2021 17:35:40 +0800
+Subject: [PATCH] drivers: i2c: connect the virtual slave into byte mode
+
+Connected the virtual slave into i2c byte mode.
+
+Signed-off-by: tommy-huang <tommy_huang@aspeedtech.com>
+Change-Id: Iae4cc8ba26c5c31f1607fa148950f138376841e2
+---
+ drivers/i2c/i2c_aspeed.c | 40 ++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 36 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/i2c/i2c_aspeed.c b/drivers/i2c/i2c_aspeed.c
+index c6179fd167..4875541ec8 100644
+--- a/drivers/i2c/i2c_aspeed.c
++++ b/drivers/i2c/i2c_aspeed.c
+@@ -333,6 +333,9 @@ struct i2c_aspeed_data {
+ 	uint32_t slave_xfer_len;
+ 	uint32_t slave_xfer_cnt;
+ 
++	/* byte mode check re-start */
++	uint8_t slave_addr_last;
++
+ #ifdef CONFIG_I2C_SLAVE
+ 	unsigned char slave_dma_buf[I2C_SLAVE_BUF_SIZE];
+ 	struct i2c_slave_config *slave_cfg;
+@@ -1570,16 +1573,25 @@ int aspeed_i2c_slave_irq(const struct device *dev)
+ 		sys_write32(AST_I2CS_PKT_DONE, i2c_base + AST_I2CS_ISR);
+ 		ret = 1;
+ 	} else {
+-		LOG_DBG("byte mode todo check\n");
++		LOG_DBG("byte mode\n");
+ 		/*only coming for byte mode*/
+ 		cmd = AST_I2CS_ACTIVE_ALL;
+ 		switch (sts) {
+ 		case AST_I2CS_SLAVE_MATCH | AST_I2CS_RX_DONE | AST_I2CS_Wait_RX_DMA:
+ 			LOG_DBG("S : Sw|D\n");
++
+ 			/* first address match is address */
+ 			byte_data =
+ 			AST_I2CC_GET_RX_BUFF(sys_read32(i2c_base + AST_I2CC_STS_AND_BUFF));
+ 			LOG_DBG("addr [%x]", byte_data);
++
++			/* If the record address is still same, it is re-start case. */
++			if ((slave_cb->write_requested) &&
++			byte_data != data->slave_addr_last) {
++				slave_cb->write_requested(data->slave_cfg);
++			}
++
++			data->slave_addr_last = byte_data;
+ 			break;
+ 		case AST_I2CS_RX_DONE | AST_I2CS_Wait_RX_DMA:
+ 			LOG_DBG("S : D\n");
+@@ -1587,6 +1599,10 @@ int aspeed_i2c_slave_irq(const struct device *dev)
+ 			AST_I2CC_GET_RX_BUFF(sys_read32(i2c_base + AST_I2CC_STS_AND_BUFF));
+ 			LOG_DBG("rx [%x]", byte_data);
+ 
++			if (slave_cb->write_received) {
++				slave_cb->write_received(data->slave_cfg
++				, byte_data);
++			}
+ 			break;
+ 		case AST_I2CS_SLAVE_MATCH | AST_I2CS_RX_DONE | AST_I2CS_Wait_TX_DMA:
+ 			cmd |= AST_I2CS_TX_CMD;
+@@ -1594,21 +1610,34 @@ int aspeed_i2c_slave_irq(const struct device *dev)
+ 			byte_data =
+ 			AST_I2CC_GET_RX_BUFF(sys_read32(i2c_base + AST_I2CC_STS_AND_BUFF));
+ 			LOG_DBG("addr : [%02x]", byte_data);
+-			/*i2c_slave_event(obj, I2C_SLAVE_READ_REQUESTED);*/
++
++			if (slave_cb->read_requested) {
++				slave_cb->read_requested(data->slave_cfg
++				, &byte_data);
++			}
++
+ 			LOG_DBG("tx: [%02x]\n", byte_data);
+ 			sys_write32(byte_data, i2c_base + AST_I2CC_STS_AND_BUFF);
+ 			break;
+ 		case AST_I2CS_TX_ACK | AST_I2CS_Wait_TX_DMA:
+ 			cmd |= AST_I2CS_TX_CMD;
+ 			LOG_DBG("S : D\n");
+-			/*i2c_slave_event(obj, I2C_SLAVE_READ_PROCESSED);*/
++
++			if (slave_cb->read_processed) {
++				slave_cb->read_processed(data->slave_cfg
++				, &byte_data);
++			}
++
+ 			LOG_DBG("tx: [%02x]\n", byte_data);
+ 			sys_write32(byte_data, i2c_base + AST_I2CC_STS_AND_BUFF);
+ 			break;
+ 		case AST_I2CS_STOP:
++			if (slave_cb->stop) {
++				slave_cb->stop(data->slave_cfg);
++			}
+ 		case AST_I2CS_STOP | AST_I2CS_TX_NAK:
+ 			LOG_DBG("S : P\n");
+-			/* i2c_slave_event(obj, I2C_SLAVE_STOP); */
++			data->slave_addr_last = 0xFF;
+ 			break;
+ 		default:
+ 			LOG_DBG("TODO no pkt_done intr ~~~ ***** sts %x\n", sts);
+@@ -1665,6 +1694,9 @@ static int i2c_aspeed_init(const struct device *dev)
+ 	config->buf_base = config->global_reg + i2c_base_offset;
+ 	config->buf_size = I2C_BUF_SIZE;
+ 
++	/* byte mode check re-start */
++	data->slave_addr_last = 0xFF;
++
+ 	clock_control_get_rate(config->clock_dev, config->clk_id, &config->clk_src);
+ 	LOG_DBG("clk src %d, div mode %d, multi-master %d, xfer mode %d\n",
+ 		config->clk_src, config->clk_div_mode, config->multi_master, config->mode);
+-- 
+2.17.1
+

--- a/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0005-drivers-i2c-apply-multi-master-always.patch
+++ b/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0005-drivers-i2c-apply-multi-master-always.patch
@@ -1,0 +1,30 @@
+From f82b896005734a1193cc8e8d7b7621a1aa8cdda5 Mon Sep 17 00:00:00 2001
+From: tommy-huang <tommy_huang@aspeedtech.com>
+Date: Fri, 15 Oct 2021 16:12:56 +0800
+Subject: [PATCH] drivers: i2c: apply multi-master always
+
+Apply i2c multi-master as default value.
+
+Signed-off-by: tommy-huang <tommy_huang@aspeedtech.com>
+Change-Id: I6969a53e780caafbe70909d6e572c9759f20126c
+---
+ drivers/i2c/i2c_aspeed.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/i2c_aspeed.c b/drivers/i2c/i2c_aspeed.c
+index 4875541ec8..f42b1408fc 100644
+--- a/drivers/i2c/i2c_aspeed.c
++++ b/drivers/i2c/i2c_aspeed.c
+@@ -1687,7 +1687,8 @@ static int i2c_aspeed_init(const struct device *dev)
+ 		config->clk_div_mode = 1;
+ 	}
+ 
+-	config->multi_master = 0;
++	/* default apply multi-master with DMA mode */
++	config->multi_master = 1;
+ 	config->mode = DMA_MODE;
+ 
+ 	/* buffer mode base and size */
+-- 
+2.17.1
+

--- a/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0006-drivers-i2c-ipmb-fix-warning-and-typo.patch
+++ b/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0006-drivers-i2c-ipmb-fix-warning-and-typo.patch
@@ -1,0 +1,44 @@
+From 07e64d84ef508b1779d812c34955f443a84ba892 Mon Sep 17 00:00:00 2001
+From: tommy-huang <tommy_huang@aspeedtech.com>
+Date: Thu, 30 Sep 2021 15:09:12 +0800
+Subject: [PATCH] drivers: i2c ipmb: fix warning and typo
+
+Change some information from err into dbg.
+Fix the data count error.
+
+Signed-off-by: tommy-huang <tommy_huang@aspeedtech.com>
+Change-Id: I9d7fd271b66f7bb372b07d4a9cd9d829a51793df
+---
+ drivers/i2c/slave/ipmb_slave.c   | 2 +-
+ include/drivers/i2c/slave/ipmb.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/i2c/slave/ipmb_slave.c b/drivers/i2c/slave/ipmb_slave.c
+index eca5bfdcd2..2634d9e592 100644
+--- a/drivers/i2c/slave/ipmb_slave.c
++++ b/drivers/i2c/slave/ipmb_slave.c
+@@ -136,7 +136,7 @@ int ipmb_slave_read(const struct device *dev, struct ipmb_msg **ipmb_data, uint8
+ 
+ 		return 0;
+ 	} else {
+-		LOG_ERR("ipmb slave read: buffer empty!");
++		LOG_DBG("ipmb slave read: buffer empty!");
+ 		return 1;
+ 	}
+ 
+diff --git a/include/drivers/i2c/slave/ipmb.h b/include/drivers/i2c/slave/ipmb.h
+index c8701f4066..120f39b559 100644
+--- a/include/drivers/i2c/slave/ipmb.h
++++ b/include/drivers/i2c/slave/ipmb.h
+@@ -12,7 +12,7 @@
+ 
+ #define GET_ADDR(addr)	((addr << 1) & 0xff)
+ 
+-#define IPMB_MSG_DATA_LEN (IPMB_TOTAL_LEN - IPMB_REQUEST_LEN - 1)
++#define IPMB_MSG_DATA_LEN (IPMB_TOTAL_LEN - 1)
+ 
+ struct ipmb_msg {
+ 	uint8_t rsSA;
+-- 
+2.17.1
+


### PR DESCRIPTION
Summary:
- To enable multiple master and fix unexpected error print from IPMB slave queue polling, Aspeed provide patch for I2C drivers.

Test plan:
[Git patch] Pass
[Build code] Pass