### PR TITLE
fby3.5: cl: Modified class type read

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_def.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_def.h
@@ -1,0 +1,7 @@
+#ifndef PLAT_DEF_H
+#define PLAT_DEF_H
+
+#define sys_class_1 0
+#define sys_class_2 1
+
+#endif


### PR DESCRIPTION
Summary:
- According to hardware design, only BIC can read class type from board ID and BIC should write to CPLD register for UART configuration.

Test plan:
- Build code: Pass
- Check CPLD register: Pass

Log:
(Check CPLD register 0x5 bit 4 on class1 system)
root@bmc-oob:~# bic-util slot2 0x18 0x52 0x3 0x42 0x1 0x5
0C

(Check CPLD 0x5 bit 4 register on class2 system)
root@bmc-oob:~# bic-util slot2 0x18 0x52 0x3 0x42 0x1 0x5
18