### PR TITLE
fby3.5: bb: Enable IPMB and fix memory leak

### DIFF
--- a/common/ipmi/ipmb.c
+++ b/common/ipmi/ipmb.c
@@ -48,14 +48,14 @@ ipmb_error ipmb_notify_client(ipmi_msg_cfg *msg_cfg);
 
 void Queue_timeout_handler(uint32_t arug0, uint32_t arug1);
 
-uint8_t IPMB_inf_index_map[MAX_IPMB_IDX + 1]; // map IPMB source/target interface to bus
+uint8_t IPMB_inf_index_map[Reserve_IFs]; // map IPMB source/target interface to bus
 
 // map IPMB interface to index
 void map_inf_index(void)
 {
   uint8_t inf, index_num;
 
-  memset(IPMB_inf_index_map, MAX_IPMB_IDX, sizeof(IPMB_inf_index_map));
+  memset(IPMB_inf_index_map, Reserve_IFs, sizeof(IPMB_inf_index_map));
   for (inf = 0x01; inf != Reserve_IFs; inf++) { // interface 0x0 reserved for BIC itself
   	for (index_num = 0; index_num < MAX_IPMB_IDX; index_num++) {
   		if (IPMB_config_table[index_num].Inf_source == inf) {

--- a/meta-facebook/yv35-bb/src/platform/hwmon.c
+++ b/meta-facebook/yv35-bb/src/platform/hwmon.c
@@ -1,2 +1,29 @@
+#include <stdint.h>
 #include "plat_func.h"
 #include "plat_gpio.h"
+
+void ISR_PWROK_SLOT1() {
+  set_BIC_slot_isolator(PWROK_STBY_BIC_SLOT1_R, FM_BIC_SLOT1_ISOLATED_EN_R);
+}
+
+void ISR_PWROK_SLOT3() {
+  set_BIC_slot_isolator(PWROK_STBY_BIC_SLOT3_R, FM_BIC_SLOT3_ISOLATED_EN_R);
+}
+
+
+void set_BIC_slot_isolator(uint8_t pwr_state_gpio_num, uint8_t isolator_gpio_num) {
+  int ret = 0;
+  uint8_t slot_pwr_status = GPIO_LOW;
+
+  slot_pwr_status = gpio_get(pwr_state_gpio_num);
+  
+  if (slot_pwr_status == GPIO_HIGH) {
+    ret = gpio_set(isolator_gpio_num, GPIO_HIGH);
+  } else if (slot_pwr_status == GPIO_LOW) {
+    ret = gpio_set(isolator_gpio_num, GPIO_LOW);
+  }
+
+  if (ret < 0) {
+    printk("failed to set slot isolator due to set gpio %d is failed\n", isolator_gpio_num);
+  }
+}

--- a/meta-facebook/yv35-bb/src/platform/plat_func.h
+++ b/meta-facebook/yv35-bb/src/platform/plat_func.h
@@ -3,4 +3,9 @@
 #include <stdbool.h>
 
 
+void ISR_PWROK_SLOT1();
+void ISR_PWROK_SLOT3();
+
+void set_BIC_slot_isolator(uint8_t pwr_state_gpio_num, uint8_t isolator_gpio_num);
+
 #endif

--- a/meta-facebook/yv35-bb/src/platform/plat_gpio.c
+++ b/meta-facebook/yv35-bb/src/platform/plat_gpio.c
@@ -18,7 +18,7 @@ GPIO_CFG plat_gpio_cfg[] = {
 //  Defalut              DISABLE  DISABLE    GPIO_INPUT    LOW         PUSH_PULL    GPIO_INT_DISABLE       NULL
   { chip_gpio,  0,       ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              }, // GPIO A group
   { chip_gpio,  1,       ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
-  { chip_gpio,  2,       ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_LOW,   PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
+  { chip_gpio,  2,       ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_LOW,   PUSH_PULL,   GPIO_INT_EDGE_BOTH,    ISR_PWROK_SLOT1   },
   { chip_gpio,  3,       ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
   { chip_gpio,  4,       ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
   { chip_gpio,  5,       ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
@@ -29,7 +29,7 @@ GPIO_CFG plat_gpio_cfg[] = {
   { chip_gpio,  10,      ENABLE,  DISABLE,   GPIO_OUTPUT,  GPIO_LOW,   PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
   { chip_gpio,  11,      ENABLE,  DISABLE,   GPIO_OUTPUT,  GPIO_LOW,   PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
   { chip_gpio,  12,      ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
-  { chip_gpio,  13,      ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_LOW,   PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
+  { chip_gpio,  13,      ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_LOW,   PUSH_PULL,   GPIO_INT_EDGE_BOTH,    ISR_PWROK_SLOT3   },
   { chip_gpio,  14,      ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_LOW,   PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
   { chip_gpio,  15,      ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
   { chip_gpio,  16,      ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              }, // GPIO C group


### PR DESCRIPTION
Summary:
- Enable IPMB between BB BIC and SB BIC.
- Increase IPMB interface map size.
- Fixed OEM bridging command memory leak in the case that BIC fail to access bridging target.

Test plan:
- Build code: Pass
- No unexpected log: Pass
- Enable IPMB: Pass
- Forced bridging fail without memory leak: Pass

Log:
- BB BIC Slot1
[BB BIC console]
1. Check isolator is disabled when slot is 12V-off.
* 12V-off slot
* Check slot power is off
uart:~$ gpio get GPIO0_A_D 2
Reading GPIO0_A_D pin 2
Value 0
* Check isolator is disabled
uart:~$ gpio get GPIO0_A_D 10
Reading GPIO0_A_D pin 10
Value 0

2. Check isolator is disabled when slot is missing.
* Plug out slot
* Check slot is missing
uart:~$ gpio get GPIO0_A_D 15
Reading GPIO0_A_D pin 15
Value 1
* Check isolator is disabled
uart:~$ gpio get GPIO0_A_D 10
Reading GPIO0_A_D pin 10
Value 0

3. Check can scan SB BIC.
uart:~$ i2c scan I2C_6
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: 20 -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: -- -- -- -- -- -- -- --
1 devices found on I2C_6

[SB BIC console]
4. Check can scan BB BIC.
uart:~$ i2c scan I2C_7
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: 20 -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: -- -- -- -- -- -- -- --
1 devices found on I2C_7

[BMC console]
5. Check can send bridge command.
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x9c 0x9c 0x0 0x05 0x18 0x01
9C 9C 00 05 07 01 00 00 80 01 01 02 BF 9C 9C 00
00 00 00 00 00 00

- BB BIC Slot3
[BB BIC console]
1. Check isolator is disabled when slot is 12V-off.
* 12V-off slot
* Check slot power is off
uart:~$ gpio get GPIO0_A_D 13
Reading GPIO0_A_D pin 13
Value 0
* Check isolator is disabled
uart:~$ gpio get GPIO0_A_D 11
Reading GPIO0_A_D pin 11
Value 0

2. Check isolator is disabled when slot is missing.
* Plug out slot
* Check slot is missing
uart:~$ gpio get GPIO0_A_D 3
Reading GPIO0_A_D pin 3
Value 1
* Check isolator is disabled
uart:~$ gpio get GPIO0_A_D 11
Reading GPIO0_A_D pin 11
Value 0

3. Check can scan SB BIC.
uart:~$ i2c scan I2C_7
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: 20 -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: -- -- -- -- -- -- -- --
1 devices found on I2C_7

[SB BIC console]
4. Check can scan BB BIC.
uart:~$ i2c scan I2C_7
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: 20 -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: -- -- -- -- -- -- -- --
1 devices found on I2C_7

[BMC console]
5. Check can send bridge command.
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x0 0x5 0x18 0x1
9C 9C 00 05 07 01 00 00 80 01 01 02 BF 9C 9C 00
00 00 00 00 00 00