### PR TITLE
fby3.5: cl:Fixed SSD reading function

### DIFF
--- a/meta-facebook/yv35-cl/src/sensor/plat_sensor.c
+++ b/meta-facebook/yv35-cl/src/sensor/plat_sensor.c
@@ -23,7 +23,7 @@ snr_cfg plat_sensor_config[] = {
   {SENSOR_NUM_TEMP_TMP75_FIO         , type_tmp75     , i2c_bus2      , tmp75_fio_addr          , tmp75_tmp_offset  , stby_access      , 0     , 0     , 0      , SNR_INIT_STATUS},
 
   // NVME
-  {SENSOR_NUM_TEMP_SSD0              , type_nvme      , i2c_bus2      , SSD0_addr               , SSD0_offset       , DC_access        , 0     , 0     , 0      , SNR_INIT_STATUS},
+  {SENSOR_NUM_TEMP_SSD0              , type_nvme      , i2c_bus2      , SSD0_addr               , SSD0_offset       , post_access      , 0     , 0     , 0      , SNR_INIT_STATUS},
                                                                                                                                                                  
   // PECI                                                                                                                                                        
   {SENSOR_NUM_TEMP_CPU               , type_peci      , NULL          , CPU_PECI_addr           , NULL              , post_access      , 0     , 0     , 0      , SNR_INIT_STATUS},


### PR DESCRIPTION
Summary:
- Added SSD drive ready check, if drive is not ready, SSD return temperature is invalid.

Design:
- According to Hynix PC711 specification , drive is not ready means subsystem can't process NVMe commands yet and the transmission may be invalid.
- Retry three rounds to check if drive is not ready. If drive not ready keep more than 3 rounds continuously, BIC would set SSD status to abnormal and return SSD temperature NA to BMC.

Test Plan:
- Build code: Pass
