### PR TITLE
fby3.5: cl: Added BMC reset and BIC cold reset

### DIFF
--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -50,6 +50,7 @@ void pal_SENSOR_GET_SENSOR_READING(ipmi_msg *msg);
 
 // IPMI APP
 void pal_APP_GET_DEVICE_ID(ipmi_msg *msg);
+void pal_APP_COLD_RESET(ipmi_msg *msg);
 void pal_APP_WARM_RESET(ipmi_msg *msg);
 void pal_APP_GET_SELFTEST_RESULTS(ipmi_msg *msg);
 void pal_APP_GET_SYSTEM_GUID(ipmi_msg *msg);
@@ -75,6 +76,7 @@ void pal_OEM_1S_SENSOR_POLL_EN(ipmi_msg *msg);
 void pal_OEM_1S_FW_UPDATE(ipmi_msg *msg);
 void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg);
 void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg);
+void pal_OEM_1S_RESET_BMC(ipmi_msg *msg);
 void pal_OEM_1S_PECIaccess(ipmi_msg *msg);
 void pal_OEM_1S_ASD_INIT(ipmi_msg *msg);
 void pal_OEM_1S_GET_SET_GPIO(ipmi_msg *msg);
@@ -196,6 +198,7 @@ enum {
   CMD_OEM_1S_FW_UPDATE = 0x9,
   CMD_OEM_1S_GET_FW_VERSION = 0xB,
   CMD_OEM_1S_GET_POST_CODE = 0x12,
+  CMD_OEM_1S_RESET_BMC = 0x16,
   CMD_OEM_1S_SET_JTAG_TAP_STA = 0x21,
   CMD_OEM_1S_JTAG_DATA_SHIFT = 0x22,
   CMD_OEM_1S_ACCURACY_SENSNR = 0x23,

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -53,6 +53,7 @@ void IPMI_APP_handler(ipmi_msg *msg)
 		pal_APP_GET_DEVICE_ID(msg);
 		break;
 	case CMD_APP_COLD_RESET:
+    pal_APP_COLD_RESET(msg);
 		break;
 	case CMD_APP_WARM_RESET:
 		pal_APP_WARM_RESET(msg);
@@ -147,6 +148,9 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
     break;
   case CMD_OEM_1S_GET_POST_CODE:
     pal_OEM_1S_GET_POST_CODE(msg);
+    break;
+  case CMD_OEM_1S_RESET_BMC:
+    pal_OEM_1S_RESET_BMC(msg);
     break;
 	case CMD_OEM_1S_SET_JTAG_TAP_STA:
 		pal_OEM_1S_SET_JTAG_TAP_STA(msg);

--- a/common/pal.c
+++ b/common/pal.c
@@ -56,6 +56,12 @@ __weak void pal_APP_GET_DEVICE_ID(ipmi_msg *msg)
 	return;
 }
 
+__weak void pal_APP_COLD_RESET(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
 __weak void pal_APP_WARM_RESET(ipmi_msg *msg)
 {
 	msg->completion_code = CC_UNSPECIFIED_ERROR;
@@ -171,6 +177,12 @@ __weak void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 {
 	msg->completion_code = CC_UNSPECIFIED_ERROR;
 	return;
+}
+
+__weak void pal_OEM_1S_RESET_BMC(ipmi_msg *msg)
+{
+  msg->completion_code = CC_UNSPECIFIED_ERROR;
+  return;
 }
 
 __weak void pal_OEM_1S_SET_JTAG_TAP_STA(ipmi_msg *msg)

--- a/common/pal.h
+++ b/common/pal.h
@@ -19,6 +19,7 @@ void pal_SENSOR_GET_SENSOR_READING(ipmi_msg *msg);
 
 // IPMI APP
 void pal_APP_GET_DEVICE_ID(ipmi_msg *msg);
+void pal_APP_COLD_RESET(ipmi_msg *msg);
 void pal_APP_WARM_RESET(ipmi_msg *msg);
 void pal_APP_GET_SELFTEST_RESULTS(ipmi_msg *msg);
 void pal_APP_GET_SYSTEM_GUID(ipmi_msg *msg);
@@ -42,6 +43,7 @@ void pal_OEM_1S_SET_GPIO(ipmi_msg *msg);
 void pal_OEM_1S_SENSOR_POLL_EN(ipmi_msg *msg);
 void pal_OEM_1S_FW_UPDATE(ipmi_msg *msg);
 void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg);
+void pal_OEM_1S_RESET_BMC(ipmi_msg *msg);
 void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg);
 void pal_OEM_1S_ACCURACY_SENSNR(ipmi_msg *msg);
 void pal_OEM_1S_ASD_INIT(ipmi_msg *msg);

