### PR TITLE
fby3.5: cl: Added OEM sensor reading for ME accessing HSC

### DIFF
--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -63,20 +63,25 @@ void pal_STORAGE_RSV_SDR(ipmi_msg *msg);
 void pal_STORAGE_GET_SDR(ipmi_msg *msg);
 
 // IPMI OEM
-void pal_OEM_MSG_OUT(ipmi_msg *msg);
-void pal_OEM_GET_GPIO(ipmi_msg *msg);
-void pal_OEM_SET_GPIO(ipmi_msg *msg);
-void pal_OEM_SEND_INTERRUPT_TO_BMC(ipmi_msg *msg);
-void pal_OEM_SENSOR_POLL_EN(ipmi_msg *msg);
-void pal_OEM_FW_UPDATE(ipmi_msg *msg);
-void pal_OEM_GET_FW_VERSION(ipmi_msg *msg);
-void pal_OEM_PECIaccess(ipmi_msg *msg);
-void pal_OEM_ASD_INIT(ipmi_msg *msg);
-void pal_OEM_GET_SET_GPIO(ipmi_msg *msg);
+void pal_OEM_SENSOR_READ(ipmi_msg *msg);
 void pal_OEM_SET_SYSTEM_GUID(ipmi_msg *msg);
-void pal_OEM_I2C_DEV_SCAN(ipmi_msg *msg);
-void pal_OEM_SET_JTAG_TAP_STA(ipmi_msg *msg);
-void pal_OEM_JTAG_DATA_SHIFT(ipmi_msg *msg);
+
+// IPMI OEM 1S
+void pal_OEM_1S_MSG_OUT(ipmi_msg *msg);
+void pal_OEM_1S_GET_GPIO(ipmi_msg *msg);
+void pal_OEM_1S_SET_GPIO(ipmi_msg *msg);
+void pal_OEM_1S_SEND_INTERRUPT_TO_BMC(ipmi_msg *msg);
+void pal_OEM_1S_SENSOR_POLL_EN(ipmi_msg *msg);
+void pal_OEM_1S_FW_UPDATE(ipmi_msg *msg);
+void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg);
+void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg);
+void pal_OEM_1S_PECIaccess(ipmi_msg *msg);
+void pal_OEM_1S_ASD_INIT(ipmi_msg *msg);
+void pal_OEM_1S_GET_SET_GPIO(ipmi_msg *msg);
+void pal_OEM_1S_ACCURACY_SENSNR(ipmi_msg *msg);
+void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg);
+void pal_OEM_1S_SET_JTAG_TAP_STA(ipmi_msg *msg);
+void pal_OEM_1S_JTAG_DATA_SHIFT(ipmi_msg *msg);
 
 
 enum {
@@ -172,28 +177,33 @@ enum {
   CMD_STORAGE_ADD_SEL = 0x44,
 };
 
-// OEM Command Codes 
+// OEM Command Codes
 enum {
-  CMD_OEM_MSG_IN = 0x1,
-  CMD_OEM_MSG_OUT = 0x2,
-  CMD_OEM_GET_GPIO = 0x3,
-  CMD_OEM_SET_GPIO = 0x4,
-  CMD_OEM_GET_GPIO_CONFIG = 0x5,
-  CMD_OEM_SET_GPIO_CONFIG = 0x6,
-  CMD_OEM_SEND_INTERRUPT_TO_BMC = 0x7,
-  CMD_OEM_FW_UPDATE = 0x9,
-  CMD_OEM_GET_FW_VERSION = 0xB,
-  CMD_OEM_GET_POST_CODE = 0x12,
-  CMD_OEM_SET_JTAG_TAP_STA = 0x21,
-  CMD_OEM_JTAG_DATA_SHIFT = 0x22,
-  CMD_OEM_ACCURACY_SENSNR = 0x23,
-  CMD_OEM_ASD_INIT = 0x28,
-  CMD_OEM_PECIaccess = 0x29,
-  CMD_OEM_SENSOR_POLL_EN = 0x30,
-  CMD_OEM_GET_SET_GPIO = 0x41,
+  CMD_OEM_SENSOR_READ = 0xE2,
   CMD_OEM_SET_SYSTEM_GUID = 0xEF,
+};
+
+// OEM 1S Command Codes 
+enum {
+  CMD_OEM_1S_MSG_IN = 0x1,
+  CMD_OEM_1S_MSG_OUT = 0x2,
+  CMD_OEM_1S_GET_GPIO = 0x3,
+  CMD_OEM_1S_SET_GPIO = 0x4,
+  CMD_OEM_1S_GET_GPIO_CONFIG = 0x5,
+  CMD_OEM_1S_SET_GPIO_CONFIG = 0x6,
+  CMD_OEM_1S_SEND_INTERRUPT_TO_BMC = 0x7,
+  CMD_OEM_1S_FW_UPDATE = 0x9,
+  CMD_OEM_1S_GET_FW_VERSION = 0xB,
+  CMD_OEM_1S_GET_POST_CODE = 0x12,
+  CMD_OEM_1S_SET_JTAG_TAP_STA = 0x21,
+  CMD_OEM_1S_JTAG_DATA_SHIFT = 0x22,
+  CMD_OEM_1S_ACCURACY_SENSNR = 0x23,
+  CMD_OEM_1S_ASD_INIT = 0x28,
+  CMD_OEM_1S_PECIaccess = 0x29,
+  CMD_OEM_1S_SENSOR_POLL_EN = 0x30,
+  CMD_OEM_1S_GET_SET_GPIO = 0x41,
 // Debug command
-  CMD_OEM_I2C_DEV_SCAN = 0x60,
+  CMD_OEM_1S_I2C_DEV_SCAN = 0x60,
 };
 
 #endif

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -104,6 +104,9 @@ void IPMI_Storage_handler(ipmi_msg *msg)
 void IPMI_OEM_handler(ipmi_msg *msg)
 {
 	switch (msg->cmd) {
+  case CMD_OEM_SENSOR_READ:
+    pal_OEM_SENSOR_READ(msg);
+    break;
 	case CMD_OEM_SET_SYSTEM_GUID:
 		pal_OEM_SET_SYSTEM_GUID(msg);
 		break;
@@ -118,55 +121,52 @@ void IPMI_OEM_handler(ipmi_msg *msg)
 void IPMI_OEM_1S_handler(ipmi_msg *msg)
 {
 	switch (msg->cmd) {
-	case CMD_OEM_MSG_IN:
+	case CMD_OEM_1S_MSG_IN:
 		break;
-	case CMD_OEM_MSG_OUT:
-		pal_OEM_MSG_OUT(msg);
+	case CMD_OEM_1S_MSG_OUT:
+		pal_OEM_1S_MSG_OUT(msg);
 		break;
-	case CMD_OEM_GET_GPIO:
-		pal_OEM_GET_GPIO(msg);
+	case CMD_OEM_1S_GET_GPIO:
+		pal_OEM_1S_GET_GPIO(msg);
 		break;
-	case CMD_OEM_SET_GPIO:
-		pal_OEM_SET_GPIO(msg);
+	case CMD_OEM_1S_SET_GPIO:
+		pal_OEM_1S_SET_GPIO(msg);
 		break;
-	case CMD_OEM_GET_GPIO_CONFIG:
+	case CMD_OEM_1S_SEND_INTERRUPT_TO_BMC:
+		pal_OEM_1S_SEND_INTERRUPT_TO_BMC(msg);
 		break;
-	case CMD_OEM_SET_GPIO_CONFIG:
+	case CMD_OEM_1S_FW_UPDATE:
+		pal_OEM_1S_FW_UPDATE(msg);
 		break;
-	case CMD_OEM_SEND_INTERRUPT_TO_BMC:
-		pal_OEM_SEND_INTERRUPT_TO_BMC(msg);
+	case CMD_OEM_1S_GET_FW_VERSION:
+		pal_OEM_1S_GET_FW_VERSION(msg);
 		break;
-	case CMD_OEM_FW_UPDATE:
-		pal_OEM_FW_UPDATE(msg);
-		break;
-	case CMD_OEM_GET_FW_VERSION:
-		pal_OEM_GET_FW_VERSION(msg);
-		break;
-  case CMD_OEM_PECIaccess:
-    pal_OEM_PECIaccess(msg);
+  case CMD_OEM_1S_PECIaccess:
+    pal_OEM_1S_PECIaccess(msg);
     break;
-  case CMD_OEM_GET_POST_CODE:
-    pal_OEM_GET_POST_CODE(msg);
+  case CMD_OEM_1S_GET_POST_CODE:
+    pal_OEM_1S_GET_POST_CODE(msg);
     break;
-	case CMD_OEM_SET_JTAG_TAP_STA:
-		pal_OEM_SET_JTAG_TAP_STA(msg);
+	case CMD_OEM_1S_SET_JTAG_TAP_STA:
+		pal_OEM_1S_SET_JTAG_TAP_STA(msg);
 		break;
-	case CMD_OEM_JTAG_DATA_SHIFT:
-		pal_OEM_JTAG_DATA_SHIFT(msg);
+	case CMD_OEM_1S_JTAG_DATA_SHIFT:
+		pal_OEM_1S_JTAG_DATA_SHIFT(msg);
 		break;
-	case CMD_OEM_SENSOR_POLL_EN:
-		pal_OEM_SENSOR_POLL_EN(msg);
-	case CMD_OEM_ACCURACY_SENSNR:
-		pal_OEM_ACCURACY_SENSNR(msg);
+	case CMD_OEM_1S_SENSOR_POLL_EN:
+		pal_OEM_1S_SENSOR_POLL_EN(msg);
+    break;
+	case CMD_OEM_1S_ACCURACY_SENSNR:
+		pal_OEM_1S_ACCURACY_SENSNR(msg);
 		break;
-	case CMD_OEM_ASD_INIT:
-		pal_OEM_ASD_INIT(msg);
+	case CMD_OEM_1S_ASD_INIT:
+		pal_OEM_1S_ASD_INIT(msg);
 		break;
-	case CMD_OEM_GET_SET_GPIO:
-		pal_OEM_GET_SET_GPIO(msg);
+	case CMD_OEM_1S_GET_SET_GPIO:
+		pal_OEM_1S_GET_SET_GPIO(msg);
 		break;
-	case CMD_OEM_I2C_DEV_SCAN: // debug command
-		pal_OEM_I2C_DEV_SCAN(msg);
+	case CMD_OEM_1S_I2C_DEV_SCAN: // debug command
+		pal_OEM_1S_I2C_DEV_SCAN(msg);
 		break;
 	default:
 		printf("invalid OEM msg netfn: %x, cmd: %x\n", msg->netfn, msg->cmd);

--- a/common/pal.c
+++ b/common/pal.c
@@ -25,6 +25,11 @@ __weak bool pal_is_to_ipmi_handler(uint8_t netfn, uint8_t cmd)
   return 0;
 }
 
+__weak bool pal_ME_is_to_ipmi_handler(uint8_t netfn, uint8_t cmd)
+{
+  return 0;
+}
+
 __weak bool pal_is_not_return_cmd(uint8_t netfn, uint8_t cmd)
 {
 	return 0;
@@ -107,79 +112,7 @@ __weak void pal_STORAGE_GET_SDR(ipmi_msg *msg)
 }
 
 // IPMI OEM
-__weak void pal_OEM_MSG_OUT(ipmi_msg *msg)
-{
-	msg->completion_code = CC_UNSPECIFIED_ERROR;
-	return;
-}
-
-__weak void pal_OEM_GET_GPIO(ipmi_msg *msg)
-{
-	msg->completion_code = CC_UNSPECIFIED_ERROR;
-	return;
-}
-
-__weak void pal_OEM_SET_GPIO(ipmi_msg *msg)
-{
-	msg->completion_code = CC_UNSPECIFIED_ERROR;
-	return;
-}
-
-__weak void pal_OEM_SEND_INTERRUPT_TO_BMC(ipmi_msg *msg)
-{
-	msg->completion_code = CC_UNSPECIFIED_ERROR;
-	return;
-}
-
-__weak void pal_OEM_SENSOR_POLL_EN(ipmi_msg *msg)
-{
-	msg->completion_code = CC_UNSPECIFIED_ERROR;
-	return;
-}
-
-__weak void pal_OEM_FW_UPDATE(ipmi_msg *msg)
-{
-	msg->completion_code = CC_UNSPECIFIED_ERROR;
-	return;
-}
-
-__weak void pal_OEM_GET_FW_VERSION(ipmi_msg *msg)
-{
-	msg->completion_code = CC_UNSPECIFIED_ERROR;
-	return;
-}
-
-__weak void pal_OEM_SET_JTAG_TAP_STA(ipmi_msg *msg)
-{
-	msg->completion_code = CC_UNSPECIFIED_ERROR;
-	return;
-}
-
-__weak void pal_OEM_JTAG_DATA_SHIFT(ipmi_msg *msg)
-{
-	msg->completion_code = CC_UNSPECIFIED_ERROR;
-	return;
-}
-
-__weak void pal_OEM_ACCURACY_SENSNR(ipmi_msg *msg)
-{
-  msg->completion_code = CC_UNSPECIFIED_ERROR;
-  return;
-}
-
-__weak void pal_OEM_ASD_INIT(ipmi_msg *msg)
-{
-  msg->completion_code = CC_UNSPECIFIED_ERROR;
-  return;
-}
-
-__weak void pal_OEM_PECIaccess(ipmi_msg *msg)
-{
-  msg->completion_code = CC_UNSPECIFIED_ERROR;
-  return;
-}
-
-__weak void pal_OEM_GET_SET_GPIO(ipmi_msg *msg)
+__weak void pal_OEM_SENSOR_READ(ipmi_msg *msg)
 {
 	msg->completion_code = CC_UNSPECIFIED_ERROR;
 	return;
@@ -191,7 +124,92 @@ __weak void pal_OEM_SET_SYSTEM_GUID(ipmi_msg *msg)
 	return;
 }
 
-__weak void pal_OEM_I2C_DEV_SCAN(ipmi_msg *msg)
+// IPMI OEM 1S
+__weak void pal_OEM_1S_MSG_OUT(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_GET_GPIO(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_SET_GPIO(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_SEND_INTERRUPT_TO_BMC(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_SENSOR_POLL_EN(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_FW_UPDATE(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg)
+{
+    msg->completion_code = CC_UNSPECIFIED_ERROR;
+    return;
+}
+
+__weak void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_SET_JTAG_TAP_STA(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_JTAG_DATA_SHIFT(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_ASD_INIT(ipmi_msg *msg)
+{
+  msg->completion_code = CC_UNSPECIFIED_ERROR;
+  return;
+}
+
+__weak void pal_OEM_1S_ACCURACY_SENSNR(ipmi_msg *msg)
+{
+  msg->completion_code = CC_UNSPECIFIED_ERROR;
+  return;
+}
+
+__weak void pal_OEM_1S_PECIaccess(ipmi_msg *msg)
+{
+  msg->completion_code = CC_UNSPECIFIED_ERROR;
+  return;
+}
+
+__weak void pal_OEM_1S_GET_SET_GPIO(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg)
 {
 	msg->completion_code = CC_UNSPECIFIED_ERROR;
 	return;
@@ -230,6 +248,16 @@ __weak uint8_t pal_load_sdr_table(void)
 __weak bool pal_load_snr_config(void)
 {
 	return 0;
+}
+
+__weak void pal_fix_fullSDR_table(void)
+{
+    return 0;
+}
+
+__weak void pal_fix_Snrconfig(void)
+{
+    return 0;
 }
 
 // fru

--- a/common/pal.h
+++ b/common/pal.h
@@ -8,6 +8,7 @@ void pal_usb_handler(uint8_t *rx_buff, int rx_len);
 
 // IPMI
 bool pal_is_to_ipmi_handler(uint8_t netfn, uint8_t cmd);
+bool pal_ME_is_to_ipmi_handler(uint8_t netfn, uint8_t cmd);
 bool pal_is_not_return_cmd(uint8_t netfn, uint8_t cmd);
 
 // IPMI CHASSIS
@@ -31,17 +32,21 @@ void pal_STORAGE_RSV_SDR(ipmi_msg *msg);
 void pal_STORAGE_GET_SDR(ipmi_msg *msg);
 
 // IPMI OEM
-void pal_OEM_MSG_OUT(ipmi_msg *msg);
-void pal_OEM_GET_GPIO(ipmi_msg *msg);
-void pal_OEM_SET_GPIO(ipmi_msg *msg);
-void pal_OEM_SENSOR_POLL_EN(ipmi_msg *msg);
-void pal_OEM_FW_UPDATE(ipmi_msg *msg);
-void pal_OEM_GET_FW_VERSION(ipmi_msg *msg);
-void pal_OEM_ACCURACY_SENSNR(ipmi_msg *msg);
-void pal_OEM_ASD_INIT(ipmi_msg *msg);
-void pal_OEM_GET_SET_GPIO(ipmi_msg *msg);
+void pal_OEM_SENSOR_READ(ipmi_msg *msg);
 void pal_OEM_SET_SYSTEM_GUID(ipmi_msg *msg);
-void pal_OEM_I2C_DEV_SCAN(ipmi_msg *msg);
+
+// IPMI OEM 1S
+void pal_OEM_1S_MSG_OUT(ipmi_msg *msg);
+void pal_OEM_1S_GET_GPIO(ipmi_msg *msg);
+void pal_OEM_1S_SET_GPIO(ipmi_msg *msg);
+void pal_OEM_1S_SENSOR_POLL_EN(ipmi_msg *msg);
+void pal_OEM_1S_FW_UPDATE(ipmi_msg *msg);
+void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg);
+void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg);
+void pal_OEM_1S_ACCURACY_SENSNR(ipmi_msg *msg);
+void pal_OEM_1S_ASD_INIT(ipmi_msg *msg);
+void pal_OEM_1S_GET_SET_GPIO(ipmi_msg *msg);
+void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg);
 
 // init
 void pal_I2C_init(void);
@@ -54,6 +59,8 @@ void pal_set_sensor_poll_interval(int *interval_ms);
 // sensor accessible
 uint8_t pal_load_sdr_table(void);
 bool pal_load_snr_config(void);
+void pal_fix_fullSDR_table(void);
+void pal_fix_Snrconfig(void);
 
 // fru
 void pal_load_fru_config(void);

--- a/common/sensor/sdr.c
+++ b/common/sensor/sdr.c
@@ -55,7 +55,7 @@ uint8_t SDR_init(void)
 	int i;
 
 	SDR_NUM = pal_load_sdr_table();
-  fix_fullSDR_table();
+  pal_fix_fullSDR_table();
 	sdr_info.start_ID = 0x0000;
 	sdr_info.current_ID = sdr_info.start_ID;
 

--- a/common/sensor/sensor.c
+++ b/common/sensor/sensor.c
@@ -186,7 +186,7 @@ bool sensor_init(void) {
     return false;
   }
 
-  fix_Snrconfig();
+  pal_fix_Snrconfig();
   map_SnrNum_SDR_CFG();  
   
   if (DEBUG_SNR) {

--- a/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
@@ -38,7 +38,7 @@
 
 	ipmb2: ipmb@10 {
 		compatible = "aspeed,ipmb";
-		reg = <0x10>;
+		reg = <0x20>;
 		label = "IPMB_2";
 		size = <10>;
 #ifdef CONFIG_I2C_IPMB_SLAVE

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmb.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmb.c
@@ -8,7 +8,7 @@
 IPMB_config pal_IPMB_config_table[] = {
 	//   index             interface         interface_source  bus              Target_addr          EnStatus  slave_addr            Rx_attr_name          Tx_attr_name//
 	{ BMC_IPMB_IDX,     I2C_IF,           BMC_IPMB_IFs,     IPMB_I2C_BMC,    BMC_I2C_ADDRESS,     Enable,   Self_I2C_ADDRESS,     "RX_BMC_IPMB_TASK",   "TX_BMC_IPMB_TASK"  },
-	{ ME_IPMB_IDX,      I2C_IF,           ME_IPMB_IFs,      IPMB_ME_BUS,     ME_I2C_ADDRESS,      Enable,   BMC_I2C_ADDRESS,     "RX_ME_IPMB_TASK",    "TX_ME_IPMB_TASK"   },
+	{ ME_IPMB_IDX,      I2C_IF,           ME_IPMB_IFs,      IPMB_ME_BUS,     ME_I2C_ADDRESS,      Enable,   Self_I2C_ADDRESS,     "RX_ME_IPMB_TASK",    "TX_ME_IPMB_TASK"   },
 	{ EXP1_IPMB_IDX,    I2C_IF,           EXP1_IPMB_IFs,    IPMB_EXP1_BUS,   BIC0_I2C_ADDRESS,    Disable,  BIC1_I2C_ADDRESS,     "RX_EPX0_IPMB_TASK",  "TX_EXP0_IPMB_TASK" },
 	{ EXP2_IPMB_IDX,    I2C_IF,           EXP2_IPMB_IFs,    IPMB_EXP2_BUS,   BIC1_I2C_ADDRESS,    Disable,  BIC0_I2C_ADDRESS,     "RX_EPX1_IPMB_TASK",  "TX_EXP1_IPMB_TASK" },
 	{ RESERVE_IPMB_IDX, Reserve_IF,       Reserve_IFs,      Reserve_BUS,     Reserve_ADDRESS,     Disable,  Reserve_ADDRESS,      "Reserve_ATTR",       "Reserve_ATTR"      },

--- a/meta-facebook/yv35-cl/src/ipmi/usb_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/usb_ipmi.c
@@ -25,7 +25,7 @@ void pal_usb_handler(uint8_t *rx_buff,int rx_len) {
   // USB driver must receive 64 byte package from bmc
   // it takes 512 + 64 byte package to receive ipmi command + 512 byte image data
   // if cmd fw_update, record next usb package as image until receive complete data
-  if ( (rx_buff[0] == (NETFN_OEM_1S_REQ << 2) ) && (rx_buff[1] == CMD_OEM_FW_UPDATE) ) {
+  if ( (rx_buff[0] == (NETFN_OEM_1S_REQ << 2) ) && (rx_buff[1] == CMD_OEM_1S_FW_UPDATE) ) {
     fwupdate_keep_data = true;
   }
 

--- a/meta-facebook/yv35-cl/src/main.c
+++ b/meta-facebook/yv35-cl/src/main.c
@@ -19,6 +19,7 @@
 void device_init() {
   adc_init();
   peci_init();
+  hsc_init();
 }
 
 void set_sys_status() {

--- a/meta-facebook/yv35-cl/src/platform/hwmon.c
+++ b/meta-facebook/yv35-cl/src/platform/hwmon.c
@@ -117,7 +117,7 @@ void send_gpio_interrupt(uint8_t gpio_num)
   msg.InF_source = Self_IFs;
   msg.InF_target = BMC_IPMB_IFs;
   msg.netfn = NETFN_OEM_1S_REQ;
-  msg.cmd = CMD_OEM_SEND_INTERRUPT_TO_BMC;
+  msg.cmd = CMD_OEM_1S_SEND_INTERRUPT_TO_BMC;
 
   msg.data[0] = WW_IANA_ID & 0xFF;
   msg.data[1] = (WW_IANA_ID >> 8) & 0xFF;

--- a/meta-facebook/yv35-cl/src/sensor/plat_sdr.c
+++ b/meta-facebook/yv35-cl/src/sensor/plat_sdr.c
@@ -2607,7 +2607,7 @@ void add_fullSDR_table( SDR_Full_sensor add_item ) {
   full_sensor_table[ SDR_NUM++ ] = add_item;
 };
 
-void fix_fullSDR_table() {
+void pal_fix_fullSDR_table() {
   uint8_t fix_array_num;
   if ( get_bic_class() ) {
     // fix usage when fix_C2SDR_table is defined

--- a/meta-facebook/yv35-cl/src/sensor/plat_sensor.c
+++ b/meta-facebook/yv35-cl/src/sensor/plat_sensor.c
@@ -135,7 +135,7 @@ void add_Snrconfig( snr_cfg add_Snrconfig ) {
   sensor_config[ SnrCfg_num++ ] = add_Snrconfig;
 };
 
-void fix_Snrconfig() {
+void pal_fix_Snrconfig() {
 /*
   SnrCfg_num = sizeof(plat_sensor_config) / sizeof(plat_sensor_config[0]);
   uint8_t fix_SnrCfg_num;


### PR DESCRIPTION
Summary:
- Added IPMB exception handling for ME reading platform power consumption.
- Added OEM command reading platform power consumption.
- Modified I2C address to leverage with Yv3.
- Fixed BMC response net function unexpectedly being shifted during bridging.
- Fixed OEM 0x38 command to corresponding define.

Test plan:
- Build code: Pass
- Read ME cache: Pass

Log:
Checked BIC OEM command implement from BMC
root@bmc-oob:~# bic-util slot4 0xc0 0xe2 0x0 0x0 0x0
00 6A 00

Checked ME cache status with test BIOS firmware that read HSC power from BIC.
me-util slot4 0xb8 0xc8 0x57 0x01 0x00 0x1 0x0 0x0
57 01 00 87 00 08 00 9C 00 41 00 4D 9D B8 61 31 00 00 00 50