### PR TITLE
Change Github Action Permissions To Allow Commenting

### DIFF
--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -239,6 +239,18 @@ jobs:
         fi
 
   Aggregate-Lint-Output:
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      deployments: read
+      issues: read
+      packages: read
+      pull-requests: write
+      repository-projects: read
+      security-events: read
+      statuses: read
+
     needs: [run-cppcheck, run-clang-format]
     if: |
         always() && 


### PR DESCRIPTION
Summary:

Change the default Github Actions Permissions for the Lint aggregation
job to allow commenting on the PR. This is needed so that a comment is
automatically generated when files need to be formatted with
clang-format.

Test Plan:

Run int Github Actions and check permissions.

Reviewers:

Subscribers:

Tasks:

Tags: CIT