### PR TITLE
fby3.5: cl:Fixed EHV VR current reading

### DIFF
--- a/meta-facebook/yv35-cl/src/sensor/dev/vr.c
+++ b/meta-facebook/yv35-cl/src/sensor/dev/vr.c
@@ -45,8 +45,8 @@ bool pal_vr_read(uint8_t sensor_num, int *reading) {
       // current
       } else if ( (sensor_num == SENSOR_NUM_CUR_PVCCD_HV) || (sensor_num == SENSOR_NUM_CUR_PVCCINFAON) || (sensor_num == SENSOR_NUM_CUR_PVCCFA_EHV)
             || (sensor_num == SENSOR_NUM_CUR_PVCCIN) || (sensor_num == SENSOR_NUM_CUR_PVCCFA_EHV_FIVRA) ) {
-        val = (((msg.data[1] << 8) | msg.data[0]) / 10);
-        *reading = (acur_cal_MBR(sensor_num,val)) & 0xffff;
+        val = ((msg.data[1] << 8) | msg.data[0]);
+        *reading = (acur_cal_MBR(sensor_num,val) / 10) & 0xffff;
 
       // temperature
       } else if ( (sensor_num == SENSOR_NUM_TEMP_PVCCD_HV) || (sensor_num == SENSOR_NUM_TEMP_PVCCINFAON) || (sensor_num == SENSOR_NUM_TEMP_PVCCFA_EHV)


### PR DESCRIPTION
Summary:
- Fixed the calculation of current reading value to avoid little current missing.

Test Plan:
- Build code: Pass

Log:
EHV VR Cur                   (0x33) :    0.82 Amps  | (ok) | UCR: 18.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA