### PR TITLE
Add clang-format Using Zephyrs Format File

### DIFF
--- a/.circleci/lint/cppcheck/cppcheck-suppressions.txt
+++ b/.circleci/lint/cppcheck/cppcheck-suppressions.txt
@@ -1,1 +1,4 @@
 variableScope
+
+// This output confuses CI, get rid of it.
+unmatchedSuppression

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# clang-format configuration file. Intended for clang-format >= 4.
+#
+# For more information, see:
+#
+#   Documentation/process/clang-format.rst
+#   https://clang.llvm.org/docs/ClangFormat.html
+#   https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+#
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+#AlignEscapedNewlines: Left # Unknown to clang-format-4.0
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  #AfterExternBlock: false # Unknown to clang-format-5.0
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  #SplitEmptyFunction: true # Unknown to clang-format-4.0
+  #SplitEmptyRecord: true # Unknown to clang-format-4.0
+  #SplitEmptyNamespace: true # Unknown to clang-format-4.0
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+#BreakBeforeInheritanceComma: false # Unknown to clang-format-4.0
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+#BreakConstructorInitializers: BeforeComma # Unknown to clang-format-4.0
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: false
+ColumnLimit: 100
+CommentPragmas: '^ IWYU pragma:'
+#CompactNamespaces: false # Unknown to clang-format-4.0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+#FixNamespaceComments: false # Unknown to clang-format-4.0
+
+# Taken from:
+#   git grep -h '^#define [^[:space:]]*FOR_EACH[^[:space:]]*(' include/ \
+#   | sed "s,^#define \([^[:space:]]*FOR_EACH[^[:space:]]*\)(.*$,  - '\1'," \
+#   | sort | uniq
+ForEachMacros:
+  - 'FOR_EACH'
+  - 'FOR_EACH_FIXED_ARG'
+  - 'RB_FOR_EACH'
+  - 'RB_FOR_EACH_CONTAINER'
+  - 'SYS_DLIST_FOR_EACH_CONTAINER'
+  - 'SYS_DLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'SYS_DLIST_FOR_EACH_NODE'
+  - 'SYS_DLIST_FOR_EACH_NODE_SAFE'
+  - 'SYS_SFLIST_FOR_EACH_CONTAINER'
+  - 'SYS_SFLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'SYS_SFLIST_FOR_EACH_NODE'
+  - 'SYS_SFLIST_FOR_EACH_NODE_SAFE'
+  - 'SYS_SLIST_FOR_EACH_CONTAINER'
+  - 'SYS_SLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'SYS_SLIST_FOR_EACH_NODE'
+  - 'SYS_SLIST_FOR_EACH_NODE_SAFE'
+  - 'Z_GENLIST_FOR_EACH_CONTAINER'
+  - 'Z_GENLIST_FOR_EACH_CONTAINER_SAFE'
+  - 'Z_GENLIST_FOR_EACH_NODE'
+  - 'Z_GENLIST_FOR_EACH_NODE_SAFE'
+  - '_WAIT_Q_FOR_EACH'
+
+#IncludeBlocks: Preserve # Unknown to clang-format-5.0
+IncludeCategories:
+  - Regex: '.*'
+    Priority: 1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+#IndentPPDirectives: None # Unknown to clang-format-5.0
+IndentWidth: 8
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+#ObjCBinPackProtocolList: Auto # Unknown to clang-format-5.0
+ObjCBlockIndentWidth: 8
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+
+# Taken from git's rules
+#PenaltyBreakAssignment: 10 # Unknown to clang-format-4.0
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 10
+PenaltyExcessCharacter: 100
+PenaltyReturnTypeOnItsOwnLine: 60
+
+PointerAlignment: Right
+ReflowComments: false
+SortIncludes: false
+#SortUsingDeclarations: false # Unknown to clang-format-4.0
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+#SpaceBeforeCtorInitializerColon: true # Unknown to clang-format-5.0
+#SpaceBeforeInheritanceColon: true # Unknown to clang-format-5.0
+SpaceBeforeParens: ControlStatements
+#SpaceBeforeRangeBasedForLoopColon: true # Unknown to clang-format-5.0
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp03
+TabWidth: 8
+UseTab: Always
+...

--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -76,104 +76,212 @@ jobs:
         touch meta-facebook/${{ matrix.platform }}/CMakeLists.txt
         west build -p auto -b ast1030_evb meta-facebook/${{ matrix.platform }}/
 
-  Run-CPPCheck:
+  run-cppcheck:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Get PR File List 
-        run: |
-          URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
-          curl -s -X GET -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $URL | jq -r '.[] | .filename' > git_diff.log
-          cat git_diff.log 
+    - name: Get PR File List 
+      shell: bash
+      run: |
+        URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
+        curl -s -X GET -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $URL | jq -r '.[] | .filename' > git_diff.log
+        cat git_diff.log 
   
