### PR TITLE
Add a Nightly Regression Build for the Main Branch

### DIFF
--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -104,7 +104,7 @@ jobs:
         ret="$OUTCOME"
         echo "$ret"
         if [ "$ret" = "success" ]; then
-          echo "badge_message=SUCCESS" >> $GITHUB_ENV
+          echo "badge_message=PASS" >> $GITHUB_ENV
           echo "badge_color=green" >> $GITHUB_ENV
           echo "build_return_code=0" >> $GITHUB_ENV
         else

--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -103,7 +103,7 @@ jobs:
       run: |
         ret="$OUTCOME"
         echo "$ret"
-        if [ "$ret" -eq 0 ]; then
+        if [ "$ret" = "success" ]; then
           echo "badge_message=SUCCESS" >> $GITHUB_ENV
           echo "badge_color=green" >> $GITHUB_ENV
           echo "build_return_code=0" >> $GITHUB_ENV

--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -108,7 +108,7 @@ jobs:
           echo "badge_color=green" >> $GITHUB_ENV
           echo "build_return_code=0" >> $GITHUB_ENV
         else
-          echo "badge_message=FAILED" >> $GITHUB_ENV
+          echo "badge_message=FAIL" >> $GITHUB_ENV
           echo "badge_color=red" >> $GITHUB_ENV
           echo "build_return_code=1" >> $GITHUB_ENV
         fi

--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -99,7 +99,7 @@ jobs:
 
     - name: Get Build Status
       env:
-        OUTCOME: ${{ steps.mvn-build.outcome }}
+        OUTCOME: ${{ steps.build.outcome }}
       run: |
         ret="$OUTCOME"
         echo "$ret"

--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -97,7 +97,9 @@ jobs:
         touch meta-facebook/${{ matrix.platform }}/CMakeLists.txt
         west build -p auto -b ast1030_evb meta-facebook/${{ matrix.platform }}/
 
-        ret=$?
+    - name: Get Build Status
+      run: |
+        ret=${{ steps.build.outputs.exit_code }}
         echo "$ret"
         if [ "$ret" -eq 0 ]; then
           echo "badge_message=SUCCESS" >> $GITHUB_ENV

--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -97,8 +97,9 @@ jobs:
         touch meta-facebook/${{ matrix.platform }}/CMakeLists.txt
         west build -p auto -b ast1030_evb meta-facebook/${{ matrix.platform }}/
 
-  
-        if [ $? -ne 0 ]; then
+        ret=$?
+        echo "$ret"
+        if [ "$ret" -eq 0 ]; then
           echo "badge_message=SUCCESS" >> $GITHUB_ENV
           echo "badge_color=green" >> $GITHUB_ENV
           echo "build_ret_code=1" >> $GITHUB_ENV

--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -1,20 +1,32 @@
-name: build_and_analyze 
-on: pull_request
+name: Build and Analyze 
+
+
+on:
+  pull_request:   # Kick off thise on every PR
+  workflow_call:  # We may want to run this workflow from other places, like nightly builds
+    inputs:
+      nightly:
+        required: false 
+        type: boolean 
+    secrets:
+      GIST_SECRET:
+        required: true
+
 jobs:
   Build-Platforms:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # This job matrix will generate a seperate job for all platforms listed.
+        # This job matrix will generate a separate job for all platforms listed.
         platform: [yv35-cl, yv35-bb]
-        # Need to set this to false otherwise it will cancle all platform builds if one fails.
+        # Need to set this to false otherwise it will cancel all platform builds if one fails.
       fail-fast: false
 
     steps:
-
     - uses: actions/checkout@v2
       with:
         path: ${{ github.event.repository.name }} 
+    
     - name: Install Dependencies
       run: |
         sudo apt-get update
@@ -78,13 +90,43 @@ jobs:
         west update
   
     - name: Build Platform
+      id: build
+      continue-on-error: true
       run: |
         cd ${{ github.event.repository.name }} 
         touch meta-facebook/${{ matrix.platform }}/CMakeLists.txt
         west build -p auto -b ast1030_evb meta-facebook/${{ matrix.platform }}/
 
+  
+        if [ $? -ne 0 ]; then
+          echo "badge_message=SUCCESS" >> $GITHUB_ENV
+          echo "badge_color=green" >> $GITHUB_ENV
+          echo "build_ret_code=1" >> $GITHUB_ENV
+        else
+          echo "badge_message=FAILED" >> $GITHUB_ENV
+          echo "badge_color=red" >> $GITHUB_ENV
+          echo "build_ret_code=0" >> $GITHUB_ENV
+        fi
+
+    - name: Update Build Badges
+      if: ${{ inputs.nightly == true }}
+      uses: schneegans/dynamic-badges-action@v1.1.0
+      with:
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: 62fb115c4fa43a02acad226534e10932 
+        filename: ${{ matrix.platform }}.json 
+        label: Build
+        message: ${{ env.badge_message }}
+        color: ${{ env.badge_color }}
+
+    - name: Check Build Failure
+      if: ${{ env.build_ret_code != '0' }} 
+      run : |
+          exit 1
+
   run-cppcheck:
     runs-on: ubuntu-latest
+    if: ${{ inputs.nightly != true }}
     steps:
 
     - name: Get PR File List 
@@ -171,6 +213,7 @@ jobs:
 
   run-clang-format:
     runs-on: ubuntu-latest
+    if: ${{ inputs.nightly != true }}
     steps:
       
     - uses: actions/checkout@v2
@@ -245,7 +288,8 @@ jobs:
     if: |
         always() && 
         (needs.run-cppcheck.result == 'failure' || 
-         needs.run-clang-format.result == 'failure')
+         needs.run-clang-format.result == 'failure') &&
+        ${{ inputs.nightly != true }}
     runs-on: ubuntu-latest
     steps:
       

