### PR TITLE
fby3.5: cl: Add read and write BIC register command

### DIFF
--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -89,6 +89,8 @@ void pal_OEM_1S_JTAG_DATA_SHIFT(ipmi_msg *msg);
 void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg);
 void pal_OEM_1S_RESET_BIC(ipmi_msg *msg);
 void pal_OEM_1S_12V_CYCLE_SLOT(ipmi_msg *msg);
+void pal_OEM_1S_READ_BIC_REGISTER(ipmi_msg *msg);
+void pal_OEM_1S_WRITE_BIC_REGISTER(ipmi_msg *msg);
 
 enum {
 	CC_SUCCESS = 0x00,
@@ -217,6 +219,8 @@ enum {
 	CMD_OEM_1S_I2C_DEV_SCAN = 0x60,
 
 	CMD_OEM_1S_12V_CYCLE_SLOT = 0x64,
+	CMD_OEM_1S_READ_BIC_REGISTER = 0x68,
+	CMD_OEM_1S_WRITE_BIC_REGISTER = 0x69,
 };
 
 #endif

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -184,6 +184,12 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 	case CMD_OEM_1S_12V_CYCLE_SLOT:
 		pal_OEM_1S_12V_CYCLE_SLOT(msg);
 		break;
+	case CMD_OEM_1S_READ_BIC_REGISTER:
+		pal_OEM_1S_READ_BIC_REGISTER(msg);
+		break;
+	case CMD_OEM_1S_WRITE_BIC_REGISTER:
+		pal_OEM_1S_WRITE_BIC_REGISTER(msg);
+		break;
 	default:
 		printf("invalid OEM msg netfn: %x, cmd: %x\n", msg->netfn, msg->cmd);
 		msg->data_len = 0;

--- a/common/pal.c
+++ b/common/pal.c
@@ -250,6 +250,18 @@ __weak void pal_OEM_1S_12V_CYCLE_SLOT(ipmi_msg *msg)
 	return;
 }
 
+__weak void pal_OEM_1S_READ_BIC_REGISTER(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_WRITE_BIC_REGISTER(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
 // init
 __weak void pal_I2C_init(void)
 {

--- a/common/pal.h
+++ b/common/pal.h
@@ -53,6 +53,8 @@ void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg);
 void pal_OEM_1S_GET_BIC_STATUS(ipmi_msg *msg);
 void pal_OEM_1S_RESET_BIC(ipmi_msg *msg);
 void pal_OEM_1S_12V_CYCLE_SLOT(ipmi_msg *msg);
+void pal_OEM_1S_READ_BIC_REGISTER(ipmi_msg *msg);
+void pal_OEM_1S_WRITE_BIC_REGISTER(ipmi_msg *msg);
 
 // init
 void pal_I2C_init(void);

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -1168,7 +1168,7 @@ void pal_OEM_1S_SET_JTAG_TAP_STA(ipmi_msg *msg)
 
 void pal_OEM_1S_ACCURACY_SENSNR(ipmi_msg *msg)
 {
-  	uint8_t status, snr_num, option, snr_report_status;
+	uint8_t status, snr_num, option, snr_report_status;
 	uint8_t enable_snr_scan = 0xC0; // following IPMI sensor status response
 	uint8_t disable_snr_scan = 0x80;
 	int reading;
@@ -1419,6 +1419,72 @@ void pal_OEM_1S_SENSOR_POLL_EN(ipmi_msg *msg)
 		msg->completion_code = CC_INVALID_DATA_FIELD;
 		return;
 	}
+
+	msg->data_len = 0;
+	msg->completion_code = CC_SUCCESS;
+	return;
+}
+
+void pal_OEM_1S_READ_BIC_REGISTER(ipmi_msg *msg)
+{
+	/*********************************
+ 	* buf 0~3: start of register address to read, LSB first
+ 	* buf 4  : bytes to read
+	***********************************/
+	if (!msg) {
+		printf("pal_OEM_1S_READ_BIC_REGISTER: parameter msg is NULL\n");
+		return;
+	}
+	if (msg->data_len != 5) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	uint32_t addr =
+		msg->data[0] | (msg->data[1] << 8) | (msg->data[2] << 16) | (msg->data[3] << 24);
+	uint8_t read_len = msg->data[4];
+	for (uint8_t i = 0; i < read_len; i++) {
+		msg->data[i] = *(uint8_t *)(addr + i);
+	}
+
+	msg->data_len = read_len;
+	msg->completion_code = CC_SUCCESS;
+	return;
+}
+
+void pal_OEM_1S_WRITE_BIC_REGISTER(ipmi_msg *msg)
+{
+	/*********************************
+ 	* buf 0~3: start of register address to write, LSB first
+ 	* buf 4  : bytes to write, <= 4 bytes
+	* buf 5~N: date to write, LSB first
+	*
+	* NOTE: The register address must be a multiple of 4
+	***********************************/
+	if (!msg) {
+		printf("pal_OEM_1S_WRITE_BIC_REGISTER: parameter msg is NULL\n");
+		return;
+	}
+	if (msg->data[4] < 1 || msg->data[4] > 4 || (msg->data_len != 5 + msg->data[4])) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	uint32_t addr =
+		msg->data[0] | (msg->data[1] << 8) | (msg->data[2] << 16) | (msg->data[3] << 24);
+	if (addr % 4) {
+		msg->completion_code = CC_INVALID_DATA_FIELD;
+		return;
+	}
+
+	uint8_t write_len = msg->data[4];
+	uint32_t reg_data = *(uint32_t *)addr;
+	/* replace write_len bytes */
+	reg_data &= ~BIT_MASK(write_len * 8);
+	for (uint8_t i = 0; i < write_len; i++) {
+		reg_data |= msg->data[i + 5] << (i * 8);
+	}
+	*(uint32_t *)addr = reg_data;
 
 	msg->data_len = 0;
 	msg->completion_code = CC_SUCCESS;


### PR DESCRIPTION
Summary:
- Add OEM command to write and read BIC register

Test Plan:
- Build Code: Pass
- Command Test: Pass

LOG:
```
read register 0x7e7b0300
root@bmc-oob:~# bic-util slot1 0xe0 0x68 0x9c 0x9c 0x00 0x00 0x03 0x7b 0x7e 0x4
9C 9C 00 01 00 02 00

write 2 bytes 0x2211 to register 0x7e7b0300
root@bmc-oob:~# bic-util slot1 0xe0 0x69 0x9c 0x9c 0x00 0x00 0x03 0x7b 0x7e 0x2 0x11 0x22
9C 9C 00

check the value has been written
root@bmc-oob:~# bic-util slot1 0xe0 0x68 0x9c 0x9c 0x00 0x00 0x03 0x7b 0x7e 0x4
9C 9C 00 11 22 02 00
```