### PR TITLE
fby3.5: cl: Add TI and Infineon VR sensor, and add OEM command to set…

### DIFF
--- a/common/ipmi/include/ipmi.h
+++ b/common/ipmi/include/ipmi.h
@@ -78,6 +78,8 @@ void pal_OEM_1S_SENSOR_POLL_EN(ipmi_msg *msg);
 void pal_OEM_1S_FW_UPDATE(ipmi_msg *msg);
 void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg);
 void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg);
+void pal_OEM_1S_SET_VR_MONITOR_STATUS(ipmi_msg *msg);
+void pal_OEM_1S_GET_VR_MONITOR_STATUS(ipmi_msg *msg);
 void pal_OEM_1S_RESET_BMC(ipmi_msg *msg);
 void pal_OEM_1S_PECIaccess(ipmi_msg *msg);
 void pal_OEM_1S_ASD_INIT(ipmi_msg *msg);
@@ -197,6 +199,8 @@ enum { CMD_OEM_1S_MSG_IN = 0x1,
        CMD_OEM_1S_FW_UPDATE = 0x9,
        CMD_OEM_1S_GET_FW_VERSION = 0xB,
        CMD_OEM_1S_GET_POST_CODE = 0x12,
+       CMD_OEM_1S_SET_VR_MONITOR_STATUS = 0x14,
+       CMD_OEM_1S_GET_VR_MONITOR_STATUS = 0x15,
        CMD_OEM_1S_RESET_BMC = 0x16,
        CMD_OEM_1S_SET_JTAG_TAP_STA = 0x21,
        CMD_OEM_1S_JTAG_DATA_SHIFT = 0x22,

--- a/common/ipmi/ipmi.c
+++ b/common/ipmi/ipmi.c
@@ -151,6 +151,12 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 	case CMD_OEM_1S_GET_POST_CODE:
 		pal_OEM_1S_GET_POST_CODE(msg);
 		break;
+	case CMD_OEM_1S_SET_VR_MONITOR_STATUS:
+		pal_OEM_1S_SET_VR_MONITOR_STATUS(msg);
+		break;
+	case CMD_OEM_1S_GET_VR_MONITOR_STATUS:
+		pal_OEM_1S_GET_VR_MONITOR_STATUS(msg);
+		break;
 	case CMD_OEM_1S_RESET_BMC:
 		pal_OEM_1S_RESET_BMC(msg);
 		break;

--- a/common/pal.c
+++ b/common/pal.c
@@ -178,6 +178,18 @@ __weak void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg)
 	return;
 }
 
+__weak void pal_OEM_1S_SET_VR_MONITOR_STATUS(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
+__weak void pal_OEM_1S_GET_VR_MONITOR_STATUS(ipmi_msg *msg)
+{
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+	return;
+}
+
 __weak void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 {
 	msg->completion_code = CC_UNSPECIFIED_ERROR;

--- a/common/pal.h
+++ b/common/pal.h
@@ -44,6 +44,8 @@ void pal_OEM_1S_SET_GPIO(ipmi_msg *msg);
 void pal_OEM_1S_SENSOR_POLL_EN(ipmi_msg *msg);
 void pal_OEM_1S_FW_UPDATE(ipmi_msg *msg);
 void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg);
+void pal_OEM_1S_SET_VR_MONITOR_STATUS(ipmi_msg *msg);
+void pal_OEM_1S_GET_VR_MONITOR_STATUS(ipmi_msg *msg);
 void pal_OEM_1S_RESET_BMC(ipmi_msg *msg);
 void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg);
 void pal_OEM_1S_ACCURACY_SENSOR_READING(ipmi_msg *msg);

