### PR TITLE
fby3.5: bb: Support get f/w version

### DIFF
--- a/meta-facebook/yv35-bb/src/ipmi/include/ipmi_def.h
+++ b/meta-facebook/yv35-bb/src/ipmi/include/ipmi_def.h
@@ -10,6 +10,14 @@
 #define PRODUCT_ID                 0x0000
 #define AUXILIARY_FW_REVISION      0x00000000
 
+#define BIC_FW_YEAR_MSB   0x20
+#define BIC_FW_YEAR_LSB   0x22
+#define BIC_FW_WEEK       0x01
+#define BIC_FW_VER        0x01
+#define BIC_FW_platform_0 0x62 // char: b
+#define BIC_FW_platform_1 0x62 // char: b
+#define BIC_FW_platform_2 0x00 // char: '\0'
+
 // firmware update interface
 #define BIC_UPDATE  0x02
 #define UPDATE_EN   0x80

--- a/meta-facebook/yv35-bb/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/yv35-bb/src/ipmi/include/plat_ipmi.h
@@ -4,4 +4,9 @@
 #include "ipmi.h"
 #include "plat_ipmb.h"
 
+enum {
+  CPNT_CPLD = 1,
+  CPNT_BIC,
+};
+
 #endif

--- a/meta-facebook/yv35-bb/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-bb/src/ipmi/plat_ipmi.c
@@ -509,3 +509,32 @@ void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg) {
   msg->completion_code = CC_SUCCESS;
   return;
 }
+
+void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg) {
+  if (msg->data_len != 1) {
+    msg->completion_code = CC_INVALID_LENGTH;
+    return;
+  }
+
+  uint8_t component = 0;
+
+  component = msg->data[0];
+  switch (component) {
+    case CPNT_CPLD:
+      msg->completion_code = CC_UNSPECIFIED_ERROR;
+      break;
+    case CPNT_BIC:
+      msg->data[0] = BIC_FW_YEAR_MSB;
+      msg->data[1] = BIC_FW_YEAR_LSB;
+      msg->data[2] = BIC_FW_WEEK;
+      msg->data[3] = BIC_FW_VER;
+      msg->data[4] = BIC_FW_platform_0;
+      msg->data[5] = BIC_FW_platform_1;
+      msg->data[6] = BIC_FW_platform_2;
+      msg->data_len = 7;
+      msg->completion_code = CC_SUCCESS;
+      break;
+    default:
+      msg->completion_code = CC_UNSPECIFIED_ERROR;
+  }
+}

--- a/meta-facebook/yv35-bb/src/main.c
+++ b/meta-facebook/yv35-bb/src/main.c
@@ -26,7 +26,7 @@ void set_sys_status() {
 void main(void)
 {
   uint8_t proj_stage = (FIRMWARE_REVISION_1 & 0xf0) >> 4;
-  printk("Hello, welcome to yv35 baseboard POC %d\n", FIRMWARE_REVISION_2);
+  printk("Hello, welcome to yv35 baseboard %x%x.%x.%x\n", BIC_FW_YEAR_MSB, BIC_FW_YEAR_LSB, BIC_FW_WEEK, BIC_FW_VER);
 
   util_init_timer();
   util_init_I2C();


### PR DESCRIPTION
Summary:
- Support to get f/w version and its format is year/week/version/platform name.
- Modify booting message about BB BIC version information.

Test plan:
- Build code: Pass
- No unexpected log: Pass
- Get fw version: Pass

Log:
- Boot message
[BB BIC console]
?)I00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x81] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x82] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspeed: pre-selected ep[0x1] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspe*** Booting Zephyr OS build v00.01.03-18-g67d81d89470e  ***
Hello, welcome to yv35 baseboard 2022.1.1
ipmi_init
ed: pre-selected ep[0x2] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint
[00:00:00.103,000] <inf> usb_cdc_acm: Device suspended

- Slot1
[BMC console]
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x9c 0x9c 0x00 0x10 0xe0 0x0b 0x9c 0x9c 0x00 0x02
9C 9C 00 10 39 0B 00 9C 9C 00 20 22 01 01 62 62 00

- Slot3
[BMC console]
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x9c 0x9c 0x00 0x10 0xe0 0x0b 0x9c 0x9c 0x00 0x02
9C 9C 00 05 39 0B 00 9C 9C 00 20 22 01 01 62 62 00