### PR TITLE
fby3.5: cl: Add 2 OEM Commands

### DIFF
--- a/common/host/kcs.h
+++ b/common/host/kcs.h
@@ -7,6 +7,19 @@
 
 #define DEBUG_KCS 0
 
+struct kcs_request {
+  uint8_t netfn;
+  uint8_t cmd;
+  uint8_t data[0];
+};
+
+struct kcs_response {
+  uint8_t netfn;
+  uint8_t cmd;
+  uint8_t cmplt_code;
+  uint8_t data[0];
+};
+
 void kcs_write(uint8_t *buf, uint32_t buf_sz);
 void kcs_init(void);
 

--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -82,7 +82,8 @@ void pal_OEM_1S_ACCURACY_SENSNR(ipmi_msg *msg);
 void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg);
 void pal_OEM_1S_SET_JTAG_TAP_STA(ipmi_msg *msg);
 void pal_OEM_1S_JTAG_DATA_SHIFT(ipmi_msg *msg);
-
+void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg);
+void pal_OEM_1S_RESET_BIC(ipmi_msg *msg);
 
 enum {
   CC_SUCCESS = 0x00,
@@ -201,6 +202,8 @@ enum {
   CMD_OEM_1S_ASD_INIT = 0x28,
   CMD_OEM_1S_PECIaccess = 0x29,
   CMD_OEM_1S_SENSOR_POLL_EN = 0x30,
+  CMD_OEM_1S_GET_BIC_STATUS = 0x31,
+  CMD_OEM_1S_RESET_BIC = 0x32,
   CMD_OEM_1S_GET_SET_GPIO = 0x41,
 // Debug command
   CMD_OEM_1S_I2C_DEV_SCAN = 0x60,

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include "cmsis_os2.h"
 #include "ipmi.h"
+#include "kcs.h"
 #include <string.h>
 #define IPMI_QUEUE_SIZE 5
 
@@ -168,6 +169,12 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 	case CMD_OEM_1S_I2C_DEV_SCAN: // debug command
 		pal_OEM_1S_I2C_DEV_SCAN(msg);
 		break;
+	case CMD_OEM_1S_GET_BIC_STATUS:
+		pal_OEM_1S_GET_BIC_STATUS(msg);
+		break;
+	case CMD_OEM_1S_RESET_BIC:
+		pal_OEM_1S_RESET_BIC(msg);
+		break;
 	default:
 		printf("invalid OEM msg netfn: %x, cmd: %x\n", msg->netfn, msg->cmd);
 		msg->data_len = 0;
@@ -181,6 +188,7 @@ ipmi_error IPMI_handler(void *arug0, void *arug1, void *arug2)
 {
 	uint8_t i;
   ipmi_msg_cfg msg_cfg;
+  uint8_t *kcs_buff;
 
   while(1) {
 
@@ -263,7 +271,34 @@ ipmi_error IPMI_handler(void *arug0, void *arug1, void *arug2)
       if (msg_cfg.buffer.InF_source == BMC_USB_IFs) {
         USB_write(&msg_cfg.buffer);
       } else if (msg_cfg.buffer.InF_source == HOST_KCS_IFs) {
-        ;
+        kcs_buff = malloc(KCS_buff_size * sizeof(uint8_t));
+		if ( kcs_buff == NULL ) { // allocate fail, retry allocate
+			k_msleep(10);
+			kcs_buff = malloc(KCS_buff_size * sizeof(uint8_t));
+			if ( kcs_buff == NULL ) {
+				printk("IPMI_handler: Fail to malloc for kcs_buff\n");
+				continue;
+			}
+		}
+		kcs_buff[0] = (msg_cfg.buffer.netfn + 1) << 2; // ipmi netfn response package
+		kcs_buff[1] = msg_cfg.buffer.cmd;
+		kcs_buff[2] = msg_cfg.buffer.completion_code;
+		if(msg_cfg.buffer.data_len) {
+			if ( msg_cfg.buffer.data_len <= (KCS_buff_size-3))
+				memcpy(&kcs_buff[3], msg_cfg.buffer.data, msg_cfg.buffer.data_len);
+			else
+				memcpy(&kcs_buff[3], msg_cfg.buffer.data, (KCS_buff_size-3));
+		}
+
+		if ( DEBUG_KCS ) {
+			printk("kcs from ipmi netfn %x, cmd %x, length %d, cc %x\n", kcs_buff[0], kcs_buff[1], msg_cfg.buffer.data_len, kcs_buff[2]);
+		}
+
+		kcs_write(kcs_buff, msg_cfg.buffer.data_len + 3);
+
+		if ( kcs_buff != NULL )
+			free(kcs_buff);
+		
       } else {
         status = ipmb_send_response(&msg_cfg.buffer, IPMB_inf_index_map[msg_cfg.buffer.InF_source]);
         if (status != ipmb_error_success) {

--- a/common/pal.c
+++ b/common/pal.c
@@ -215,6 +215,18 @@ __weak void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg)
 	return;
 }
 
+__weak void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg)
+{
+  msg->completion_code = CC_UNSPECIFIED_ERROR;
+  return;
+}
+
+__weak void pal_OEM_1S_RESET_BIC(ipmi_msg *msg)
+{
+  msg->completion_code = CC_UNSPECIFIED_ERROR;
+  return;
+}
+
 // init
 __weak void pal_I2C_init(void)
 {

--- a/common/pal.h
+++ b/common/pal.h
@@ -47,6 +47,8 @@ void pal_OEM_1S_ACCURACY_SENSNR(ipmi_msg *msg);
 void pal_OEM_1S_ASD_INIT(ipmi_msg *msg);
 void pal_OEM_1S_GET_SET_GPIO(ipmi_msg *msg);
 void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg);
+void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg);
+void pal_OEM_1S_RESET_BIC(ipmi_msg *msg);
 
 // init
 void pal_I2C_init(void);

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -73,16 +73,21 @@ bool add_sel_evt_record(addsel_msg_t *sel_msg) {
 }
 
 bool pal_is_to_ipmi_handler(uint8_t netfn, uint8_t cmd) {
-  if ( (netfn == NETFN_OEM_1S_REQ) && (cmd == CMD_OEM_1S_FW_UPDATE) ) {
-    return 1;
-  }
+  if (netfn == NETFN_OEM_1S_REQ) {
+    if (  (cmd == CMD_OEM_FW_UPDATE) ||
+          (cmd == CMD_OEM_1S_GET_BIC_STATUS) ||
+          (cmd == CMD_OEM_1S_RESET_BIC) )
+      return 1;
 
   return 0;
 }
 
 bool pal_ME_is_to_ipmi_handler(uint8_t netfn, uint8_t cmd) {
-  if ( (netfn == NETFN_OEM_REQ) && (cmd == CMD_OEM_SENSOR_READ) ) {
-    return 1;
+  if (netfn == NETFN_OEM_1S_REQ) {
+    if (  (cmd == CMD_OEM_1S_FW_UPDATE) ||
+          (cmd == CMD_OEM_1S_GET_BIC_STATUS) ||
+          (cmd == CMD_OEM_1S_RESET_BIC) )
+      return 1;
   }
 
   return 0;
@@ -1236,6 +1241,43 @@ void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg) {
     copy_snoop_read_buffer( offset, postcode_num, msg->data );
   }
   msg->data_len = postcode_num;
+  msg->completion_code = CC_SUCCESS;
+  return;
+}
+
+void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg) {
+  if (!msg){
+    printf("<error> pal_OEM_1S_GET_BIC_STATUS: parameter msg is NULL\n");
+    return;
+  }
+
+  if ( msg->data_len != 0 ){
+    msg->completion_code = CC_INVALID_LENGTH;
+    return;
+  }
+
+  msg->data[0] = FIRMWARE_REVISION_1;
+  msg->data[1] = FIRMWARE_REVISION_2;
+
+  msg->data_len = 2;
+  msg->completion_code = CC_SUCCESS;
+  return;
+}
+
+void pal_OEM_1S_RESET_BIC(ipmi_msg *msg) {
+  if (!msg){
+    printf("<error> pal_OEM_1S_RESET_BIC: parameter msg is NULL\n");
+    return;
+  }
+
+  if ( msg->data_len != 0 ){
+    msg->completion_code = CC_INVALID_LENGTH;
+    return;
+  }
+
+  submit_bic_warm_reset();
+
+  msg->data_len = 0;
   msg->completion_code = CC_SUCCESS;
   return;
 }


### PR DESCRIPTION
Summary:
- Add 2 commands BIC_STATUS(NetFn:0x38|Cmd:0x31) and RESET_BIC(NetFn:0x38|Cmd:0x32).
- Support for out-band and in-band.

Test plain:
- Build code: Pass
- Out-band command: Pass
- In-band command: Pass