### PR TITLE
fby3.5: cl: Add ASD initialization command

### DIFF
--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -71,6 +71,7 @@ void pal_OEM_SENSOR_POLL_EN(ipmi_msg *msg);
 void pal_OEM_FW_UPDATE(ipmi_msg *msg);
 void pal_OEM_GET_FW_VERSION(ipmi_msg *msg);
 void pal_OEM_PECIaccess(ipmi_msg *msg);
+void pal_OEM_ASD_INIT(ipmi_msg *msg);
 void pal_OEM_GET_SET_GPIO(ipmi_msg *msg);
 void pal_OEM_SET_SYSTEM_GUID(ipmi_msg *msg);
 void pal_OEM_I2C_DEV_SCAN(ipmi_msg *msg);
@@ -186,6 +187,7 @@ enum {
   CMD_OEM_SET_JTAG_TAP_STA = 0x21,
   CMD_OEM_JTAG_DATA_SHIFT = 0x22,
   CMD_OEM_ACCURACY_SENSNR = 0x23,
+  CMD_OEM_ASD_INIT = 0x28,
   CMD_OEM_PECIaccess = 0x29,
   CMD_OEM_SENSOR_POLL_EN = 0x30,
   CMD_OEM_GET_SET_GPIO = 0x41,

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -159,6 +159,9 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 	case CMD_OEM_ACCURACY_SENSNR:
 		pal_OEM_ACCURACY_SENSNR(msg);
 		break;
+	case CMD_OEM_ASD_INIT:
+		pal_OEM_ASD_INIT(msg);
+		break;
 	case CMD_OEM_GET_SET_GPIO:
 		pal_OEM_GET_SET_GPIO(msg);
 		break;

--- a/common/pal.c
+++ b/common/pal.c
@@ -167,6 +167,12 @@ __weak void pal_OEM_ACCURACY_SENSNR(ipmi_msg *msg)
   return;
 }
 
+__weak void pal_OEM_ASD_INIT(ipmi_msg *msg)
+{
+  msg->completion_code = CC_UNSPECIFIED_ERROR;
+  return;
+}
+
 __weak void pal_OEM_PECIaccess(ipmi_msg *msg)
 {
   msg->completion_code = CC_UNSPECIFIED_ERROR;

--- a/common/pal.h
+++ b/common/pal.h
@@ -38,6 +38,7 @@ void pal_OEM_SENSOR_POLL_EN(ipmi_msg *msg);
 void pal_OEM_FW_UPDATE(ipmi_msg *msg);
 void pal_OEM_GET_FW_VERSION(ipmi_msg *msg);
 void pal_OEM_ACCURACY_SENSNR(ipmi_msg *msg);
+void pal_OEM_ASD_INIT(ipmi_msg *msg);
 void pal_OEM_GET_SET_GPIO(ipmi_msg *msg);
 void pal_OEM_SET_SYSTEM_GUID(ipmi_msg *msg);
 void pal_OEM_I2C_DEV_SCAN(ipmi_msg *msg);

--- a/common/util/hal_gpio.c
+++ b/common/util/hal_gpio.c
@@ -79,7 +79,7 @@ interrupt type:
   GPIO_INT_LEVEL_LOW
   GPIO_INT_LEVEL_HIGH
 */
-static int gpio_interrupt_conf(uint8_t gpio_num, gpio_flags_t flags) {
+int gpio_interrupt_conf(uint8_t gpio_num, gpio_flags_t flags) {
   return gpio_pin_interrupt_configure(dev_gpio[gpio_num / GPIO_GROUP_SIZE], (gpio_num % GPIO_GROUP_SIZE), flags);
 }
 

--- a/common/util/hal_gpio.h
+++ b/common/util/hal_gpio.h
@@ -76,5 +76,6 @@ void gpio_show(void);
 int gpio_get(uint8_t);
 int gpio_set(uint8_t, uint8_t);
 bool gpio_init(void);
+int gpio_interrupt_conf(uint8_t, gpio_flags_t);
 
 #endif

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -18,6 +18,7 @@
 #include "hal_snoop.h"
 #include "hal_peci.h"
 #include <drivers/peci.h>
+#include "plat_func.h"
 
 bool add_sel_evt_record(addsel_msg_t *sel_msg) {
   ipmb_error status;
@@ -1077,6 +1078,28 @@ void pal_OEM_ACCURACY_SENSNR(ipmi_msg *msg) {
       msg->completion_code = CC_UNSPECIFIED_ERROR; // unknown error
       break;
   }
+  return;
+}
+
+void pal_OEM_ASD_INIT(ipmi_msg *msg) {
+  if (!msg){
+    printf("pal_OEM_ASD_INIT: parameter msg is NULL\n");
+    return;
+  }
+
+  if (msg->data_len != 1) {
+    msg->completion_code = CC_INVALID_LENGTH;
+    return;
+  }
+
+  if (msg->data[0] == 0x01) {
+    enable_asd_gpio_interrupt();
+  } else if (msg->data[0] == 0xff) {
+    disable_asd_gpio_interrupt();
+  }
+
+  msg->data_len = 0;
+  msg->completion_code = CC_SUCCESS;
   return;
 }
 

--- a/meta-facebook/yv35-cl/src/main.c
+++ b/meta-facebook/yv35-cl/src/main.c
@@ -38,6 +38,7 @@ void main(void)
   util_init_I2C();
 
   set_sys_config();
+  disable_asd_gpio_interrupt();
   sensor_init();
   FRU_init();
   ipmi_init();

--- a/meta-facebook/yv35-cl/src/platform/hwmon.c
+++ b/meta-facebook/yv35-cl/src/platform/hwmon.c
@@ -132,3 +132,17 @@ void send_gpio_interrupt(uint8_t gpio_num)
     printk("No response from bmc for gpio %d interrupt\n", gpio_num);
   }
 }
