### PR TITLE
fby3.5: cl: Supported BB BIC IPMB and fixed IPMB interface

### DIFF
--- a/common/ipmi/include/ipmb.h
+++ b/common/ipmi/include/ipmb.h
@@ -70,6 +70,7 @@
 #define IPMB_MQUEUE_POLL_DELAY_ms 10
 #define IPMB_SEQ_TIMEOUT_ms 1000
 #define IPMB_SEQ_TIMEOUT_STACK_SIZE 500
+#define IPMB_RESERVE_IDX 0xFF
 
 #define Enable  1
 #define Disable 0
@@ -77,17 +78,18 @@
 #define IS_RESPONSE(msg) (msg.netfn & 0x01) 
 
 enum{
-  Self_IFs = 0x0,
-  ME_IPMB_IFs = 0x01,
-  BMC_IPMB_IFs = 0x02,
-  HOST_KCS_IFs = 0x03,
+  Self_IFs        = 0x0,
+  ME_IPMB_IFs     = 0x01,
+  BMC_IPMB_IFs    = 0x02,
+  HOST_KCS_IFs    = 0x03,
   SERVER_IPMB_IFs = 0x04,
-  EXP1_IPMB_IFs = 0x05,
-  EXP2_IPMB_IFs = 0x06,
-  SLOT1_BIC_IFs = 0x07,
-  SLOT3_BIC_IFs = 0x08,
+  EXP1_IPMB_IFs   = 0x05,
+  SLOT1_BIC_IFs   = 0x07,
+  SLOT3_BIC_IFs   = 0x08,
+  BB_IPMB_IFs     = 0x10,
+  EXP2_IPMB_IFs   = 0x15,
 
-  BMC_USB_IFs = 0x10,
+  BMC_USB_IFs     = 0x20,
   Reserve_IFs,
 };
 

--- a/common/ipmi/ipmb.c
+++ b/common/ipmi/ipmb.c
@@ -56,13 +56,13 @@ void map_inf_index(void)
   uint8_t inf, index_num;
 
   memset(IPMB_inf_index_map, Reserve_IFs, sizeof(IPMB_inf_index_map));
-  for (inf = 0x01; inf != Reserve_IFs; inf++) { // interface 0x0 reserved for BIC itself
-  	for (index_num = 0; index_num < MAX_IPMB_IDX; index_num++) {
-  		if (IPMB_config_table[index_num].Inf_source == inf) {
-  			IPMB_inf_index_map[inf] = index_num;
-  			break;
-  		}
-  	}
+  for(index_num = 0; IPMB_config_table[index_num].index != IPMB_RESERVE_IDX; index_num++) {
+    for(inf = 0; inf < Reserve_IFs; inf++) {
+      if (IPMB_config_table[index_num].Inf_source == inf) {
+        IPMB_inf_index_map[inf] = index_num;
+        break;
+      }
+    }
   }
 }
 

--- a/meta-facebook/yv35-cl/src/ipmi/include/plat_ipmb.h
+++ b/meta-facebook/yv35-cl/src/ipmi/include/plat_ipmb.h
@@ -3,23 +3,26 @@
 
 #include "plat_i2c.h"
 
-#define IPMB_BMC_BUS  i2c_bus7
-#define IPMB_ME_BUS   i2c_bus3
-#define IPMB_EXP1_BUS i2c_bus8
-#define IPMB_EXP2_BUS i2c_bus9
-#define Reserve_BUS 0xff
+#define IPMB_BMC_BUS    i2c_bus7
+#define IPMB_ME_BUS     i2c_bus3
+#define IPMB_EXP1_BUS   i2c_bus8
+#define IPMB_EXP2_BUS   i2c_bus9
+#define IPMB_BB_BIC_BUS i2c_bus8
+#define Reserve_BUS     0xff
 
-#define BMC_I2C_ADDRESS  0x10
-#define ME_I2C_ADDRESS   0x16
-#define Self_I2C_ADDRESS 0x20
-#define BIC1_I2C_ADDRESS 0x20
-#define BIC2_I2C_ADDRESS 0x20
-#define Reserve_ADDRESS  0xff
+#define BMC_I2C_ADDRESS    0x10
+#define ME_I2C_ADDRESS     0x16
+#define Self_I2C_ADDRESS   0x20
+#define BIC1_I2C_ADDRESS   0x20
+#define BIC2_I2C_ADDRESS   0x20
+#define BB_BIC_I2C_ADDRESS 0x20
+#define Reserve_ADDRESS    0xff
 
 enum {
 	BMC_IPMB_IDX,
 	ME_IPMB_IDX,
 	EXP1_IPMB_IDX,
+	BB_IPMB_IDX = EXP1_IPMB_IDX,
 	EXP2_IPMB_IDX,
 	RESERVE_IPMB_IDX,
 };

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmb.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmb.c
@@ -12,7 +12,7 @@ IPMB_config pal_IPMB_config_table[] = {
 	{ ME_IPMB_IDX,      I2C_IF,           ME_IPMB_IFs,      IPMB_ME_BUS,     ME_I2C_ADDRESS,      Enable,   Self_I2C_ADDRESS,     "RX_ME_IPMB_TASK",    "TX_ME_IPMB_TASK"   },
 	{ EXP1_IPMB_IDX,    I2C_IF,           EXP1_IPMB_IFs,    IPMB_EXP1_BUS,   BIC1_I2C_ADDRESS,    Disable,  Self_I2C_ADDRESS,     "RX_EPX1_IPMB_TASK",  "TX_EXP1_IPMB_TASK" },
 	{ EXP2_IPMB_IDX,    I2C_IF,           EXP2_IPMB_IFs,    IPMB_EXP2_BUS,   BIC2_I2C_ADDRESS,    Disable,  Self_I2C_ADDRESS,     "RX_EPX2_IPMB_TASK",  "TX_EXP2_IPMB_TASK" },
-	{ RESERVE_IPMB_IDX, Reserve_IF,       Reserve_IFs,      Reserve_BUS,     Reserve_ADDRESS,     Disable,  Reserve_ADDRESS,      "Reserve_ATTR",       "Reserve_ATTR"      },
+	{ IPMB_RESERVE_IDX, Reserve_IF,       Reserve_IFs,      Reserve_BUS,     Reserve_ADDRESS,     Disable,  Reserve_ADDRESS,      "Reserve_ATTR",       "Reserve_ATTR"      },
 };
 
 bool pal_load_IPMB_config(void)