-      - name: Check for C/CPP Sources
-        run : |
-          # Only keep the source files to check or CPPCheck gets confused.
-          sed '/\(c$\|cpp$\|c$\|cc$\|cu$\|cxx$\|h$\|hh$\|hpp$\|hxx$\|tcc$\)/!d' git_diff.log > /tmp/cppcheck_file_list.log
-
-          if [ -s /tmp/cppcheck_file_list.log ]; then
-            echo "contains_c_source=true" >> $GITHUB_ENV
-          else
-            echo "contains_c_source=false" >> $GITHUB_ENV
-          fi
-
-      - uses: actions/checkout@v2
-        name: Checkout Repo
-        if: env.contains_c_source == 'true'
+    - name: Check for C/CPP Sources
+      shell: bash
+      run : |
+        CPP_FILE_LIST="/tmp/cppcheck_file_list.log"
         
-      - uses: actions/setup-python@v2
-        name: Setup Python
-        if: env.contains_c_source == 'true'
+        # Only keep the source files to check or CPPCheck gets confused.
+        sed '/\(c$\|cpp$\|c$\|cc$\|cu$\|cxx$\|h$\|hh$\|hpp$\|hxx$\|tcc$\)/!d' git_diff.log > $CPP_FILE_LIST
 
-      - name: Install CPPCheck
-        if: env.contains_c_source == 'true'
-        run: sudo apt-get install -y cppcheck
+        if [ -s $CPP_FILE_LIST ]; then
+          echo "C/C++ source files kept:"
+          cat $CPP_FILE_LIST
+        fi
+        
+        if [ -s $CPP_FILE_LIST ]; then
+          echo "contains_c_source=true" >> $GITHUB_ENV
+        else
+          echo "contains_c_source=false" >> $GITHUB_ENV
+        fi
 
-      - name: Run CPPCheck on Modified Source Files
-        if: env.contains_c_source == 'true'
-        continue-on-error: true
-        shell: bash
-        run: |
-          # These files specify the config for cppcheck and a list of errors to suppress
-          CPPCHECK_CONFIG=.circleci/lint/cppcheck/cppcheck.cfg
-          CPPCHECK_SUPPRESSED=.circleci/lint/cppcheck/cppcheck-suppressions.txt
+    - uses: actions/checkout@v2
+      name: Checkout Repo
+      if: env.contains_c_source == 'true'
+        
+    - uses: actions/setup-python@v2
+      name: Setup Python
+      if: env.contains_c_source == 'true'
 
-          echo "Files to check:"
-          cat /tmp/cppcheck_file_list.log
+    - name: Install CPPCheck
+      if: env.contains_c_source == 'true'
+      run: sudo apt-get install -y cppcheck
 
-          options=( "-j2"
-            "--inconclusive"
-            "--enable=performance,style,portability,information"
-            "--library=.circleci/lint/cppcheck/cppcheck.cfg"
-            "--suppressions-list=.circleci/lint/cppcheck/cppcheck-suppressions.txt"
-            "--file-list=/tmp/cppcheck_file_list.log"
-            "--template={file}:{line}:{column}:{message}"
-            "--output-file=/tmp/cppcheck.log"
-            "--report-progress")
-  
-          cppcheck "${options[@]}"
+    - name: Run CPPCheck on Modified Source Files
+      if: env.contains_c_source == 'true'
+      continue-on-error: true
+      shell: bash
+      run: |
+        # These files specify the config for cppcheck and a list of errors to suppress
+        CPPCHECK_CONFIG=.circleci/lint/cppcheck/cppcheck.cfg
+        CPPCHECK_SUPPRESSED=.circleci/lint/cppcheck/cppcheck-suppressions.txt
 
+        echo "Files to check:"
+        cat /tmp/cppcheck_file_list.log
+
+        options=( "-j2"
+          "--inconclusive"
+          "--enable=performance,style,portability,information"
+          "--library=.circleci/lint/cppcheck/cppcheck.cfg"
+          "--suppressions-list=.circleci/lint/cppcheck/cppcheck-suppressions.txt"
+          "--file-list=/tmp/cppcheck_file_list.log"
+          "--template={file}:{line}:{column}:{message}"
+          "--output-file=/tmp/cppcheck.log"
+          "--report-progress")
+
+        cppcheck "${options[@]}"
+        
+        if [ -s /tmp/cppcheck.log ]; then
           echo "Errors Found:"
           cat /tmp/cppcheck.log
+        fi
 
-      - uses: actions/upload-artifact@master
-        name: Upload CPPCheck error log
-        if: env.contains_c_source == 'true'
-        with:
-          name: cppcheck-output
-          path: /tmp/cppcheck.log
 
-      - name: Check for cppcheck output
-        if: env.contains_c_source == 'true'
-        run : |
-          if [ -s /tmp/cppcheck_file_list.log ]; then
-            exit 1
-          fi
+    - uses: actions/upload-artifact@master
+      name: Upload CPPCheck error log
+      if: env.contains_c_source == 'true'
+      with:
+        name: cppcheck-output
+        path: /tmp/cppcheck.log
 
