### PR TITLE
Fix Handler Declarations in K_WORK_DELAYABLE_DEFINE

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/hwmon.c
+++ b/meta-facebook/yv35-cl/src/platform/hwmon.c
@@ -21,8 +21,8 @@ static uint8_t card_type_2ou = 0;
 #define PROC_FAIL_START_DELAY_SECOND 10
 #define CATERR_START_DELAY_SECOND 2
 
-static void proc_fail_handler(void *, void *, void *);
-static void CatErr_handler(void *, void *, void *);
+static void proc_fail_handler(struct k_work *);
+static void CatErr_handler(struct k_work *);
 
 K_WORK_DELAYABLE_DEFINE(proc_fail_work, proc_fail_handler);
 K_WORK_DELAYABLE_DEFINE(CatErr_work, CatErr_handler);
@@ -549,7 +549,7 @@ void disable_PRDY_interrupt()
 	gpio_interrupt_conf(H_BMC_PRDY_BUF_N, GPIO_INT_DISABLE);
 }
 
-static void proc_fail_handler(void *arug0, void *arug1, void *arug2)
+static void proc_fail_handler(struct k_work *work)
 {
 	/* if have not received kcs and post code, add FRB3 event log. */
 	if ((get_kcs_ok() == 0) && (get_postcode_ok() == 0)) {
@@ -571,7 +571,7 @@ static void proc_fail_handler(void *arug0, void *arug1, void *arug2)
 	}
 }
 
-static void CatErr_handler(void *arug0, void *arug1, void *arug2)
+static void CatErr_handler(struct k_work *work)
 {
 	if ((gpio_get(RST_PLTRST_BUF_N) == 1) || (gpio_get(PWRGD_SYS_PWROK) == 1)) {
 		addsel_msg_t sel_msg;


### PR DESCRIPTION
Summary:

K_WORK_DELAYABLE_DEFINE needs a callback function with the function
parameter type of "struct k_work *"

```
/home/goldenbug/openbic/openbic/meta-facebook/yv35-cl/src/platform/hwmon.c:29:38: note: (near initialization for 'CatErr_work.work.handler')
   29 | K_WORK_DELAYABLE_DEFINE(CatErr_work, CatErr_handler);
      |                                      ^~~~~~~~~~~~~~
/home/goldenbug/openbic/zephyr/include/kernel.h:3482:14: note: in definition of macro 'Z_WORK_DELAYABLE_INITIALIZER'
 3482 |   .handler = work_handler, \
      |              ^~~~~~~~~~~~
/home/goldenbug/openbic/openbic/meta-facebook/yv35-cl/src/platform/hwmon.c:29:1: note: in expansion of macro 'K_WORK_DELAYABLE_DEFINE'
   29 | K_WORK_DELAYABLE_DEFINE(CatErr_work, CatErr_handler);
```

Test Plan:

- Build oby35-cl
- Pass CI

Reviewers:

Subscribers:

Tasks:

Tags: oby35-cl