### PR TITLE
fby3.5: cl:Fix warning message when building image

### DIFF
--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -41,7 +41,7 @@ static inline void pack_ipmi_resp(struct ipmi_response *resp, ipmi_msg *ipmi_res
 }
 
 void ipmi_init(void);
-ipmi_error IPMI_handler(void *arug0, void *arug1, void *arug2);
+void IPMI_handler(void *arug0, void *arug1, void *arug2);
 
 // IPMI CHASSIS
 void pal_CHASSIS_GET_CHASSIS_STATUS(ipmi_msg *msg);

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -4,7 +4,9 @@
 #include "cmsis_os2.h"
 #include "ipmi.h"
 #include "kcs.h"
+#include "usb.h"
 #include <string.h>
+#include <stdlib.h>
 #define IPMI_QUEUE_SIZE 5
 
 struct k_thread IPMI_thread;
@@ -198,7 +200,7 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 	return;
 }
 
-ipmi_error IPMI_handler(void *arug0, void *arug1, void *arug2)
+void IPMI_handler(void *arug0, void *arug1, void *arug2)
 {
 	uint8_t i;
 	ipmi_msg_cfg msg_cfg;

--- a/common/pal.c
+++ b/common/pal.c
@@ -299,12 +299,12 @@ __weak bool pal_load_sensor_config(void)
 
 __weak void pal_fix_fullSDR_table(void)
 {
-	return 0;
+	return;
 }
 
 __weak void pal_fix_Sensorconfig(void)
 {
-	return 0;
+	return;
 }
 
 // fru

--- a/common/sensor/sensor.h
+++ b/common/sensor/sensor.h
@@ -176,6 +176,7 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode);
 bool sensor_init(void);
 void sensor_poll_disable();
 void sensor_poll_enable();
+void clear_unaccessible_sensor_cache();
 
 /* i2c-mux tca9548 */
 bool tca9548_select_chan(uint8_t sensor_num, void *args);

--- a/common/usb/usb.h
+++ b/common/usb/usb.h
@@ -1,6 +1,8 @@
 #ifndef USB_H
 #define USB_H
 
+#include "ipmb.h"
+
 #define DEBUG_USB 0
 #define USB_HANDLER_STACK_SIZE 2000
 #define RX_BUFF_SIZE    64
@@ -8,5 +10,6 @@
 
 void usb_dev_init(void);
 void usb_slavedev_init(void);
+void USB_write(ipmi_msg *ipmi_resp);
 
 #endif

--- a/common/util/fru.c
+++ b/common/util/fru.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include "fru.h"
 #include "plat_fru.h"
+#include <string.h>
 
 EEPROM_CFG fru_config[FRU_CFG_NUM];
 
@@ -27,7 +28,7 @@ uint8_t get_FRU_access(uint8_t FRUID)
 
 	ID_No = find_FRU_ID(FRUID);
 
-	if (!ID_No == -1) { // FRU ID not found
+	if (ID_No == -1) { // FRU ID not found
 		return 0xFF;
 	}
 

--- a/common/util/guid.c
+++ b/common/util/guid.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include "guid.h"
 #include "plat_guid.h"
 

--- a/common/util/hal_gpio.c
+++ b/common/util/hal_gpio.c
@@ -182,7 +182,7 @@ void init_gpio_dev(void)
 #endif
 }
 
-bool gpio_init(void)
+void gpio_init(void)
 {
 	uint8_t i;
 
@@ -222,6 +222,4 @@ bool gpio_init(void)
 			}
 		}
 	}
-
-	return 1;
 }

--- a/common/util/hal_gpio.h
+++ b/common/util/hal_gpio.h
@@ -75,7 +75,8 @@ extern uint8_t gpio_ind_to_num_table_cnt;
 void gpio_show(void);
 int gpio_get(uint8_t);
 int gpio_set(uint8_t, uint8_t);
