### PR TITLE
fby3.5: cl:Modified post code buffer size

### DIFF
--- a/common/util/hal_snoop.h
+++ b/common/util/hal_snoop.h
@@ -2,7 +2,7 @@
 #define SNOOP_H
 
 #define SNOOP_STACK_SIZE 500
-#define SNOOP_MAX_LEN 236
+#define SNOOP_MAX_LEN 244
 
 extern int snoop_read_num;
 void copy_snoop_read_buffer( uint8_t offset, int size_num, uint8_t *buffer );


### PR DESCRIPTION
Summary:
- Modified post code buffer size to match BMC max data buffer size.

Test plan:
- Build code: Pass

Log:
root@bmc-oob:~# bic-util slot1 --get_post_code
util_get_postcode: returns 244 bytes
A7 A9 A9 A2 A2 A7 A7 A7 A9 A9 A8 AA AE E0 E0 E0
E1 E4 E3 E5 AF AF B0 B5 7E CF 7E 73 CD B0 7E C1
70 B1 B1 7E C2 7E 70 7E 7E B1 B1 B1 B6 7E B4 7E
B8 C5 B2 C6 B3 B3 B3 B3 B3 B3 B3 B6 B6 B6 B0 B7
B6 B6 7E 7E 7E B7 B7 B6 B6 B7 B7 7E 70 7E 70 70
B7 7E BE BE 7E 7E D2 7E D2 D6 70 B9 B7 B7 B7 B7
B7 B7 B7 B7 B8 B8 B8 B8 B8 B8 B8 B8 B8 D7 C9 DA
D9 DB BA B9 70 70 70 7E CB BB BB BB BB BB BB BB
BB BB BB 7E 7E D0 7E D0 7E D0 7E D1 7E D1 7E 70
7E B7 CA CA DC 7E CC BC BC BC BC BC CE C6 7E BF
AF AF AF E6 E7 E9 EB EC ED EE 02 22 50 00 04 06
0B 0C 0D 15 7F 00 7F 40 41 42 47 4F 61 68 70 79
91 92 94 94 94 94 94 94 94 94 94 94 94 94 94 94
94 94 95 96 EF 92 92 92 92 92 92 92 92 99 91 92
92 92 92 92 92 92 92 92 97 98 92 99 92 92 92 92
92 92 92 92
