### PR TITLE
fby3.5: cl: Add JTAG command

### DIFF
--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -72,6 +72,8 @@ void pal_OEM_GET_FW_VERSION(ipmi_msg *msg);
 void pal_OEM_GET_SET_GPIO(ipmi_msg *msg);
 void pal_OEM_SET_SYSTEM_GUID(ipmi_msg *msg);
 void pal_OEM_I2C_DEV_SCAN(ipmi_msg *msg);
+void pal_OEM_SET_JTAG_TAP_STA(ipmi_msg *msg);
+void pal_OEM_JTAG_DATA_SHIFT(ipmi_msg *msg);
 
 
 enum {
@@ -178,6 +180,8 @@ enum {
   CMD_OEM_SENSOR_POLL_EN = 0x7,
   CMD_OEM_FW_UPDATE = 0x9,
   CMD_OEM_GET_FW_VERSION = 0xB,
+  CMD_OEM_SET_JTAG_TAP_STA = 0x21,
+  CMD_OEM_JTAG_DATA_SHIFT = 0x22,
   CMD_OEM_GET_SET_GPIO = 0x41,
   CMD_OEM_SET_SYSTEM_GUID = 0xEF,
 // Debug command

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -142,6 +142,12 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 	case CMD_OEM_GET_FW_VERSION:
 		pal_OEM_GET_FW_VERSION(msg);
 		break;
+	case CMD_OEM_SET_JTAG_TAP_STA:
+		pal_OEM_SET_JTAG_TAP_STA(msg);
+		break;
+	case CMD_OEM_JTAG_DATA_SHIFT:
+		pal_OEM_JTAG_DATA_SHIFT(msg);
+		break;
 	case CMD_OEM_GET_SET_GPIO:
 		pal_OEM_GET_SET_GPIO(msg);
 		break;

--- a/common/pal.c
+++ b/common/pal.c
@@ -142,6 +142,18 @@ __weak void pal_OEM_GET_FW_VERSION(ipmi_msg *msg)
 	return;
 }
 
+__weak void pal_OEM_SET_JTAG_TAP_STA(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_JTAG_DATA_SHIFT(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
 __weak void pal_OEM_GET_SET_GPIO(ipmi_msg *msg)
 {
 	msg->completion_code = CC_UNSPECIFIED_ERROR;

--- a/common/util/hal_jtag.c
+++ b/common/util/hal_jtag.c
@@ -1,0 +1,97 @@
+#include <stdio.h>
+#include <string.h>
+#include "hal_jtag.h"
+
+static char *jtag_device = "JTAG1";
+
+void jtag_set_tap(uint8_t data, uint8_t bitlength){
+  const struct device *dev;
+  dev = device_get_binding(jtag_device);
+  if (!dev) {
+    printf("JTAG device not found\n");
+    return;
+  }
+  uint8_t value, index;
+
+  for (index = 0; index < bitlength; index++) {
+    value = data & 0x01;
+
+    jtag_sw_xfer(dev, JTAG_TCK, 0);
+    jtag_sw_xfer(dev, JTAG_TDI, 0);
+    jtag_sw_xfer(dev, JTAG_TMS, value);
+    jtag_sw_xfer(dev, JTAG_TCK, 1);
+    jtag_sw_xfer(dev, JTAG_TDI, 0);
+    jtag_sw_xfer(dev, JTAG_TMS, value);
+
+    data = data >> 1;
+  }
+}
+
+void jtag_shift_data(uint16_t Wbit, uint8_t *Wdate, uint16_t Rbit, uint8_t *Rdate, uint8_t lastidx){
+  const struct device *dev;
+  dev = device_get_binding(jtag_device);
+  if (!dev) {
+    printf("JTAG device not found\n");
+    return;
+  }
+
+  uint8_t value, tdo_val, TMS_val = 0;
+  uint16_t RnWbit, RnWbyte, index;
+
+  RnWbit = (Wbit > Rbit) ? Wbit : Rbit;
+  RnWbyte = (RnWbit + 7) >> 3;
+
+  for (index = 0; index < RnWbit; index++) {
+    if ((Wbit != 0) && (Rbit != 0)) {
+      value = Wdate[index / 8] & 0x01;
+      if ((Wbit == 1) && (Rbit == 1)) {
+        TMS_val = lastidx;
+      }
+
+      jtag_sw_xfer(dev, JTAG_TCK, 0);
+      jtag_sw_xfer(dev, JTAG_TDI, value);
+      jtag_sw_xfer(dev, JTAG_TMS, TMS_val);
+      jtag_sw_xfer(dev, JTAG_TCK, 1);
+      jtag_sw_xfer(dev, JTAG_TDI, value);
+      jtag_sw_xfer(dev, JTAG_TMS, TMS_val);
+      jtag_tdo_get(dev, &tdo_val);
+
+      Wdate[index / 8] = Wdate[index / 8] >> 1;
+      Rdate[index / 8] |= tdo_val << index % 8;
+      Wbit--;
+      Rbit--;
+    }
+    else if (Wbit != 0) {
+      value = Wdate[index / 8] & 0x01;
+      if ((Wbit == 1)) {
+        TMS_val = lastidx;
+      }
+
+      jtag_sw_xfer(dev, JTAG_TCK, 0);
+      jtag_sw_xfer(dev, JTAG_TDI, value);
+      jtag_sw_xfer(dev, JTAG_TMS, TMS_val);
+      jtag_sw_xfer(dev, JTAG_TCK, 1);
+      jtag_sw_xfer(dev, JTAG_TDI, value);
+      jtag_sw_xfer(dev, JTAG_TMS, TMS_val);
+
+      Wdate[index / 8] = Wdate[index / 8] >> 1;
+      Wbit--;
+    }
+    else if (Rbit != 0) {
+      if ((Rbit == 1)) {
+        TMS_val = lastidx;
+      }
+
+      jtag_sw_xfer(dev, JTAG_TCK, 0);
+      jtag_sw_xfer(dev, JTAG_TDI, 0);
+      jtag_sw_xfer(dev, JTAG_TMS, TMS_val);
+      jtag_sw_xfer(dev, JTAG_TCK, 1);
+      jtag_sw_xfer(dev, JTAG_TDI, 0);
+      jtag_sw_xfer(dev, JTAG_TMS, TMS_val);
+      jtag_tdo_get(dev, &tdo_val);
+
+      Rdate[index / 8] |= tdo_val << index % 8;
+      Rbit--;
+    }
+  }
+}

--- a/common/util/hal_jtag.h
+++ b/common/util/hal_jtag.h
@@ -1,0 +1,9 @@
+#ifndef HAL_JTAG_H
+#define HAL_JTAG_H
+
+#include <drivers/jtag.h>
+
+void jtag_set_tap(uint8_t data, uint8_t bitlength);
+void jtag_shift_data(uint16_t Wbit, uint8_t *Wdate, uint16_t Rbit, uint8_t *Rdate, uint8_t lastidx);
+
+#endif


### PR DESCRIPTION
Summary:
- Support OEM JTAG command SET_JTAG_TAP_STA and JTAG_DATA_SHIFT for ASD.

Note:
Due to the issue mentioned in #51, the operating system cannot be booted with the zephyr firmware.
So before testing the JTAG command, you need to use the freeRTOS firmware to start the OS, then update to Zephyr and continue testing.

Test plan:
-Build code: Pass

Log:
```
ASD enable
root@bmc-oob:~# bic-util slot1 --set_gpio 52 1
slot 1: setting [52]BMC_JTAG_SEL_R to 1
JTAG reset
root@bmc-oob:~# bic-util slot1 0xe0 0x21 0x9c 0x9c 0x00 0x08 0xff
9C 9C 00
JTAG TAP to shift_DR
root@bmc-oob:~# bic-util slot1 0xe0 0x21 0x9c 0x9c 0x00 0x04 0x02
9C 9C 00
JTAG read something
root@bmc-oob:~# bic-util slot1 0xe0 0x22 0x9c 0x9c 0x00 0x02 0x00 0x00 0x40 0x00 0x00
9C 9C 00 13 41 04 20 00 00 00 00
JTAG reset
root@bmc-oob:~# bic-util slot1 0xe0 0x21 0x9c 0x9c 0x00 0x08 0xff
9C 9C 00
JTAG TAP to shift_IR
root@bmc-oob:~# bic-util slot1 0xe0 0x21 0x9c 0x9c 0x00 0x05 0x06
9C 9C 00
JTAG read something
root@bmc-oob:~# bic-util slot1 0xe0 0x22 0x9c 0x9c 0x00 0x00 0x00 0x06 0x00 0x00
9C 9C 00 01
```