### PR TITLE
SDK: v00.01.01: Snoop patch for reading way fix

### DIFF
--- a/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0001-drivers-misc-snoop_aspeed-Add-blocking-non-blocking-.patch
+++ b/fix_patch/tag_v00.01.01_8ac09a4e6cd6666f0802d5aac121b65051270f41/0001-drivers-misc-snoop_aspeed-Add-blocking-non-blocking-.patch
@@ -1,0 +1,67 @@
+From c008b76d755b26c1dcb784bb42bf20dd7e933ea9 Mon Sep 17 00:00:00 2001
+From: Chia-Wei Wang <chiawei_wang@aspeedtech.com>
+Date: Thu, 28 Oct 2021 12:09:46 +0800
+Subject: [PATCH] drivers: misc/snoop_aspeed: Add blocking/non-blocking read
+ support
+
+Support snooped data byte read in either blocking or non-blocking way.
+
+Signed-off-by: Chia-Wei Wang <chiawei_wang@aspeedtech.com>
+Change-Id: I1ebbeb6cda5b1412bf09fffaae60b680f3460604
+---
+ drivers/misc/aspeed/snoop_aspeed.c           | 7 +++----
+ include/drivers/misc/aspeed/snoop_aspeed.h   | 2 +-
+ samples/drivers/misc/aspeed/snoop/src/main.c | 2 +-
+ 3 files changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/misc/aspeed/snoop_aspeed.c b/drivers/misc/aspeed/snoop_aspeed.c
+index b980bd0d14..dcde617b05 100644
+--- a/drivers/misc/aspeed/snoop_aspeed.c
++++ b/drivers/misc/aspeed/snoop_aspeed.c
+@@ -57,15 +57,14 @@ struct snoop_aspeed_config {
+ 	uint16_t port[SNOOP_CHANNEL_NUM];
+ };
+ 
+-int snoop_aspeed_read(const struct device *dev, uint32_t ch, uint8_t *out)
++int snoop_aspeed_read(const struct device *dev, uint32_t ch, uint8_t *out, bool blocking)
+ {
+ 	int rc;
+ 	struct snoop_aspeed_data *data = (struct snoop_aspeed_data *)dev->data;
+ 
+-	rc = k_sem_take(&data->rx[ch].lock, K_NO_WAIT);
+-	if (rc) {
++	rc = k_sem_take(&data->rx[ch].lock, (blocking) ? K_FOREVER : K_NO_WAIT);
++	if (rc)
+ 		return rc;
+-	}
+ 
+ 	*out = data->rx[ch].data;
+ 
+diff --git a/include/drivers/misc/aspeed/snoop_aspeed.h b/include/drivers/misc/aspeed/snoop_aspeed.h
+index 8b1bbf35e6..6fd31444b9 100644
+--- a/include/drivers/misc/aspeed/snoop_aspeed.h
++++ b/include/drivers/misc/aspeed/snoop_aspeed.h
+@@ -8,6 +8,6 @@
+ 
+ #define SNOOP_CHANNEL_NUM	2
+ 
+-int snoop_aspeed_read(const struct device *dev, uint32_t ch, uint8_t *out);
++int snoop_aspeed_read(const struct device *dev, uint32_t ch, uint8_t *out, bool blocking);
+ 
+ #endif
+diff --git a/samples/drivers/misc/aspeed/snoop/src/main.c b/samples/drivers/misc/aspeed/snoop/src/main.c
+index 90734fb72f..3a90148c75 100644
+--- a/samples/drivers/misc/aspeed/snoop/src/main.c
++++ b/samples/drivers/misc/aspeed/snoop/src/main.c
+@@ -23,7 +23,7 @@ void main(void)
+ 
+ 	while (1) {
+ 		for (i = 0; i < SNOOP_CHANNEL_NUM; ++i) {
+-			rc = snoop_aspeed_read(snoop_dev, i, &snoop_data[i]);
++			rc = snoop_aspeed_read(snoop_dev, i, &snoop_data[i], true);
+ 			if (rc == 0)
+ 				printk("snoop[%d] = 0x%02x\n", i, snoop_data[i]);
+ 		}
+-- 
+2.25.1
+


### PR DESCRIPTION
Summary:
- To fix BIC resource would be occupied in snoop reading by support reading data in either blocking or non-blocking way, Aspeed provide patch for Snoop drivers.

Test plan:
[Git patch] Pass
[Build code] Pass