### PR TITLE
fby3.5: cl: Added IPMB exception for ME

### DIFF
--- a/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
@@ -36,9 +36,9 @@
   clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	status = "okay";
 
-	ipmb2: ipmb@20 {
+	ipmb2: ipmb@10 {
 		compatible = "aspeed,ipmb";
-		reg = <0x20>;
+		reg = <0x10>;
 		label = "IPMB_2";
 		size = <10>;
 #ifdef CONFIG_I2C_IPMB_SLAVE

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmb.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmb.c
@@ -8,7 +8,7 @@
 IPMB_config pal_IPMB_config_table[] = {
 	//   index             interface         interface_source  bus              Target_addr          EnStatus  slave_addr            Rx_attr_name          Tx_attr_name//
 	{ BMC_IPMB_IDX,     I2C_IF,           BMC_IPMB_IFs,     IPMB_I2C_BMC,    BMC_I2C_ADDRESS,     Enable,   Self_I2C_ADDRESS,     "RX_BMC_IPMB_TASK",   "TX_BMC_IPMB_TASK"  },
-	{ ME_IPMB_IDX,      I2C_IF,           ME_IPMB_IFs,      IPMB_ME_BUS,     ME_I2C_ADDRESS,      Enable,   Self_I2C_ADDRESS,     "RX_ME_IPMB_TASK",    "TX_ME_IPMB_TASK"   },
+	{ ME_IPMB_IDX,      I2C_IF,           ME_IPMB_IFs,      IPMB_ME_BUS,     ME_I2C_ADDRESS,      Enable,   BMC_I2C_ADDRESS,     "RX_ME_IPMB_TASK",    "TX_ME_IPMB_TASK"   },
 	{ EXP1_IPMB_IDX,    I2C_IF,           EXP1_IPMB_IFs,    IPMB_EXP1_BUS,   BIC0_I2C_ADDRESS,    Disable,  BIC1_I2C_ADDRESS,     "RX_EPX0_IPMB_TASK",  "TX_EXP0_IPMB_TASK" },
 	{ EXP2_IPMB_IDX,    I2C_IF,           EXP2_IPMB_IFs,    IPMB_EXP2_BUS,   BIC1_I2C_ADDRESS,    Disable,  BIC0_I2C_ADDRESS,     "RX_EPX1_IPMB_TASK",  "TX_EXP1_IPMB_TASK" },
 	{ RESERVE_IPMB_IDX, Reserve_IF,       Reserve_IFs,      Reserve_BUS,     Reserve_ADDRESS,     Disable,  Reserve_ADDRESS,      "Reserve_ATTR",       "Reserve_ATTR"      },


### PR DESCRIPTION
Summary:
- Added exception handling for ME interface that bridging ME request to BMC.
- Added exception handling for BMC response with request from ME that bridging BMC response to ME.
- Modified BIC I2C slave address to 0x10, same as BMC, to receive IPMB from ME.

Test plan:
- Build code: Pass
- Checked ME addsel command: Pass

Log:
root@bmc-oob:~# log-util slot2 --print
2021 Nov 28 22:02:42 log-util: User cleared FRU: 2 logs
2    slot2    2021-11-28 23:51:49    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2021-11-28 23:51:49, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion