### PR TITLE
fby3.5: cl: Updated sensor threshold and added sensor

### DIFF
--- a/common/util/hal_peci.c
+++ b/common/util/hal_peci.c
@@ -103,4 +103,103 @@ int peci_write(uint8_t cmd, uint8_t address, uint8_t u8Index, uint16_t u16Param,
   return ret;
 }
 
+bool peci_retry_read(uint8_t cmd, uint8_t address, uint8_t u8Index, uint16_t u16Param, uint8_t u8ReadLen, uint8_t *readBuf) {
+  uint8_t i, ret, retry = 3;
+  for(i = 0; i < retry; ++i) {
+    memcpy(&readBuf[0], 0, u8ReadLen * sizeof(uint8_t));
+    ret = peci_read(cmd, address, u8Index, u16Param, u8ReadLen, readBuf);
+    if (!ret) {
+      if (readBuf[0] == PECI_CC_RSP_SUCCESS) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
+bool peci_getPwr(uint8_t sensor_num, int *reading) {
+  uint8_t rdpkgcfgCmd = PECI_RD_PKG_CFG0_CMD;
+  uint8_t PECIaddr = 0x30;
+  uint8_t readlen = 0x05;
+  uint8_t *readbuf = malloc( 2 * readlen * sizeof(uint8_t) );
+  uint8_t u8index[2] = { 0x03 , 0x1F };
+  uint16_t u16Param[2] = { 0x00FF , 0x0000 };
+  uint8_t ret, complete_code;
+  bool is_retry_success = false;
+  uint32_t pkg_energy, run_time, diff_energy, diff_time;
+  static uint32_t last_pkg_energy = 0, last_run_time = 0;
+
+  peci_read( rdpkgcfgCmd , PECIaddr , u8index[0] , u16Param[0] , readlen , readbuf );
+  complete_code = readbuf[0];
+  if ( complete_code == PECI_CC_RSP_TIMEOUT || complete_code == PECI_CC_OUT_OF_RESOURCES_TIMEOUT ) {
+    is_retry_success = peci_retry_read( rdpkgcfgCmd , PECIaddr , u8index[0] , u16Param[0] , readlen , readbuf );
+    if ( !is_retry_success ) {
+      printf("PECI sensor [%x] response timeout. Reach Max retry.\n", sensor_num );
+      free(readbuf);
+      return false;
+    }
+  }
+  ret = peci_read( rdpkgcfgCmd , PECIaddr , u8index[1] , u16Param[1] , readlen , &readbuf[5] );
+  complete_code = readbuf[5];
+  if ( complete_code == PECI_CC_RSP_TIMEOUT || complete_code == PECI_CC_OUT_OF_RESOURCES_TIMEOUT ) {
+    is_retry_success = peci_retry_read( rdpkgcfgCmd , PECIaddr , u8index[1] , u16Param[1] , readlen , &readbuf[5] );
+    if ( !is_retry_success ) {
+      printf("PECI sensor [%x] response timeout. Reach Max retry.\n", sensor_num );
+      free(readbuf);
+      return false;
+    }
+  }
+  if ( ret ) {
+    free( readbuf );
+    return false;
+  }
+  if ( readbuf[0] != PECI_CC_RSP_SUCCESS || readbuf[5] != PECI_CC_RSP_SUCCESS ) {
+    if ( readbuf[0] == PECI_CC_ILLEGAL_REQUEST || readbuf[5] == PECI_CC_ILLEGAL_REQUEST ) {
+      printf("Unknown request\n");
+    } else {
+      printf("PECI control hardware, firmware or associated logic error\n");
+    }
+    free( readbuf );
+    return false;
+  }
+
+  pkg_energy = readbuf[4];
+  pkg_energy = ( pkg_energy << 8 ) | readbuf[3];
+  pkg_energy = ( pkg_energy << 8 ) | readbuf[2];
+  pkg_energy = ( pkg_energy << 8 ) | readbuf[1];
+
+  run_time = readbuf[9];
+  run_time = ( run_time << 8 ) | readbuf[8];
+  run_time = ( run_time << 8 ) | readbuf[7];
+  run_time = ( run_time << 8 ) | readbuf[6];
+
+  if ( last_pkg_energy == 0 && last_run_time == 0 ) { // first read, need second data to calculate
+    last_pkg_energy = pkg_energy;
+    last_run_time = run_time;
+    free( readbuf );
+    return false;
+  }
+
+  if( pkg_energy >= last_pkg_energy ) {
+    diff_energy = pkg_energy - last_pkg_energy;
+  } else {
+    diff_energy = pkg_energy + ( 0xffffffff - last_pkg_energy + 1 );
+  }
+  last_pkg_energy = pkg_energy;
+
+  if( run_time >= last_run_time ) {
+    diff_time = run_time - last_run_time;
+  } else {
+    diff_time = run_time + ( 0xffffffff - last_run_time + 1 );
+  }
+  last_run_time = run_time;
+
+  if( diff_time == 0 ) {
+    free(readbuf);
+    return false;
+  } else {
+    free(readbuf);
+    *reading = ((float)diff_energy / (float)diff_time * 0.06103515625); // energy / unit time
+    return true;
+  }
+}

--- a/common/util/hal_peci.h
+++ b/common/util/hal_peci.h
@@ -32,6 +32,8 @@ int peci_init();
 int peci_ping(uint8_t address);
 int peci_read(uint8_t cmd, uint8_t address, uint8_t u8Index, uint16_t u16Param, uint8_t u8ReadLen, uint8_t *readBuf);
 int peci_write(uint8_t cmd, uint8_t address, uint8_t u8Index, uint16_t u16Param, uint8_t u8ReadLen, uint8_t *readBuf, uint8_t u8WriteLen, uint8_t *writeBuf);
+bool peci_retry_read(uint8_t cmd, uint8_t address, uint8_t u8Index, uint16_t u16Param, uint8_t u8ReadLen, uint8_t *readBuf);
+bool peci_getPwr(uint8_t sensor_num, int *reading);
 
 #endif
 

--- a/meta-facebook/yv35-cl/src/sensor/dev/peci.c
+++ b/meta-facebook/yv35-cl/src/sensor/dev/peci.c
@@ -48,6 +48,17 @@ bool pal_peci_read(uint8_t sensor_num, int *reading) {
   } else if ( sensor_num == SENSOR_NUM_TEMP_DIMM_H ){
     u8Index = 0x0E;
     u16Param = 0x0007;
+  } else if ( sensor_num == SENSOR_NUM_PWR_CPU ){
+    ret = peci_getPwr(sensor_num, &val);
+    if (ret) {
+      *reading = (acur_cal_MBR(sensor_num,val)) & 0xffff;
+      sensor_config[SnrNum_SnrCfg_map[sensor_num]].cache = *reading;
+      sensor_config[SnrNum_SnrCfg_map[sensor_num]].cache_status = SNR_READ_ACUR_SUCCESS;
+      return true;
+    } else {
+      sensor_config[SnrNum_SnrCfg_map[sensor_num]].cache_status = SNR_FAIL_TO_ACCESS;
+      return false;
+    }
   } else {
     printf("Unrecognized sensor reading\n");
     return false;

--- a/meta-facebook/yv35-cl/src/sensor/plat_sdr.c
+++ b/meta-facebook/yv35-cl/src/sensor/plat_sdr.c
@@ -42,7 +42,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -57,7 +57,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
+    0x96,   // UNRT
     0x32,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
@@ -94,7 +94,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -109,8 +109,8 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
-    0x32,   // UCT
+    0x96,   // UNRT
+    0x5D,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -146,7 +146,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -161,8 +161,8 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
-    0x32,   // UCT
+    0x96,   // UNRT
+    0x28,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -198,7 +198,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x80,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -250,7 +250,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -266,7 +266,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0x4A,   // UCT
+    0x54,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -302,7 +302,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -354,7 +354,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -370,7 +370,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0x00,   // UCT
+    0x55,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -406,7 +406,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -422,7 +422,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0x00,   // UCT
+    0x55,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -458,7 +458,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -474,7 +474,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0x00,   // UCT
+    0x55,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -510,7 +510,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -526,7 +526,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0x00,   // UCT
+    0x55,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -562,7 +562,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -578,7 +578,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0x00,   // UCT
+    0x55,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -614,7 +614,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -630,7 +630,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0x00,   // UCT
+    0x55,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -718,7 +718,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -770,7 +770,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -785,8 +785,8 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
-    0x55,   // UCT
+    0x69,   // UNRT
+    0x57,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -822,7 +822,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -837,7 +837,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
+    0x7D,   // UNRT
     0x64,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
@@ -874,7 +874,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -889,7 +889,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
+    0x7D,   // UNRT
     0x64,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
@@ -926,7 +926,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -941,7 +941,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
+    0x7D,   // UNRT
     0x64,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
@@ -978,7 +978,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -993,7 +993,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
+    0x7D,   // UNRT
     0x64,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
@@ -1030,7 +1030,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_DEGREE_C,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -1045,7 +1045,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
+    0x7D,   // UNRT
     0x64,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
@@ -1082,7 +1082,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_VOL,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x40,   // [7:0] M bits
@@ -1097,12 +1097,12 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
-    0x00,   // UCT
-    0x00,   // UNCT
-    0x00,   // LNRT
-    0x00,   // LCT
-    0x00,   // LNCT
+    0xE0,   // UNRT
+    0xCF,   // UCT
+    0xCB,   // UNCT
+    0x9E,   // LNRT
+    0xA9,   // LCT
+    0xAD,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1134,10 +1134,10 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_VOL,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x11,   // [7:0] M bits
+    0x12,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
@@ -1150,11 +1150,11 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0x00,   // UCT
-    0x00,   // UNCT
+    0xC4,   // UCT
+    0xC1,   // UNCT
     0x00,   // LNRT
-    0x00,   // LCT
-    0x00,   // LNCT
+    0xAB,   // LCT
+    0xAE,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1186,10 +1186,10 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_VOL,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x11,   // [7:0] M bits
+    0x12,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
@@ -1201,12 +1201,12 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
-    0x00,   // UCT
-    0x00,   // UNCT
-    0x00,   // LNRT
-    0x00,   // LCT
-    0x00,   // LNCT
+    0xDE,   // UNRT
+    0xC4,   // UCT
+    0xC1,   // UNCT
+    0x80,   // LNRT
+    0xAB,   // LCT
+    0xAE,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1238,27 +1238,27 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_VOL,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x37,   // [7:0] M bits
+    0x05,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
     0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-    0xC0,   // Rexp, Bexp
+    0xD0,   // Rexp, Bexp
     0x00,   // analog characteristic
     0x00,   // nominal reading
     0x00,   // normal maximum
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
-    0x00,   // UCT
-    0x00,   // UNCT
-    0x00,   // LNRT
-    0x00,   // LCT
-    0x00,   // LNCT
+    0xF4,   // UNRT
+    0xDD,   // UCT
+    0xD8,   // UNCT
+    0xA8,   // LNRT
+    0xC4,   // LCT
+    0xC8,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1290,7 +1290,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit 
+    IPMI_SENSOR_UNIT_VOL,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
     0x01,   // [7:0] M bits
@@ -1305,12 +1305,12 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
-    0x00,   // UCT
-    0x00,   // UNCT
-    0x00,   // LNRT
-    0x00,   // LCT
-    0x00,   // LNCT
+    0xD1,   // UNRT
+    0xBE,   // UCT
+    0xBA,   // UNCT
+    0x90,   // LNRT
+    0xA9,   // LCT
+    0xAD,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1318,6 +1318,214 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // OEM
     IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
     "P1V8_STBY Vol",
+  },
+  {   // P5V STBY ADC voltage
+    0x00,0x00,  // record ID
+    IPMI_SDR_VER_15,  // SDR ver
+    IPMI_SDR_FULL_SENSOR,   // record type
+    IPMI_SDR_FULL_SENSOR_MIN_LEN,   // size of struct
+
+    Self_I2C_ADDRESS<<1,   // owner id
+    0x00,   // owner lun
+    SENSOR_NUM_VOL_STBY5V,    // sensor number
+
+    IPMI_SDR_ENTITY_ID_SYS_BOARD,   // entity id
+    0x00,   // entity instance
+    IPMI_SDR_SENSOR_INIT_SCAN| IPMI_SDR_SENSOR_INIT_EVENT| IPMI_SDR_SENSOR_INIT_THRESHOLD| IPMI_SDR_SENSOR_INIT_TYPE| IPMI_SDR_SENSOR_INIT_DEF_EVENT| IPMI_SDR_SENSOR_INIT_DEF_SCAN,   // sensor init
+    IPMI_SDR_SENSOR_CAP_THRESHOLD_RW| IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO,    // sensor capabilities
+    IPMI_SDR_SENSOR_TYPE_TEMPERATURE,   // sensor type
+    IPMI_SDR_EVENT_TYPE_THRESHOLD,    // event/reading type
+    0x00,   // assert event mask
+    IPMI_SDR_CMP_RETURN_LCT| IPMI_SDR_ASSERT_MASK_UCT_HI| IPMI_SDR_ASSERT_MASK_LCT_LO,    // assert threshold reading mask
+    0x00,   // deassert event mask
+    IPMI_SDR_CMP_RETURN_UCT| IPMI_SDR_DEASSERT_MASK_UCT_LO| IPMI_SDR_DEASSERT_MASK_LCT_HI,    // deassert threshold reading mask
+    0x00,   // discrete reading mask/ settable
+    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
+    0x00,   // sensor unit
+    IPMI_SENSOR_UNIT_VOL,   // base unit
+    0x00,   // modifier unit
+    IPMI_SDR_LINEAR_LINEAR,   // linearization
+    0x1B,   // [7:0] M bits
+    0x00,   // [9:8] M bits, tolerance
+    0x00,   // [7:0] B bits
+    0x00,   // [9:8] B bits, tolerance
+    0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+    0xD0,   // Rexp, Bexp
+    0x00,   // analog characteristic
+    0x00,   // nominal reading
+    0x00,   // normal maximum
+    0x00,   // normal minimum
+    0x00,   // sensor maximum reading
+    0x00,   // sensor minimum reading
+    0xD7,   // UNRT
+    0xC6,   // UCT
+    0xC2,   // UNCT
+    0x94,   // LNRT
+    0xAC,   // LCT
+    0xB0,   // LNCT
+    0x00,   // positive-going threshold
+    0x00,   // negative-going threshold
+    0x00,   // reserved
+    0x00,   // reserved
+    0x00,   // OEM
+    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
+    "P5V_STBY Vol",
+  },
+  {   // P12V DIMM ADC voltage
+    0x00,0x00,  // record ID
+    IPMI_SDR_VER_15,  // SDR ver
+    IPMI_SDR_FULL_SENSOR,   // record type
+    IPMI_SDR_FULL_SENSOR_MIN_LEN,   // size of struct
+
+    Self_I2C_ADDRESS<<1,   // owner id
+    0x00,   // owner lun
+    SENSOR_NUM_VOL_DIMM12V,    // sensor number
+
+    IPMI_SDR_ENTITY_ID_SYS_BOARD,   // entity id
+    0x00,   // entity instance
+    IPMI_SDR_SENSOR_INIT_SCAN| IPMI_SDR_SENSOR_INIT_EVENT| IPMI_SDR_SENSOR_INIT_THRESHOLD| IPMI_SDR_SENSOR_INIT_TYPE| IPMI_SDR_SENSOR_INIT_DEF_EVENT| IPMI_SDR_SENSOR_INIT_DEF_SCAN,   // sensor init
+    IPMI_SDR_SENSOR_CAP_THRESHOLD_RW| IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO,    // sensor capabilities
+    IPMI_SDR_SENSOR_TYPE_TEMPERATURE,   // sensor type
+    IPMI_SDR_EVENT_TYPE_THRESHOLD,    // event/reading type
+    0x00,   // assert event mask
+    IPMI_SDR_CMP_RETURN_LCT| IPMI_SDR_ASSERT_MASK_UCT_HI| IPMI_SDR_ASSERT_MASK_LCT_LO,    // assert threshold reading mask
+    0x00,   // deassert event mask
+    IPMI_SDR_CMP_RETURN_UCT| IPMI_SDR_DEASSERT_MASK_UCT_LO| IPMI_SDR_DEASSERT_MASK_LCT_HI,    // deassert threshold reading mask
+    0x00,   // discrete reading mask/ settable
+    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
+    0x00,   // sensor unit
+    IPMI_SENSOR_UNIT_VOL,   // base unit
+    0x00,   // modifier unit
+    IPMI_SDR_LINEAR_LINEAR,   // linearization
+    0x40,   // [7:0] M bits
+    0x00,   // [9:8] M bits, tolerance
+    0x00,   // [7:0] B bits
+    0x00,   // [9:8] B bits, tolerance
+    0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+    0xD0,   // Rexp, Bexp
+    0x00,   // analog characteristic
+    0x00,   // nominal reading
+    0x00,   // normal maximum
+    0x00,   // normal minimum
+    0x00,   // sensor maximum reading
+    0x00,   // sensor minimum reading
+    0x00,   // UNRT
+    0xDC,   // UCT
+    0xD8,   // UNCT
+    0x00,   // LNRT
+    0x9C,   // LCT
+    0x9F,   // LNCT
+    0x00,   // positive-going threshold
+    0x00,   // negative-going threshold
+    0x00,   // reserved
+    0x00,   // reserved
+    0x00,   // OEM
+    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
+    "P12V_DIMM Vol",
+  },
+  {   // P1V2 STBY ADC voltage
+    0x00,0x00,  // record ID
+    IPMI_SDR_VER_15,  // SDR ver
+    IPMI_SDR_FULL_SENSOR,   // record type
+    IPMI_SDR_FULL_SENSOR_MIN_LEN,   // size of struct
+
+    Self_I2C_ADDRESS<<1,   // owner id
+    0x00,   // owner lun
+    SENSOR_NUM_VOL_STBY1V2,    // sensor number
+
+    IPMI_SDR_ENTITY_ID_SYS_BOARD,   // entity id
+    0x00,   // entity instance
+    IPMI_SDR_SENSOR_INIT_SCAN| IPMI_SDR_SENSOR_INIT_EVENT| IPMI_SDR_SENSOR_INIT_THRESHOLD| IPMI_SDR_SENSOR_INIT_TYPE| IPMI_SDR_SENSOR_INIT_DEF_EVENT| IPMI_SDR_SENSOR_INIT_DEF_SCAN,   // sensor init
+    IPMI_SDR_SENSOR_CAP_THRESHOLD_RW| IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO,    // sensor capabilities
+    IPMI_SDR_SENSOR_TYPE_TEMPERATURE,   // sensor type
+    IPMI_SDR_EVENT_TYPE_THRESHOLD,    // event/reading type
+    0x00,   // assert event mask
+    IPMI_SDR_CMP_RETURN_LCT| IPMI_SDR_ASSERT_MASK_UCT_HI| IPMI_SDR_ASSERT_MASK_LCT_LO,    // assert threshold reading mask
+    0x00,   // deassert event mask
+    IPMI_SDR_CMP_RETURN_UCT| IPMI_SDR_DEASSERT_MASK_UCT_LO| IPMI_SDR_DEASSERT_MASK_LCT_HI,    // deassert threshold reading mask
+    0x00,   // discrete reading mask/ settable
+    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
+    0x00,   // sensor unit
+    IPMI_SENSOR_UNIT_VOL,   // base unit
+    0x00,   // modifier unit
+    IPMI_SDR_LINEAR_LINEAR,   // linearization
+    0x06,   // [7:0] M bits
+    0x00,   // [9:8] M bits, tolerance
+    0x00,   // [7:0] B bits
+    0x00,   // [9:8] B bits, tolerance
+    0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+    0xD0,   // Rexp, Bexp
+    0x00,   // analog characteristic
+    0x00,   // nominal reading
+    0x00,   // normal maximum
+    0x00,   // normal minimum
+    0x00,   // sensor maximum reading
+    0x00,   // sensor minimum reading
+    0xE8,   // UNRT
+    0xD6,   // UCT
+    0xD2,   // UNCT
+    0xA0,   // LNRT
+    0xBA,   // LCT
+    0xBE,   // LNCT
+    0x00,   // positive-going threshold
+    0x00,   // negative-going threshold
+    0x00,   // reserved
+    0x00,   // reserved
+    0x00,   // OEM
+    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
+    "P1V2_STBY Vol",
+  },
+  {   // P3V3 M2 ADC voltage
+    0x00,0x00,  // record ID
+    IPMI_SDR_VER_15,  // SDR ver
+    IPMI_SDR_FULL_SENSOR,   // record type
+    IPMI_SDR_FULL_SENSOR_MIN_LEN,   // size of struct
+
+    Self_I2C_ADDRESS<<1,   // owner id
+    0x00,   // owner lun
+    SENSOR_NUM_VOL_M2_3V3,    // sensor number
+
+    IPMI_SDR_ENTITY_ID_SYS_BOARD,   // entity id
+    0x00,   // entity instance
+    IPMI_SDR_SENSOR_INIT_SCAN| IPMI_SDR_SENSOR_INIT_EVENT| IPMI_SDR_SENSOR_INIT_THRESHOLD| IPMI_SDR_SENSOR_INIT_TYPE| IPMI_SDR_SENSOR_INIT_DEF_EVENT| IPMI_SDR_SENSOR_INIT_DEF_SCAN,   // sensor init
+    IPMI_SDR_SENSOR_CAP_THRESHOLD_RW| IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO,    // sensor capabilities
+    IPMI_SDR_SENSOR_TYPE_TEMPERATURE,   // sensor type
+    IPMI_SDR_EVENT_TYPE_THRESHOLD,    // event/reading type
+    0x00,   // assert event mask
+    IPMI_SDR_CMP_RETURN_LCT| IPMI_SDR_ASSERT_MASK_UCT_HI| IPMI_SDR_ASSERT_MASK_LCT_LO,    // assert threshold reading mask
+    0x00,   // deassert event mask
+    IPMI_SDR_CMP_RETURN_UCT| IPMI_SDR_DEASSERT_MASK_UCT_LO| IPMI_SDR_DEASSERT_MASK_LCT_HI,    // deassert threshold reading mask
+    0x00,   // discrete reading mask/ settable
+    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
+    0x00,   // sensor unit
+    IPMI_SENSOR_UNIT_VOL,   // base unit
+    0x00,   // modifier unit
+    IPMI_SDR_LINEAR_LINEAR,   // linearization
+    0x12,   // [7:0] M bits
+    0x00,   // [9:8] M bits, tolerance
+    0x00,   // [7:0] B bits
+    0x00,   // [9:8] B bits, tolerance
+    0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+    0xD0,   // Rexp, Bexp
+    0x00,   // analog characteristic
+    0x00,   // nominal reading
+    0x00,   // normal maximum
+    0x00,   // normal minimum
+    0x00,   // sensor maximum reading
+    0x00,   // sensor minimum reading
+    0x00,   // UNRT
+    0xCC,   // UCT
+    0xC8,   // UNCT
+    0x00,   // LNRT
+    0xA4,   // LCT
+    0xA7,   // LNCT
+    0x00,   // positive-going threshold
+    0x00,   // negative-going threshold
+    0x00,   // reserved
+    0x00,   // reserved
+    0x00,   // OEM
+    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
+    "P3V3_M2 Vol",
   },
   {   // PVCCIN VR voltage
     0x00,0x00,  // record ID
@@ -1342,27 +1550,27 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_VOL,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x5E,   // [7:0] M bits
+    0x01,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
     0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-    0xC0,   // Rexp, Bexp
+    0xE0,   // Rexp, Bexp
     0x00,   // analog characteristic
     0x00,   // nominal reading
     0x00,   // normal maximum
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
-    0xC8,   // UCT
-    0x00,   // UNCT
-    0x00,   // LNRT
-    0x00,   // LCT
-    0x00,   // LNCT
+    0xDC,   // UNRT
+    0xB7,   // UCT
+    0xBB,   // UNCT
+    0x28,   // LNRT
+    0xAC,   // LCT
+    0xA9,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1394,27 +1602,27 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_VOL,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x5E,   // [7:0] M bits
+    0x01,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
     0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-    0xC0,   // Rexp, Bexp
+    0xE0,   // Rexp, Bexp
     0x00,   // analog characteristic
     0x00,   // nominal reading
     0x00,   // normal maximum
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
-    0xC8,   // UCT
-    0x00,   // UNCT
-    0x00,   // LNRT
-    0x00,   // LCT
-    0x00,   // LNCT
+    0xDC,   // UNRT
+    0xB6,   // UCT
+    0xBA,   // UNCT
+    0x28,   // LNRT
+    0xB1,   // LCT
+    0xAE,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1446,27 +1654,27 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_VOL,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x5E,   // [7:0] M bits
+    0x01,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
     0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-    0xC0,   // Rexp, Bexp
+    0xE0,   // Rexp, Bexp
     0x00,   // analog characteristic
     0x00,   // nominal reading
     0x00,   // normal maximum
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
-    0xC8,   // UCT
-    0x00,   // UNCT
-    0x00,   // LNRT
-    0x00,   // LCT
-    0x00,   // LNCT
+    0xDC,   // UNRT
+    0xBC,   // UCT
+    0xB8,   // UNCT
+    0x28,   // LNRT
+    0xAB,   // LCT
+    0xAF,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1498,27 +1706,27 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_VOL,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
-   0x41,   // [7:0] M bits
-   0x80,   // [9:8] M bits, tolerance
+   0x07,   // [7:0] M bits
+   0x00,   // [9:8] M bits, tolerance
    0x00,   // [7:0] B bits
    0x00,   // [9:8] B bits, tolerance
    0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-   0xB0,   // Rexp, Bexp
+   0xD0,   // Rexp, Bexp
    0x00,   // analog characteristic
    0x00,   // nominal reading
    0x00,   // normal maximum
    0x00,   // normal minimum
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
-   0x00,   // UNRT
-   0xC8,   // UCT
-   0x00,   // UNCT
-   0x00,   // LNRT
-   0x00,   // LCT
-   0x00,   // LNCT
+   0xD6,   // UNRT
+   0xAD,   // UCT
+   0xAA,   // UNCT
+   0x39,   // LNRT
+   0x97,   // LCT
+   0x9A,   // LNCT
    0x00,   // positive-going threshold
    0x00,   // negative-going threshold
    0x00,   // reserved
@@ -1550,27 +1758,27 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_VOL,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
-   0x36,   // [7:0] M bits
+   0x07,   // [7:0] M bits
    0x00,   // [9:8] M bits, tolerance
    0x00,   // [7:0] B bits
    0x00,   // [9:8] B bits, tolerance
    0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-   0xC0,   // Rexp, Bexp
+   0xD0,   // Rexp, Bexp
    0x00,   // analog characteristic
    0x00,   // nominal reading
    0x00,   // normal maximum
    0x00,   // normal minimum
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
-   0x00,   // UNRT
-   0xC8,   // UCT
-   0x00,   // UNCT
-   0x00,   // LNRT
-   0x00,   // LCT
-   0x00,   // LNCT
+   0xC8,   // UNRT
+   0x99,   // UCT
+   0x96,   // UNCT
+   0x39,   // LNRT
+   0x82,   // LCT
+   0x85,   // LNCT
    0x00,   // positive-going threshold
    0x00,   // negative-going threshold
    0x00,   // reserved
@@ -1602,10 +1810,10 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
     0x00,   // sensor unit
-    0x00,   // base unit
+    IPMI_SENSOR_UNIT_VOL,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x33,   // [7:0] M bits
+    0x44,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
@@ -1617,12 +1825,12 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
-    0xFF,   // UCT
-    0x00,   // UNCT
-    0x00,   // LNRT
-    0x00,   // LCT
-    0x00,   // LNCT
+    0xD3,   // UNRT
+    0xC2,   // UCT
+    0xBF,   // UNCT
+    0x94,   // LNRT
+    0x9F,   // LCT
+    0xA2,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1654,15 +1862,15 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_AMP,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
-   0x7D,   // [7:0] M bits
+   0x13,   // [7:0] M bits
    0x00,   // [9:8] M bits, tolerance
    0x00,   // [7:0] B bits
    0x00,   // [9:8] B bits, tolerance
    0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-   0xD0,   // Rexp, Bexp
+   0xE0,   // Rexp, Bexp
    0x00,   // analog characteristic
    0x00,   // nominal reading
    0x00,   // normal maximum
@@ -1670,7 +1878,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xFF,   // UCT
+   0xD3,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -1706,10 +1914,10 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_AMP,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
-   0x2E,   // [7:0] M bits
+   0x4D,   // [7:0] M bits
    0x00,   // [9:8] M bits, tolerance
    0x00,   // [7:0] B bits
    0x00,   // [9:8] B bits, tolerance
@@ -1722,7 +1930,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xC8,   // UCT
+   0xDD,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -1758,10 +1966,10 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_AMP,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
-   0x1A,   // [7:0] M bits
+   0x27,   // [7:0] M bits
    0x00,   // [9:8] M bits, tolerance
    0x00,   // [7:0] B bits
    0x00,   // [9:8] B bits, tolerance
@@ -1774,7 +1982,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xC8,   // UCT
+   0xDA,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -1810,15 +2018,15 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_AMP,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
-   0x1F,   // [7:0] M bits
+   0x08,   // [7:0] M bits
    0x00,   // [9:8] M bits, tolerance
    0x00,   // [7:0] B bits
    0x00,   // [9:8] B bits, tolerance
    0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-   0xD0,   // Rexp, Bexp
+   0xE0,   // Rexp, Bexp
    0x00,   // analog characteristic
    0x00,   // nominal reading
    0x00,   // normal maximum
@@ -1826,7 +2034,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xC8,   // UCT
+   0xE1,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -1862,10 +2070,10 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_AMP,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
-   0x0F,   // [7:0] M bits
+   0x22,   // [7:0] M bits
    0x00,   // [9:8] M bits, tolerance
    0x00,   // [7:0] B bits
    0x00,   // [9:8] B bits, tolerance
@@ -1878,7 +2086,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xC8,   // UCT
+   0xDA,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -1914,10 +2122,10 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_AMP,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
-   0x17,   // [7:0] M bits
+   0x18,   // [7:0] M bits
    0x00,   // [9:8] M bits, tolerance
    0x00,   // [7:0] B bits
    0x00,   // [9:8] B bits, tolerance
@@ -1930,7 +2138,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xC8,   // UCT
+   0xD9,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -1943,6 +2151,58 @@ SDR_Full_sensor plat_sensor_table[] = {
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
    "PVCCINFAON Cur",
  },
+  {   // CPU power
+   0x00,0x00,  // record ID
+   IPMI_SDR_VER_15,  // SDR ver
+   IPMI_SDR_FULL_SENSOR,   // record type
+   IPMI_SDR_FULL_SENSOR_MIN_LEN,   // size of struct
+
+   Self_I2C_ADDRESS<<1,   // owner id
+   0x00,   // owner lun
+   SENSOR_NUM_PWR_CPU,    // sensor number
+
+   IPMI_SDR_ENTITY_ID_SYS_BOARD,   // entity id
+   0x00,   // entity instance
+   IPMI_SDR_SENSOR_INIT_SCAN| IPMI_SDR_SENSOR_INIT_EVENT| IPMI_SDR_SENSOR_INIT_THRESHOLD| IPMI_SDR_SENSOR_INIT_TYPE| IPMI_SDR_SENSOR_INIT_DEF_EVENT| IPMI_SDR_SENSOR_INIT_DEF_SCAN,   // sensor init
+   IPMI_SDR_SENSOR_CAP_THRESHOLD_RW| IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO,    // sensor capabilities
+   IPMI_SDR_SENSOR_TYPE_TEMPERATURE,   // sensor type
+   IPMI_SDR_EVENT_TYPE_THRESHOLD,    // event/reading type
+   0x00,   // assert event mask
+   IPMI_SDR_CMP_RETURN_LCT| IPMI_SDR_ASSERT_MASK_UCT_HI| IPMI_SDR_ASSERT_MASK_LCT_LO,    // assert threshold reading mask
+   0x00,   // deassert event mask
+   IPMI_SDR_CMP_RETURN_UCT| IPMI_SDR_DEASSERT_MASK_UCT_LO| IPMI_SDR_DEASSERT_MASK_LCT_HI,    // deassert threshold reading mask
+   0x00,   // discrete reading mask/ settable
+   IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
+   0x00,   // sensor unit
+   IPMI_SENSOR_UNIT_WATT,   // base unit
+   0x00,   // modifier unit
+   IPMI_SDR_LINEAR_LINEAR,   // linearization
+   0x01,   // [7:0] M bits
+   0x00,   // [9:8] M bits, tolerance
+   0x00,   // [7:0] B bits
+   0x00,   // [9:8] B bits, tolerance
+   0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+   0x00,   // Rexp, Bexp
+   0x00,   // analog characteristic
+   0x00,   // nominal reading
+   0x00,   // normal maximum
+   0x00,   // normal minimum
+   0x00,   // sensor maximum reading
+   0x00,   // sensor minimum reading
+   0x00,   // UNRT
+   0x00,   // UCT
+   0x00,   // UNCT
+   0x00,   // LNRT
+   0x00,   // LCT
+   0x00,   // LNCT
+   0x00,   // positive-going threshold
+   0x00,   // negative-going threshold
+   0x00,   // reserved
+   0x00,   // reserved
+   0x00,   // OEM
+   IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
+   "CPU Pwr",
+  },
   {   // HSCIN power
    0x00,0x00,  // record ID
    IPMI_SDR_VER_15,  // SDR ver
@@ -1966,15 +2226,15 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_WATT,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
-   0x9C,   // [7:0] M bits
+   0x01,   // [7:0] M bits
    0x00,   // [9:8] M bits, tolerance
    0x00,   // [7:0] B bits
    0x00,   // [9:8] B bits, tolerance
    0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-   0xE0,   // Rexp, Bexp
+   0x00,   // Rexp, Bexp
    0x00,   // analog characteristic
    0x00,   // nominal reading
    0x00,   // normal maximum
@@ -1982,7 +2242,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xFF,   // UCT
+   0xB2,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -2018,7 +2278,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_WATT,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
    0x52,   // [7:0] M bits
@@ -2034,7 +2294,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xC8,   // UCT
+   0x00,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -2070,7 +2330,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_WATT,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
    0x2F,   // [7:0] M bits
@@ -2086,7 +2346,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xC8,   // UCT
+   0x00,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -2122,7 +2382,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_WATT,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
    0x38,   // [7:0] M bits
@@ -2138,7 +2398,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xC8,   // UCT
+   0x00,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -2174,7 +2434,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_WATT,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
    0xA5,   // [7:0] M bits
@@ -2190,7 +2450,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xC8,   // UCT
+   0x00,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -2226,7 +2486,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // discrete reading mask/ settable
    IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
    0x00,   // sensor unit
-   0x00,   // base unit
+   IPMI_SENSOR_UNIT_WATT,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
    0x17,   // [7:0] M bits
@@ -2242,7 +2502,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0x00,   // UNRT
-   0xC8,   // UCT
+   0x00,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -2264,7 +2524,7 @@ uint8_t fix_C2SDR_table[][10]= {
 SDR_Full_sensor fix_1ouSDR_table[] = {
 // SDR_Full_sensor struct member
 };
-SDR_Full_sensor fix_2ouSDR_table[] = {
+SDR_Full_sensor fix_DVPSDR_table[] = {
 // SDR_Full_sensor struct member
 };
 
@@ -2371,10 +2631,10 @@ void fix_fullSDR_table() {
     }
   }
   if ( get_2ou_status() ) {
-    // fix usage when fix_2ouSDR_table is defined
-    fix_array_num = sizeof( fix_2ouSDR_table ) / sizeof( fix_2ouSDR_table[0] );
+    // fix usage when fix_DVPSDR_table is defined
+    fix_array_num = sizeof( fix_DVPSDR_table ) / sizeof( fix_DVPSDR_table[0] );
     while( fix_array_num ) {
-      add_fullSDR_table( fix_2ouSDR_table[ fix_array_num - 1 ] );
+      add_fullSDR_table( fix_DVPSDR_table[ fix_array_num - 1 ] );
       fix_array_num--;
     }
   }

--- a/meta-facebook/yv35-cl/src/sensor/plat_sensor.c
+++ b/meta-facebook/yv35-cl/src/sensor/plat_sensor.c
@@ -35,12 +35,17 @@ snr_cfg plat_sensor_config[] = {
   {SENSOR_NUM_TEMP_DIMM_E            , type_peci      , NULL          , CPU_PECI_addr           , NULL              , post_access      , 0     , 0     , 0      , SNR_INIT_STATUS},
   {SENSOR_NUM_TEMP_DIMM_G            , type_peci      , NULL          , CPU_PECI_addr           , NULL              , post_access      , 0     , 0     , 0      , SNR_INIT_STATUS},
   {SENSOR_NUM_TEMP_DIMM_H            , type_peci      , NULL          , CPU_PECI_addr           , NULL              , post_access      , 0     , 0     , 0      , SNR_INIT_STATUS},
+  {SENSOR_NUM_PWR_CPU                , type_peci      , NULL          , CPU_PECI_addr           , NULL              , post_access      , 0     , 0     , 0      , SNR_INIT_STATUS},
                                                                                                                                                                  
   // adc voltage                                                                                                                                                 
   {SENSOR_NUM_VOL_STBY12V            , type_adc       , adc_port0     , NULL                    , NULL              , stby_access      , 667   , 100   , 0      , SNR_INIT_STATUS},
   {SENSOR_NUM_VOL_STBY3V             , type_adc       , adc_port2     , NULL                    , NULL              , stby_access      , 2     , 1     , 0      , SNR_INIT_STATUS},
   {SENSOR_NUM_VOL_STBY1V05           , type_adc       , adc_port3     , NULL                    , NULL              , stby_access      , 1     , 1     , 0      , SNR_INIT_STATUS},
   {SENSOR_NUM_VOL_BAT3V              , type_adc       , adc_port4     , NULL                    , NULL              , stby_access      , 3     , 1     , 0      , SNR_INIT_STATUS},
+  {SENSOR_NUM_VOL_STBY5V             , type_adc       , adc_port9     , NULL                    , NULL              , stby_access      , 711   , 200   , 0      , SNR_INIT_STATUS},
+  {SENSOR_NUM_VOL_DIMM12V            , type_adc       , adc_port11    , NULL                    , NULL              , DC_access        , 667   , 100   , 0      , SNR_INIT_STATUS},
+  {SENSOR_NUM_VOL_STBY1V2            , type_adc       , adc_port13    , NULL                    , NULL              , stby_access      , 1     , 1     , 0      , SNR_INIT_STATUS},
+  {SENSOR_NUM_VOL_M2_3V3             , type_adc       , adc_port14    , NULL                    , NULL              , DC_access        , 2     , 1     , 0      , SNR_INIT_STATUS},
   {SENSOR_NUM_VOL_STBY1V8            , type_adc       , adc_port15    , NULL                    , NULL              , stby_access      , 1     , 1     , 0      , SNR_INIT_STATUS},
 
   // VR voltage
@@ -87,7 +92,7 @@ snr_cfg fix_C2Snrconfig_table[] = {
 snr_cfg fix_1ouSnrconfig_table[] = {
 // number , type , port , address , offset , access check , arg0 , arg1 , cache , cache_status
 };
-snr_cfg fix_2ouSnrconfig_table[] = {
+snr_cfg fix_DVPSnrconfig_table[] = {
 // number , type , port , address , offset , access check , arg0 , arg1 , cache , cache_status
 };
 
@@ -150,10 +155,10 @@ void fix_Snrconfig() {
     }
   }
   if ( get_2ou_status() ) {
-    // fix usage when fix_2ouSnrconfig_table is defined
-    fix_SnrCfg_num = sizeof( fix_2ouSnrconfig_table ) / sizeof( fix_2ouSnrconfig_table[0] );
+    // fix usage when fix_DVPSnrconfig_table is defined
+    fix_SnrCfg_num = sizeof( fix_DVPSnrconfig_table ) / sizeof( fix_DVPSnrconfig_table[0] );
     while ( fix_SnrCfg_num ) {
-      add_Snrconfig ( fix_2ouSnrconfig_table[ fix_SnrCfg_num - 1 ] );
+      add_Snrconfig ( fix_DVPSnrconfig_table[ fix_SnrCfg_num - 1 ] );
       fix_SnrCfg_num--;
     }
   }

--- a/meta-facebook/yv35-cl/src/sensor/sensor_def.h
+++ b/meta-facebook/yv35-cl/src/sensor/sensor_def.h
@@ -71,13 +71,16 @@ enum {
 #define SENSOR_NUM_VOL_STBY3V            0x22
 #define SENSOR_NUM_VOL_STBY1V05          0x23
 #define SENSOR_NUM_VOL_STBY1V8           0x24
-#define SENSOR_NUM_VOL_HSCIN             0x26
-#define SENSOR_NUM_VOL_VCCIN             0x0F
-#define SENSOR_NUM_VOL_PVCCIN            0x27
-#define SENSOR_NUM_VOL_PVCCFA_EHV_FIVRA  0x28
-#define SENSOR_NUM_VOL_PVCCFA_EHV        0x29
-#define SENSOR_NUM_VOL_PVCCD_HV          0x2A
-#define SENSOR_NUM_VOL_PVCCINFAON        0x2C
+#define SENSOR_NUM_VOL_STBY5V            0x25
+#define SENSOR_NUM_VOL_DIMM12V           0x26
+#define SENSOR_NUM_VOL_STBY1V2           0x27
+#define SENSOR_NUM_VOL_M2_3V3            0x28
+#define SENSOR_NUM_VOL_HSCIN             0x29
+#define SENSOR_NUM_VOL_PVCCIN            0x2A
+#define SENSOR_NUM_VOL_PVCCFA_EHV_FIVRA  0x2C
+#define SENSOR_NUM_VOL_PVCCFA_EHV        0x2D
+#define SENSOR_NUM_VOL_PVCCD_HV          0x2E
+#define SENSOR_NUM_VOL_PVCCINFAON        0x2F
 
 #define SENSOR_NUM_CUR_HSCOUT            0x30
 #define SENSOR_NUM_CUR_PVCCIN            0x31
@@ -86,6 +89,7 @@ enum {
 #define SENSOR_NUM_CUR_PVCCD_HV          0x34
 #define SENSOR_NUM_CUR_PVCCINFAON        0x35
 
+#define SENSOR_NUM_PWR_CPU               0x38
 #define SENSOR_NUM_PWR_HSCIN             0x39
 #define SENSOR_NUM_PWR_PVCCIN            0x3A
 #define SENSOR_NUM_PWR_PVCCFA_EHV_FIVRA  0x3C


### PR DESCRIPTION
Summary:
- Added sensor by adding SDR table and sensor config.
- Added sensor base uint in SDR table.
- Updated sensor SDR threshold by power department provided.
- Added peci read CPU power function.

Test plan:
- Build code: Pass
- Modify sensor threshold: Pass

Log:
root@bmc-oob:~# sensor-util slot1 --threshold
MB Inlet Temp                (0x1) :   27.00 C     | (ok) | UCR: 50.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
MB Outlet Temp               (0x2) :   41.00 C     | (ok) | UCR: 93.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
Front IO Temp                (0x3) :   26.00 C     | (ok) | UCR: 40.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
PCH Temp                     (0x4) :   44.00 C     | (ok) | UCR: 77.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU Temp                     (0x15) :   41.00 C     | (ok) | UCR: 84.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC Therm Margin             (0x14) :  -40.00 C     | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU TjMax                    (0x5) :   81.00 C     | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMA Temp                   (0x6) :   37.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMC Temp                   (0x7) :   36.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMD Temp                   (0x9) :   34.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME Temp                   (0xA) :   36.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMG Temp                   (0xB) :   33.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH Temp                   (0xC) :   31.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SSD0 Temp                    (0xD) :   29.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Temp                     (0xE) :   36.00 C     | (ok) | UCR: 87.00 | UNC: NA | UNR: 105.00 | LCR: NA | LNC: NA | LNR: NA
PVCCIN Temp                  (0xF) :   47.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
EHV_FIVRA Temp               (0x10) :   45.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
PVCCFA_EHV Temp              (0x11) :   37.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
PVCCD_HV Temp                (0x12) :   37.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
PVCCINFAON Temp              (0x13) :   45.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
P12V_STBY Vol                (0x20) :   12.42 Volts | (ok) | UCR: 13.25 | UNC: 12.99 | UNR: 14.34 | LCR: 10.82 | LNC: 11.07 | LNR: 10.11
P3V_BAT Vol                  (0x21) :    3.13 Volts | (lnc) | UCR: 3.53 | UNC: 3.47 | UNR: NA | LCR: 3.08 | LNC: 3.13 | LNR: NA
P3V3_STBY Vol                (0x22) :    3.33 Volts | (ok) | UCR: 3.53 | UNC: 3.47 | UNR: 4.00 | LCR: 3.08 | LNC: 3.13 | LNR: 2.30
P1V8_STBY Vol                (0x24) :    1.79 Volts | (ok) | UCR: 1.90 | UNC: 1.86 | UNR: 2.09 | LCR: 1.69 | LNC: 1.73 | LNR: 1.44
P1V05_PCH Vol                (0x23) :    1.05 Volts | (ok) | UCR: 1.11 | UNC: 1.08 | UNR: 1.22 | LCR: 0.98 | LNC: 1.00 | LNR: 0.84
P12V_DIMM Vol                (0x26) :   12.29 Volts | (ok) | UCR: 14.08 | UNC: 13.82 | UNR: NA | LCR: 9.98 | LNC: 10.18 | LNR: NA
P1V2_STBY Vol                (0x27) :    1.19 Volts | (ok) | UCR: 1.28 | UNC: 1.26 | UNR: 1.39 | LCR: 1.12 | LNC: 1.14 | LNR: 0.96
P3V3_M2 Vol                  (0x28) :    3.29 Volts | (ok) | UCR: 3.67 | UNC: 3.60 | UNR: NA | LCR: 2.95 | LNC: 3.01 | LNR: NA
HSC Input Vol                (0x29) :   12.17 Volts | (ok) | UCR: 13.19 | UNC: 12.99 | UNR: 14.35 | LCR: 10.81 | LNC: 11.02 | LNR: 10.06
PVCCIN Vol                   (0x2A) :    1.75 Volts | (ok) | UCR: 1.83 | UNC: 1.87 | UNR: 2.20 | LCR: 1.72 | LNC: 1.69 | LNR: 0.40
EHV_FIVRA Vol                (0x2C) :    1.79 Volts | (ok) | UCR: 1.82 | UNC: 1.86 | UNR: 2.20 | LCR: 1.77 | LNC: 1.74 | LNR: 0.40
HSC Output Cur               (0x30) :   11.21 Amps  | (ok) | UCR: 40.09 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCIN Cur                   (0x31) :   38.50 Amps  | (ok) | UCR: 170.17 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
EHV_FIVRA Cur                (0x32) :    2.73 Amps  | (ok) | UCR: 85.02 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCFA_EHV Cur               (0x33) :    0.96 Amps  | (ok) | UCR: 18.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCD_HV Cur                 (0x34) :    1.70 Amps  | (ok) | UCR: 74.12 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCINFAON Cur               (0x35) :   21.84 Amps  | (ok) | UCR: 52.08 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Input Pwr                (0x39) :  138.00 Watts | (ok) | UCR: 178.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCIN Pwr                   (0x3A) :   68.88 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
EHV_FIVRA Pwr                (0x3C) :    5.64 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCFA_EHV Pwr               (0x3D) :    1.96 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCD_HV Pwr                 (0x3E) :    1.82 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCINFAON Pwr               (0x3F) :   22.77 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
