### PR TITLE
fby3.5: cl: Version commit for oby35-cl-2022.13.01

### DIFF
--- a/meta-facebook/yv35-cl/src/ipmi/include/ipmi_def.h
+++ b/meta-facebook/yv35-cl/src/ipmi/include/ipmi_def.h
@@ -4,7 +4,7 @@
 #define DEVICE_ID 0x00
 #define DEVICE_REVISION 0x80
 #define FIRMWARE_REVISION_1 0x11
-#define FIRMWARE_REVISION_2 0x08
+#define FIRMWARE_REVISION_2 0x09
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
 #define PRODUCT_ID 0x0000
@@ -12,7 +12,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x11
+#define BIC_FW_WEEK 0x13
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x63 // char: c
 #define BIC_FW_platform_1 0x6c // char: l


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Craterlake BIC oby35-cl-2022.13.01.

Test Plan:
- Build code: Pass

Log:
get firmware revision
root@bmc-oob:~# bic-util slot1 0x18 0x1
00 80 11 09 02 BF 9C 9C 00 00 00 00 00 00 00
get firmware version
root@bmc-oob:~# bic-util slot1 0xE0 0xB 0x9c 0x9c 0x0 0x2
9C 9C 00 20 22 13 01 63 6C 00