### PR TITLE
fby3.5: bb: Support slot 12V cycle

### DIFF
--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -86,6 +86,7 @@ void pal_OEM_1S_SET_JTAG_TAP_STA(ipmi_msg *msg);
 void pal_OEM_1S_JTAG_DATA_SHIFT(ipmi_msg *msg);
 void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg);
 void pal_OEM_1S_RESET_BIC(ipmi_msg *msg);
+void pal_OEM_1S_12V_CYCLE_SLOT(ipmi_msg *msg);
 
 enum {
   CC_SUCCESS = 0x00,
@@ -210,6 +211,8 @@ enum {
   CMD_OEM_1S_GET_SET_GPIO = 0x41,
 // Debug command
   CMD_OEM_1S_I2C_DEV_SCAN = 0x60,
+
+  CMD_OEM_1S_12V_CYCLE_SLOT = 0x64,
 };
 
 #endif

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -179,6 +179,9 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 	case CMD_OEM_1S_RESET_BIC:
 		pal_OEM_1S_RESET_BIC(msg);
 		break;
+	case CMD_OEM_1S_12V_CYCLE_SLOT:
+		pal_OEM_1S_12V_CYCLE_SLOT(msg);
+		break;
 	default:
 		printf("invalid OEM msg netfn: %x, cmd: %x\n", msg->netfn, msg->cmd);
 		msg->data_len = 0;

--- a/common/pal.c
+++ b/common/pal.c
@@ -239,6 +239,12 @@ __weak void pal_OEM_1S_RESET_BIC(ipmi_msg *msg)
 	return;
 }
 
+__weak void pal_OEM_1S_12V_CYCLE_SLOT(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
 // init
 __weak void pal_I2C_init(void)
 {

--- a/common/pal.h
+++ b/common/pal.h
@@ -51,6 +51,7 @@ void pal_OEM_1S_GET_SET_GPIO(ipmi_msg *msg);
 void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg);
 void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg);
 void pal_OEM_1S_RESET_BIC(ipmi_msg *msg);
+void pal_OEM_1S_12V_CYCLE_SLOT(ipmi_msg *msg);
 
 // init
 void pal_I2C_init(void);

--- a/meta-facebook/yv35-bb/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-bb/src/ipmi/plat_ipmi.c
@@ -7,6 +7,7 @@
 #include "ipmi.h"
 #include "plat_ipmi.h"
 #include "hal_gpio.h"
+#include "plat_gpio.h"
 #include "ipmi_def.h"
 #include "guid.h"
 #include "plat_guid.h"
@@ -537,4 +538,50 @@ void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg) {
     default:
       msg->completion_code = CC_UNSPECIFIED_ERROR;
   }
+}
+
+void pal_OEM_1S_12V_CYCLE_SLOT(ipmi_msg *msg) {
+  if (msg->data_len != 0) {
+    msg->completion_code = CC_INVALID_LENGTH;
+    return;
+  }
+
+  uint8_t retry = 3, isolator_num;
+  I2C_MSG i2c_msg;
+
+  i2c_msg.bus = CPLD_IO_I2C_BUS;
+  i2c_msg.slave_addr = CPLD_IO_I2C_ADDR;
+  i2c_msg.tx_len = 2;
+
+  if (msg->InF_source == SLOT1_BIC_IFs) {
+    isolator_num = FM_BIC_SLOT1_ISOLATED_EN_R;
+    i2c_msg.data[0] = CPLD_IO_REG_OFS_HSC_EN_SLOT1; // offset
+
+  } else if (msg->InF_source == SLOT3_BIC_IFs) {
+    isolator_num = FM_BIC_SLOT3_ISOLATED_EN_R;
+    i2c_msg.data[0] = CPLD_IO_REG_OFS_HSC_EN_SLOT3; // offset
+  }
+
+  // Before slot 12V off, disable isolator
+  i2c_msg.data[1] = 0x00;
+  gpio_set(isolator_num, GPIO_LOW);
+  if (i2c_master_write(&i2c_msg, retry) < 0) {
+    printk("slot off fail\n");
+    msg->completion_code = CC_UNSPECIFIED_ERROR;
+    return;
+  }
+
+  k_msleep(2000);
+
+  // After slot 12V on, enable isolator
+  i2c_msg.data[1] = 0x01;
+  if (i2c_master_write(&i2c_msg, retry) < 0) {
+    printk("slot on fail\n");
+    msg->completion_code = CC_UNSPECIFIED_ERROR;
+    return;
+  }
+  gpio_set(isolator_num, GPIO_HIGH);
+
+  msg->completion_code = CC_SUCCESS;
+  return;
 }

--- a/meta-facebook/yv35-bb/src/platform/plat_i2c.h
+++ b/meta-facebook/yv35-bb/src/platform/plat_i2c.h
@@ -18,4 +18,10 @@
 
 #define I2C_BUS_NUM 10
 
+#define CPLD_IO_I2C_BUS   i2c_bus1
+#define CPLD_IO_I2C_ADDR  (0x1E >> 1)
+
+#define CPLD_IO_REG_OFS_HSC_EN_SLOT1 0x09
+#define CPLD_IO_REG_OFS_HSC_EN_SLOT3 0x0B
+
 #endif


### PR DESCRIPTION
Summary:
- Support slot 12V cycle.

Test plan:
- Build code: Pass
- No unexpected log: Pass
- Slot 12V cycle: Pass

Log:
- Slot1
[BMC console]
root@bmc-oob:~# power-util slot1 12V-cycle
12V Power cycling fru 1...
^@^Watchdog: 300s
Before: CE0_CTRL=0x00000000, CE1_CTRL=0x00000000
cs0_status = 2, cs1_status = 2
After: CE0_CTRL=0x000B0D41, CE1_CTRL=0x000B0D41
...
bmc-oob. login: root
Password:
root@bmc-oob:~#

- Slot3
[BMC console]
root@bmc-oob:~# power-util slot1 12V-cycle
12V Power cycling fru 1...
^@^@watchdog: 300s
Before: CE0_CTRL=0x00000000, CE1_CTRL=0x00000000
cs0_status = 2, cs1_status = 2
After: CE0_CTRL=0x000B0D41, CE1_CTRL=0x000B0D41
...
bmc-oob. login: root
Password:
root@bmc-oob:~#
