### PR TITLE
fby3.5: cl: Modified BIC version format

### DIFF
--- a/meta-facebook/yv35-cl/src/ipmi/include/ipmi_def.h
+++ b/meta-facebook/yv35-cl/src/ipmi/include/ipmi_def.h
@@ -10,6 +10,14 @@
 #define PRODUCT_ID 0x0000
 #define AUXILIARY_FW_REVISION 0x00000000
 
+#define BIC_FW_YEAR_MSB   0x20
+#define BIC_FW_YEAR_LSB   0x21
+#define BIC_FW_WEEK       0x51
+#define BIC_FW_VER        0x01
+#define BIC_FW_platform_0 0x63 // char: c
+#define BIC_FW_platform_1 0x6c // char: l
+#define BIC_FW_platform_2 0x00 // char: '\0'
+
 // firmware update interface
 #define BIOS_UPDATE 0x00
 #define CPLD_UPDATE 0x01

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -920,9 +920,14 @@ void pal_OEM_GET_FW_VERSION(ipmi_msg *msg) {
       msg->completion_code = CC_UNSPECIFIED_ERROR;
       break;
     case CPNT_BIC:
-      msg->data[0] = FIRMWARE_REVISION_1;
-      msg->data[1] = FIRMWARE_REVISION_2;
-      msg->data_len = 2;
+      msg->data[0] = BIC_FW_YEAR_MSB;
+      msg->data[1] = BIC_FW_YEAR_LSB;
+      msg->data[2] = BIC_FW_WEEK;
+      msg->data[3] = BIC_FW_VER;
+      msg->data[4] = BIC_FW_platform_0;
+      msg->data[5] = BIC_FW_platform_1;
+      msg->data[6] = BIC_FW_platform_2;
+      msg->data_len = 7;
       msg->completion_code = CC_SUCCESS;
       break;
     case CPNT_ME:


### PR DESCRIPTION
Summary:
- Modified BIC version format to year/week/version/platform.

Test plan:
- Build code: Pass
- Update sensor threshold: Pass

Log:
root@bmc-oob:~# bic-util slot1 0xe0 0xb 0x9c 0x9c 0x0 2
9C 9C 00 20 21 51 01 63 6C 00
