### PR TITLE
fby3.5: cl: Fixed OEM accurate reading command

### DIFF
--- a/common/sensor/sensor.h
+++ b/common/sensor/sensor.h
@@ -27,9 +27,9 @@
 
 static inline int acur_cal_MBR(uint8_t sensor_num, int val) { // for better accuracy, enlarge SDR to two byte scale
   if( SDR_M(sensor_num) == 0 ) {
-    return ( val * 0xff * SDR_Rexp(sensor_num) );
+    return ( (val << 8) * SDR_Rexp(sensor_num) );
   }
-  return ( val * 0xff / SDR_M(sensor_num) * SDR_Rexp(sensor_num) ); 
+  return ( (val << 8) / SDR_M(sensor_num) * SDR_Rexp(sensor_num) ); 
 }
 
 static inline int cal_MBR(uint8_t sensor_num, int val){

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -1043,9 +1043,9 @@ void pal_OEM_ACCURACY_SENSNR(ipmi_msg *msg) {
 
   switch (status) {
     case SNR_READ_SUCCESS:
-      msg->data[0] = (reading << 8 ) & 0xff; // fix 1 byte data to 2 byte
+      msg->data[0] = reading & 0xff;
       msg->data[1] = 0x00;
-      msg->data[2] = snr_report_status;
+      msg->data[2] = snr_report_status; 
       msg->data_len = 3;
       msg->completion_code = CC_SUCCESS;
       break;


### PR DESCRIPTION
Summary:
- Modified accurate sensor calculate API, scale MBR by times 256.
- Modified standard reading scale in OEM accurate reading command to help BMC get sensor reading.

Test plan:
- Build code: Pass
- Get sensor: Pass

Log:

root@bmc-oob:~# bic-util slot1 0xe0 0x23 0x9c 0x9c 0x0 0x1 0
9C 9C 00 1B 00 C0
root@bmc-oob:~# bic-util slot1 0xe0 0x23 0x9c 0x9c 0x0 0x31 0
9C 9C 00 32 64 C0

root@bmc-oob:~# sensor-util slot1 --threshold
MB Inlet Temp                (0x1) :   27.00 C     | (ok) | UCR: 50.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
MB Outlet Temp               (0x2) :   41.00 C     | (ok) | UCR: 93.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
Front IO Temp                (0x3) :   26.00 C     | (ok) | UCR: 40.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
PCH Temp                     (0x4) :   43.00 C     | (ok) | UCR: 77.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU Temp                     (0x15) :   41.00 C     | (ok) | UCR: 84.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC Therm Margin             (0x14) :  -41.00 C     | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU TjMax                    (0x5) :   82.00 C     | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMA Temp                   (0x6) :   38.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMC Temp                   (0x7) :   37.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMD Temp                   (0x9) :   35.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME Temp                   (0xA) :   37.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMG Temp                   (0xB) :   33.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH Temp                   (0xC) :   32.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SSD0 Temp                    (0xD) :   29.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Temp                     (0xE) :   36.00 C     | (ok) | UCR: 87.00 | UNC: NA | UNR: 105.00 | LCR: NA | LNC: NA | LNR: NA
PVCCIN Temp                  (0xF) :   48.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
EHV_FIVRA Temp               (0x10) :   46.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
PVCCFA_EHV Temp              (0x11) :   38.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
PVCCD_HV Temp                (0x12) :   39.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
PVCCINFAON Temp              (0x13) :   46.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
P12V_STBY Vol                (0x20) :   12.42 Volts | (ok) | UCR: 13.25 | UNC: 12.99 | UNR: 14.34 | LCR: 10.82 | LNC: 11.07 | LNR: 10.11
P3V_BAT Vol                  (0x21) :    3.13 Volts | (lnc) | UCR: 3.53 | UNC: 3.47 | UNR: NA | LCR: 3.08 | LNC: 3.13 | LNR: NA
P3V3_STBY Vol                (0x22) :    3.33 Volts | (ok) | UCR: 3.53 | UNC: 3.47 | UNR: 4.00 | LCR: 3.08 | LNC: 3.13 | LNR: 2.30
P1V8_STBY Vol                (0x24) :    1.80 Volts | (ok) | UCR: 1.90 | UNC: 1.86 | UNR: 2.09 | LCR: 1.69 | LNC: 1.73 | LNR: 1.44
P1V05_PCH Vol                (0x23) :    1.05 Volts | (ok) | UCR: 1.11 | UNC: 1.08 | UNR: 1.22 | LCR: 0.98 | LNC: 1.00 | LNR: 0.84
P12V_DIMM Vol                (0x26) :   12.35 Volts | (ok) | UCR: 14.08 | UNC: 13.82 | UNR: NA | LCR: 9.98 | LNC: 10.18 | LNR: NA
P1V2_STBY Vol                (0x27) :    1.19 Volts | (ok) | UCR: 1.28 | UNC: 1.26 | UNR: 1.39 | LCR: 1.12 | LNC: 1.14 | LNR: 0.96
P3V3_M2 Vol                  (0x28) :    3.31 Volts | (ok) | UCR: 3.67 | UNC: 3.60 | UNR: NA | LCR: 2.95 | LNC: 3.01 | LNR: NA
HSC Input Vol                (0x29) :   12.24 Volts | (ok) | UCR: 13.19 | UNC: 12.99 | UNR: 14.35 | LCR: 10.81 | LNC: 11.02 | LNR: 10.06
PVCCIN Vol                   (0x2A) :    1.76 Volts | (ok) | UCR: 1.83 | UNC: 1.87 | UNR: 2.20 | LCR: 1.72 | LNC: 1.69 | LNR: 0.40
EHV_FIVRA Vol                (0x2C) :    1.79 Volts | (ok) | UCR: 1.82 | UNC: 1.86 | UNR: 2.20 | LCR: 1.77 | LNC: 1.74 | LNR: 0.40
HSC Output Cur               (0x30) :   11.21 Amps  | (ok) | UCR: 40.09 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCIN Cur                   (0x31) :   38.50 Amps  | (ok) | UCR: 170.17 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
EHV_FIVRA Cur                (0x32) :    2.73 Amps  | (ok) | UCR: 85.02 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCFA_EHV Cur               (0x33) :    0.96 Amps  | (ok) | UCR: 18.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCD_HV Cur                 (0x34) :    1.70 Amps  | (ok) | UCR: 74.12 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCINFAON Cur               (0x35) :   21.84 Amps  | (ok) | UCR: 52.08 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Input Pwr                (0x39) :  137.00 Watts | (ok) | UCR: 178.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCIN Pwr                   (0x3A) :   68.06 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
EHV_FIVRA Pwr                (0x3C) :    4.70 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCFA_EHV Pwr               (0x3D) :    1.96 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCD_HV Pwr                 (0x3E) :    1.82 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVCCINFAON Pwr               (0x3F) :   21.85 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA