### PR TITLE
Remove Unnecessary Imports From west.yml

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -10,7 +10,9 @@ manifest:
       remote: aspeed
       path: zephyr
       revision: 653496121d08aab03c528132eafdab4d80c09680
-      import: true
+      import: 
+        name-allowlist:
+          - cmsis
 
   self:
     path: openbic


### PR DESCRIPTION
Summary:

We currently import all modules imported from the Zephyr Aspeed repo.
However we don't need the vast majority of them and it only increases
repo size when cloning.

Test Plan:

Build clean repo.

Reviewers:

Subscribers:

Tasks:

Tags: common