--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -102,11 +102,11 @@ jobs:
         if [ "$ret" -eq 0 ]; then
           echo "badge_message=SUCCESS" >> $GITHUB_ENV
           echo "badge_color=green" >> $GITHUB_ENV
-          echo "build_ret_code=0" >> $GITHUB_ENV
+          echo "build_return_code=0" >> $GITHUB_ENV
         else
           echo "badge_message=FAILED" >> $GITHUB_ENV
           echo "badge_color=red" >> $GITHUB_ENV
-          echo "build_ret_code=1" >> $GITHUB_ENV
+          echo "build_return_code=1" >> $GITHUB_ENV
         fi
 
     - name: Update Build Badges
@@ -121,7 +121,7 @@ jobs:
         color: ${{ env.badge_color }}
 
     - name: Check Build Failure
-      if: ${{ env.build_ret_code != '0' }} 
+      if: ${{ env.build_return_code != '0' }} 
       run : |
           exit 1
 

--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -98,8 +98,10 @@ jobs:
         west build -p auto -b ast1030_evb meta-facebook/${{ matrix.platform }}/
 
     - name: Get Build Status
+      env:
+        OUTCOME: ${{ steps.mvn-build.outcome }}
       run: |
-        ret=${{ steps.build.outputs.exit_code }}
+        ret="$OUTCOME"
         echo "$ret"
         if [ "$ret" -eq 0 ]; then
           echo "badge_message=SUCCESS" >> $GITHUB_ENV

--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -102,11 +102,11 @@ jobs:
         if [ "$ret" -eq 0 ]; then
           echo "badge_message=SUCCESS" >> $GITHUB_ENV
           echo "badge_color=green" >> $GITHUB_ENV
-          echo "build_ret_code=1" >> $GITHUB_ENV
+          echo "build_ret_code=0" >> $GITHUB_ENV
         else
           echo "badge_message=FAILED" >> $GITHUB_ENV
           echo "badge_color=red" >> $GITHUB_ENV
-          echo "build_ret_code=0" >> $GITHUB_ENV
+          echo "build_ret_code=1" >> $GITHUB_ENV
         fi
 
     - name: Update Build Badges

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,6 @@
 name: Nightly Regression Build
 
 on:
-  pull_request:
   schedule:
       - cron: '0 0 * * *' # Once per day at midnight
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,36 @@
+name: Nightly Regression Build
+
+on:
+  pull_request:
+  schedule:
+      - cron: '0 0 * * *' # Once per day at midnight
+
+jobs:
+  # This will skip the nightly if there are no new commits since the privious nightly.
+  # Might as well save some electrons on the weekend.
+  check_date:
+    runs-on: ubuntu-latest
+    name: Check latest commit
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: print latest_commit
+        run: echo ${{ github.sha }}
+
+      - id: should_run
+        continue-on-error: true
+        name: check latest commit is less than a day
+        if: ${{ github.event_name == 'schedule' }}
+        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
+
+  # Only kick off the nightly when there are changes.
+  kickoff_nightly:
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    name: kickoff nightly
+    uses: facebook/OpenBIC/.github/workflows/build_and_lint_pr.yml@nightly_build
+    with:
+      nightly: true # We don't want to run linters on nightly because it creates a lot of pointless noise.
+    secrets:
+      GIST_SECRET: ${{ secrets.GIST_SECRET }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ OpenBIC is an open software framework to build a complete firmware image for a B
 
 | Platform | Status | Description |
 |-------|--------|-------------|
-Yosemite v3.5 | N/A | Yosemite Compute
+oby35-cl | ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/goldenbug/62fb115c4fa43a02acad226534e10932/raw/yv35-cl.json) | Yosemite v3.5 Crater Lake Board
+oby35-bb | ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/goldenbug/62fb115c4fa43a02acad226534e10932/raw/yv35-bb.json) | Yosemite v3.5 Baseboard
 
 ## Contents
 
@@ -93,6 +94,8 @@ Clean build application and Zephyr code
 cd $zephyrproject/openbic.odm
 touch meta-facebook/yv35-cl/CMakeLists.txt
 west build -p auto -b ast1030_evb meta-facebook/yv35-cl/
-```## License
+```
+
+## License
 
 OpenBIC is [Apache 2.0 licensed](https://github.com/facebookincubator/OpenBIC/blob/main/LICENSE)

--- a/meta-facebook/yv35-bb/src/main.c
+++ b/meta-facebook/yv35-bb/src/main.c
@@ -20,6 +20,7 @@ void set_sys_status()
 	gpio_set(BIC_READY_R, GPIO_HIGH);
 }
 
+void main(void)
 {
 	printk("Hello, welcome to yv35 baseboard %x%x.%x.%x\n", BIC_FW_YEAR_MSB, BIC_FW_YEAR_LSB,
 	       BIC_FW_WEEK, BIC_FW_VER);

--- a/meta-facebook/yv35-bb/src/main.c
+++ b/meta-facebook/yv35-bb/src/main.c
@@ -20,7 +20,6 @@ void set_sys_status()
 	gpio_set(BIC_READY_R, GPIO_HIGH);
 }
 
-void main(void)
 {
 	printk("Hello, welcome to yv35 baseboard %x%x.%x.%x\n", BIC_FW_YEAR_MSB, BIC_FW_YEAR_LSB,
 	       BIC_FW_WEEK, BIC_FW_VER);


### PR DESCRIPTION
Summary:

Adding a nightly regression build that mirrors the normal CI build
process for the main branch.

Test Plan:

Run on Github Actions in PR.

Reviewers:

Subscribers:

Tasks:

Tags: