### PR TITLE
fby3.5: cl:Add OEM set system guid command

### DIFF
--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -857,14 +857,18 @@ void pal_OEM_1S_PECIaccess(ipmi_msg *msg) {
   return;
 }
 
-void pal_OEM_1S_SET_SYSTEM_GUID(ipmi_msg *msg) {
-  uint8_t status;
-  EEPROM_ENTRY guid_entry;
-
+void pal_OEM_SET_SYSTEM_GUID(ipmi_msg *msg) {
+  if (!msg){
+    printf("pal_OEM_SET_SYSTEM_GUID: parameter msg is NULL\n");
+    return;
+  }
   if (msg->data_len != 16) {
     msg->completion_code = CC_INVALID_LENGTH;
     return;
   }
+
+  uint8_t status;
+  EEPROM_ENTRY guid_entry;
 
   guid_entry.offset = 0;
   guid_entry.data_len = msg->data_len;
@@ -889,6 +893,8 @@ void pal_OEM_1S_SET_SYSTEM_GUID(ipmi_msg *msg) {
       msg->completion_code = CC_UNSPECIFIED_ERROR;
       break;
   }
+  
+  msg->data_len = 0;
   return;
 }
 


### PR DESCRIPTION
Summary:
- Add OEM set system guid command(NetFn 0x30, Command 0xEF).

Test Plan:
- Build Code: Pass
- Command Test: Pass

Log:
```
root@bmc-oob:~# guid-util slot1 sys --set TWA1814500183
root@bmc-oob:~# guid-util slot1 sys --get
0xC2:0x90:0x0D:0x00:0x48:0x1A:0xDD:0x11:0x4D:0xFE:0x41:0x18:0x14:0x50:0x01:0x83
```
