### PR TITLE
fby3.5: cl: Fixed clear sensor cache sequence

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/hwmon.c
+++ b/meta-facebook/yv35-cl/src/platform/hwmon.c
@@ -66,6 +66,7 @@ void ISR_DC_on() {
     k_work_schedule(&set_DCon_5s_work, K_SECONDS(DC_ON_5_SECOND));
   } else {
     set_DCon_5s_status();
+    clear_unaccessible_sensor_cache();
 
     if (gpio_get(FM_SLPS3_PLD_N) && gpio_get(RST_RSMRST_BMC_N)) {
       addsel_msg_t sel_msg;
@@ -96,7 +97,6 @@ void ISR_PWRGD_CPU() {
     }
     reset_kcs_ok();
     reset_postcode_ok();
-    clear_unaccessible_sensor_cache();
   }
   send_gpio_interrupt(PWRGD_CPU_LVC3);
 }


### PR DESCRIPTION
Summary:
- Checked sensor cache clear function, only post complete access sensor cache cleared while DC off.
- Fixed clear sensor cache timing after setting DC off flag, so all DC access and post complete access sensors would be set to initial status to avoid BMC accidentally reading unexpectedly cache data.

Test Plan:
- Build code: Pass
- Stress DC cycle over 800 rounds: Pass