@@ -21,8 +21,16 @@ bool pal_load_IPMB_config(void)
   bic_class = get_bic_class();
 
   // class1 1ou ipmi bus and class2 bb ipmi bus shared same i2c bus
-  if (get_1ou_status() || (bic_class == sys_class_2 )) {
+  if (get_1ou_status() && (bic_class == sys_class_1 )) {
     pal_IPMB_config_table[EXP1_IPMB_IDX].EnStatus = Enable;
+  } else if (get_1ou_status() && (bic_class == sys_class_2 )){
+    pal_IPMB_config_table[EXP1_IPMB_IDX].index = BB_IPMB_IDX;
+    pal_IPMB_config_table[BB_IPMB_IDX].Inf_source = BB_IPMB_IFs;
+    pal_IPMB_config_table[BB_IPMB_IDX].bus = IPMB_BB_BIC_BUS;
+    pal_IPMB_config_table[BB_IPMB_IDX].target_addr = BB_BIC_I2C_ADDRESS;
+    pal_IPMB_config_table[BB_IPMB_IDX].Rx_attr_name = "RX_BB_BIC_IPMB_TASK";
+    pal_IPMB_config_table[BB_IPMB_IDX].Tx_attr_name = "TX_BB_BIC_IPMB_TASK";
+    pal_IPMB_config_table[BB_IPMB_IDX].EnStatus = Enable;
   }
 
   if (get_2ou_status()) {  // check present status
@@ -36,7 +44,6 @@ bool pal_load_IPMB_config(void)
       i2c_freq_set(pal_IPMB_config_table[EXP2_IPMB_IDX].bus, I2C_SPEED_FAST);
       pal_IPMB_config_table[EXP2_IPMB_IDX].EnStatus = Disable;
     } else {
-      i2c_freq_set(pal_IPMB_config_table[EXP2_IPMB_IDX].bus, I2C_SPEED_FAST_PLUS);
       pal_IPMB_config_table[EXP2_IPMB_IDX].EnStatus = Enable;
     }
 


### PR DESCRIPTION
Summary:
- Added class2 check and set IPMB config for BB BIC.
- Modified IPMB bridge interface to align with Yv3.
- Fixed IPMB interface and index mapping.

Test Plan:
- Build code: Pass
- Bridge command: Pass

Log:
Test bridge command on class1 system with 1ou and 2ou expansion BIC:
root@bmc-oob:~# bic-util slot1 0x18 0x1
00 80 11 04 02 BF 9C 9C 00 00 00 00 00 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x0 0x1 0x18 0x1
9C 9C 00 01 07 01 00 50 01 06 02 02 21 57 01 00
18 0B 06 02 40 01
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x0 0x2 0x18 0x1
9C 9C 00 02 07 01 00 20 81 15 50 02 BF 15 A0 00
46 31 01 00 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x0 0x5 0x18 0x1
9C 9C 00 05 07 01 00 25 80 25 01 02 BF 4C 1C 00
50 57 00 00 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x0 0x15 0x18 0x1
9C 9C 00 15 07 01 00 25 80 27 04 02 BF 4C 1C 00
50 57 00 00 00 00

Test bridge command on class2 system with 2ou expansion BIC:
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x0 0x01 0x18 0x01
9C 9C 00 01 07 01 00 50 01 86 01 02 20 57 01 00
18 0B 00 02 70 00
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x0 0x02 0x18 0x01
9C 9C 00 02 07 01 00 20 81 01 03 02 BF 15 A0 00
46 31 00 00 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x0 0x05 0x18 0x01
BIC no response!
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x0 0x10 0x18 0x01
9C 9C 00 10 07 01 00 00 80 01 01 02 BF 9C 9C 00
00 00 00 00 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x0 0x15 0x18 0x01
9C 9C 00 15 07 01 00 25 80 47 04 02 BF 4C 1C 00
50 57 00 00 00 00