### PR TITLE
fby3.5: cl: Add Two OEM Commands

### DIFF
--- a/common/host/kcs.c
+++ b/common/host/kcs.c
@@ -13,19 +13,6 @@ K_KERNEL_STACK_MEMBER(KCS_POLL_stack, KCS_POLL_stack_STACK_SIZE);
 
 static const struct device *kcs_dev;
 
-struct kcs_request {
-  uint8_t netfn;
-  uint8_t cmd;
-  uint8_t data[0];
-};
-
-struct kcs_response {
-  uint8_t netfn;
-  uint8_t cmd;
-  uint8_t cmplt_code;
-  uint8_t data[0];
-};
-
 int kcs_aspeed_read(const struct device *dev,
         uint8_t *buf, uint32_t buf_sz);
 
@@ -95,18 +82,6 @@ void kcs_read(void* arvg0, void* arvg1, void* arvg2)
         printf("KCS retrying put ipmi msgq\n");
       }
 
-      res = (struct kcs_response *)ibuf;
-      res->netfn = (current_msg.buffer.netfn + 1) << 2; // ipmi netfn response package
-      res->cmd = current_msg.buffer.cmd;
-      res->cmplt_code = current_msg.buffer.completion_code;
-      if (current_msg.buffer.data_len != 0) {
-        memcpy(res->data, current_msg.buffer.data, current_msg.buffer.data_len);
-      }
-      if ( DEBUG_KCS ) {
-        printk("kcs from ipmi netfn %x, cmd %x, length %d, cc %x\n", res->netfn, res->cmd, current_msg.buffer.data_len, res->cmplt_code);
-      }
-
-      kcs_write(ibuf, current_msg.buffer.data_len + 3);
     } else { // default command for BMC, should add BIC firmware update, BMC reset, real time sensor read in future
       bridge_msg.data_len = rc - 2; // exclude netfn, cmd
       bridge_msg.seq_source = 0xff; // No seq for KCS

--- a/common/host/kcs.h
+++ b/common/host/kcs.h
@@ -7,6 +7,19 @@
 
 #define DEBUG_KCS 0
 
+struct kcs_request {
+  uint8_t netfn;
+  uint8_t cmd;
+  uint8_t data[0];
+};
+
+struct kcs_response {
+  uint8_t netfn;
+  uint8_t cmd;
+  uint8_t cmplt_code;
+  uint8_t data[0];
+};
+
 void kcs_write(uint8_t *buf, uint32_t buf_sz);
 void kcs_init(void);
 

--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -82,7 +82,8 @@ void pal_OEM_1S_ACCURACY_SENSNR(ipmi_msg *msg);
 void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg);
 void pal_OEM_1S_SET_JTAG_TAP_STA(ipmi_msg *msg);
 void pal_OEM_1S_JTAG_DATA_SHIFT(ipmi_msg *msg);
-
+void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg);
+void pal_OEM_1S_RESET_BIC(ipmi_msg *msg);
 
 enum {
   CC_SUCCESS = 0x00,
@@ -201,6 +202,8 @@ enum {
   CMD_OEM_1S_ASD_INIT = 0x28,
   CMD_OEM_1S_PECIaccess = 0x29,
   CMD_OEM_1S_SENSOR_POLL_EN = 0x30,
+  CMD_OEM_1S_GET_BIC_STATUS = 0x31,
+  CMD_OEM_1S_RESET_BIC = 0x32,
   CMD_OEM_1S_GET_SET_GPIO = 0x41,
 // Debug command
   CMD_OEM_1S_I2C_DEV_SCAN = 0x60,

--- a/common/pal.c
+++ b/common/pal.c
@@ -215,6 +215,18 @@ __weak void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg)
 	return;
 }
 
+__weak void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_RESET_BIC(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
 // init
 __weak void pal_I2C_init(void)
 {

--- a/common/pal.h
+++ b/common/pal.h
@@ -47,6 +47,8 @@ void pal_OEM_1S_ACCURACY_SENSNR(ipmi_msg *msg);
 void pal_OEM_1S_ASD_INIT(ipmi_msg *msg);
 void pal_OEM_1S_GET_SET_GPIO(ipmi_msg *msg);
 void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg);
+void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg);
+void pal_OEM_1S_RESET_BIC(ipmi_msg *msg);
 
 // init
 void pal_I2C_init(void);

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -73,8 +73,11 @@ bool add_sel_evt_record(addsel_msg_t *sel_msg) {
 }
 
 bool pal_is_to_ipmi_handler(uint8_t netfn, uint8_t cmd) {
-  if ( (netfn == NETFN_OEM_1S_REQ) && (cmd == CMD_OEM_1S_FW_UPDATE) ) {
-    return 1;
+  if (netfn == NETFN_OEM_1S_REQ) {
+    if (  (cmd == CMD_OEM_1S_FW_UPDATE) ||
+          (cmd == CMD_OEM_1S_GET_BIC_STATUS) ||
+          (cmd == CMD_OEM_1S_RESET_BIC) )
+      return 1;
   }
 
   return 0;
@@ -1236,6 +1239,43 @@ void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg) {
     copy_snoop_read_buffer( offset, postcode_num, msg->data );
   }
   msg->data_len = postcode_num;
+  msg->completion_code = CC_SUCCESS;
+  return;
+}
+
+void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg) {
+  if (!msg){
+    printf("<error> pal_OEM_1S_GET_BIC_STATUS: parameter msg is NULL\n");
+    return;
+  }
+
+  if ( msg->data_len != 0 ){
+    msg->completion_code = CC_INVALID_LENGTH;
+    return;
+  }
+
+  msg->data[0] = FIRMWARE_REVISION_1;
+  msg->data[1] = FIRMWARE_REVISION_2;
+
+  msg->data_len = 2;
+  msg->completion_code = CC_SUCCESS;
+  return;
+}
+
+void pal_OEM_1S_RESET_BIC(ipmi_msg *msg) {
+  if (!msg){
+    printf("<error> pal_OEM_1S_RESET_BIC: parameter msg is NULL\n");
+    return;
+  }
+
+  if ( msg->data_len != 0 ){
+    msg->completion_code = CC_INVALID_LENGTH;
+    return;
+  }
+
+  submit_bic_warm_reset();
+
+  msg->data_len = 0;
   msg->completion_code = CC_SUCCESS;
   return;
 }


### PR DESCRIPTION
Summary:
- Add two commands, BIC_STATUS(NetFn:0x38|Cmd:0x31) and RESET_BIC(NetFn:0x38|Cmd:0x32).
- Support for out-band and in-band.

Test plain:
- Build code: Pass
- Out-band command: Pass
- In-band command: Pass