### PR TITLE
fby3.5: bb: Fix reset problem

### DIFF
--- a/meta-facebook/yv35-bb/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-bb/boards/ast1030_evb.overlay
@@ -211,6 +211,10 @@
 	spi-max-frequency = <50000000>;
 };
 
+&wdt0 {
+	status = "okay";
+};
+
 &wdt1 {
 	status = "okay";
 };


### PR DESCRIPTION
Summary:
- Fix BB BIC can't reset problem.
The root cause is Zephyr SDK04 change the wdt of dts architecture.
If we don't enable wdt0 before, the kernel won't find wdt1.

Test plan:
- Build code: Pass
- Warm reset: Pass
- Cold reset: Pass

Log:
1. Warm reset.
- Before fix
uart:~$ kernel reboot warm
No device named wdt1.
Failed to reboot: spinning endlessly...

- After fix
uart:~$ kernel reboot warm0)I00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x81] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x82] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspeed: pre-selected ep[0x1] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspee*** Booting Zephyr OS build v00.01.04  ***
Hello, welcome to yv35 baseboard 2022.1.1
ipmi_init
d: pre-selected ep[0x2] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint
[00:00:00.100,000] <inf> usb_cdc_acm: Device suspended

2. Cold reset.
- Before fix
uart:~$ kernel reboot cold
No device named wdt1.
Failed to reboot: spinning endlessly...

- After fix
uart:~$ kernel reboot cold0)I00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x81] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x82] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspeed: pre-selected ep[0x1] as IN endpoint
[00:00:00.000,000] <wrn> usb_dc_aspee*** Booting Zephyr OS build v00.01.04  ***
Hello, welcome to yv35 baseboard 2022.1.1
ipmi_init
d: pre-selected ep[0x2] as IN endpoint
[00:00:00.000,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint
[00:00:00.100,000] <inf> usb_cdc_acm: Device suspended