### PR TITLE
fby3.5: cl: Added ME FW mode switch

### DIFF
--- a/common/pal.c
+++ b/common/pal.c
@@ -358,3 +358,11 @@ __weak void gpio_UV_callback_handler(uint32_t pins) {
   return;
 }
 
+// platform
+__weak void pal_warm_reset_prepare() {
+  return;
+}
+
+__weak void pal_cold_reset_prepare() {
+  return;
+}

--- a/common/pal.h
+++ b/common/pal.h
@@ -87,4 +87,8 @@ void gpio_IL_callback_handler(uint32_t pins);
 void gpio_MP_callback_handler(uint32_t pins);
 void gpio_QT_callback_handler(uint32_t pins);
 void gpio_UV_callback_handler(uint32_t pins);
+
+// platform
+void pal_warm_reset_prepare();
+void pal_cold_reset_prepare();
 #endif

--- a/common/util/util_sys.c
+++ b/common/util/util_sys.c
@@ -28,6 +28,7 @@ bool get_boot_source_ACon() {
 #define bic_warm_reset_delay 100
 
 void bic_warm_reset() {
+  pal_warm_reset_prepare();
   k_msleep(bic_warm_reset_delay);
   sys_reboot(SYS_REBOOT_WARM);
 }
@@ -42,6 +43,7 @@ void submit_bic_warm_reset() {
 #define bic_cold_reset_delay 100
 
 void bic_cold_reset() {
+  pal_cold_reset_prepare();
   k_msleep(bic_cold_reset_delay);
   sys_reboot(SYS_REBOOT_COLD);
 }

--- a/meta-facebook/yv35-cl/src/main.c
+++ b/meta-facebook/yv35-cl/src/main.c
@@ -48,6 +48,7 @@ void main(void)
   usb_dev_init();
   device_init();
   set_sys_status();
+  set_ME_restore();
 }
 
 #define DEF_PROJ_GPIO_PRIORITY 61

--- a/meta-facebook/yv35-cl/src/platform/plat_func.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_func.h
@@ -36,4 +36,5 @@ uint8_t get_2ou_cardtype();
 void send_gpio_interrupt(uint8_t gpio_num);
 void enable_PRDY_interrupt();
 void disable_PRDY_interrupt();
+void set_ME_restore();
 #endif

--- a/meta-facebook/yv35-cl/src/platform/platform.c
+++ b/meta-facebook/yv35-cl/src/platform/platform.c
@@ -1,6 +1,122 @@
 #include <zephyr.h>
+#include <stdlib.h>
+#include "ipmi.h"
 #include "plat_gpio.h"
 
+#define ME_FW_recovery  0x01
+#define ME_FW_restore   0x02
+
+static void set_ME_FW_mode(uint8_t ME_FW_mode) {
+  ipmi_msg *me_msg;
+  ipmb_error status;
+
+  me_msg = (ipmi_msg*)malloc(sizeof(ipmi_msg));
+  if (me_msg == NULL) {
+    printk("ME restore msg alloc fail\n");
+    return false;
+  }
+
+  me_msg->seq_source = 0xFF;
+  me_msg->netfn = NETFN_NM_REQ;
+  me_msg->cmd = 0xDF; // Get Intel ME FW Capabilities
+  me_msg->InF_source = Self_IFs;
+  me_msg->InF_target = ME_IPMB_IFs;
+  me_msg->data_len = 4;
+  me_msg->data[0] = 0x57;
+  me_msg->data[1] = 0x01;
+  me_msg->data[2] = 0x00;
+  me_msg->data[3] = ME_FW_mode;
+  status = ipmb_read(me_msg, IPMB_inf_index_map[me_msg->InF_target]);
+
+  if ( status != ipmb_error_success ) {
+    printk("set_ME_FW_mode reach ME fail with status: %x\n", status);
+  }
+
+  free(me_msg);
+  return;
+}
+
+static void ME_enter_restore() {
+  set_ME_FW_mode(ME_FW_restore);
+  return;
+}
+
+static void ME_enter_recovery() {
+  ipmi_msg *me_msg;
+  ipmb_error status;
+  uint8_t retry = 3;
+
+  for(int i = 0;i < retry; i++) {
+    set_ME_FW_mode(ME_FW_recovery);
+    k_msleep(2000);
+
+    me_msg = (ipmi_msg*)malloc(sizeof(ipmi_msg));
+    if (me_msg == NULL) {
+      printk("ME recovery msg alloc fail\n");
+      k_msleep(10);
+      continue;
+    }
+
+    me_msg->seq_source = 0xFF;
+    me_msg->netfn = NETFN_APP_REQ;
+    me_msg->cmd = CMD_APP_GET_SELFTEST_RESULTS;
+    me_msg->InF_source = Self_IFs;
+    me_msg->InF_target = ME_IPMB_IFs;
+    me_msg->data_len = 0;
+    status = ipmb_read(me_msg, IPMB_inf_index_map[me_msg->InF_target]);
+    if ( status == ipmb_error_success ) {
+      if ( (me_msg->data_len == 2) && (me_msg->data[0] == 0x81 ) && (me_msg->data[1] == 0x02 ) ) {
+        if (me_msg != NULL) {
+          free(me_msg);
+        }
+        break;
+      }
+    } else {
+      printk("ME restore get selftest fail with status: %x\n", status);
+    }
+    if (me_msg != NULL) {
+      free(me_msg);
+    }
+  }
+
+  return;
+}
+
+void set_ME_restore() {
+  ipmi_msg *me_msg;
+  ipmb_error status;
+
+  me_msg = (ipmi_msg*)malloc(sizeof(ipmi_msg));
+  if (me_msg == NULL) {
+    printk("ME restore msg alloc fail\n");
+    return false;
+  }
+
+  me_msg->seq_source = 0xFF;
+  me_msg->netfn = NETFN_APP_REQ;
+  me_msg->cmd = CMD_APP_GET_SELFTEST_RESULTS;
+  me_msg->InF_source = Self_IFs;
+  me_msg->InF_target = ME_IPMB_IFs;
+  me_msg->data_len = 0;
+  status = ipmb_read(me_msg, IPMB_inf_index_map[me_msg->InF_target]);
+  if ( status == ipmb_error_success ) {
+    if ( (me_msg->data_len == 2) && (me_msg->data[0] == 0x81 ) && (me_msg->data[1] == 0x02 ) ) {
+      ME_enter_restore();
+    }
+  } else {
+    printk("ME restore get selftest fail with status: %x\n", status);
+  }
+  free(me_msg);
+  return;
+}
+
+void pal_warm_reset_prepare() {
+  ME_enter_recovery();
+}
+
+void pal_cold_reset_prepare() {
+  ME_enter_recovery();
+}
 
 /* BMC reset */
 void BMC_reset_handler() {


### PR DESCRIPTION
Summary:
- During BIC firmware update or reset command, BIC firmware will be reset, risking ME request drop or ME fail to access flash due to BIC probing flash as SPI slave device.
- To avoid ME sending IPMB or accessing flash, BIC should set ME into recovery mode before BIC reset itself.

Test Plan:
- Build code: Pass
- BIC reset and check ME status: Pass