### PR TITLE
fby3.5: cl: Added PECI util and PECI access command

### DIFF
--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -70,6 +70,7 @@ void pal_OEM_SEND_INTERRUPT_TO_BMC(ipmi_msg *msg);
 void pal_OEM_SENSOR_POLL_EN(ipmi_msg *msg);
 void pal_OEM_FW_UPDATE(ipmi_msg *msg);
 void pal_OEM_GET_FW_VERSION(ipmi_msg *msg);
+void pal_OEM_PECIaccess(ipmi_msg *msg);
 void pal_OEM_GET_SET_GPIO(ipmi_msg *msg);
 void pal_OEM_SET_SYSTEM_GUID(ipmi_msg *msg);
 void pal_OEM_I2C_DEV_SCAN(ipmi_msg *msg);
@@ -185,6 +186,7 @@ enum {
   CMD_OEM_SET_JTAG_TAP_STA = 0x21,
   CMD_OEM_JTAG_DATA_SHIFT = 0x22,
   CMD_OEM_ACCURACY_SENSNR = 0x23,
+  CMD_OEM_PECIaccess = 0x29,
   CMD_OEM_SENSOR_POLL_EN = 0x30,
   CMD_OEM_GET_SET_GPIO = 0x41,
   CMD_OEM_SET_SYSTEM_GUID = 0xEF,

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -142,6 +142,9 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 	case CMD_OEM_GET_FW_VERSION:
 		pal_OEM_GET_FW_VERSION(msg);
 		break;
+  case CMD_OEM_PECIaccess:
+    pal_OEM_PECIaccess(msg);
+    break;
   case CMD_OEM_GET_POST_CODE:
     pal_OEM_GET_POST_CODE(msg);
     break;

--- a/common/pal.c
+++ b/common/pal.c
@@ -4,6 +4,7 @@
 #include "ipmi.h"
 #include "pal.h"
 
+
 /***********************************************************
 *
 * Create weak function here
@@ -162,8 +163,14 @@ __weak void pal_OEM_JTAG_DATA_SHIFT(ipmi_msg *msg)
 
 __weak void pal_OEM_ACCURACY_SENSNR(ipmi_msg *msg)
 {
-	msg->completion_code = CC_UNSPECIFIED_ERROR;
-	return;
+  msg->completion_code = CC_UNSPECIFIED_ERROR;
+  return;
+}
+
+__weak void pal_OEM_PECIaccess(ipmi_msg *msg)
+{
+  msg->completion_code = CC_UNSPECIFIED_ERROR;
+  return;
 }
 
 __weak void pal_OEM_GET_SET_GPIO(ipmi_msg *msg)

--- a/common/util/hal_peci.c
+++ b/common/util/hal_peci.c
@@ -1,0 +1,106 @@
+#include <stdio.h>
+#include <drivers/peci.h>
+#include "hal_peci.h"
+
+
+const struct device *dev;
+
+int peci_init() {
+  dev = device_get_binding("PECI");
+  int ret;
+  uint32_t bitrate = 1000;
+  if (!dev) {
+    printf("peci device not found");
+    return false;
+  }
+  ret = peci_config(dev, bitrate);
+  if (ret) {
+    printf("set bitrate %dKbps failed %d\n", bitrate, ret);
+    return ret;
+  }
+  ret = peci_enable(dev);
+  if (ret) {
+    printf("peci enable failed %d\n", ret);
+    return ret;
+  }
+
+  return ret;
+}
+
+int peci_ping(uint8_t address) {
+  struct peci_msg pkgcfg;
+  int ret;
+
+  pkgcfg.addr = address;
+  pkgcfg.cmd_code = PECI_CMD_PING;
+  pkgcfg.tx_buffer.buf = NULL;
+  pkgcfg.tx_buffer.len = 0x0;
+  pkgcfg.rx_buffer.len = 0x0;
+  
+  ret = peci_transfer(dev, &pkgcfg);
+  if (ret) {
+    printf("ping failed %d\n", ret);
+    free(pkgcfg.tx_buffer.buf);
+    return ret;
+  }
+  
+  free(pkgcfg.tx_buffer.buf);
+  return ret;
+}
+
+int peci_read(uint8_t cmd, uint8_t address, uint8_t u8Index, uint16_t u16Param, uint8_t u8ReadLen, uint8_t *readBuf) {
+  struct peci_msg rdpkgcfg;
+  int ret;
+  rdpkgcfg.cmd_code = cmd;
+  rdpkgcfg.addr = address;
+  rdpkgcfg.tx_buffer.len = 0x05;
+  rdpkgcfg.rx_buffer.len = u8ReadLen;
+  rdpkgcfg.tx_buffer.buf = malloc(rdpkgcfg.tx_buffer.len * sizeof(uint8_t));
+  rdpkgcfg.rx_buffer.buf = readBuf;
+  rdpkgcfg.tx_buffer.buf[0] = 0x00;
+  rdpkgcfg.tx_buffer.buf[1] = u8Index;
+  rdpkgcfg.tx_buffer.buf[2] = u16Param & 0xff;
+  rdpkgcfg.tx_buffer.buf[3] = u16Param >> 8;  
+  ret = peci_transfer(dev, &rdpkgcfg);
+  
+  if (DEBUG_PECI) {
+    uint8_t index;
+    for (index = 0; index < 5; index++)
+      printf("%02x ", readBuf[index]);
+    printf("\n");
+  }
+
+  if (ret) {
+    printf("peci read failed %d\n", ret);
+    free(rdpkgcfg.tx_buffer.buf);
+    return ret;
+  }
+
+  free(rdpkgcfg.tx_buffer.buf);
+  return ret;  
+}
+
+int peci_write(uint8_t cmd, uint8_t address, uint8_t u8Index, uint16_t u16Param, uint8_t u8ReadLen, uint8_t *readBuf, uint8_t u8WriteLen, uint8_t *writeBuf) {
+  struct peci_msg wrpkgcfg;
+  int ret;
+
+  wrpkgcfg.addr = address;
+  wrpkgcfg.cmd_code = cmd;
+  wrpkgcfg.tx_buffer.len = u8WriteLen;
+  wrpkgcfg.rx_buffer.len = u8ReadLen;
+  wrpkgcfg.rx_buffer.buf = readBuf;
+  wrpkgcfg.tx_buffer.buf = (uint8_t *)malloc(u8WriteLen * sizeof(uint8_t));
+  memcpy(&wrpkgcfg.tx_buffer.buf[0], &writeBuf[0], u8WriteLen);
+  
+  ret = peci_transfer(dev, &wrpkgcfg);
+  if (ret) {
+    free(wrpkgcfg.tx_buffer.buf);
+    printk("peci write failed %d\n", ret);
+    return ret;
+  }
+  
+  free(wrpkgcfg.tx_buffer.buf);
+  return ret;
+}
+
+

--- a/common/util/hal_peci.h
+++ b/common/util/hal_peci.h
@@ -1,0 +1,38 @@
+#ifndef HAL_PECI_H
+#define HAL_PECI_H
+
+#define DEBUG_PECI 0
+
+enum peci_cmd {
+  PECI_PING_CMD                = 0x00,
+  PECI_GET_TEMP0_CMD           = 0x01,
+  PECI_GET_TEMP1_CMD           = 0x02,
+  PECI_RD_PCI_CFG0_CMD         = 0x61,
+  PECI_RD_PCI_CFG1_CMD         = 0x62,
+  PECI_WR_PCI_CFG0_CMD         = 0x65,
+  PECI_WR_PCI_CFG1_CMD         = 0x66,
+  PECI_CRASHDUMP_CMD           = 0x71,
+  PECI_RD_PKG_CFG0_CMD         = 0xA1,
+  PECI_RD_PKG_CFG1_CMD         = 0xA,
+  PECI_WR_PKG_CFG0_CMD         = 0xA5,
+  PECI_WR_PKG_CFG1_CMD         = 0xA6,
+  PECI_RD_IAMSR0_CMD           = 0xB1,
+  PECI_RD_IAMSR1_CMD           = 0xB2,
+  PECI_WR_IAMSR0_CMD           = 0xB5,
+  PECI_WR_IAMSR1_CMD           = 0xB6,
+  PECI_RD_PCI_CFG_LOCAL0_CMD   = 0xE1,
+  PECI_RD_PCI_CFG_LOCAL1_CMD   = 0xE2,
+  PECI_WR_PCI_CFG_LOCAL0_CMD   = 0xE5,
+  PECI_WR_PCI_CFG_LOCAL1_CMD   = 0xE6,
+  PECI_GET_DIB_CMD             = 0xF7,
+};
+
+
+int peci_init();
+int peci_ping(uint8_t address);
+int peci_read(uint8_t cmd, uint8_t address, uint8_t u8Index, uint16_t u16Param, uint8_t u8ReadLen, uint8_t *readBuf);
+int peci_write(uint8_t cmd, uint8_t address, uint8_t u8Index, uint16_t u16Param, uint8_t u8ReadLen, uint8_t *readBuf, uint8_t u8WriteLen, uint8_t *writeBuf);
+
+#endif
+
+

--- a/meta-facebook/yv35-cl/src/sensor/dev/peci.c
+++ b/meta-facebook/yv35-cl/src/sensor/dev/peci.c
@@ -4,48 +4,12 @@
 #include "sensor_def.h"
 #include "pal.h"
 #include <drivers/peci.h>
-
-const struct device *dev ;
-
-bool peci_init(){
-  dev = device_get_binding("PECI");
-  int ret;
-  uint32_t bitrate = 1000;
-  if (!dev) {
-    printk("peci device not found");
-    return false;
-  }
-  ret = peci_config(dev, bitrate);
-  if (ret) {
-    printk("set bitrate %dKbps failed %d\n", bitrate, ret);
-    return false;
-  }
-  ret = peci_enable(dev);
-  if (ret) {
-    printk("peci enable failed %d\n", ret);
-    return false;
-  }
-  return true;
-}
-
-bool peci_retry_transfer( struct peci_msg *msg ){
-  int retry = 0;
-  while ( retry < 3 ){
-    free(msg->rx_buffer.buf);
-    msg->rx_buffer.buf = malloc(msg->rx_buffer.len);
-    if ( !peci_transfer(dev, msg) ) {
-      if ( msg->rx_buffer.buf[0] == 0x40 ) {
-        return true;
-      }
-    }
-    retry++;
-  }
-  return false;
-}
+#include "hal_peci.h"
+#include <string.h>
 
 bool pal_peci_read(uint8_t sensor_num, int *reading) {
-  struct peci_msg rdpkgcfg;
-  uint8_t u8Index;
+  uint8_t u8Index, u8ReadLen = 0x05, address, *readBuf;
+  uint8_t cmd = PECI_CMD_RD_PKG_CFG0;
   uint16_t u16Param;
   int val , ret , complete_code;
   static uint8_t cpu_temp_tjmax = 0;
@@ -53,99 +17,123 @@ bool pal_peci_read(uint8_t sensor_num, int *reading) {
   if ( sensor_num == SENSOR_NUM_TEMP_CPU_MARGIN ) {
     u8Index = 0x02;
     u16Param = 0x00ff;
-  }else if ( sensor_num == SENSOR_NUM_TEMP_CPU ){
+  } else if ( sensor_num == SENSOR_NUM_TEMP_CPU ){
     if( !get_tjmax ) {
       return false;
-    }else {
+    } else {
       return true;
     }
-  }else if ( sensor_num == SENSOR_NUM_TEMP_CPU_TJMAX ){
+  } else if ( sensor_num == SENSOR_NUM_TEMP_CPU_TJMAX ){
     if( get_tjmax ) {
       return true;
-    }else {
+    } else {
       u8Index = 0x10;
       u16Param = 0x0000;
     }
-  }else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_A ){
+  } else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_A ){
     u8Index = 0x0E;
     u16Param = 0x0000;
-  }else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_C ){
+  } else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_C ){
     u8Index = 0x0E;
     u16Param = 0x0002;
-  }else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_D ){
+  } else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_D ){
     u8Index = 0x0E;
     u16Param = 0x0003;
-  }else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_E ){
+  } else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_E ){
     u8Index = 0x0E;
     u16Param = 0x0004;
-  }else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_G ){
+  } else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_G ){
     u8Index = 0x0E;
     u16Param = 0x0006;
-  }else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_H ){
+  } else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_H ){
     u8Index = 0x0E;
     u16Param = 0x0007;
-  }else {
+  } else {
     printf("Unrecognized sensor reading\n");
     return false;
   }
+  address = sensor_config[SnrNum_SnrCfg_map[sensor_num]].slave_addr;
+  readBuf = (uint8_t *)malloc(u8ReadLen * sizeof(uint8_t));
+  if ( readBuf == NULL ) {
+    return false;
+  }
 
-  rdpkgcfg.addr = sensor_config[SnrNum_SnrCfg_map[sensor_num]].slave_addr;
-  rdpkgcfg.tx_buffer.len = PECI_RD_PKG_WR_LEN;
-  rdpkgcfg.rx_buffer.len = PECI_RD_PKG_LEN_DWORD;
-  rdpkgcfg.tx_buffer.buf = malloc(rdpkgcfg.tx_buffer.len);
-  rdpkgcfg.rx_buffer.buf = malloc(rdpkgcfg.rx_buffer.len);
-  rdpkgcfg.cmd_code = 0xa1 ;
-  rdpkgcfg.tx_buffer.buf[0] =0x0;
-  rdpkgcfg.tx_buffer.buf[1] =u8Index;
-  rdpkgcfg.tx_buffer.buf[2] =u16Param & 0xff;
-  rdpkgcfg.tx_buffer.buf[3] =u16Param >> 8;
-  ret = peci_transfer(dev, &rdpkgcfg);
-  complete_code = rdpkgcfg.rx_buffer.buf[0];
+  ret = peci_read(cmd, address, u8Index, u16Param, u8ReadLen, readBuf);
+  complete_code = readBuf[0];
+
   if ( ret ) {
     if ( sensor_num == SENSOR_NUM_TEMP_CPU_MARGIN ) {
       sensor_config[SnrNum_SnrCfg_map[SENSOR_NUM_TEMP_CPU]].cache_status = SNR_FAIL_TO_ACCESS;
     }
-    free(rdpkgcfg.tx_buffer.buf);
-    free(rdpkgcfg.rx_buffer.buf);
+    if ( readBuf != NULL ) {
+      free(readBuf);
+    }
     sensor_config[SnrNum_SnrCfg_map[sensor_num]].cache_status = SNR_FAIL_TO_ACCESS;
     return false;
   }
-  if ( complete_code != 0x40 ) {
-    bool retry_transfer_val = 0;
-    if ( complete_code == 0x80 || complete_code == 0x81 ) {
-      retry_transfer_val = peci_retry_transfer( &rdpkgcfg ) ;
-      if ( !retry_transfer_val ){
-        printk("PECI sensor [%x] response timeout. Retry is appropriate.\n", sensor_num );
+
+  if (complete_code != PECI_CC_RSP_SUCCESS) {
+
+    // retry block
+    bool is_retry_success = false;
+    if ( complete_code == PECI_CC_RSP_TIMEOUT || complete_code == PECI_CC_OUT_OF_RESOURCES_TIMEOUT ) {
+      uint8_t i, retry = 3;
+       for(i = 0; i < retry; i++) {
+         memcpy(&readBuf[0], 0, u8ReadLen * sizeof(uint8_t));
+         ret = peci_read(cmd, address, u8Index, u16Param, u8ReadLen, readBuf);
+         if (!ret) {
+           if ( readBuf[0] == PECI_CC_RSP_SUCCESS ) {
+             is_retry_success = true;
+             complete_code = PECI_CC_RSP_SUCCESS;
+             break;
+           }
+         }
+       }
+    // retry block
+
+      if (!is_retry_success) {
+        printf("PECI sensor [%x] response timeout. Reach Max retry.\n", sensor_num );
         sensor_config[SnrNum_SnrCfg_map[sensor_num]].cache_status = SNR_FAIL_TO_ACCESS;
+        if ( readBuf != NULL ) {
+          free(readBuf);
+        }
+        return false;
       }
-    }else if ( complete_code == 0x90 ) {
-      printk("Unknown request\n");
+      
+    } else if (complete_code == PECI_CC_ILLEGAL_REQUEST) {
+      printf("Unknown request\n");
       sensor_config[SnrNum_SnrCfg_map[sensor_num]].cache_status = SNR_NOT_FOUND;
-    }else {
-      printk("PECI control hardware, firmware or associated logic error\n");
+      if ( readBuf != NULL ) {
+        free(readBuf);
+      }
+      return false;
+    } else {
+      printf("PECI control hardware, firmware or associated logic error\n");
       sensor_config[SnrNum_SnrCfg_map[sensor_num]].cache_status = SNR_UNSPECIFIED_ERROR;
-    }
-    if ( !retry_transfer_val ){
-      free(rdpkgcfg.tx_buffer.buf);
-      free(rdpkgcfg.rx_buffer.buf);
+      if ( readBuf != NULL ) {
+        free(readBuf);
+      }
       return false;
     }
   }
+      
+  // PECI_CC_RSP_SUCCESS
   if ( sensor_num == SENSOR_NUM_TEMP_CPU_MARGIN ) {
-    val = ( ( 0xFFFF - ( (rdpkgcfg.rx_buffer.buf[2] << 8) | rdpkgcfg.rx_buffer.buf[1] ) ) >> 6 ) +1;
+    val = ( ( 0xFFFF - ( (readBuf[2] << 8) | readBuf[1] ) ) >> 6 ) +1;
     sensor_config[SnrNum_SnrCfg_map[SENSOR_NUM_TEMP_CPU]].cache = cpu_temp_tjmax - (cal_MBR(sensor_num,val) & 0xff);
     sensor_config[SnrNum_SnrCfg_map[SENSOR_NUM_TEMP_CPU]].cache_status = SNR_READ_SUCCESS;
-  }else if ( sensor_num == SENSOR_NUM_TEMP_CPU_TJMAX ) {
-    val = rdpkgcfg.rx_buffer.buf[3];
+  } else if ( sensor_num == SENSOR_NUM_TEMP_CPU_TJMAX ) {
+    val = readBuf[3];
     cpu_temp_tjmax = val;
     get_tjmax = 1;
-  }else {
-    val = rdpkgcfg.rx_buffer.buf[1];
+  } else {
+    val = readBuf[1];
   }
-  free(rdpkgcfg.tx_buffer.buf);
-  free(rdpkgcfg.rx_buffer.buf);
-  *reading = cal_MBR(sensor_num,val) & 0xff;
+  if ( readBuf != NULL ) {
+    free(readBuf);
+  }
+  *reading = (acur_cal_MBR(sensor_num,val)) & 0xffff; 
   sensor_config[SnrNum_SnrCfg_map[sensor_num]].cache = *reading;
-  sensor_config[SnrNum_SnrCfg_map[sensor_num]].cache_status = SNR_READ_SUCCESS;
+  sensor_config[SnrNum_SnrCfg_map[sensor_num]].cache_status = SNR_READ_ACUR_SUCCESS;
   return true;
 }


### PR DESCRIPTION
Summary:
- Added PECI access OEM command.
- Added PECI util read function.
- Added PECI util write function.
- Added PECI util ping function.
- Modified PECI read function for CPU and DIMM sensor.

Test plan:
- Build code: Pass
- Get PECI sensor reading: Pass
- PECI read/write: Pass

Log:
root@bmc-oob:~# sensor-util slot3
MB Inlet Temp                (0x1) :   26.00       | (ok)
MB Outlet Temp               (0x2) :   44.00       | (ok)
Front IO Temp                (0x3) :   24.00       | (ok)
PCH Temp                     (0x4) :   42.00       | (ok)
CPU Temp                     (0x15) :   41.00       | (ok)
SOC Therm Margin             (0x14) :  -50.00       | (ok)
CPU TjMax                    (0x5) :   91.00       | (ok)
DIMMA Temp                   (0x6) :   39.00       | (ok)
DIMMC Temp                   (0x7) :   38.00       | (ok)
DIMMD Temp                   (0x9) :   35.00       | (ok)
DIMME Temp                   (0xA) :   39.00       | (ok)
DIMMG Temp                   (0xB) :   35.00       | (ok)
DIMMH Temp                   (0xC) :   32.00       | (ok)

root@bmc-oob:~# bic-util slot3 0xE0 0x29 0x9C 0x9C 0x0 0x30 0x05 0x05 0xA1 0x00 0x21 0x00 0x00
9C 9C 00 40 CC 00 00 00
root@bmc-oob:~# bic-util slot3 0xE0 0x29 0x9C 0x9C 0x0 0x30 0x0A 0x01 0xA5 0x00 0x21 0x00 0x00 0xFF 0x00 0x00 0x00
9C 9C 00 40
root@bmc-oob:~# bic-util slot3 0xE0 0x29 0x9C 0x9C 0x0 0x30 0x05 0x05 0xA1 0x00 0x21 0x00 0x00
9C 9C 00 40 FF 00 00 00