-bool gpio_init(void);
+uint8_t gpio_conf(uint8_t gpio_num, int dir);
+void gpio_init(void);
 int gpio_interrupt_conf(uint8_t, gpio_flags_t);
 
 #endif

--- a/common/util/hal_i2c.c
+++ b/common/util/hal_i2c.c
@@ -135,7 +135,6 @@ int i2c_master_write(I2C_MSG *msg, uint8_t retry)
 void i2c_scan(uint8_t bus, uint8_t *slave_addr, uint8_t *slave_addr_len)
 {
 	uint8_t first = 0x04, last = 0x77;
-	*slave_addr_len = 0;
 
 	for (uint8_t i = 0; i <= last; i += 16) {
 		for (uint8_t j = 0; j < 16; j++) {

--- a/common/util/hal_i2c.h
+++ b/common/util/hal_i2c.h
@@ -78,5 +78,6 @@ void i2c_freq_set(uint8_t i2c_bus, uint8_t i2c_speed_mode);
 int i2c_master_read(I2C_MSG *msg, uint8_t retry);
 int i2c_master_write(I2C_MSG *msg, uint8_t retry);
 void util_init_I2C(void);
+void i2c_scan(uint8_t bus, uint8_t *slave_addr, uint8_t *slave_addr_len);
 
 #endif

--- a/common/util/hal_peci.c
+++ b/common/util/hal_peci.c
@@ -1,4 +1,6 @@
 #include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 #include <drivers/peci.h>
 #include "hal_peci.h"
 

--- a/common/util/util_spi.c
+++ b/common/util/util_spi.c
@@ -11,6 +11,7 @@
 #include <sys/util.h>
 #include "cmsis_os2.h"
 #include "util_spi.h"
+#include "util_sys.h"
 
 static char *flash_device[6] = { "fmc_cs0",  "fmc_cs1",	 "spi1_cs0",
 				 "spi1_cs1", "spi2_cs0", "spi2_cs1" };

--- a/common/util/util_sys.h
+++ b/common/util/util_sys.h
@@ -4,5 +4,6 @@
 void set_boot_source();
 bool get_boot_source_ACon();
 void submit_bic_warm_reset();
+void submit_bic_cold_reset();
 
 #endif

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmb.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmb.c
@@ -5,6 +5,7 @@
 #include "plat_i2c.h"
 #include "plat_ipmi.h"
 #include "plat_def.h"
+#include "plat_func.h"
 
 IPMB_config pal_IPMB_config_table[] = {
 	//   index             interface         interface_source  bus              Target_addr          EnStatus  slave_addr            Rx_attr_name          Tx_attr_name//

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -20,6 +20,7 @@
 #include <drivers/peci.h>
 #include "plat_func.h"
 #include "util_sys.h"
+#include "hal_i2c.h"
 
 bool add_sel_evt_record(addsel_msg_t *sel_msg)
 {
@@ -1173,7 +1174,7 @@ void pal_OEM_1S_SET_JTAG_TAP_STA(ipmi_msg *msg)
 
 void pal_OEM_1S_ACCURACY_SENSOR_READING(ipmi_msg *msg)
 {
-	uint8_t status, sensor_num, option, sensor_report_status;
+	uint8_t status = -1, sensor_num, option, sensor_report_status;
 	uint8_t enable_sensor_scan = 0xC0; // following IPMI sensor status response
 	uint8_t disable_sensor_scan = 0x80;
 	int reading;
@@ -1322,8 +1323,10 @@ void pal_OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg)
 	}
 
 	uint8_t bus = i2c_bus_to_index[msg->data[0]];
+	uint8_t i2c_scan_len = 0;
 
-	i2c_scan(bus, &msg->data[0], &msg->data_len);
+	i2c_scan(bus, &msg->data[0], &i2c_scan_len);
+	msg->data_len = i2c_scan_len;
 
 	msg->completion_code = CC_SUCCESS;
 	return;

--- a/meta-facebook/yv35-cl/src/main.c
+++ b/meta-facebook/yv35-cl/src/main.c
@@ -38,7 +38,6 @@ void set_sys_status()
 
 void main(void)
 {
-	uint8_t proj_stage = (FIRMWARE_REVISION_1 & 0xf0) >> 4;
 	printk("Hello, wellcome to yv35 craterlake %x%x.%x.%x\n", BIC_FW_YEAR_MSB, BIC_FW_YEAR_LSB,
 	       BIC_FW_WEEK, BIC_FW_VER);
 

--- a/meta-facebook/yv35-cl/src/platform/hwmon.c
+++ b/meta-facebook/yv35-cl/src/platform/hwmon.c
@@ -7,6 +7,7 @@
 #include "libipmi.h"
 #include "sensor_def.h"
 #include "plat_def.h"
+#include "sensor.h"
 
 static bool is_DC_on = 0;
 static bool is_DC_on_5s = 0;
@@ -21,8 +22,8 @@ static uint8_t card_type_2ou = 0;
 #define PROC_FAIL_START_DELAY_SECOND 10
 #define CATERR_START_DELAY_SECOND 2
 
-static void proc_fail_handler(void *, void *, void *);
-static void CatErr_handler(void *, void *, void *);
+static void proc_fail_handler();
+static void CatErr_handler();
 
 K_WORK_DELAYABLE_DEFINE(proc_fail_work, proc_fail_handler);
 K_WORK_DELAYABLE_DEFINE(CatErr_work, CatErr_handler);
@@ -549,7 +550,7 @@ void disable_PRDY_interrupt()
 	gpio_interrupt_conf(H_BMC_PRDY_BUF_N, GPIO_INT_DISABLE);
 }
 
-static void proc_fail_handler(void *arug0, void *arug1, void *arug2)
+static void proc_fail_handler()
 {
 	/* if have not received kcs and post code, add FRB3 event log. */
 	if ((get_kcs_ok() == 0) && (get_postcode_ok() == 0)) {
@@ -571,7 +572,7 @@ static void proc_fail_handler(void *arug0, void *arug1, void *arug2)
 	}
 }
 
-static void CatErr_handler(void *arug0, void *arug1, void *arug2)
+static void CatErr_handler()
 {
 	if ((gpio_get(RST_PLTRST_BUF_N) == 1) || (gpio_get(PWRGD_SYS_PWROK) == 1)) {
 		addsel_msg_t sel_msg;

--- a/meta-facebook/yv35-cl/src/platform/plat_fru.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_fru.h
@@ -14,4 +14,5 @@ enum {
 	MAX_FRU_ID,
 };
 
+void pal_load_fru_config(void);
 #endif

--- a/meta-facebook/yv35-cl/src/platform/plat_func.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_func.h
@@ -44,4 +44,5 @@ void enable_PRDY_interrupt();
 void disable_PRDY_interrupt();
 void set_ME_restore();
 void pal_warm_reset_prepare();
+void submit_bmc_warm_reset();
 #endif

--- a/meta-facebook/yv35-cl/src/platform/plat_guid.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_guid.h
@@ -7,4 +7,6 @@ enum {
 	MAX_GUID_ID,
 };
 
+extern const EEPROM_CFG guid_config[];
+
 #endif

--- a/meta-facebook/yv35-cl/src/platform/platform.c
+++ b/meta-facebook/yv35-cl/src/platform/platform.c
@@ -132,7 +132,7 @@ void BMC_reset_handler()
 	gpio_set(RST_BMC_R_N, GPIO_HIGH);
 }
 
-K_DELAYED_WORK_DEFINE(BMC_reset_work, BMC_reset_handler);
+K_WORK_DELAYABLE_DEFINE(BMC_reset_work, BMC_reset_handler);
 void submit_bmc_warm_reset()
 {
 	k_work_schedule(&BMC_reset_work, K_MSEC(1000));

--- a/meta-facebook/yv35-cl/src/sensor/dev/adc.c
+++ b/meta-facebook/yv35-cl/src/sensor/dev/adc.c
@@ -25,7 +25,7 @@
 #define ADC_REFERENCE ADC_REF_INTERNAL
 #define ADC_ACQUISITION_TIME ADC_ACQ_TIME_DEFAULT
 
-static struct device *dev_adc[ADC_NUM];
+static const struct device *dev_adc[ADC_NUM];
 static int16_t sample_buffer[BUFFER_SIZE];
 
 struct adc_channel_cfg channel_cfg = {

--- a/meta-facebook/yv35-cl/src/sensor/dev/hsc.c
+++ b/meta-facebook/yv35-cl/src/sensor/dev/hsc.c
@@ -37,7 +37,7 @@ bool hsc_init()
 bool pal_hsc_read(uint8_t sensor_num, int *reading)
 {
 	uint8_t retry = 5;
-	int val;
+	int val = -1;
 	I2C_MSG msg;
 
 	msg.bus = sensor_config[SensorNum_SensorCfg_map[sensor_num]].port;

--- a/meta-facebook/yv35-cl/src/sensor/dev/vr.c
+++ b/meta-facebook/yv35-cl/src/sensor/dev/vr.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include "sensor.h"
 #include "hal_i2c.h"
 #include "sensor_def.h"

--- a/meta-facebook/yv35-cl/src/sensor/plat_sdr.c
+++ b/meta-facebook/yv35-cl/src/sensor/plat_sdr.c
@@ -5,6 +5,7 @@
 #include "sensor.h"
 #include "sensor_def.h"
 #include "plat_ipmb.h"
+#include "plat_func.h"
 
 enum {
 	threshold_UNR,


### PR DESCRIPTION
Summary:
- Fix warning message when building image

Test Plan:
- Build code: Pass
- AC cycle 200 times: Pass
- DC cycle 200 times: Pass
- Reset 200 times: Pass
- Sanity test: Pass

Log:
-Before fix
warning: implicit declaration of function 'submit_bic_cold_reset'; did you mean 'submit_bic_warm_reset'? [-Wimplicit-function-declaration]
  213 |  submit_bic_cold_reset();
warning: implicit declaration of function 'clear_unaccessible_sensor_cache' [-Wimplicit-function-declaration]
   81 |   clear_unaccessible_sensor_cache();
warning: initialization of 'uint8_t *' {aka 'unsigned char *'} from 'int' makes pointer from integer without a cast [-Wint-conversion]
  134 |  uint8_t *readbuf = malloc(2 * readlen * sizeof(uint8_t));
warning: comparison of constant '-1' with boolean expression is always false [-Wbool-compare]
   30 |  if (!ID_No == -1) { // FRU ID not found
warning: implicit declaration of function 'get_bic_class' [-Wimplicit-function-declaration]
 3054 |  if (get_bic_class()) {
warning: implicit declaration of function 'get_1ou_status' [-Wimplicit-function-declaration]
 3072 |  if (get_1ou_status()) {
warning: implicit declaration of function 'get_2ou_status' [-Wimplicit-function-declaration]
 3080 |  if (get_2ou_status()) {
warning: Macro is deprecated
  135 | K_DELAYED_WORK_DEFINE(BMC_reset_work, BMC_reset_handler);
warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   55 |  dev_adc[adc0] = device_get_binding("ADC0");
warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   58 |  dev_adc[adc1] = device_get_binding("ADC1");
warning: implicit declaration of function 'memset' [-Wimplicit-function-declaration]
   40 |   memset(&msg.data[0], 0, 2);
warning: implicit declaration of function 'pal_load_fru_config' [-Wimplicit-function-declaration]
  106 |  pal_load_fru_config();
...