--- a/common/sensor/dev/tps53689.c
+++ b/common/sensor/dev/tps53689.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <string.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "util_pmbus.h"
+
+uint8_t tps53689_read(uint8_t sensor_num, int *reading)
+{
+	if (reading == NULL) {
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	uint8_t retry = 5;
+	sensor_val *sval = (sensor_val *)reading;
+	I2C_MSG msg;
+	memset(sval, 0, sizeof(sensor_val));
+
+	msg.bus = sensor_config[SensorNum_SensorCfg_map[sensor_num]].port;
+	msg.slave_addr = sensor_config[SensorNum_SensorCfg_map[sensor_num]].slave_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = sensor_config[SensorNum_SensorCfg_map[sensor_num]].offset;
+
+	if (i2c_master_read(&msg, retry))
+		return SENSOR_FAIL_TO_ACCESS;
+
+	uint8_t offset = sensor_config[SensorNum_SensorCfg_map[sensor_num]].offset;
+	if (offset == PMBUS_READ_VOUT) {
+		/* ULINEAR16, get exponent from VOUT_MODE */
+		float exponent;
+		if (!get_exponent_from_vout_mode(sensor_num, &exponent))
+			return SENSOR_FAIL_TO_ACCESS;
+
+		float actual_value = ((msg.data[1] << 8) | msg.data[0]) * exponent;
+		sval->integer = actual_value;
+		sval->fraction = (actual_value - sval->integer) * 1000;
+	} else if (offset == PMBUS_READ_IOUT || offset == PMBUS_READ_TEMPERATURE_1 ||
+		   offset == PMBUS_READ_POUT) {
+		/* SLINEAR11 */
+		uint16_t read_value = (msg.data[1] << 8) | msg.data[0];
+		float actual_value = slinear11_to_float(read_value);
+		sval->integer = actual_value;
+		sval->fraction = (actual_value - sval->integer) * 1000;
+	} else {
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t tps53689_init(uint8_t sensor_num)
+{
+	sensor_config[SensorNum_SensorCfg_map[sensor_num]].read = tps53689_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/sensor/dev/xdpe15284.c
+++ b/common/sensor/dev/xdpe15284.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+#include <string.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "util_pmbus.h"
+
+uint8_t xdpe15284_read(uint8_t sensor_num, int *reading)
+{
+	if (reading == NULL) {
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	uint8_t retry = 5;
+	sensor_val *sval = (sensor_val *)reading;
+	I2C_MSG msg;
+	memset(sval, 0, sizeof(sensor_val));
+
+	msg.bus = sensor_config[SensorNum_SensorCfg_map[sensor_num]].port;
+	msg.slave_addr = sensor_config[SensorNum_SensorCfg_map[sensor_num]].slave_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = sensor_config[SensorNum_SensorCfg_map[sensor_num]].offset;
+
+	if (i2c_master_read(&msg, retry))
+		return SENSOR_FAIL_TO_ACCESS;
+
+	uint8_t offset = sensor_config[SensorNum_SensorCfg_map[sensor_num]].offset;
+	if (offset == PMBUS_READ_VOUT) {
+		/* ULINEAR16, get exponent from VOUT_MODE */
+		float exponent;
+		if (!get_exponent_from_vout_mode(sensor_num, &exponent))
+			return SENSOR_FAIL_TO_ACCESS;
+
+		float actual_value = ((msg.data[1] << 8) | msg.data[0]) * exponent;
+		sval->integer = actual_value;
+		sval->fraction = (actual_value - sval->integer) * 1000;
+	} else if (offset == PMBUS_READ_IOUT || offset == PMBUS_READ_TEMPERATURE_1 ||
+		   offset == PMBUS_READ_POUT) {
+		/* SLINEAR11 */
+		uint16_t read_value = (msg.data[1] << 8) | msg.data[0];
+		float actual_value = slinear11_to_float(read_value);
+		if (offset == PMBUS_READ_IOUT && actual_value < 0) {
+			/* In the case POUT is 0, IOUT may read small negative value, replace this case with 0 */
+			sval->integer = 0;
+			sval->fraction = 0;
+		} else {
+			sval->integer = actual_value;
+			sval->fraction = (actual_value - sval->integer) * 1000;
+		}
+	} else {
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t xdpe15284_init(uint8_t sensor_num)
+{
+	sensor_config[SensorNum_SensorCfg_map[sensor_num]].read = xdpe15284_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/sensor/sensor.c
+++ b/common/sensor/sensor.c
@@ -24,9 +24,9 @@ uint8_t SensorNum_SDR_map[SENSOR_NUM_MAX];
 bool enable_sensor_poll = 1;
 static bool sensor_poll_eanble_flag = 1;
 
-const int negative_ten_power[16] = { 1,	    1,		1,	   1,	     1,	      1,
-				     1,	    1000000000, 100000000, 10000000, 1000000, 100000,
-				     10000, 1000,	100,	   10 };
+const int negative_ten_power[16] = { 1,     1,		1,	 1,	1,       1,
+				     1,     1000000000, 100000000, 10000000, 1000000, 100000,
+				     10000, 1000,       100,       10 };
 
 sensor_cfg *sensor_config;
 
@@ -40,6 +40,8 @@ SENSOR_DRIVE_INIT_DECLARE(pex89000);
 SENSOR_DRIVE_INIT_DECLARE(intel_peci);
 SENSOR_DRIVE_INIT_DECLARE(pch);
 SENSOR_DRIVE_INIT_DECLARE(adm1278);
+SENSOR_DRIVE_INIT_DECLARE(tps53689);
+SENSOR_DRIVE_INIT_DECLARE(xdpe15284);
 
 struct sensor_drive_api {
 	enum sensor_dev dev;
@@ -50,6 +52,7 @@ struct sensor_drive_api {
 	SENSOR_DRIVE_TYPE_INIT_MAP(mp5990),   SENSOR_DRIVE_TYPE_INIT_MAP(isl28022),
 	SENSOR_DRIVE_TYPE_INIT_MAP(pex89000), SENSOR_DRIVE_TYPE_INIT_MAP(intel_peci),
 	SENSOR_DRIVE_TYPE_INIT_MAP(pch),      SENSOR_DRIVE_TYPE_INIT_MAP(adm1278),
+	SENSOR_DRIVE_TYPE_INIT_MAP(tps53689), SENSOR_DRIVE_TYPE_INIT_MAP(xdpe15284),
 };
 
 static void init_SensorNum(void)

--- a/common/sensor/sensor.c
+++ b/common/sensor/sensor.c
@@ -24,9 +24,9 @@ uint8_t SensorNum_SDR_map[SENSOR_NUM_MAX];
 bool enable_sensor_poll = 1;
 static bool sensor_poll_eanble_flag = 1;
 
-const int negative_ten_power[16] = { 1,     1,		1,	 1,	1,       1,
-				     1,     1000000000, 100000000, 10000000, 1000000, 100000,
-				     10000, 1000,       100,       10 };
+const int negative_ten_power[16] = { 1,	    1,		1,	   1,	     1,	      1,
+				     1,	    1000000000, 100000000, 10000000, 1000000, 100000,
+				     10000, 1000,	100,	   10 };
 
 sensor_cfg *sensor_config;
 

--- a/common/sensor/sensor.h
+++ b/common/sensor/sensor.h
@@ -39,6 +39,8 @@ enum sensor_dev {
 	sensor_dev_mp5990 = 0x10,
 	sensor_dev_isl28022 = 0x11,
 	sensor_dev_pex89000 = 0x12,
+	sensor_dev_tps53689 = 0x13,
+	sensor_dev_xdpe15284 = 0x14,
 	sensor_dev_max
 };
 

--- a/common/util/util_pmbus.c
+++ b/common/util/util_pmbus.c
@@ -1,0 +1,72 @@
+#include <stdint.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+
+const float slinear11_exponents[32] = { 1.0,
+					2.0,
+					4.0,
+					8.0,
+					16.0,
+					32.0,
+					64.0,
+					128.0,
+					256.0,
+					512.0,
+					1024.0,
+					2048.0,
+					4096.0,
+					8192.0,
+					16384.0,
+					32768.0,
+					0.0000152587890625,
+					0.000030517578125,
+					0.00006103515625,
+					0.0001220703125,
+					0.000244140625,
+					0.00048828125,
+					0.0009765625,
+					0.001953125,
+					0.00390625,
+					0.0078125,
+					0.015625,
+					0.03125,
+					0.0625,
+					0.125,
+					0.25,
+					0.5 };
+
+float slinear11_to_float(uint16_t read_value)
+{
+	uint8_t exponent;
+	int16_t mantissa;
+	float lsb;
+	float ret;
+
+	exponent = read_value >> 11;
+	mantissa = read_value & 0x07FF;
+	/* Sign extend Mantissa to 16 bits */
+	if (mantissa > 0x03FF)
+		mantissa |= 0xF800;
+
+	lsb = slinear11_exponents[exponent];
+	ret = mantissa * lsb;
+	return ret;
+}
+
+bool get_exponent_from_vout_mode(uint8_t sensor_num, float *exponent)
+{
+	uint8_t retry = 5;
+	I2C_MSG msg;
+
+	msg.bus = sensor_config[SensorNum_SensorCfg_map[sensor_num]].port;
+	msg.slave_addr = sensor_config[SensorNum_SensorCfg_map[sensor_num]].slave_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 1;
+	msg.data[0] = PMBUS_VOUT_MODE;
+
+	if (i2c_master_read(&msg, retry))
+		return false;
+
+	*exponent = slinear11_exponents[msg.data[0] & 0x1f];
+	return true;
+}

--- a/common/util/util_pmbus.h
+++ b/common/util/util_pmbus.h
@@ -1,0 +1,7 @@
+#ifndef UTIL_PMBUS_H
+#define UTIL_PMBUS_H
+
+float slinear11_to_float(uint16_t);
+bool get_exponent_from_vout_mode(uint8_t, float *);
+
+#endif

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -913,7 +913,7 @@ void pal_OEM_1S_PECIaccess(ipmi_msg *msg)
 		if (cmd != PECI_GET_DIB_CMD && cmd != PECI_GET_TEMP0_CMD) {
 			if (msg->data[0] != PECI_CC_RSP_SUCCESS) {
 				msg->data[0] = (msg->data[0] == 0xf9) ? PECI_CC_ILLEGAL_REQUEST :
-									      msg->data[0];
+									msg->data[0];
 				memset(&msg->data[1], 0xff, u8ReadLen - 1);
 			}
 		}
@@ -1118,27 +1118,103 @@ void pal_OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 	case CPNT_PVCCD_HV:
 	case CPNT_PVCCINFAON:
 	case CPNT_PVCCFA_EHV:
+		i2c_msg.tx_len = 1;
+		i2c_msg.rx_len = 7;
 		i2c_msg.bus = i2c_bus5;
-		i2c_msg.tx_len = 3;
-		i2c_msg.data[0] = 0xC7;
-		i2c_msg.data[1] = 0x94;
-		i2c_msg.data[2] = 0x00;
+		i2c_msg.data[0] = PMBUS_IC_DEVICE_ID;
 
-		if (!i2c_master_write(&i2c_msg, retry)) {
-			i2c_msg.tx_len = 1;
-			i2c_msg.data[0] = 0xC5;
-			i2c_msg.rx_len = 4;
+		if (i2c_master_read(&i2c_msg, retry)) {
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+			return;
+		}
 
-			if (!i2c_master_read(&i2c_msg, retry)) {
-				memcpy(&msg->data[0], &i2c_msg.data[3], 1);
-				memcpy(&msg->data[1], &i2c_msg.data[2], 1);
-				memcpy(&msg->data[2], &i2c_msg.data[1], 1);
-				memcpy(&msg->data[3], &i2c_msg.data[0], 1);
-				msg->data_len = 4;
-				msg->completion_code = CC_SUCCESS;
-			} else {
+		if (i2c_msg.data[0] == 0x04 && i2c_msg.data[1] == 0x00 && i2c_msg.data[2] == 0x81 &&
+		    i2c_msg.data[3] == 0xD2 && i2c_msg.data[4] == 0x49) {
+			/* Renesas isl69259 */
+			i2c_msg.tx_len = 3;
+			i2c_msg.data[0] = 0xC7;
+			i2c_msg.data[1] = 0x94;
+			i2c_msg.data[2] = 0x00;
+
+			if (i2c_master_write(&i2c_msg, retry)) {
 				msg->completion_code = CC_UNSPECIFIED_ERROR;
+				return;
 			}
+
+			i2c_msg.tx_len = 1;
+			i2c_msg.rx_len = 4;
+			i2c_msg.data[0] = 0xC5;
+
+			if (i2c_master_read(&i2c_msg, retry)) {
+				msg->completion_code = CC_UNSPECIFIED_ERROR;
+				return;
+			}
+
+			msg->data[0] = i2c_msg.data[3];
+			msg->data[1] = i2c_msg.data[2];
+			msg->data[2] = i2c_msg.data[1];
+			msg->data[3] = i2c_msg.data[0];
+			msg->data_len = 4;
+			msg->completion_code = CC_SUCCESS;
+
+		} else if (i2c_msg.data[0] == 0x06 && i2c_msg.data[1] == 0x54 &&
+			   i2c_msg.data[2] == 0x49 && i2c_msg.data[3] == 0x53 &&
+			   i2c_msg.data[4] == 0x68 && i2c_msg.data[5] == 0x90 &&
+			   i2c_msg.data[6] == 0x00) {
+			/* TI tps53689 */
+			i2c_msg.tx_len = 1;
+			i2c_msg.rx_len = 2;
+			i2c_msg.data[0] = 0xF4;
+
+			if (i2c_master_read(&i2c_msg, retry)) {
+				msg->completion_code = CC_UNSPECIFIED_ERROR;
+				return;
+			}
+
+			msg->data[0] = i2c_msg.data[1];
+			msg->data[1] = i2c_msg.data[0];
+			msg->data_len = 2;
+			msg->completion_code = CC_SUCCESS;
+
+		} else if (i2c_msg.data[0] == 0x02 && i2c_msg.data[2] == 0x8A) {
+			/* Infineon xdpe15284 */
+			i2c_msg.tx_len = 6;
+			i2c_msg.data[0] = 0xFD;
+			i2c_msg.data[1] = 0x04;
+			i2c_msg.data[2] = 0x00;
+			i2c_msg.data[3] = 0x00;
+			i2c_msg.data[4] = 0x00;
+			i2c_msg.data[5] = 0x00;
+
+			if (i2c_master_write(&i2c_msg, retry)) {
+				msg->completion_code = CC_UNSPECIFIED_ERROR;
+				return;
+			}
+
+			i2c_msg.tx_len = 2;
+			i2c_msg.data[0] = 0xFE;
+			i2c_msg.data[1] = 0x2D;
+
+			if (i2c_master_write(&i2c_msg, retry)) {
+				msg->completion_code = CC_UNSPECIFIED_ERROR;
+				return;
+			}
+
+			i2c_msg.tx_len = 1;
+			i2c_msg.rx_len = 5;
+			i2c_msg.data[0] = 0xFD;
+
+			if (i2c_master_read(&i2c_msg, retry)) {
+				msg->completion_code = CC_UNSPECIFIED_ERROR;
+				return;
+			}
+
+			msg->data[0] = i2c_msg.data[4];
+			msg->data[1] = i2c_msg.data[3];
+			msg->data[2] = i2c_msg.data[2];
+			msg->data[3] = i2c_msg.data[1];
+			msg->data_len = 4;
+			msg->completion_code = CC_SUCCESS;
 		} else {
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 		}
@@ -1353,6 +1429,40 @@ void pal_OEM_1S_GET_POST_CODE(ipmi_msg *msg)
 	}
 
 	msg->data_len = postcode_num;
+	msg->completion_code = CC_SUCCESS;
+	return;
+}
+
+void pal_OEM_1S_SET_VR_MONITOR_STATUS(ipmi_msg *msg)
+{
+	if (msg->data_len != 1) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	if (msg->data[0] == 0) {
+		set_vr_monitor_status(0);
+	} else if (msg->data[0] == 1) {
+		set_vr_monitor_status(1);
+	} else {
+		msg->completion_code = CC_INVALID_DATA_FIELD;
+		return;
+	}
+
+	msg->data_len = 0;
+	msg->completion_code = CC_SUCCESS;
+	return;
+}
+
+void pal_OEM_1S_GET_VR_MONITOR_STATUS(ipmi_msg *msg)
+{
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	msg->data[0] = get_vr_monitor_status();
+	msg->data_len = 1;
 	msg->completion_code = CC_SUCCESS;
 	return;
 }

--- a/meta-facebook/yv35-cl/src/platform/hwmon.c
+++ b/meta-facebook/yv35-cl/src/platform/hwmon.c
@@ -12,6 +12,7 @@ static bool is_DC_on = 0;
 static bool is_DC_on_5s = 0;
 static bool is_DC_off_10s = 0;
 static bool is_post_complete = 0;
+static bool vr_monitor_status = 1;
 static bool bic_class = sys_class_1;
 static bool is_1ou_present = 0;
 static bool is_2ou_present = 0;
@@ -424,6 +425,16 @@ void set_post_status()
 bool get_post_status()
 {
 	return is_post_complete;
+}
+
+void set_vr_monitor_status(bool value)
+{
+	vr_monitor_status = value;
+}
+
+bool get_vr_monitor_status()
+{
+	return vr_monitor_status;
 }
 
 uint8_t get_2ou_cardtype()

--- a/meta-facebook/yv35-cl/src/platform/plat_func.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_func.h
@@ -33,6 +33,8 @@ bool get_post_status();
 void set_DC_on_5s_status();
 bool get_DC_on_5s_status();
 void set_DC_off_10s_status();
+void set_vr_monitor_status(bool);
+bool get_vr_monitor_status();
 void set_sys_config();
 void set_post_thread();
 bool get_bic_class();

--- a/meta-facebook/yv35-cl/src/sensor/plat_hook.c
+++ b/meta-facebook/yv35-cl/src/sensor/plat_hook.c
@@ -169,3 +169,12 @@ bool post_access(uint8_t sensor_num)
 {
 	return get_post_status();
 }
+
+bool VR_access(uint8_t sensor_num)
+{
+	if (DC_access(sensor_num)) {
+		return get_vr_monitor_status();
+	} else {
+		return false;
+	}
+}

--- a/meta-facebook/yv35-cl/src/sensor/plat_hook.h
+++ b/meta-facebook/yv35-cl/src/sensor/plat_hook.h
@@ -33,5 +33,6 @@ bool post_cpu_margin_read(uint8_t sensor_num, void *args, int *reading);
 bool stby_access(uint8_t sensor_num);
 bool DC_access(uint8_t sensor_num);
 bool post_access(uint8_t sensor_num);
+bool VR_access(uint8_t sensor_num);
 
 #endif

--- a/meta-facebook/yv35-cl/src/sensor/plat_sensor.c
+++ b/meta-facebook/yv35-cl/src/sensor/plat_sensor.c
@@ -84,70 +84,70 @@ sensor_cfg plat_sensor_config[] = {
 
 	// VR voltage
 	{ SENSOR_NUM_VOL_PVCCD_HV, sensor_dev_isl69259, i2c_bus5, PVCCD_HV_addr, VR_VOL_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_VOL_PVCCINFAON, sensor_dev_isl69259, i2c_bus5, PVCCINFAON_addr, VR_VOL_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_VOL_PVCCFA_EHV, sensor_dev_isl69259, i2c_bus5, PVCCFA_EHV_addr, VR_VOL_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[1],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[1],
 	  NULL, NULL, NULL },
-	{ SENSOR_NUM_VOL_PVCCIN, sensor_dev_isl69259, i2c_bus5, PVCCIN_addr, VR_VOL_CMD, DC_access,
+	{ SENSOR_NUM_VOL_PVCCIN, sensor_dev_isl69259, i2c_bus5, PVCCIN_addr, VR_VOL_CMD, VR_access,
 	  0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0], NULL, NULL,
 	  NULL },
 	{ SENSOR_NUM_VOL_PVCCFA_EHV_FIVRA, sensor_dev_isl69259, i2c_bus5, PVCCFA_EHV_FIVRA_addr,
-	  VR_VOL_CMD, DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read,
+	  VR_VOL_CMD, VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read,
 	  &isl69259_pre_read_args[1], NULL, NULL, NULL },
 
 	// VR current
 	{ SENSOR_NUM_CUR_PVCCD_HV, sensor_dev_isl69259, i2c_bus5, PVCCD_HV_addr, VR_CUR_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_CUR_PVCCINFAON, sensor_dev_isl69259, i2c_bus5, PVCCINFAON_addr, VR_CUR_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_CUR_PVCCFA_EHV, sensor_dev_isl69259, i2c_bus5, PVCCFA_EHV_addr, VR_CUR_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[1],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[1],
 	  NULL, NULL, NULL },
-	{ SENSOR_NUM_CUR_PVCCIN, sensor_dev_isl69259, i2c_bus5, PVCCIN_addr, VR_CUR_CMD, DC_access,
+	{ SENSOR_NUM_CUR_PVCCIN, sensor_dev_isl69259, i2c_bus5, PVCCIN_addr, VR_CUR_CMD, VR_access,
 	  0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0], NULL, NULL,
 	  NULL },
 	{ SENSOR_NUM_CUR_PVCCFA_EHV_FIVRA, sensor_dev_isl69259, i2c_bus5, PVCCFA_EHV_FIVRA_addr,
-	  VR_CUR_CMD, DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read,
+	  VR_CUR_CMD, VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read,
 	  &isl69259_pre_read_args[1], NULL, NULL, NULL },
 
 	// VR temperature
 	{ SENSOR_NUM_TEMP_PVCCD_HV, sensor_dev_isl69259, i2c_bus5, PVCCD_HV_addr, VR_TEMP_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_TEMP_PVCCINFAON, sensor_dev_isl69259, i2c_bus5, PVCCINFAON_addr, VR_TEMP_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_TEMP_PVCCFA_EHV, sensor_dev_isl69259, i2c_bus5, PVCCFA_EHV_addr, VR_TEMP_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[1],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[1],
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_TEMP_PVCCIN, sensor_dev_isl69259, i2c_bus5, PVCCIN_addr, VR_TEMP_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_TEMP_PVCCFA_EHV_FIVRA, sensor_dev_isl69259, i2c_bus5, PVCCFA_EHV_FIVRA_addr,
-	  VR_TEMP_CMD, DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read,
+	  VR_TEMP_CMD, VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read,
 	  &isl69259_pre_read_args[1], NULL, NULL, NULL },
 
 	// VR power
 	{ SENSOR_NUM_PWR_PVCCD_HV, sensor_dev_isl69259, i2c_bus5, PVCCD_HV_addr, VR_PWR_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_PWR_PVCCINFAON, sensor_dev_isl69259, i2c_bus5, PVCCINFAON_addr, VR_PWR_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0],
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_PWR_PVCCFA_EHV, sensor_dev_isl69259, i2c_bus5, PVCCFA_EHV_addr, VR_PWR_CMD,
-	  DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[1],
+	  VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[1],
 	  NULL, NULL, NULL },
-	{ SENSOR_NUM_PWR_PVCCIN, sensor_dev_isl69259, i2c_bus5, PVCCIN_addr, VR_PWR_CMD, DC_access,
+	{ SENSOR_NUM_PWR_PVCCIN, sensor_dev_isl69259, i2c_bus5, PVCCIN_addr, VR_PWR_CMD, VR_access,
 	  0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read, &isl69259_pre_read_args[0], NULL, NULL,
 	  NULL },
 	{ SENSOR_NUM_PWR_PVCCFA_EHV_FIVRA, sensor_dev_isl69259, i2c_bus5, PVCCFA_EHV_FIVRA_addr,
-	  VR_PWR_CMD, DC_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read,
+	  VR_PWR_CMD, VR_access, 0, 0, 0, SENSOR_INIT_STATUS, pre_isl69259_read,
 	  &isl69259_pre_read_args[1], NULL, NULL, NULL },
 
 	// ME
@@ -205,7 +205,33 @@ void add_Sensorconfig(sensor_cfg add_Sensorconfig)
 	sensor_config[SensorCfg_num++] = add_Sensorconfig;
 };
 
-void pal_fix_Sensorconfig(){
+void check_vr_type(uint8_t index)
+{
+	uint8_t retry = 5;
+	I2C_MSG msg;
+
+	msg.bus = sensor_config[index].port;
+	msg.slave_addr = sensor_config[index].slave_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 7;
+	msg.data[0] = PMBUS_IC_DEVICE_ID;
+
+	if (i2c_master_read(&msg, retry))
+		return;
+
+	if (msg.data[0] == 0x06 && msg.data[1] == 0x54 && msg.data[2] == 0x49 &&
+	    msg.data[3] == 0x53 && msg.data[4] == 0x68 && msg.data[5] == 0x90 &&
+	    msg.data[6] == 0x00) {
+		/* TI tps53689 */
+		sensor_config[index].type = sensor_dev_tps53689;
+	} else if (msg.data[0] == 0x02 && msg.data[2] == 0x8A) {
+		/* Infineon xdpe15284 */
+		sensor_config[index].type = sensor_dev_xdpe15284;
+	}
+}
+
+void pal_fix_Sensorconfig()
+{
 	/*
   SensorCfg_num = sizeof(plat_sensor_config) / sizeof(plat_sensor_config[0]);
   uint8_t fix_SensorCfg_num;
@@ -237,4 +263,13 @@ void pal_fix_Sensorconfig(){
     printk("fix sensor SDR and config table not match\n");
   }
 */
+
+	uint8_t sensor_num = sizeof(plat_sensor_config) / sizeof(plat_sensor_config[0]);
+
+	/* check sensor type of VR */
+	for (uint8_t index = 0; index < sensor_num; index++) {
+		if (sensor_config[index].type == sensor_dev_isl69259) {
+			check_vr_type(index);
+		}
+	}
 };


### PR DESCRIPTION
…/get vr monitor status

Summary:
- Add TI VR(tps53689) and Infineon VR(xdpe15284) sensor.
- Check VR type when initializing sensor.
- Add OEM command to set/get VR sensor monitor status.
- Modify access check function of VR sensors.
- OEM get FW version command support reading TI and Infineon VR version.

Test Plan:
- Build Code: Pass
- Command test: Pass

Log:
```
TI VR
root@bmc-oob:~# sensor-util slot1
...
VCCIN SPS Temp               (0xF) :   44.62 C     | (ok)
FIVRA SPS Temp               (0x10) :   40.00 C     | (ok)
EHV SPS Temp                 (0x11) :   33.62 C     | (ok)
VCCD SPS Temp                (0x12) :   35.12 C     | (ok)
FAON SPS Temp                (0x13) :   36.06 C     | (ok)
...
VCCIN VR Vol                 (0x2A) :    1.77 Volts | (ok)
FIVRA VR Vol                 (0x2C) :    1.80 Volts | (ok)
EHV VR Vol                   (0x2D) :    1.80 Volts | (ok)
VCCD VR Vol                  (0x2E) :    1.14 Volts | (ok)
FAON VR Vol                  (0x2F) :    1.06 Volts | (ok)
HSC Output Cur               (0x30) :    7.38 Amps  | (ok)
VCCIN VR Cur                 (0x31) :   30.25 Amps  | (ok)
FIVRA VR Cur                 (0x32) :    2.16 Amps  | (ok)
EHV VR Cur                   (0x33) :    0.20 Amps  | (ok)
VCCD VR Cur                  (0x34) :    1.75 Amps  | (ok)
FAON VR Cur                  (0x35) :    6.86 Amps  | (ok)
CPU PWR                      (0x38) :   67.00 Watts | (ok)
HSC Input Pwr                (0x39) :   88.78 Watts | (ok)
VCCIN VR Pout                (0x3A) :   53.56 Watts | (ok)
FIVRA VR Pout                (0x3C) :    4.73 Watts | (ok)
EHV VR Pout                  (0x3D) :    0.32 Watts | (ok)
VCCD VR Pout                 (0x3E) :    2.04 Watts | (ok)
FAON VR Pout                 (0x3F) :    7.31 Watts | (ok)

INFINEON VR
root@bmc-oob:~# sensor-util slot1
...
VCCIN SPS Temp               (0xF) :   44.00 C     | (ok)
FIVRA SPS Temp               (0x10) :   40.00 C     | (ok)
EHV SPS Temp                 (0x11) :   35.00 C     | (ok)
VCCD SPS Temp                (0x12) :   36.00 C     | (ok)
FAON SPS Temp                (0x13) :   39.00 C     | (ok)
...
VCCIN VR Vol                 (0x2A) :    1.77 Volts | (ok)
FIVRA VR Vol                 (0x2C) :    1.80 Volts | (ok)
EHV VR Vol                   (0x2D) :    1.80 Volts | (ok)
VCCD VR Vol                  (0x2E) :    1.14 Volts | (ok)
FAON VR Vol                  (0x2F) :    1.06 Volts | (ok)
HSC Output Cur               (0x30) :    5.43 Amps  | (ok)
VCCIN VR Cur                 (0x31) :   15.94 Amps  | (ok)
FIVRA VR Cur                 (0x32) :    2.19 Amps  | (ok)
EHV VR Cur                   (0x33) :    0.00 Amps  | (ok)
VCCD VR Cur                  (0x34) :    0.94 Amps  | (ok)
FAON VR Cur                  (0x35) :    7.06 Amps  | (ok)
CPU PWR                      (0x38) :   44.00 Watts | (ok)
HSC Input Pwr                (0x39) :   65.52 Watts | (ok)
VCCIN VR Pout                (0x3A) :   28.25 Watts | (ok)
FIVRA VR Pout                (0x3C) :    3.88 Watts | (ok)
EHV VR Pout                  (0x3D) :    0.00 Watts | (ok)
VCCD VR Pout                 (0x3E) :    1.25 Watts | (ok)
FAON VR Pout                 (0x3F) :    7.62 Watts | (ok)

Test get/set vr monitor status command
Disable VR monitor status
root@bmc-oob:~# bic-util slot1 0xe0 0x14 0x9c 0x9c 0x00 0x0
9C 9C 00
Check vr monitor status
root@bmc-oob:~# bic-util slot1 0xe0 0x15 0x9c 0x9c 0x00
9C 9C 00 00
root@bmc-oob:~# sensor-util slot1
...
VCCIN SPS Temp               (0xF) : NA | (na)
FIVRA SPS Temp               (0x10) : NA | (na)
EHV SPS Temp                 (0x11) : NA | (na)
VCCD SPS Temp                (0x12) : NA | (na)
FAON SPS Temp                (0x13) : NA | (na)
...
VCCIN VR Vol                 (0x2A) : NA | (na)
FIVRA VR Vol                 (0x2C) : NA | (na)
EHV VR Vol                   (0x2D) : NA | (na)
VCCD VR Vol                  (0x2E) : NA | (na)
FAON VR Vol                  (0x2F) : NA | (na)
HSC Output Cur               (0x30) :    9.77 Amps  | (ok)
VCCIN VR Cur                 (0x31) : NA | (na)
FIVRA VR Cur                 (0x32) : NA | (na)
EHV VR Cur                   (0x33) : NA | (na)
VCCD VR Cur                  (0x34) : NA | (na)
FAON VR Cur                  (0x35) : NA | (na)
CPU PWR                      (0x38) :   89.00 Watts | (ok)
HSC Input Pwr                (0x39) :  116.94 Watts | (ok)
VCCIN VR Pout                (0x3A) : NA | (na)
FIVRA VR Pout                (0x3C) : NA | (na)
EHV VR Pout                  (0x3D) : NA | (na)
VCCD VR Pout                 (0x3E) : NA | (na)
FAON VR Pout                 (0x3F) : NA | (na)
Enable VR monitor status
root@bmc-oob:~# bic-util slot1 0xe0 0x14 0x9c 0x9c 0x00 0x1
9C 9C 00
Check VR monitor status
root@bmc-oob:~# bic-util slot1 0xe0 0x15 0x9c 0x9c 0x00
9C 9C 00 01
root@bmc-oob:~# sensor-util slot1
...
VCCIN SPS Temp               (0xF) :   52.00 C     | (ok)
FIVRA SPS Temp               (0x10) :   50.00 C     | (ok)
EHV SPS Temp                 (0x11) :   42.00 C     | (ok)
VCCD SPS Temp                (0x12) :   42.00 C     | (ok)
FAON SPS Temp                (0x13) :   50.00 C     | (ok)
...
VCCIN VR Vol                 (0x2A) :    1.77 Volts | (ok)
FIVRA VR Vol                 (0x2C) :    1.80 Volts | (ok)
EHV VR Vol                   (0x2D) :    1.80 Volts | (ok)
VCCD VR Vol                  (0x2E) :    1.14 Volts | (ok)
FAON VR Vol                  (0x2F) :    1.02 Volts | (ok)
HSC Output Cur               (0x30) :    9.82 Amps  | (ok)
VCCIN VR Cur                 (0x31) :   33.30 Amps  | (ok)
FIVRA VR Cur                 (0x32) :    3.30 Amps  | (ok)
EHV VR Cur                   (0x33) :    1.10 Amps  | (ok)
VCCD VR Cur                  (0x34) :    1.00 Amps  | (ok)
FAON VR Cur                  (0x35) :   22.80 Amps  | (ok)
CPU PWR                      (0x38) :   89.00 Watts | (ok)
HSC Input Pwr                (0x39) :  117.13 Watts | (ok)
VCCIN VR Pout                (0x3A) :   58.00 Watts | (ok)
FIVRA VR Pout                (0x3C) :    5.00 Watts | (ok)
EHV VR Pout                  (0x3D) :    2.00 Watts | (ok)
VCCD VR Pout                 (0x3E) :    1.00 Watts | (ok)
FAON VR Pout                 (0x3F) :   23.00 Watts | (ok)
```

```
TI VR version
root@bmc-oob:~# bic-util slot1 0xe0 0xB 0x9c 0x9c 0x00 0x5
9C 9C 00 4A 26

Infineon VR version
root@bmc-oob:~# bic-util slot4 0xe0 0x0b 0x9c 0x9c 0x00 0x5
9C 9C 00 06 CE A1 32
```