### PR TITLE
Remove Clang-Format Comment Generation Step

### DIFF
--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -93,7 +93,7 @@ jobs:
         CPP_FILE_LIST="/tmp/cppcheck_file_list.log"
         
         # Only keep the source files to check or CPPCheck gets confused.
-        sed '/\(c$\|cpp$\|c$\|cc$\|cu$\|cxx$\|h$\|hh$\|hpp$\|hxx$\|tcc$\)/!d' git_diff.log > $CPP_FILE_LIST
+        sed '/\(\.c$\|\.cpp$\|\.c$\|\.cc$\|\.cu$\|\.cxx$\|\.h$\|\.hh$\|\.hpp$\|\.hxx$\|\.tcc$\)/!d' git_diff.log > $CPP_FILE_LIST
 
         if [ -s $CPP_FILE_LIST ]; then
           echo "C/C++ source files kept:"
@@ -182,7 +182,7 @@ jobs:
         CLANG_FORMAT_FILE_LIST="/tmp/clang_format_file_list.log"
         
         # Only keep the source files to check or clang-format starts checking everything.
-        sed '/\(c$\|cpp$\|c$\|cc$\|cu$\|cxx$\|h$\|hh$\|hpp$\|hxx$\|tcc$\)/!d' /tmp/change_set.log > $CLANG_FORMAT_FILE_LIST
+        sed '/\(\.c$\|\.cpp$\|\.c$\|\.cc$\|\.cu$\|\.cxx$\|\.h$\|\.hh$\|\.hpp$\|\.hxx$\|\.tcc$\)/!d' /tmp/change_set.log > $CLANG_FORMAT_FILE_LIST
 
         if [ -s $CLANG_FORMAT_FILE_LIST ]; then
           echo "C/C++ source files kept for clang-format:"
@@ -191,6 +191,7 @@ jobs:
         
         if [ -s $CLANG_FORMAT_FILE_LIST ]; then
           echo "contains_c_source=true" >> $GITHUB_ENV
+          echo "contains_clang_errors=false" >> $GITHUB_ENV
         else
           echo "contains_c_source=false" >> $GITHUB_ENV
         fi
@@ -218,39 +219,21 @@ jobs:
          
           # Clang format outputs to stderr... why do you do this clang-format 
           if ! clang-format "${options[@]}" $FILE_PATH &> /dev/null ; then
-            echo $FILE_PATH "has clang-format errors!"
+            echo -e "\u001b[31;1m$FILE_PATH has clang-format errors!\u001b[0m"
             echo $FILE_PATH >> /tmp/clang-format.log
+            echo "contains_clang_errors=true" >> $GITHUB_ENV
           fi
 
         done
-  
-    - uses: actions/upload-artifact@master
-      if: env.contains_c_source == 'true'
-      name: Upload clang-format error log
-      with:
-        name: clang-format-output
-        path: /tmp/clang-format.log
-
+ 
     - name: Check for clang-format output
-      if: env.contains_c_source == 'true'
+      if: env.contains_c_source == 'true' && env.contains_clang_errors == 'true'
       run : |
         if [ -s /tmp/clang-format.log ]; then
           exit 1
         fi
 
   Aggregate-Lint-Output:
-    permissions:
-      actions: read
-      checks: read
-      contents: read
-      deployments: read
-      issues: read
-      packages: read
-      pull-requests: write
-      repository-projects: read
-      security-events: read
-      statuses: read
-
     needs: [run-cppcheck, run-clang-format]
     if: |
         always() && 
@@ -270,23 +253,6 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         path: /tmp/artifacts
-
-    - name: Load comment variable
-      id: load-clang-env-variable
-      run: echo "::set-output name=clang-format-comment::$(cat /tmp/artifacts/clang-format-output/clang-format.log)"
-
-    - uses: actions/github-script@v6
-      if: needs.run-clang-format.result == 'failure'
-      name: Comment on clang-format
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: "These files have clang-format errors:\n ${{ steps.load-clang-env-variable.outputs.clang-format-comment}}\n\n You can fix these errors by running \"clang-format --style=file -i $file\" on the effected files"
-          })
 
     - name: Run reviewdog
       env:


### PR DESCRIPTION
Summary:

When pull requests are made from a fork of a repo GitHub Tokens have
only read permissions by default. Unfortunately this means that a Github
action can't post a comment to the PR, like in the case of the
clang-format action.

Because of that I'm removing the code that generates the comment and
instead simply having the job for clang-formatting fail and requiring
the submitter go and investigate the cause.

Test Plan:

Run the action on the public Repo with and without files failing
clang-format checks.

Reviewers:

Subscribers:

Tasks:

Tags: CIT