### PR TITLE
fby3.5: cl: Modified SPI mux switch sequence

### DIFF
--- a/meta-facebook/yv35-cl/src/main.c
+++ b/meta-facebook/yv35-cl/src/main.c
@@ -22,8 +22,11 @@ void device_init() {
   hsc_init();
 }
 
-void set_sys_status() {
+void switch_spi_mux() {
   gpio_set(FM_SPI_PCH_MASTER_SEL_R, GPIO_LOW);
+}
+
+void set_sys_status() {
   gpio_set(BIC_READY, GPIO_HIGH);
   set_DC_status();
   set_DCon_5s_status();
@@ -50,10 +53,18 @@ void main(void)
   set_sys_status();
 }
 
-#define DEF_PROJ_GPIO_PRIORITY 61
+#define DEF_PROJ_GPIO_PRIORITY 78
 
 DEVICE_DEFINE(PRE_DEF_PROJ_GPIO, "PRE_DEF_PROJ_GPIO_NAME",
         &gpio_init, NULL,
         NULL, NULL,
         POST_KERNEL, DEF_PROJ_GPIO_PRIORITY,
+        NULL);
+
+#define SWITCH_SPI_MUX_PRIORITY 81 // right after spi driver init
+
+DEVICE_DEFINE(PRE_SWITCH_SPI_MUX, "PRE_SWITCH_SPI_MUX_NAME",
+        &switch_spi_mux, NULL,
+        NULL, NULL,
+        POST_KERNEL, SWITCH_SPI_MUX_PRIORITY,
         NULL);


### PR DESCRIPTION
Summary:
- During BIC bootup, requires switching SPI MUX to BIC and makes ME fail to access BIOS flash during AC on.
- Fixed SPI MUX switch sequence as short as possible to allow ME access flash after BIC initializing SPI driver.

Test Plan:
- Build code: Pass
- Measured SPI sequence: Pass
- Clear cmos and check ME selftest: Pass

Log:
root@bmc-oob:~# me-util slot2 0x18 0x4
55 00
root@bmc-oob:~# bic-util slot2 --clear_cmos
root@bmc-oob:~# me-util slot2 0x18 0x4
55 00