### PR TITLE
fby3.5: cl: Added FRU access for DPV2

### DIFF
--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -378,6 +378,11 @@ void pal_STORAGE_READ_FRUID_DATA(ipmi_msg *msg) {
   fru_entry.offset = (msg->data[2] << 8) | msg->data[1];
   fru_entry.data_len = msg->data[3];
 
+  if ( fru_entry.data_len >= 32 ) { // According to IPMI, messages are limited to 32 bytes
+    msg->completion_code = CC_LENGTH_EXCEEDED;
+    return;
+  }
+
   status = FRU_read(&fru_entry);
 
   msg->data_len = fru_entry.data_len + 1;
@@ -419,6 +424,10 @@ void pal_STORAGE_WRITE_FRUID_DATA(ipmi_msg *msg) {
   fru_entry.config.dev_id = msg->data[0];
   fru_entry.offset = (msg->data[2] << 8) | msg->data[1];
   fru_entry.data_len = msg->data_len - 3; // skip id and offset
+  if ( fru_entry.data_len >= 32 ) { // According to IPMI, messages are limited to 32 bytes
+    msg->completion_code = CC_LENGTH_EXCEEDED;
+    return;
+  }
   memcpy(&fru_entry.data[0], &msg->data[3], fru_entry.data_len);
 
   msg->data[0] = msg->data_len - 3;

--- a/meta-facebook/yv35-cl/src/platform/plat_fru.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_fru.c
@@ -4,15 +4,21 @@
 #include "pal.h"
 #include "fru.h"
 
-#define MB_FRU_PORT 0x01
-#define MB_FRU_ADDR 0x54
-
 const EEPROM_CFG plat_fru_config[] = {
   {
     NV_ATMEL_24C128,
     MB_FRU_ID,
     MB_FRU_PORT,
     MB_FRU_ADDR,
+    FRU_DEV_ACCESS_BYTE,
+    FRU_START,
+    FRU_SIZE,
+  },
+  {
+    NV_ATMEL_24C128,
+    DPV2_FRU_ID,
+    DPV2_FRU_PORT,
+    DPV2_FRU_ADDR,
     FRU_DEV_ACCESS_BYTE,
     FRU_START,
     FRU_SIZE,

--- a/meta-facebook/yv35-cl/src/platform/plat_fru.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_fru.h
@@ -1,8 +1,15 @@
 #ifndef PLAT_FRU_H
 #define PLAT_FRU_H
 
+#define MB_FRU_PORT 0x01
+#define MB_FRU_ADDR 0x54
+
+#define DPV2_FRU_PORT 0x08
+#define DPV2_FRU_ADDR 0x51
+
 enum {
   MB_FRU_ID,
+  DPV2_FRU_ID,
   // OTHER_FRU_ID,
   MAX_FRU_ID,
 };


### PR DESCRIPTION
Summary:
- Added FRU write and read feature for DPV2.
- Added FRU write and read length check to avoid invalid access.

Test plan:
- Build code: Pass
- FRU write/read: Pass

Log:
root@bmc-oob:~# bic-util slot2 0x28 0x11 0x01 0x00 0x00 0x06
06 FF FF FF FF FF FF
root@bmc-oob:~# bic-util slot2 0x28 0x12 0x01 0x0 0x0 0x23 0x34 0x56 0x78 0x9a 0xbc
06
root@bmc-oob:~# bic-util slot2 0x28 0x11 0x01 0x00 0x00 0x06
06 23 34 56 78 9A BC