### PR TITLE
Fix lint error in common/host/

### DIFF
--- a/common/host/kcs.c
+++ b/common/host/kcs.c
@@ -45,7 +45,6 @@ void kcs_read(void* arvg0, void* arvg1, void* arvg2)
   ipmb_error status;
 
   struct kcs_request *req;
-  struct kcs_response *res;
 
   while (1) {
     k_msleep(KCS_POLLING_INTERVAL);


### PR DESCRIPTION
Summary:

The res struct isn't used in this function and is therfore throwing a
lint error. There isn't any reason to keep it if it's unused because it
will just cause confusion.

Test Plan:

Build Code / CI

Reviewers:

Subscribers:

Tasks:

Tags: