### PR TITLE
fby3.5: cl: Add KCS fail handle and KCS driver patch

### DIFF
--- a/fix_patch/tag_v00.01.04_edb7dc6f3cc5cde814dd10e8ec02da62f833bdaf/0001-ipmi-kcs_aspeed-Fix-the-missing-break.patch
+++ b/fix_patch/tag_v00.01.04_edb7dc6f3cc5cde814dd10e8ec02da62f833bdaf/0001-ipmi-kcs_aspeed-Fix-the-missing-break.patch
@@ -1,0 +1,28 @@
+From ced4e6cd516f50f1ab6137901412f192887aa904 Mon Sep 17 00:00:00 2001
+From: Chia-Wei Wang <chiawei_wang@aspeedtech.com>
+Date: Wed, 9 Feb 2022 09:12:03 +0800
+Subject: [PATCH] ipmi: kcs_aspeed: Fix the missing break
+
+Fix the missing 'break' for switch statement.
+
+Signed-off-by: Chia-Wei Wang <chiawei_wang@aspeedtech.com>
+Change-Id: I672ac50a0ae046a84be7e0578593173e33829705
+---
+ drivers/ipmi/kcs_aspeed.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/ipmi/kcs_aspeed.c b/drivers/ipmi/kcs_aspeed.c
+index 5a1f0fc3d7..1543097f2f 100644
+--- a/drivers/ipmi/kcs_aspeed.c
++++ b/drivers/ipmi/kcs_aspeed.c
+@@ -279,6 +279,7 @@ static void kcs_handle_data(struct kcs_aspeed_data *kcs)
+ 		kcs_read_data(kcs);
+ 		kcs_write_data(kcs, KCS_DUMMY_ZERO);
+ 		kcs->phase = KCS_PHASE_IDLE;
++		break;
+ 
+ 	default:
+ 		kcs_force_abort(kcs);
+-- 
+2.25.1
+


### PR DESCRIPTION
Summary:
- As host send KCS request to BMC during BMC reboot, BIC IPMB handler pend forever and fail to response IPMB anymore. Added KCS request fail handling.
- Aspeed provide KCS patch to fix unexpectedly abort KCS during state machine error handle.

Test plan:
- Build code: Pass
- KCS fail test: Pass
Kept sending IPMI request from host to BMC during BMC reboot.
Checked BIC IPMB working well before BMC reboot and after BMC initialization.

Log:
[root@Stream8_211112 ~]# ipmitool raw 0x6 0x1
 20 81 16 04 02 bf 15 a0 00 46 31 01 00 00 00
[root@Stream8_211112 ~]# ipmitool raw 0x6 0x1
No data available
Get Device ID command failed
^[[AUnable to send RAW command (channel=0x0 netfn=0x6 lun=0x0 cmd=0x1 rsp=0xff): Unspecified error
[root@Stream8_211112 ~]# ipmitool raw 0x6 0x1
Get Device ID command failed: 0xff Unspecified error
Unable to send RAW command (channel=0x0 netfn=0x6 lun=0x0 cmd=0x1 rsp=0xff): Unspecified error
[root@Stream8_211112 ~]# ipmitool raw 0x6 0x1
Get Device ID command failed: 0xff Unspecified error
Unable to send RAW command (channel=0x0 netfn=0x6 lun=0x0 cmd=0x1 rsp=0xff): Unspecified error
[root@Stream8_211112 ~]# ipmitool raw 0x6 0x1
Get Device ID command failed: 0xff Unspecified error
^[[AUnable to send RAW command (channel=0x0 netfn=0x6 lun=0x0 cmd=0x1 rsp=0xff): Unspecified error
[root@Stream8_211112 ~]# ipmitool raw 0x6 0x1
Get Device ID command failed: 0xff Unspecified error
 20 81 16 04 02 bf 15 a0 00 46 31 01 00 00 00
[root@Stream8_211112 ~]# ipmitool raw 0x6 0x1
 20 81 16 04 02 bf 15 a0 00 46 31 01 00 00 00