### PR TITLE
fby3.5: bb: Version commit for oby35-bb-2022.11.01

### DIFF
--- a/meta-facebook/yv35-bb/src/ipmi/include/ipmi_def.h
+++ b/meta-facebook/yv35-bb/src/ipmi/include/ipmi_def.h
@@ -3,7 +3,9 @@
 
 #define DEVICE_ID 0x00
 #define DEVICE_REVISION 0x80
-#define FIRMWARE_REVISION_1 0x01
+// Bit 0 boade: 01h CL  02h BB
+// Bit 1 stage: 00h POC 01h EVT
+#define FIRMWARE_REVISION_1 0x12
 #define FIRMWARE_REVISION_2 0x01
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -12,7 +14,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x01
+#define BIC_FW_WEEK 0x11
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x62 // char: b
 #define BIC_FW_platform_1 0x62 // char: b

--- a/meta-facebook/yv35-bb/src/main.c
+++ b/meta-facebook/yv35-bb/src/main.c
@@ -27,7 +27,6 @@ void set_sys_status()
 
 void main(void)
 {
-	uint8_t proj_stage = (FIRMWARE_REVISION_1 & 0xf0) >> 4;
 	printk("Hello, welcome to yv35 baseboard %x%x.%x.%x\n", BIC_FW_YEAR_MSB, BIC_FW_YEAR_LSB,
 	       BIC_FW_WEEK, BIC_FW_VER);
 


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Baseboard BIC oby35-bb-2022.11.01.
- Remove unused parameters.
- Modify baseboard BIC revision.

Test plan:
- Build code: Pass

Log:
1. Get firmware revision.
root@bmc-oob:~# bic-util slot1 0xE0 0x02 0x9C 0x9C 0x00 0x10 0x18 0x01
9C 9C 00 10 07 01 00 00 80 12 01 02 BF 9C 9C 00
00 00 00 00 00 00

2. Get firmware version
root@bmc-oob:~# fw-util slot1 --version bb_bic
BB Bridge-IC Version: oby35-bb-v2022.11.01

root@bmc-oob:~# bic-util slot1 0xE0 0x02 0x9C 0x9C 0x00 0x10 0xE0 0x0B 0x9C 0x9C 0x00 0x02
9C 9C 00 10 39 0B 00 9C 9C 00 20 22 11 01 62 62
00