+
+void enable_asd_gpio_interrupt() {
+  gpio_interrupt_conf(H_BMC_PRDY_BUF_N, GPIO_INT_EDGE_FALLING);
+  gpio_interrupt_conf(PWRGD_CPU_LVC3, GPIO_INT_EDGE_BOTH);
+  gpio_interrupt_conf(RST_PLTRST_BUF_N, GPIO_INT_EDGE_BOTH);
+  gpio_interrupt_conf(FM_DBP_PRESENT_N, GPIO_INT_EDGE_BOTH);
+}
+
+void disable_asd_gpio_interrupt() {
+  gpio_interrupt_conf(H_BMC_PRDY_BUF_N, GPIO_INT_DISABLE);
+  gpio_interrupt_conf(PWRGD_CPU_LVC3, GPIO_INT_DISABLE);
+  gpio_interrupt_conf(RST_PLTRST_BUF_N, GPIO_INT_DISABLE);
+  gpio_interrupt_conf(FM_DBP_PRESENT_N, GPIO_INT_DISABLE);
+}

--- a/meta-facebook/yv35-cl/src/platform/plat_func.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_func.h
@@ -19,4 +19,6 @@ bool get_DC_status();
 void set_post_status();
 bool get_post_status();
 void send_gpio_interrupt(uint8_t gpio_num);
+void enable_asd_gpio_interrupt();
+void disable_asd_gpio_interrupt();
 #endif


### PR DESCRIPTION
Summary:
- Default disable ASD GPIO interrupt.
- Support OEM ASD init command to enable or disable ASD GPIO interrupt.

Test Plan:
- Build code: Pass
- Command test: Pass

Log:
```
root@bmc-oob:~# bic-util slot1 0xe0 0x28 0x9c 0x9c 0x00 0x01
9C 9C 00
root@bmc-oob:~# bic-util slot1 0xe0 0x28 0x9c 0x9c 0x00 0xff
9C 9C 00
```
