### PR TITLE
fby3.5: bb: Support sled cycle button

### DIFF
--- a/meta-facebook/yv35-bb/src/platform/hwmon.c
+++ b/meta-facebook/yv35-bb/src/platform/hwmon.c
@@ -1,2 +1,42 @@
 #include "plat_func.h"
 #include "plat_gpio.h"
+#include "plat_i2c.h"
+
+
+struct k_delayed_work sled_cycle_work;
+
+K_DELAYED_WORK_DEFINE(sled_cycle_work, sled_cycle_work_handler);
+
+void ISR_sled_cycle() {
+  uint8_t bb_btn_status = GPIO_HIGH;
+
+  bb_btn_status = gpio_get(BB_BUTTON_BMC_BIC_N_R);
+  // press sled cycle button
+  if (bb_btn_status == GPIO_LOW) {
+    k_delayed_work_submit(&sled_cycle_work, K_SECONDS(MAX_PRESS_SLED_BTN_TIME_s));
+
+  // release sled cycle button
+  } else if (bb_btn_status == GPIO_HIGH) {
+    k_delayed_work_cancel(&sled_cycle_work);
+  }
+}
+
+
+void sled_cycle_work_handler(struct k_work *item) {
+  set_sled_cycle();
+}
+
+void set_sled_cycle() {
+  uint8_t retry = 5;
+  I2C_MSG msg;
+
+  msg.bus = CPLD_IO_I2C_BUS;
+  msg.slave_addr = CPLD_IO_I2C_ADDR;
+  msg.tx_len = 2;
+  msg.data[0] = CPLD_IO_REG_OFS_SLED_CYCLE; // offset
+  msg.data[1] = 0x01; // value
+
+  if (i2c_master_write(&msg, retry) < 0) {
+    printk("sled cycle fail\n");
+  }
+}

--- a/meta-facebook/yv35-bb/src/platform/plat_func.h
+++ b/meta-facebook/yv35-bb/src/platform/plat_func.h
@@ -1,6 +1,14 @@
 #ifndef PLAT_FUNC_H
 #define PLAT_FUNC_H
 #include <stdbool.h>
+#include <kernel.h>
 
+#define MAX_PRESS_SLED_BTN_TIME_s 4
+
+void ISR_sled_cycle();
+
+void sled_cycle_work_handler(struct k_work *item);
+
+void set_sled_cycle();
 
 #endif

--- a/meta-facebook/yv35-bb/src/platform/plat_gpio.c
+++ b/meta-facebook/yv35-bb/src/platform/plat_gpio.c
@@ -38,7 +38,7 @@ GPIO_CFG plat_gpio_cfg[] = {
   { chip_gpio,  19,      ENABLE,  DISABLE,   GPIO_OUTPUT,  GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
   { chip_gpio,  20,      ENABLE,  DISABLE,   GPIO_OUTPUT,  GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
   { chip_gpio,  21,      ENABLE,  DISABLE,   GPIO_OUTPUT,  GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
-  { chip_gpio,  22,      ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_HIGH,  OPEN_DRAIN,  GPIO_INT_DISABLE,      NULL              },
+  { chip_gpio,  22,      ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_LOW,   PUSH_PULL,   GPIO_INT_EDGE_BOTH,    ISR_sled_cycle    },
   { chip_gpio,  23,      ENABLE,  DISABLE,   GPIO_OUTPUT,  GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },
   { chip_gpio,  24,      ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_LOW,   PUSH_PULL,   GPIO_INT_DISABLE,      NULL              }, // GPIO D group
   { chip_gpio,  25,      ENABLE,  DISABLE,   GPIO_INPUT,   GPIO_HIGH,  PUSH_PULL,   GPIO_INT_DISABLE,      NULL              },

--- a/meta-facebook/yv35-bb/src/platform/plat_i2c.h
+++ b/meta-facebook/yv35-bb/src/platform/plat_i2c.h
@@ -18,4 +18,8 @@
 
 #define I2C_BUS_NUM 10
 
+#define CPLD_IO_I2C_BUS   i2c_bus1
+#define CPLD_IO_I2C_ADDR  (0x1E >> 1)
+#define CPLD_IO_REG_OFS_SLED_CYCLE 0x2B
+
 #endif


### PR DESCRIPTION
Summary:
- When pressing the baseboard button for more than 4 seconds will sled cycle system.
- When pressing the debug card PWR button for more than 4 seconds will sled cycle system.

Test plan:
- Build code: Pass
- No unexpected log: Pass
- Baseboard button: Pass
- Debug card PWR button: Pass

Log:
- Pressing the baseboard button
uart:~$ ?)I00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x81] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x82] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspeed: pre-selected ep[0x1] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspeed*** Booting Zephyr OS build v00.01.03-18-g67d81d89470e  ***
Hello, welcome to yv35 baseboard POC 1
ipmi_init
: pre-selected ep[0x2] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint
[00:00:00.103,000] <inf> usb_cdc_acm: Device suspended

- Pressing the debug card PWR button
uart:~$ ?)I00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x81] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x82] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspeed: pre-selected ep[0x1] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspeed*** Booting Zephyr OS build v00.01.03-18-g67d81d89470e  ***
Hello, welcome to yv35 baseboard POC 1
ipmi_init
: pre-selected ep[0x2] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint
[00:00:00.103,000] <inf> usb_cdc_acm: Device suspended