### PR TITLE
fby3.5: cl: Modify ASDInit behavior

### DIFF
--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -1158,11 +1158,11 @@ void pal_OEM_1S_ASD_INIT(ipmi_msg *msg) {
   }
 
   if (msg->data[0] == 0x01) {
-    enable_asd_gpio_interrupt();
+    enable_PRDY_interrupt();
   } else if (msg->data[0] == 0xff) {
-    disable_asd_gpio_interrupt();
+    disable_PRDY_interrupt();
   } else {
-    disable_asd_gpio_interrupt();
+    disable_PRDY_interrupt();
     msg->completion_code = CC_INVALID_DATA_FIELD;
     return;
   }

--- a/meta-facebook/yv35-cl/src/main.c
+++ b/meta-facebook/yv35-cl/src/main.c
@@ -39,7 +39,7 @@ void main(void)
   util_init_I2C();
 
   set_sys_config();
-  disable_asd_gpio_interrupt();
+  disable_PRDY_interrupt();
   sensor_init();
   FRU_init();
   ipmi_init();

--- a/meta-facebook/yv35-cl/src/platform/hwmon.c
+++ b/meta-facebook/yv35-cl/src/platform/hwmon.c
@@ -133,16 +133,10 @@ void send_gpio_interrupt(uint8_t gpio_num)
   }
 }
 
-void enable_asd_gpio_interrupt() {
+void enable_PRDY_interrupt() {
   gpio_interrupt_conf(H_BMC_PRDY_BUF_N, GPIO_INT_EDGE_FALLING);
-  gpio_interrupt_conf(PWRGD_CPU_LVC3, GPIO_INT_EDGE_BOTH);
-  gpio_interrupt_conf(RST_PLTRST_BUF_N, GPIO_INT_EDGE_BOTH);
-  gpio_interrupt_conf(FM_DBP_PRESENT_N, GPIO_INT_EDGE_BOTH);
 }
 
-void disable_asd_gpio_interrupt() {
+void disable_PRDY_interrupt() {
   gpio_interrupt_conf(H_BMC_PRDY_BUF_N, GPIO_INT_DISABLE);
-  gpio_interrupt_conf(PWRGD_CPU_LVC3, GPIO_INT_DISABLE);
-  gpio_interrupt_conf(RST_PLTRST_BUF_N, GPIO_INT_DISABLE);
-  gpio_interrupt_conf(FM_DBP_PRESENT_N, GPIO_INT_DISABLE);
 }

--- a/meta-facebook/yv35-cl/src/platform/plat_func.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_func.h
@@ -19,6 +19,6 @@ bool get_DC_status();
 void set_post_status();
 bool get_post_status();
 void send_gpio_interrupt(uint8_t gpio_num);
-void enable_asd_gpio_interrupt();
-void disable_asd_gpio_interrupt();
+void enable_PRDY_interrupt();
+void disable_PRDY_interrupt();
 #endif


### PR DESCRIPTION
Summary:
- ASDInit command only enable/disable interrupt of H_BMC_PRDY_BUF_N.

Test plan:
- Build code: Pass
- Command test: Pass

Log:
```
// BIC console
uart:~$ md 7e780008 1
[7e780008] 00008006  // bit 26 is 0, interrupt of H_BMC_PRDY_BUF_N is disable.

// BMC console enable ASD
root@bmc-oob:~# bic-util slot1 0xe0 0x28 0x9c 0x9c 0x00 0x01
9C 9C 00

// BIC console
uart:~$ md 7e780008 1
[7e780008] 04008006  // bit 26 is 1, interrupt of H_BMC_PRDY_BUF_N is enable.

// BMC console disalbe ASD
root@bmc-oob:~# bic-util slot1 0xe0 0x28 0x9c 0x9c 0x00 0xff
9C 9C 00

// BIC console
uart:~$ md 7e780008 1
[7e780008] 00008006  // bit 26 is 0, interrupt of H_BMC_PRDY_BUF_N is disable.

```