-  Aggregate-Lint-Output:
-    needs: [Run-CPPCheck]
-    if: always() && (needs.Run-CPPCheck.result == 'failure')
+    - name: Check for cppcheck output
+      if: env.contains_c_source == 'true'
+      run : |
+        if [ -s /tmp/cppcheck.log ]; then
+          exit 1
+        fi
+
+  run-clang-format:
     runs-on: ubuntu-latest
     steps:
       
-      - uses: actions/checkout@v2
-        name: Checkout Repo
-       
-      - uses: reviewdog/action-setup@v1
-        with:
-          reviewdog_version: latest 
+    - uses: actions/checkout@v2
+      name: Checkout Repo
 
-      - name: Download CPPCheck Error Log
-        uses: actions/download-artifact@v2
-        with:
-          name: cppcheck-output
+    - name: Get PR File List 
+      shell: bash
+      run: |
+        URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
+        curl -s -X GET -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" $URL | jq -r '.[] | .filename' > /tmp/change_set.log
+        cat /tmp/change_set.log 
 
-      - name: catFile
-        run: |
-          cat cppcheck.log
+    - name: Check for C/CPP Sources
+      shell: bash
+      run : |
+        CLANG_FORMAT_FILE_LIST="/tmp/clang_format_file_list.log"
+        
+        # Only keep the source files to check or clang-format starts checking everything.
+        sed '/\(c$\|cpp$\|c$\|cc$\|cu$\|cxx$\|h$\|hh$\|hpp$\|hxx$\|tcc$\)/!d' /tmp/change_set.log > $CLANG_FORMAT_FILE_LIST
 
-      - name: Run reviewdog
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cat cppcheck.log | reviewdog -efm="%f:%l:%c:%m" -filter-mode=nofilter -reporter=github-pr-check
+        if [ -s $CLANG_FORMAT_FILE_LIST ]; then
+          echo "C/C++ source files kept for clang-format:"
+          cat $CLANG_FORMAT_FILE_LIST
+        fi
+        
+        if [ -s $CLANG_FORMAT_FILE_LIST ]; then
+          echo "contains_c_source=true" >> $GITHUB_ENV
+        else
+          echo "contains_c_source=false" >> $GITHUB_ENV
+        fi
+
+    - name: Install Clang-Format 
+      if: env.contains_c_source == 'true'
+      run: sudo apt-get install -y clang-format 
+
+    - name: Run clang-format on changed fileset.
+      if: env.contains_c_source == 'true'
+      continue-on-error: true
+      shell: bash
+      run: |
+        echo "Files to check:"
+        cat /tmp/clang_format_file_list.log 
+        
+        FILE_PATHS=$(cat /tmp/clang_format_file_list.log)
+        for FILE_PATH in $FILE_PATHS
+        do
+          
+          options=( 
+            "--style=file"
+            "--dry-run"
+            "--Werror")
+         
+          # Clang format outputs to stderr... why do you do this clang-format 
+          if ! clang-format "${options[@]}" $FILE_PATH &> /dev/null ; then
+            echo $FILE_PATH "has clang-format errors!"
+            echo $FILE_PATH >> /tmp/clang-format.log
+          fi
+
+        done
+  
+    - uses: actions/upload-artifact@master
+      if: env.contains_c_source == 'true'
+      name: Upload clang-format error log
+      with:
+        name: clang-format-output
+        path: /tmp/clang-format.log
+
+    - name: Check for clang-format output
+      if: env.contains_c_source == 'true'
+      run : |
+        if [ -s /tmp/clang-format.log ]; then
+          exit 1
+        fi
+
+  Aggregate-Lint-Output:
+    needs: [run-cppcheck, run-clang-format]
+    if: |
+        always() && 
+        (needs.run-cppcheck.result == 'failure' || 
+         needs.run-clang-format.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      
+    - uses: actions/checkout@v2
+      name: Checkout Repo
+     
+    - uses: reviewdog/action-setup@v1
+      with:
+        reviewdog_version: latest 
+
+    - name: Download all artifacts 
+      uses: actions/download-artifact@v2
+      with:
+        path: /tmp/artifacts
+
+    - name: Load comment variable
+      id: load-clang-env-variable
+      run: echo "::set-output name=clang-format-comment::$(cat /tmp/artifacts/clang-format-output/clang-format.log)"
+
+    - uses: actions/github-script@v5
+      if: needs.run-clang-format.result == 'failure'
+      name: Comment on clang-format
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: "These files have clang-format errors:\n ${{ steps.load-clang-env-variable.outputs.clang-format-comment}}\n\n You can fix these errors by running \"clang-format -i\" on the effected files"
+          })
+
+    - name: Run reviewdog
+      env:
+        REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        CPP_FILE=/tmp/artifacts/cppcheck-output/cppcheck.log
+        if test -f "$CPP_FILE"; then
+          cat "$CPP_FILE" | reviewdog -efm="%f:%l:%c:%m" -filter-mode=nofilter -reporter=github-pr-check
+        fi
+


### PR DESCRIPTION
Summary:

Add clang format to the CI so that it runs on PRs and is reported by
reviewdog.

Test Plan:

Test on OpenSource Repo to verify it functions correctly.

Reviewers:

Subscribers:

Tasks:

Tags: CIT
