### PR TITLE
fby3.5: bb: Support get slot index

### DIFF
--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -67,6 +67,7 @@ void pal_STORAGE_GET_SDR(ipmi_msg *msg);
 // IPMI OEM
 void pal_OEM_SENSOR_READ(ipmi_msg *msg);
 void pal_OEM_SET_SYSTEM_GUID(ipmi_msg *msg);
+void pal_OEM_GET_MB_INDEX(ipmi_msg *msg);
 
 // IPMI OEM 1S
 void pal_OEM_1S_MSG_OUT(ipmi_msg *msg);
@@ -186,6 +187,7 @@ enum {
 enum {
 	CMD_OEM_SENSOR_READ = 0xE2,
 	CMD_OEM_SET_SYSTEM_GUID = 0xEF,
+	CMD_OEM_GET_MB_INDEX = 0xF0,
 };
 
 // OEM 1S Command Codes

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -111,6 +111,9 @@ void IPMI_OEM_handler(ipmi_msg *msg)
 	case CMD_OEM_SET_SYSTEM_GUID:
 		pal_OEM_SET_SYSTEM_GUID(msg);
 		break;
+	case CMD_OEM_GET_MB_INDEX:
+		pal_OEM_GET_MB_INDEX(msg);
+		break;
 	default:
 		printf("invalid OEM msg netfn: %x, cmd: %x\n", msg->netfn, msg->cmd);
 		msg->data_len = 0;

--- a/common/pal.c
+++ b/common/pal.c
@@ -129,6 +129,12 @@ __weak void pal_OEM_SET_SYSTEM_GUID(ipmi_msg *msg)
 	return;
 }
 
+__weak void pal_OEM_GET_MB_INDEX(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
 // IPMI OEM 1S
 __weak void pal_OEM_1S_MSG_OUT(ipmi_msg *msg)
 {

--- a/common/pal.h
+++ b/common/pal.h
@@ -35,6 +35,7 @@ void pal_STORAGE_GET_SDR(ipmi_msg *msg);
 // IPMI OEM
 void pal_OEM_SENSOR_READ(ipmi_msg *msg);
 void pal_OEM_SET_SYSTEM_GUID(ipmi_msg *msg);
+void pal_OEM_GET_MB_INDEX(ipmi_msg *msg);
 
 // IPMI OEM 1S
 void pal_OEM_1S_MSG_OUT(ipmi_msg *msg);

--- a/meta-facebook/yv35-bb/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-bb/src/ipmi/plat_ipmi.c
@@ -402,6 +402,27 @@ void pal_SENSOR_GET_SENSOR_READING(ipmi_msg *msg)
 	return;
 }
 
+void pal_OEM_GET_MB_INDEX(ipmi_msg *msg)
+{
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	if (msg->InF_source == SLOT1_BIC_IFs) {
+		msg->data[0] = 0x01;
+	} else if (msg->InF_source == SLOT3_BIC_IFs) {
+		msg->data[0] = 0x03;
+	} else {
+		msg->data[0] = 0xFF;
+		return;
+	}
+
+	msg->data_len = 1;
+	msg->completion_code = CC_SUCCESS;
+	return;
+}
+
 void pal_OEM_1S_MSG_OUT(ipmi_msg *msg)
 {
 	uint8_t target_IF;


### PR DESCRIPTION
Summary:
- Support get slot index.

Test plan:
- Build code: Pass
- No unexpected log: Pass
- Get slot index: Pass

Log:
- Slot 1
root@bmc-oob:~# bic-util slot1 0xE0 0x02 0x9C 0x9C 0x00 0x10 0xC0 0xF0
9C 9C 00 10 31 F0 00 01

- Slot 3
root@bmc-oob:~# bic-util slot1 0xE0 0x02 0x9C 0x9C 0x00 0x10 0xC0 0xF0
9C 9C 00 10 31 F0 00 03