### PR TITLE
fby3.5: cl:Updated sensor threshold and sensor config

### DIFF
--- a/meta-facebook/yv35-cl/src/sensor/plat_sdr.c
+++ b/meta-facebook/yv35-cl/src/sensor/plat_sdr.c
@@ -58,7 +58,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x96,   // UNRT
-    0x32,   // UCT
+    0x30,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -161,7 +161,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x96,   // UNRT
+    0x00,   // UNRT
     0x28,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
@@ -173,7 +173,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // reserved
     0x00,   // OEM
     IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-    "Front IO Temp",
+    "FIO Temp",
   },
   {   // CPU margin on board temperature
     0x00,0x00,  // record ID
@@ -197,7 +197,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     IPMI_SDR_CMP_RETURN_UCT| IPMI_SDR_DEASSERT_MASK_UCT_LO| IPMI_SDR_DEASSERT_MASK_LCT_HI,    // deassert threshold reading mask
     0x00,   // discrete reading mask/ settable
     IPMI_SDR_UCT_SETTABLE| IPMI_SDR_LCT_SETTABLE| IPMI_SDR_UCT_READABLE| IPMI_SDR_LCT_READABLE,   // threshold mask/ readable threshold mask
-    0x80,   // sensor unit
+    0x00,   // sensor unit
     IPMI_SENSOR_UNIT_DEGREE_C,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
@@ -213,7 +213,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
+    0x7D,   // UNRT
     0x00,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
@@ -317,7 +317,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x00,   // UNRT
+    0x7D,   // UNRT
     0x00,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
@@ -734,7 +734,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0x4D,   // UCT
+    0x4A,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -785,8 +785,8 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0x69,   // UNRT
-    0x57,   // UCT
+    0x7D,   // UNRT
+    0x56,   // UCT
     0x00,   // UNCT
     0x00,   // LNRT
     0x00,   // LCT
@@ -849,7 +849,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // reserved
     0x00,   // OEM
     IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-    "PVCCIN Temp",
+    "VCCIN SPS Temp",
   },
   {   // PVCCFA_EHV_FIVRA VR temperature
     0x00,0x00,  // record ID
@@ -901,7 +901,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // reserved
     0x00,   // OEM
     IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-    "EHV_FIVRA Temp",
+    "FIVRA SPS Temp",
   },
   {   // PVCCFA_EHV VR temperature
     0x00,0x00,  // record ID
@@ -953,7 +953,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // reserved
     0x00,   // OEM
     IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-    "PVCCFA_EHV Temp",
+    "EHV SPS Temp",
   },
   {   // PVCCD_HV VR temperature
     0x00,0x00,  // record ID
@@ -1005,7 +1005,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // reserved
     0x00,   // OEM
     IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-    "PVCCD_HV Temp",
+    "VCCD SPS Temp",
   },
   {   // PVCCINFAON VR temperature
     0x00,0x00,  // record ID
@@ -1057,7 +1057,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // reserved
     0x00,   // OEM
     IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-    "PVCCINFAON Temp",
+    "FAON SPS Temp",
   },
   {   // P12V STBY ADC voltage 
     0x00,0x00,  // record ID
@@ -1085,7 +1085,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     IPMI_SENSOR_UNIT_VOL,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x40,   // [7:0] M bits
+    0x3F,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
@@ -1097,12 +1097,12 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0xE0,   // UNRT
-    0xCF,   // UCT
-    0xCB,   // UNCT
-    0x9E,   // LNRT
-    0xA9,   // LCT
-    0xAD,   // LNCT
+    0xE4,   // UNRT
+    0xD4,   // UCT
+    0xD2,   // UNCT
+    0xA0,   // LNRT
+    0xAA,   // LCT
+    0xAC,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1137,7 +1137,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     IPMI_SENSOR_UNIT_VOL,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x0E,   // [7:0] M bits
+    0x0F,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
@@ -1150,11 +1150,11 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0xE6,   // UCT
-    0xE1,   // UNCT
+    0xEA,   // UCT
+    0xE7,   // UNCT
     0x00,   // LNRT
-    0xC8,   // LCT
-    0xCC,   // LNCT
+    0xB8,   // LCT
+    0xBA,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1202,11 +1202,11 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0xDE,   // UNRT
-    0xC4,   // UCT
-    0xC1,   // UNCT
+    0xC6,   // UCT
+    0xC4,   // UNCT
     0x80,   // LNRT
-    0xAB,   // LCT
-    0xAE,   // LNCT
+    0xA9,   // LCT
+    0xAB,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1241,7 +1241,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     IPMI_SENSOR_UNIT_VOL,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x05,   // [7:0] M bits
+    0x06,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
@@ -1253,12 +1253,12 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0xF4,   // UNRT
-    0xDD,   // UCT
-    0xD8,   // UNCT
-    0xA8,   // LNRT
-    0xC4,   // LCT
-    0xC8,   // LNCT
+    0xCB,   // UNRT
+    0xBA,   // UCT
+    0xB8,   // UNCT
+    0x8C,   // LNRT
+    0xA1,   // LCT
+    0xA3,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1293,24 +1293,24 @@ SDR_Full_sensor plat_sensor_table[] = {
     IPMI_SENSOR_UNIT_VOL,   // base unit 
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x01,   // [7:0] M bits
+    0x09,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
     0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-    0xE0,   // Rexp, Bexp
+    0xD0,   // Rexp, Bexp
     0x00,   // analog characteristic
     0x00,   // nominal reading
     0x00,   // normal maximum
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0xD1,   // UNRT
-    0xBE,   // UCT
-    0xBA,   // UNCT
-    0x90,   // LNRT
-    0xA9,   // LCT
-    0xAD,   // LNCT
+    0xE8,   // UNRT
+    0xD5,   // UCT
+    0xD3,   // UNCT
+    0xA0,   // LNRT
+    0xBA,   // LCT
+    0xBC,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1358,11 +1358,11 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0xD7,   // UNRT
-    0xC6,   // UCT
-    0xC2,   // UNCT
+    0xC8,   // UCT
+    0xC6,   // UNCT
     0x94,   // LNRT
-    0xAC,   // LCT
-    0xB0,   // LNCT
+    0xAA,   // LCT
+    0xAC,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1397,12 +1397,12 @@ SDR_Full_sensor plat_sensor_table[] = {
     IPMI_SENSOR_UNIT_VOL,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x40,   // [7:0] M bits
+    0x07,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
     0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-    0xD0,   // Rexp, Bexp
+    0xE0,   // Rexp, Bexp
     0x00,   // analog characteristic
     0x00,   // nominal reading
     0x00,   // normal maximum
@@ -1410,11 +1410,11 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0xDC,   // UCT
-    0xD8,   // UNCT
+    0xCB,   // UCT
+    0xC9,   // UNCT
     0x00,   // LNRT
-    0x9C,   // LCT
-    0x9F,   // LNCT
+    0x8D,   // LCT
+    0x8F,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1462,11 +1462,11 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0xE8,   // UNRT
-    0xD6,   // UCT
-    0xD2,   // UNCT
+    0xD8,   // UCT
+    0xD6,   // UNCT
     0xA0,   // LNRT
-    0xBA,   // LCT
-    0xBE,   // LNCT
+    0xB8,   // LCT
+    0xBA,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1501,7 +1501,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     IPMI_SENSOR_UNIT_VOL,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x12,   // [7:0] M bits
+    0x11,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
@@ -1514,11 +1514,11 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0x00,   // UNRT
-    0xCC,   // UCT
-    0xC8,   // UNCT
+    0xDA,   // UCT
+    0xD8,   // UNCT
     0x00,   // LNRT
-    0xA4,   // LCT
-    0xA7,   // LNCT
+    0xAB,   // LCT
+    0xAD,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1566,18 +1566,18 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0xDC,   // UNRT
-    0xB7,   // UCT
-    0xBB,   // UNCT
+    0xC1,   // UCT
+    0xBF,   // UNCT
     0x28,   // LNRT
-    0xAC,   // LCT
-    0xA9,   // LNCT
+    0xA4,   // LCT
+    0xA6,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
     0x00,   // reserved
     0x00,   // OEM
     IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-    "PVCCIN Vol",
+    "VCCIN VR Vol",
   },
   {   // PVCCFA_EHV_FIVRA VR voltage
     0x00,0x00,  // record ID
@@ -1618,18 +1618,18 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0xDC,   // UNRT
-    0xB6,   // UCT
-    0xBA,   // UNCT
+    0xC0,   // UCT
+    0xBE,   // UNCT
     0x28,   // LNRT
-    0xB1,   // LCT
-    0xAE,   // LNCT
+    0xA9,   // LCT
+    0xAB,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
     0x00,   // reserved
     0x00,   // OEM
     IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-    "EHV_FIVRA Vol",
+    "FIVRA VR Vol",
   },
   {   // PVCCFA_EHV VR voltage
     0x00,0x00,  // record ID
@@ -1670,18 +1670,18 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
     0xDC,   // UNRT
-    0xBC,   // UCT
-    0xB8,   // UNCT
+    0xBE,   // UCT
+    0xBC,   // UNCT
     0x28,   // LNRT
-    0xAB,   // LCT
-    0xAF,   // LNCT
+    0xAA,   // LCT
+    0xAC,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
     0x00,   // reserved
     0x00,   // OEM
     IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-    "PVCCFA_EHV Vol",
+    "EHV VR Vol",
   },
   {   // PVCCD_HV VR voltage
    0x00,0x00,  // record ID
@@ -1722,18 +1722,18 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0xD6,   // UNRT
-   0xAD,   // UCT
-   0xAA,   // UNCT
+   0xAF,   // UCT
+   0xAD,   // UNCT
    0x39,   // LNRT
-   0x97,   // LCT
-   0x9A,   // LNCT
+   0x96,   // LCT
+   0x98,   // LNCT
    0x00,   // positive-going threshold
    0x00,   // negative-going threshold
    0x00,   // reserved
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "PVCCD_HV Vol",
+   "VCCD VR Vol",
  },
  {   // PVCCINFAON VR voltage
    0x00,0x00,  // record ID
@@ -1774,18 +1774,18 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
    0xC8,   // UNRT
-   0x99,   // UCT
-   0x96,   // UNCT
+   0x9B,   // UCT
+   0x99,   // UNCT
    0x39,   // LNRT
-   0x82,   // LCT
-   0x85,   // LNCT
+   0x81,   // LCT
+   0x82,   // LNCT
    0x00,   // positive-going threshold
    0x00,   // negative-going threshold
    0x00,   // reserved
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "PVCCINFAON Vol",
+   "FAON VR Vol",
  },
  {   // HSCIN voltage
     0x00,0x00,  // record ID
@@ -1813,7 +1813,7 @@ SDR_Full_sensor plat_sensor_table[] = {
     IPMI_SENSOR_UNIT_VOL,   // base unit
     0x00,   // modifier unit
     IPMI_SDR_LINEAR_LINEAR,   // linearization
-    0x44,   // [7:0] M bits
+    0x3F,   // [7:0] M bits
     0x00,   // [9:8] M bits, tolerance
     0x00,   // [7:0] B bits
     0x00,   // [9:8] B bits, tolerance
@@ -1825,12 +1825,12 @@ SDR_Full_sensor plat_sensor_table[] = {
     0x00,   // normal minimum
     0x00,   // sensor maximum reading
     0x00,   // sensor minimum reading
-    0xD3,   // UNRT
-    0xC2,   // UCT
-    0xBF,   // UNCT
-    0x94,   // LNRT
-    0x9F,   // LCT
-    0xA2,   // LNCT
+    0xE4,   // UNRT
+    0xD4,   // UCT
+    0xD2,   // UNCT
+    0xA0,   // LNRT
+    0xAA,   // LCT
+    0xAC,   // LNCT
     0x00,   // positive-going threshold
     0x00,   // negative-going threshold
     0x00,   // reserved
@@ -1941,7 +1941,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "PVCCIN Cur",
+   "VCCIN VR Cur",
  },
  {   // PVCCFA_EHV_FIVRA VR current
    0x00,0x00,  // record ID
@@ -1993,7 +1993,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "EHV_FIVRA Cur",
+   "FIVRA VR Cur",
  },
  {   // PVCCFA_EHV VR current
    0x00,0x00,  // record ID
@@ -2045,7 +2045,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "PVCCFA_EHV Cur",
+   "EHV VR Cur",
  },
  {   // PVCCD_HV VR current
    0x00,0x00,  // record ID
@@ -2097,7 +2097,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "PVCCD_HV Cur",
+   "VCCD VR Cur",
  },
  {   // PVCCINFAON VR current
    0x00,0x00,  // record ID
@@ -2149,7 +2149,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "PVCCINFAON Cur",
+   "FAON VR Cur",
  },
   {   // CPU power
    0x00,0x00,  // record ID
@@ -2201,7 +2201,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "CPU Pwr",
+   "CPU PWR",
   },
   {   // HSCIN power
    0x00,0x00,  // record ID
@@ -2229,20 +2229,20 @@ SDR_Full_sensor plat_sensor_table[] = {
    IPMI_SENSOR_UNIT_WATT,   // base unit
    0x00,   // modifier unit
    IPMI_SDR_LINEAR_LINEAR,   // linearization
-   0x01,   // [7:0] M bits
+   0x15,   // [7:0] M bits
    0x00,   // [9:8] M bits, tolerance
    0x00,   // [7:0] B bits
    0x00,   // [9:8] B bits, tolerance
    0x00,   // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-   0x00,   // Rexp, Bexp
+   0xF0,   // Rexp, Bexp
    0x00,   // analog characteristic
    0x00,   // nominal reading
    0x00,   // normal maximum
    0x00,   // normal minimum
    0x00,   // sensor maximum reading
    0x00,   // sensor minimum reading
-   0x00,   // UNRT
-   0xB2,   // UCT
+   0xE5,   // UNRT
+   0x00,   // UCT
    0x00,   // UNCT
    0x00,   // LNRT
    0x00,   // LCT
@@ -2305,7 +2305,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "PVCCIN Pwr",
+   "VCCIN VR Pout",
  },
  {   // PVCCFA_EHV_FIVRA power
    0x00,0x00,  // record ID
@@ -2357,7 +2357,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "EHV_FIVRA Pwr",
+   "FIVRA VR Pout",
  },
  {   // PVCCFA_EHV power
    0x00,0x00,  // record ID
@@ -2409,7 +2409,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "PVCCFA_EHV Pwr",
+   "EHV VR Pout",
  },
  {   // PVCCD_HV power
    0x00,0x00,  // record ID
@@ -2461,7 +2461,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "PVCCD_HV Pwr",
+   "VCCD VR Pout",
  },
  {   // PVCCINFAON power
    0x00,0x00,  // record ID
@@ -2513,7 +2513,7 @@ SDR_Full_sensor plat_sensor_table[] = {
    0x00,   // reserved
    0x00,   // OEM
    IPMI_SDR_STRING_TYPE_ASCII_8,   // ID len, should be same as "size of struct"
-   "PVCCINFAON Pwr",
+   "FAON VR Pout",
  },
 };
 

--- a/meta-facebook/yv35-cl/src/sensor/plat_sensor.c
+++ b/meta-facebook/yv35-cl/src/sensor/plat_sensor.c
@@ -77,7 +77,7 @@ snr_cfg plat_sensor_config[] = {
   {SENSOR_NUM_PWR_PVCCFA_EHV_FIVRA   , type_vr        , i2c_bus5      , PVCCFA_EHV_FIVRA_addr   , VR_PWR_CMD        , DC_access        , 0     , 0     , 0      , SNR_INIT_STATUS},
   
   // ME
-  {SENSOR_NUM_TEMP_PCH               , type_pch       , i2c_bus3      , PCH_addr                , NULL              , stby_access      , 0     , 0     , 0      , SNR_INIT_STATUS},
+  {SENSOR_NUM_TEMP_PCH               , type_pch       , i2c_bus3      , PCH_addr                , NULL              , post_access      , 0     , 0     , 0      , SNR_INIT_STATUS},
   
   // HSC
   {SENSOR_NUM_TEMP_HSC               , type_hsc       , i2c_bus2      , HSC_addr                , HSC_TEMP_CMD      , stby_access      , 0     , 0     , 0      , SNR_INIT_STATUS},

--- a/meta-facebook/yv35-cl/src/sensor/sensor_def.h
+++ b/meta-facebook/yv35-cl/src/sensor/sensor_def.h
@@ -49,7 +49,7 @@ enum {
 #define SENSOR_NUM_TEMP_TMP75_OUT         0x02
 #define SENSOR_NUM_TEMP_TMP75_FIO         0x03
 #define SENSOR_NUM_TEMP_PCH               0x04
-#define SENSOR_NUM_TEMP_CPU               0x15
+#define SENSOR_NUM_TEMP_CPU               0x05
 #define SENSOR_NUM_TEMP_DIMM_A            0x06
 #define SENSOR_NUM_TEMP_DIMM_C            0x07
 #define SENSOR_NUM_TEMP_DIMM_D            0x09
@@ -59,7 +59,7 @@ enum {
 #define SENSOR_NUM_TEMP_SSD0              0x0D
 #define SENSOR_NUM_TEMP_HSC               0x0E
 #define SENSOR_NUM_TEMP_CPU_MARGIN        0x14
-#define SENSOR_NUM_TEMP_CPU_TJMAX         0x05
+#define SENSOR_NUM_TEMP_CPU_TJMAX         0x15
 #define SENSOR_NUM_TEMP_PVCCIN            0x0F
 #define SENSOR_NUM_TEMP_PVCCFA_EHV_FIVRA  0x10
 #define SENSOR_NUM_TEMP_PVCCFA_EHV        0x11
@@ -69,8 +69,8 @@ enum {
 #define SENSOR_NUM_VOL_STBY12V           0x20
 #define SENSOR_NUM_VOL_BAT3V             0x21
 #define SENSOR_NUM_VOL_STBY3V            0x22
-#define SENSOR_NUM_VOL_STBY1V05          0x23
-#define SENSOR_NUM_VOL_STBY1V8           0x24
+#define SENSOR_NUM_VOL_STBY1V05          0x24
+#define SENSOR_NUM_VOL_STBY1V8           0x23
 #define SENSOR_NUM_VOL_STBY5V            0x25
 #define SENSOR_NUM_VOL_DIMM12V           0x26
 #define SENSOR_NUM_VOL_STBY1V2           0x27


### PR DESCRIPTION
Summary:
- Updated sensor threshold and access condition by EE provided.
- Fixed sensor define number in sensor table.

Test plan:
- Build code: Pass
- Update sensor threshold: Pass

Log:
root@bmc-oob:~# sensor-util slot1 --threshold
MB Inlet Temp                (0x1) :   26.10 C     | (ok) | UCR: 48.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
MB Outlet Temp               (0x2) :   36.14 C     | (ok) | UCR: 93.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
FIO Temp                     (0x3) :   25.10 C     | (ok) | UCR: 40.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PCH Temp                     (0x4) :   39.15 C     | (ok) | UCR: 74.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU TjMax                    (0x15) :   82.32 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
SOC Therm Margin             (0x14) :  -48.19 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
CPU Temp                     (0x5) :   34.13 C     | (ok) | UCR: 84.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMA Temp                   (0x6) :   33.13 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMC Temp                   (0x7) :   32.13 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMD Temp                   (0x9) :   31.12 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME Temp                   (0xA) :   32.13 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMG Temp                   (0xB) :   30.12 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH Temp                   (0xC) :   29.11 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SSD0 Temp                    (0xD) :   29.11 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Temp                     (0xE) :    8.99 C     | (ok) | UCR: 86.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
VCCIN SPS Temp               (0xF) :   42.16 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
FIVRA SPS Temp               (0x10) :   40.16 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
EHV SPS Temp                 (0x11) :   35.14 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
VCCD SPS Temp                (0x12) :   36.14 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
FAON SPS Temp                (0x13) :   42.16 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
P12V_STBY Vol                (0x20) :   12.29 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
P3V_BAT Vol                  (0x21) :    3.16 Volts | (ok) | UCR: 3.51 | UNC: 3.46 | UNR: NA | LCR: 2.76 | LNC: 2.79 | LNR: NA
P3V3_STBY Vol                (0x22) :    3.36 Volts | (ok) | UCR: 3.56 | UNC: 3.53 | UNR: 4.00 | LCR: 3.04 | LNC: 3.08 | LNR: 2.30
P1V8_STBY Vol                (0x23) :    1.81 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.09 | LCR: 1.67 | LNC: 1.69 | LNR: 1.44
P1V05_PCH Vol                (0x24) :    1.06 Volts | (ok) | UCR: 1.12 | UNC: 1.10 | UNR: 1.22 | LCR: 0.97 | LNC: 0.98 | LNR: 0.84
P5V_STBY Vol                 (0x25) :    5.04 Volts | (ok) | UCR: 5.40 | UNC: 5.35 | UNR: 5.80 | LCR: 4.59 | LNC: 4.64 | LNR: 4.00
P12V_DIMM Vol                (0x26) :   12.24 Volts | (ok) | UCR: 14.21 | UNC: 14.07 | UNR: NA | LCR: 9.87 | LNC: 10.01 | LNR: NA
P1V2_STBY Vol                (0x27) :    1.21 Volts | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.39 | LCR: 1.10 | LNC: 1.12 | LNR: 0.96
P3V3_M2 Vol                  (0x28) :    3.34 Volts | (ok) | UCR: 3.71 | UNC: 3.67 | UNR: NA | LCR: 2.91 | LNC: 2.94 | LNR: NA
HSC Input Vol                (0x29) :   12.07 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
VCCIN VR Vol                 (0x2A) :    1.79 Volts | (ok) | UCR: 1.93 | UNC: 1.91 | UNR: 2.20 | LCR: 1.64 | LNC: 1.66 | LNR: 0.40
FIVRA VR Vol                 (0x2C) :    1.81 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.20 | LCR: 1.69 | LNC: 1.71 | LNR: 0.40
EHV VR Vol                   (0x2D) :    1.81 Volts | (ok) | UCR: 1.90 | UNC: 1.88 | UNR: 2.20 | LCR: 1.70 | LNC: 1.72 | LNR: 0.40
VCCD VR Vol                  (0x2E) :    1.15 Volts | (ok) | UCR: 1.23 | UNC: 1.21 | UNR: 1.50 | LCR: 1.05 | LNC: 1.06 | LNR: 0.40
FAON VR Vol                  (0x2F) :    1.03 Volts | (ok) | UCR: 1.09 | UNC: 1.07 | UNR: 1.40 | LCR: 0.90 | LNC: 0.91 | LNR: 0.40
HSC Output Cur               (0x30) :    9.01 Amps  | (ok) | UCR: 40.09 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCIN VR Cur                 (0x31) :   23.85 Amps  | (ok) | UCR: 170.17 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
FIVRA VR Cur                 (0x32) :    3.98 Amps  | (ok) | UCR: 85.02 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
EHV VR Cur                   (0x33) :    1.00 Amps  | (ok) | UCR: 18.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCD VR Cur                  (0x34) :    2.00 Amps  | (ok) | UCR: 74.12 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
FAON VR Cur                  (0x35) :   21.08 Amps  | (ok) | UCR: 52.08 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU PWR                      (0x38) :   73.29 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Input Pwr                (0x39) :  104.93 Watts | (ok) | UCR: NA | UNC: NA | UNR: 480.90 | LCR: NA | LNC: NA | LNR: NA
VCCIN VR Pout                (0x3A) :   43.09 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
FIVRA VR Pout                (0x3C) :    7.00 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
EHV VR Pout                  (0x3D) :    0.88 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCD VR Pout                 (0x3E) :    1.94 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
FAON VR Pout                 (0x3F) :   21.02 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA