### PR TITLE
fby3.5: cl:Add KCS kernel config check before calling KCS APIs

### DIFF
--- a/common/host/kcs.c
+++ b/common/host/kcs.c
@@ -7,6 +7,7 @@
 #include "kcs.h"
 #include "pal.h"
 
+#ifdef CONFIG_IPMI_KCS_ASPEED
 struct k_thread kcs_polling;
 K_KERNEL_STACK_MEMBER(KCS_POLL_stack, KCS_POLL_stack_STACK_SIZE);
 
@@ -127,3 +128,5 @@ void kcs_init(void)
 			kcs_read, NULL, NULL, NULL, CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
 	k_thread_name_set(&kcs_polling, "kcs_polling");
 }
+
+#endif

--- a/common/ipmi/ipmb.c
+++ b/common/ipmi/ipmb.c
@@ -253,8 +253,6 @@ void IPMB_TXTask(void *pvParameters, void *arvg0, void *arvg1)
 	I2C_MSG *msg;
 	uint8_t ipmb_buffer_tx[IPMI_MSG_MAX_LENGTH + IPMB_RESP_HEADER_LENGTH], status = 0,
 									       retry = 5;
-	uint8_t *kcs_buff;
-
 	memcpy(&ipmb_cfg, (IPMB_config *)pvParameters, sizeof(IPMB_config));
 
 	while (1) {
@@ -404,8 +402,10 @@ void IPMB_TXTask(void *pvParameters, void *arvg0, void *arvg1)
 						printf("IPMB_TXTask: Bridging msg from reserve IFs\n");
 					} else if (current_msg_tx->buffer.InF_source == Self_IFs) {
 						printf("IPMB_TXTask: BIC sending command fail\n"); // Rain - Should record or notice command fail
+#ifdef CONFIG_IPMI_KCS_ASPEED
 					} else if (current_msg_tx->buffer.InF_source ==
 						   HOST_KCS_IFs) {
+						uint8_t *kcs_buff;
 						kcs_buff = malloc(KCS_buff_size * sizeof(uint8_t));
 						if (kcs_buff ==
 						    NULL) { // allocate fail, retry allocate
@@ -436,6 +436,7 @@ void IPMB_TXTask(void *pvParameters, void *arvg0, void *arvg1)
 						if (kcs_buff != NULL) {
 							free(kcs_buff);
 						}
+#endif
 					} else {
 						ipmb_error status;
 						current_msg_tx->buffer.data_len = 0;
@@ -494,7 +495,6 @@ void IPMB_RXTask(void *pvParameters, void *arvg0, void *arvg1)
 	struct IPMB_config ipmb_cfg;
 	struct ipmb_msg *msg = NULL;
 	uint8_t *ipmb_buffer_rx;
-	uint8_t *kcs_buff;
 	uint8_t rx_len;
 	static uint16_t i = 0;
 	int ret;
@@ -614,9 +614,10 @@ void IPMB_RXTask(void *pvParameters, void *arvg0, void *arvg1)
 									      [current_msg_rx->buffer
 										       .InF_target]],
 							&current_msg, K_NO_WAIT);
+#ifdef CONFIG_IPMI_KCS_ASPEED
 					} else if (current_msg_rx->buffer.InF_source ==
 						   HOST_KCS_IFs) {
-#ifdef CONFIG_IPMI_KCS_ASPEED
+						uint8_t *kcs_buff;
 						kcs_buff = malloc(KCS_buff_size * sizeof(uint8_t));
 						if (kcs_buff ==
 						    NULL) { // allocate fail, retry allocate
@@ -646,7 +647,6 @@ void IPMB_RXTask(void *pvParameters, void *arvg0, void *arvg1)
 							free(kcs_buff);
 						}
 #endif
-
 					} else if (current_msg_rx->buffer.InF_source ==
 						   ME_IPMB_IFs) {
 						ipmb_error status;

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -196,7 +196,6 @@ ipmi_error IPMI_handler(void *arug0, void *arug1, void *arug2)
 {
 	uint8_t i;
 	ipmi_msg_cfg msg_cfg;
-	uint8_t *kcs_buff;
 
 	while (1) {
 		k_msgq_get(&ipmi_msgq, &msg_cfg, K_FOREVER);
@@ -285,8 +284,9 @@ ipmi_error IPMI_handler(void *arug0, void *arug1, void *arug2)
 
 			if (msg_cfg.buffer.InF_source == BMC_USB_IFs) {
 				USB_write(&msg_cfg.buffer);
-			} else if (msg_cfg.buffer.InF_source == HOST_KCS_IFs) {
 #ifdef CONFIG_IPMI_KCS_ASPEED
+			} else if (msg_cfg.buffer.InF_source == HOST_KCS_IFs) {
+				uint8_t *kcs_buff;
 				kcs_buff = malloc(KCS_buff_size * sizeof(uint8_t));
 				if (kcs_buff == NULL) { // allocate fail, retry allocate
 					k_msleep(10);
@@ -320,7 +320,6 @@ ipmi_error IPMI_handler(void *arug0, void *arug1, void *arug2)
 				if (kcs_buff != NULL)
 					free(kcs_buff);
 #endif
-
 			} else {
 				status = ipmb_send_response(
 					&msg_cfg.buffer,


### PR DESCRIPTION
Summary:
- Add to check the KCS kernel configuration is enabled or not before we call KCS API in common layer code.

Test Plan:
- Build code: Pass
- Test send ipmi command from host: Pass

Log:
[root@Stream8_211112 ~]# ipmitool raw 0x06 0x01
 20 81 16 07 02 bf 15 a0 00 46 31 01 00 00 00