--- a/common/util/util_sys.c
+++ b/common/util/util_sys.c
@@ -29,7 +29,7 @@ bool get_boot_source_ACon() {
 
 void bic_warm_reset() {
   k_msleep(bic_warm_reset_delay);
-  sys_reboot(0); // arvg unused
+  sys_reboot(SYS_REBOOT_WARM);
 }
 
 K_WORK_DEFINE(bic_warm_reset_work, bic_warm_reset);
@@ -37,3 +37,17 @@ void submit_bic_warm_reset() {
   k_work_submit(&bic_warm_reset_work);
 }
 /* bic warm reset work */
+
+/* bic cold reset work */
+#define bic_cold_reset_delay 100
+
+void bic_cold_reset() {
+  k_msleep(bic_cold_reset_delay);
+  sys_reboot(SYS_REBOOT_COLD);
+}
+
+K_WORK_DEFINE(bic_cold_reset_work, bic_cold_reset);
+void submit_bic_cold_reset() {
+  k_work_submit(&bic_cold_reset_work);
+}
+/* bic cold reset work */

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -77,6 +77,7 @@ bool add_sel_evt_record(addsel_msg_t *sel_msg) {
 bool pal_is_to_ipmi_handler(uint8_t netfn, uint8_t cmd) {
   if (netfn == NETFN_OEM_1S_REQ) {
     if (  (cmd == CMD_OEM_1S_FW_UPDATE) ||
+          (cmd == CMD_OEM_1S_RESET_BMC) ||
           (cmd == CMD_OEM_1S_GET_BIC_STATUS) ||
           (cmd == CMD_OEM_1S_RESET_BIC) )
       return 1;
@@ -195,6 +196,19 @@ void pal_APP_GET_DEVICE_ID(ipmi_msg *msg)
   msg->completion_code = CC_SUCCESS;
 
 	return;
+}
+
+void pal_APP_COLD_RESET(ipmi_msg *msg)
+{
+  if (msg->data_len != 0) {
+    msg->completion_code = CC_INVALID_LENGTH;
+    return;
+  }
+
+  submit_bic_cold_reset();
+
+  msg->completion_code = CC_SUCCESS;
+  return;
 }
 
 void pal_APP_WARM_RESET(ipmi_msg *msg)
@@ -1247,6 +1261,20 @@ void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg) {
     }
     copy_snoop_read_buffer( offset, postcode_num, msg->data );
   }
+  msg->data_len = postcode_num;
+  msg->completion_code = CC_SUCCESS;
+  return;
+}
+
+void pal_OEM_1S_RESET_BMC(ipmi_msg *msg) {
+  int postcode_num = snoop_read_num;
+  if ( msg->data_len != 0 ){
+    msg->completion_code = CC_INVALID_LENGTH;
+    return;
+  }
+
+  submit_bmc_warm_reset();
+
   msg->data_len = postcode_num;
   msg->completion_code = CC_SUCCESS;
   return;

--- a/meta-facebook/yv35-cl/src/platform/platform.c
+++ b/meta-facebook/yv35-cl/src/platform/platform.c
@@ -1,0 +1,16 @@
+#include <zephyr.h>
+#include "plat_gpio.h"
+
+
+/* BMC reset */
+void BMC_reset_handler() {
+  gpio_set(RST_BMC_R_N, GPIO_LOW);
+  k_msleep(10);
+  gpio_set(RST_BMC_R_N, GPIO_HIGH);
+}
+
+K_DELAYED_WORK_DEFINE(BMC_reset_work, BMC_reset_handler);
+void submit_bmc_warm_reset() {
+  k_work_schedule(&BMC_reset_work, K_MSEC(1000));
+}
+/* BMC reset */


### PR DESCRIPTION
Summary:
- Added BMC reset function to allow host recovery BMC.
- Added IPMB standard cold reset command.

Test plain:
- Build code: Pass
- Command test: Pass

Log:
reset bmc:
[root@Stream8_211112 ~]# ipmitool raw 0x38 0x16 0x9c 0x9c 0x0
 9c 9c 00
(Checked BMC reset from BMC console)

bic cold reset:
root@bmc-oob:~# bic-util slot4 0x18 0x3

root@bmc-oob:~#
(Checked BIC reset from BIC console)