### PR TITLE
fby3.5: bb: Fix IPMB interface mapping

### DIFF
--- a/meta-facebook/yv35-bb/src/ipmi/plat_ipmb.c
+++ b/meta-facebook/yv35-bb/src/ipmi/plat_ipmb.c
@@ -11,7 +11,7 @@ IPMB_config pal_IPMB_config_table[] = {
 	  Enable, Self_I2C_ADDRESS, "RX_SLOT1_BIC_IPMB_TASK", "TX_SLOT1_BIC_IPMB_TASK" },
 	{ SLOT3_BIC_IPMB_IDX, I2C_IF, SLOT3_BIC_IFs, IPMB_SLOT3_BIC_BUS, SLOT3_BIC_I2C_ADDRESS,
 	  Enable, Self_I2C_ADDRESS, "RX_SLOT3_BIC_IPMB_TASK", "TX_SLOT3_BIC_IPMB_TASK" },
-	{ RESERVE_IPMB_IDX, Reserve_IF, Reserve_IFs, Reserve_BUS, Reserve_ADDRESS, Disable,
+	{ IPMB_RESERVE_IDX, Reserve_IF, Reserve_IFs, Reserve_BUS, Reserve_ADDRESS, Disable,
 	  Reserve_ADDRESS, "Reserve_ATTR", "Reserve_ATTR" },
 };
 


### PR DESCRIPTION
Summary:
- Fix BB BIC hang on IPMB interface map initializing problem.

Test Plan:
- Build code: Pass
- No unexpected log: Pass
- Bridge command: Pass

Log:
- Before fix
[BB BIC console]
uart:~$ ?)I00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x81] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x82] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspeed: pre-selected ep[0x1] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspe*** Booting Zephyr OS build v00.01.03-18-g67d81d89470e  ***
Hello, welcome to yv35 baseboard 2022.1.1
ipmi_init

- After fix
[BB BIC console]
uart:~$ ?)I00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x81] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x82] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspeed: pre-selected ep[0x1] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspe*** Booting Zephyr OS build v00.01.03-18-g67d81d89470e  ***
Hello, welcome to yv35 baseboard 2022.1.1
ipmi_init
ed: pre-selected ep[0x2] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint
[00:00:00.103,000] <inf> usb_cdc_acm: Device suspended

uart:~$

[BMC console]
root@bmc-oob:~# bic-util slot1 0xE0 0x02 0x9C 0x9C 0x00 0x10 0x18 0x01
9C 9C 00 10 07 01 00 00 80 01 01 02 BF 9C 9C 00
00 00 00 00 00 00