### PR TITLE
fby3.5: cl:Add OEM sensor poll enable command

### DIFF
--- a/common/sensor/sensor.c
+++ b/common/sensor/sensor.c
@@ -13,6 +13,7 @@ uint8_t SnrNum_SnrCfg_map[SENSOR_NUM_MAX];
 uint8_t SnrNum_SDR_map[SENSOR_NUM_MAX];
 
 bool enable_sensor_poll = 1;
+static bool snr_poll_eanble_flag = 1;
 
 const int negative_ten_power[16] = {1,1,1,1,1,1,1,1000000000,100000000,10000000,1000000,100000,10000,1000,100,10};
 
@@ -145,6 +146,14 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode) 
   return SNR_UNSPECIFIED_ERROR; // should not reach here
 }
 
+void disable_snr_poll() {
+  snr_poll_eanble_flag = 0;
+}
+
+void enable_snr_poll() {
+  snr_poll_eanble_flag = 1;
+}
+
 void SNR_poll_handler(void *arug0, void *arug1, void *arug2) {
   uint8_t poll_num;
   int reading, SNR_POLL_INTERVEL_ms;
@@ -154,6 +163,9 @@ void SNR_poll_handler(void *arug0, void *arug1, void *arug2) {
 
   while(1) {
     for (poll_num = 0; poll_num < SENSOR_NUM_MAX; poll_num++) {
+      if (snr_poll_eanble_flag == 0) { /* skip if disable sesnor poll */
+        continue;
+      }
       if (SnrNum_SnrCfg_map[poll_num] == sensor_null) { // sensor not exist
         continue;
       }

--- a/common/sensor/sensor.c
+++ b/common/sensor/sensor.c
@@ -164,7 +164,7 @@ void SNR_poll_handler(void *arug0, void *arug1, void *arug2) {
   while(1) {
     for (poll_num = 0; poll_num < SENSOR_NUM_MAX; poll_num++) {
       if (snr_poll_eanble_flag == 0) { /* skip if disable sesnor poll */
-        continue;
+        break;
       }
       if (SnrNum_SnrCfg_map[poll_num] == sensor_null) { // sensor not exist
         continue;

--- a/common/sensor/sensor.h
+++ b/common/sensor/sensor.h
@@ -70,5 +70,7 @@ extern uint8_t SnrNum_SnrCfg_map[SENSOR_NUM_MAX];
 
 uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode);
 bool sensor_init(void);
+void disable_snr_poll();
+void enable_snr_poll();
 
 #endif

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -1289,3 +1289,27 @@ void pal_OEM_1S_RESET_BIC(ipmi_msg *msg) {
   msg->completion_code = CC_SUCCESS;
   return;
 }
+
+void pal_OEM_1S_SENSOR_POLL_EN(ipmi_msg *msg) {
+  if (!msg){
+    printf("pal_OEM_1S_SENSOR_POLL_EN: parameter msg is NULL\n");
+    return;
+  }
+  if (msg->data_len != 1) {
+    msg->completion_code = CC_INVALID_LENGTH;
+    return;
+  }
+
+  if (msg->data[0] == 0) {  /* enable sensor poll */
+    enable_snr_poll();
+  } else if (msg->data[0] == 1) {  /* disable sensor poll */
+    disable_snr_poll();
+  } else {
+    msg->completion_code = CC_INVALID_DATA_FIELD;
+    return;
+  }
+
+  msg->data_len = 0;
+  msg->completion_code = CC_SUCCESS;
+  return;
+}


### PR DESCRIPTION
Summary:
- Add OEM sensor poll enable command.

Test Plan:
- Build Code: Pass
- Command Test: Pass

Log:
```
root@bmc-oob:~# bic-util slot1 0xe0 0x30 0x9c 0x9c 0x00 1
9C 9C 00
root@bmc-oob:~# bic-util slot1 0xe0 0x30 0x9c 0x9c 0x00 0
9C 9C 00
```
