### PR TITLE
Add patch to extend the ipmb buffer

### DIFF
--- a/fix_patch/tag_v00.01.04_edb7dc6f3cc5cde814dd10e8ec02da62f833bdaf/0002-drivers-ipmb-Extend-the-ipmb-buffer.patch
+++ b/fix_patch/tag_v00.01.04_edb7dc6f3cc5cde814dd10e8ec02da62f833bdaf/0002-drivers-ipmb-Extend-the-ipmb-buffer.patch
@@ -1,0 +1,29 @@
+From 125da7f29475853823530a0906f48b833643ad2b Mon Sep 17 00:00:00 2001
+From: Tommy Haung <tommy_huang@aspeedtech.com>
+Date: Wed, 16 Mar 2022 14:12:59 +0800
+Subject: [PATCH] drivers: ipmb: Extend the ipmb buffer
+
+Extend the ipmb buffer count from 0x100 into 0x102
+
+Signed-off-by: Tommy Haung <tommy_huang@aspeedtech.com>
+Change-Id: I8c0c58ced8b695c13b62b8a9158aad0cf385ac6a
+---
+ include/drivers/i2c/slave/ipmb.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/drivers/i2c/slave/ipmb.h b/include/drivers/i2c/slave/ipmb.h
+index d71805bb2a..da2a6d6c53 100644
+--- a/include/drivers/i2c/slave/ipmb.h
++++ b/include/drivers/i2c/slave/ipmb.h
+@@ -8,7 +8,7 @@
+ 
+ /* ipmb define*/
+ #define IPMB_REQUEST_LEN	0x7
+-#define IPMB_TOTAL_LEN		0x100
++#define IPMB_TOTAL_LEN		0x102
+ 
+ #define GET_ADDR(addr)	((addr << 1) & 0xff)
+ #define LIST_SIZE sizeof(sys_snode_t)
+-- 
+2.17.1
+


### PR DESCRIPTION
Summary:
- Extend ipmb buffer from 250 bytes to 252 bytes.
- Fix the issue that HOST cannot get post code using the command "ipmitool raw 0x30 0x49".
It is caused by ipmb driver losing the data excess 250 bytes.

Test Plan:
- Build Code: Pass
- Command Test: Pass

LOG:
```
[root@localhost ~]# ipmitool raw 0x30 0x49
 92 92 92 92 92 92 92 92 99 92 98 97 92 92 92 92
 92 92 92 92 92 91 99 92 92 92 92 92 92 92 92 ef
 96 95 94 94 94 94 94 94 94 94 94 94 94 92 91 70
 68 61 4f 47 42 41 40 7f 7f 15 0d 0c 0b 06 04 00
 50 22 02 23 03 ee ed ec eb e9 e7 e6 af bf 7e c6
 ce bc bc bc bc bc cc 7e dc ca ca b7 7e 70 7e d1
 7e d1 7e d0 7e d0 7e d0 7e 7e bb bb bb bb bb bb
 bb bb bb bb cb 7e 70 70 70 b9 ba db d9 da c9 d7
 b8 b8 b8 b8 b8 b8 b8 b8 b8 b7 b7 b7 b9 70 d6 d2
 7e d2 7e 7e be be 7e b7 70 70 7e 70 7e b7 b7 b6
 b6 b7 b7 7e 7e 7e b6 b6 b7 b0 b6 b6 b6 b3 b3 c6
 b2 c5 b8 7e b4 7e b6 b1 b1 b1 7e 7e 70 7e c2 7e
 b1 b1 70 c1 7e b0 cd 73 7e cf 7e b5 bf b0 af af
 e5 e3 e4 e1 e0 e0 e0 ae aa a8 a9 a9 a7 a7 a7 a2
 a2 a9 a9 a7 a3 a3 a1 00 19 55 52 15 4d 4a 49 49
 48 7f 02 00
```