### PR TITLE
fby3.5: cl: Modified GPIO internal setting and sensor threshold

### DIFF
--- a/meta-facebook/yv35-cl/src/main.c
+++ b/meta-facebook/yv35-cl/src/main.c
@@ -26,6 +26,7 @@ void set_sys_status() {
   gpio_set(BIC_READY, GPIO_HIGH);
   set_DC_status();
   set_post_status();
+  set_SCU_setting();
 }
 
 void main(void)

--- a/meta-facebook/yv35-cl/src/platform/hwmon.c
+++ b/meta-facebook/yv35-cl/src/platform/hwmon.c
@@ -38,6 +38,13 @@ void ISR_DBP_PRSNT(){
   send_gpio_interrupt(FM_DBP_PRESENT_N);
 }
 
+void set_SCU_setting() {
+  sys_write32(0xffffffff, 0x7e6e2610);
+  sys_write32(0xffffffff, 0x7e6e2614);
+  sys_write32(0x30000000, 0x7e6e2618);
+  sys_write32(0x00000F04, 0x7e6e261c);
+}
+
 void set_DC_status() {
   is_DC_on = gpio_get(PWRGD_SYS_PWROK);
   printk("set dc status %d\n", is_DC_on);

--- a/meta-facebook/yv35-cl/src/platform/plat_func.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_func.h
@@ -13,6 +13,7 @@ void ISR_PLTRST();
 void ISR_DBP_PRSNT();
 void ISR_post_complete();
 
+void set_SCU_setting();
 void set_DC_status();
 bool get_DC_status();
 void set_post_status();

--- a/meta-facebook/yv35-cl/src/sensor/plat_sdr.c
+++ b/meta-facebook/yv35-cl/src/sensor/plat_sdr.c
@@ -1137,7 +1137,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     IPMI_SENSOR_UNIT_VOL,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x12,   // [7:0] M bits
+    0x0E,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
@@ -1150,11 +1150,11 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0xC4,   // UCT
-    0xC1,   // UNCT
+    0xE6,   // UCT
+    0xE1,   // UNCT
     0x00,   // LNRT
-    0xAB,   // LCT
-    0xAE,   // LNCT
+    0xC8,   // LCT
+    0xCC,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved


### PR DESCRIPTION
Summary:
- Modified GPIO pin internal control setting to correct voltage.
- Modified ADC battery sensor threshold.

Test plan:
- Build code: Pass
- Checked sensor threshold: Pass
- Checked GPIO internal setting: Pass

Log:

P3V_BAT Vol                  (0x21) :    3.14 Volts | (ok) | UCR: 3.22 | UNC: 3.15 | UNR: NA | LCR: 2.80 | LNC: 2.86 | LNR: NA

uart:~$ md 0x7e6e2610 4

[7e6e2610] ffffffff ffffffff 30000000 00000f04

uart:~$ md 0x7e6e2630 3

[7e6e2630] ff000000 000000ff 000f0000