### PR TITLE
Add patch to correct i2c timeout

### DIFF
--- a/fix_patch/tag_v00.01.04_edb7dc6f3cc5cde814dd10e8ec02da62f833bdaf/0003-drivers-i2c-Correct-the-timeout-time-as-35ms.patch
+++ b/fix_patch/tag_v00.01.04_edb7dc6f3cc5cde814dd10e8ec02da62f833bdaf/0003-drivers-i2c-Correct-the-timeout-time-as-35ms.patch
@@ -1,0 +1,99 @@
+From f0ef645f404467a7a9579fabc268ff11995f1f79 Mon Sep 17 00:00:00 2001
+From: Tommy Haung <tommy_huang@aspeedtech.com>
+Date: Wed, 16 Mar 2022 19:01:40 +0800
+Subject: [PATCH] drivers: i2c: Correct the timeout time as 35ms
+
+Following the SMBUS define, extend the timeout time into
+35ms.
+
+Signed-off-by: Tommy Haung <tommy_huang@aspeedtech.com>
+Change-Id: I29ccc11a179f0da63e6d9262884ff2a4dc755c4f
+---
+ drivers/i2c/i2c_aspeed.c | 36 +++++++++++++++++++++++++++++++++---
+ 1 file changed, 33 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/i2c/i2c_aspeed.c b/drivers/i2c/i2c_aspeed.c
+index f289bc81ff..04bd5d2079 100644
+--- a/drivers/i2c/i2c_aspeed.c
++++ b/drivers/i2c/i2c_aspeed.c
+@@ -248,6 +248,9 @@ LOG_MODULE_REGISTER(i2c_aspeed);
+ /***************************************************************************/
+ #define SLAVE_TRIGGER_CMD		(AST_I2CS_ACTIVE_ALL | AST_I2CS_PKT_MODE_EN)
+ 
++#define I2C_TIMEOUT_CLK		0x2
++#define I2C_TIMEOUT_COUNT		0x8 // i2c timeout setting (wait about 35ms)
++
+ #define DEV_CFG(dev) \
+ 	((struct i2c_aspeed_config *)(dev)->config)
+ #define DEV_DATA(dev) \
+@@ -473,7 +476,7 @@ static uint32_t i2c_aspeed_select_clock(const struct device *dev)
+ {
+ 	const struct i2c_aspeed_config *config = DEV_CFG(dev);
+ 	struct i2c_aspeed_data *data = DEV_DATA(dev);
+-	uint32_t ac_timing;
++	uint32_t ac_timing = 0;
+ 	int i;
+ 	int div = 0;
+ 	int divider_ratio = 0;
+@@ -540,6 +543,8 @@ static uint32_t i2c_aspeed_select_clock(const struct device *dev)
+ 
+ 		/*Divisor : Base Clock : tCKHighMin : tCK High : tCK Low*/
+ 		ac_timing = ((scl_high-1) << 20) | (scl_high << 16) | (scl_low << 12) | (div);
++		ac_timing |= AST_I2CC_toutBaseCLK(I2C_TIMEOUT_CLK);
++		ac_timing |= AST_I2CC_tTIMEOUT(I2C_TIMEOUT_COUNT);
+ 	} else {
+ 		for (i = 0; i < ARRAY_SIZE(aspeed_old_i2c_timing_table); i++) {
+ 			if ((config->clk_src / aspeed_old_i2c_timing_table[i].divisor) <
+@@ -623,7 +628,7 @@ static int i2c_aspeed_configure(const struct device *dev,
+ 	const struct i2c_aspeed_config *config = DEV_CFG(dev);
+ 	struct i2c_aspeed_data *data = DEV_DATA(dev);
+ 	uint32_t i2c_base = DEV_BASE(dev);
+-	uint32_t fun_ctrl = AST_I2CC_BUS_AUTO_RELEASE;
++	uint32_t fun_ctrl = 0;
+ 
+ 	if (I2C_ADDR_10_BITS & dev_config_raw) {
+ 		return -EINVAL;
+@@ -684,7 +689,7 @@ static int i2c_aspeed_configure(const struct device *dev,
+ 		sys_write32(0xffff, i2c_base + AST_I2CS_IER);
+ 	} else {
+ 		/*Set interrupt generation of I2C slave controller*/
+-		sys_write32(AST_I2CS_PKT_DONE, i2c_base + AST_I2CS_IER);
++		sys_write32((AST_I2CS_PKT_DONE | AST_I2CS_INACTIVE_TO), i2c_base + AST_I2CS_IER);
+ 	}
+ #endif
+ 	return 0;
+@@ -1668,6 +1673,31 @@ int aspeed_i2c_slave_irq(const struct device *dev)
+ 		sts &= ~AST_I2CS_ADDR_MASK;
+ 	}
+ 
++	if (AST_I2CS_INACTIVE_TO & sts) {
++		struct i2c_aspeed_config *i2c_config = DEV_CFG(dev);
++		uint32_t cmd = AST_I2CS_ACTIVE_ALL | AST_I2CS_PKT_MODE_EN;
++
++		/*Turn off slave mode.*/
++		sys_write32(~AST_I2CC_SLAVE_EN & sys_read32(i2c_base + AST_I2CC_FUN_CTRL)
++		, i2c_base + AST_I2CC_FUN_CTRL);
++
++		/*Set slave mode.*/
++		if (i2c_config->mode == DMA_MODE) {
++			cmd |= AST_I2CS_RX_DMA_EN;
++		} else if (i2c_config->mode == BUFF_MODE) {
++			cmd |= AST_I2CS_RX_BUFF_EN;
++		} else {
++			cmd &= ~AST_I2CS_PKT_MODE_EN;
++		}
++
++		/*Turn on slave mode and apply slave type*/
++		sys_write32(AST_I2CC_SLAVE_EN | sys_read32(i2c_base + AST_I2CC_FUN_CTRL)
++		, i2c_base + AST_I2CC_FUN_CTRL);
++		sys_write32(cmd, i2c_base + AST_I2CS_CMD_STS);
++
++		return 1;
++	}
++
+ 	if (AST_I2CS_PKT_DONE & sts)
+ 		aspeed_i2c_slave_packet_irq(dev, i2c_base, sts);
+ 	else
+-- 
+2.17.1
+


### PR DESCRIPTION
Summary:
- Correct the i2c timeout time as 35ms.
- Fix BIC keeping SDA low.
This issue is encountered if BMC stops transmitting while BIC sends ACK.

Test Plan:
- Build Code: Pass
- Apply patch: Pass