### PR TITLE
Fix CPPCheck Config Files

### DIFF
--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -131,8 +131,8 @@ jobs:
       shell: bash
       run: |
         # These files specify the config for cppcheck and a list of errors to suppress
-        CPPCHECK_CONFIG=.circleci/lint/cppcheck/cppcheck.cfg
-        CPPCHECK_SUPPRESSED=.circleci/lint/cppcheck/cppcheck-suppressions.txt
+        CPPCHECK_CONFIG=scripts/linters/cppcheck/cppcheck.cfg
+        CPPCHECK_SUPPRESSED=scripts/linters/cppcheck/cppcheck-suppressions.txt
 
         echo "Files to check:"
         cat /tmp/cppcheck_file_list.log
@@ -140,8 +140,8 @@ jobs:
         options=( "-j2"
           "--inconclusive"
           "--enable=performance,style,portability,information"
-          "--library=.circleci/lint/cppcheck/cppcheck.cfg"
-          "--suppressions-list=.circleci/lint/cppcheck/cppcheck-suppressions.txt"
+          "--library=scripts/linters/cppcheck/cppcheck.cfg"
+          "--suppressions-list=scripts/linters/cppcheck/cppcheck-suppressions.txt"
           "--file-list=/tmp/cppcheck_file_list.log"
           "--template={file}:{line}:{column}:{message}"
           "--output-file=/tmp/cppcheck.log"

--- a/scripts/linters/cppcheck/cppcheck-suppressions.txt
+++ b/scripts/linters/cppcheck/cppcheck-suppressions.txt
@@ -1,0 +1,4 @@
+variableScope
+
+// This output confuses CI, get rid of it.
+unmatchedSuppression

--- a/scripts/linters/cppcheck/cppcheck.cfg
+++ b/scripts/linters/cppcheck/cppcheck.cfg
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<def version="2">
+  <define name="TEST(A,B)" value="void __ ## A ## _ ## B ( )"/>
+  <define name="TEST_F(A,B)" value="void __ ## A ## _ ## B ( )"/>
+  <define name="TEST_P(A,B)" value="void __ ## A ## _ ## B ( )"/>
+  <define name="TYPED_TEST(A,B)" value="void __ ## A ## _ ## B ( )"/>
+</def>


### PR DESCRIPTION
Summary:

CPPCheck config files were deleted when the CircleCI config was removed.
CPPCheck will work without them but it won't have all the proper erros
suppressed.

Test Plan:

Test Internally and on Github Actions

Tags: CIT