### PR TITLE
fby3.5: common: Delay ready time

### DIFF
--- a/common/lib/util_sys.h
+++ b/common/lib/util_sys.h
@@ -41,4 +41,6 @@ uint8_t get_me_mode();
 int pal_submit_bmc_cold_reset();
 int pal_submit_12v_cycle_slot();
 
+void set_sys_ready_pin(uint8_t ready_gpio_name);
+
 #endif

--- a/common/sensor/sensor.c
+++ b/common/sensor/sensor.c
@@ -31,6 +31,8 @@ uint8_t sdr_index_map[SENSOR_NUM_MAX];
 bool enable_sensor_poll_thread = true;
 static bool sensor_poll_enable_flag = true;
 
+static bool is_sensor_ready_flag = false;
+
 const int negative_ten_power[16] = { 1,	    1,		1,	   1,	     1,	      1,
 				     1,	    1000000000, 100000000, 10000000, 1000000, 100000,
 				     10000, 1000,	100,	   10 };
@@ -235,7 +237,10 @@ void sensor_poll_handler(void *arug0, void *arug1, void *arug2)
 
 	while (1) {
 		for (poll_num = 0; poll_num < SENSOR_NUM_MAX; poll_num++) {
-			if (sensor_poll_enable_flag == 0) { /* skip if disable sensor poll */
+			if (sensor_poll_enable_flag == false) { /* skip if disable sensor poll */
+
+				// Due to except skip sensor polling
+				is_sensor_ready_flag = true;
 				break;
 			}
 			if (sensor_config_index_map[poll_num] == SENSOR_NULL) { // sensor not exist
@@ -245,6 +250,9 @@ void sensor_poll_handler(void *arug0, void *arug1, void *arug2)
 
 			k_yield();
 		}
+
+		is_sensor_ready_flag = true;
+
 		k_msleep(sensor_poll_interval_ms);
 	}
 }
@@ -388,4 +396,9 @@ bool sensor_init(void)
 	}
 
 	return true;
+}
+
+bool check_is_sensor_ready()
+{
+	return is_sensor_ready_flag;
 }

--- a/common/sensor/sensor.h
+++ b/common/sensor/sensor.h
@@ -227,5 +227,6 @@ void enable_sensor_poll();
 void pal_fix_sensor_config(void);
 bool check_sensor_num_exist(uint8_t sensor_num);
 void add_sensor_config(sensor_cfg config);
+bool check_is_sensor_ready();
 
 #endif

--- a/meta-facebook/yv35-bb/src/platform/plat_init.c
+++ b/meta-facebook/yv35-bb/src/platform/plat_init.c
@@ -1,3 +1,4 @@
+#include "util_sys.h"
 #include "hal_gpio.h"
 #include "plat_gpio.h"
 #include "plat_fan.h"
@@ -14,7 +15,7 @@ void pal_pre_init()
 
 void pal_set_sys_status()
 {
-	gpio_set(BIC_READY_R, GPIO_HIGH);
+	set_sys_ready_pin(BIC_READY_R);
 }
 
 #define DEF_PROJ_GPIO_PRIORITY 61

--- a/meta-facebook/yv35-cl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_init.c
@@ -27,13 +27,13 @@ void pal_post_init()
 
 void pal_set_sys_status()
 {
-	gpio_set(BIC_READY, GPIO_HIGH);
 	set_DC_status(PWRGD_SYS_PWROK);
 	set_DC_on_delayed_status();
 	set_DC_off_delayed_status();
 	set_post_status(FM_BIOS_POST_CMPLT_BMC_N);
 	set_CPU_power_status(PWRGD_CPU_LVC3);
 	set_post_thread();
+	set_sys_ready_pin(BIC_READY);
 }
 
 int switch_spi_mux(const struct device *args)


### PR DESCRIPTION
fby3.5: common: Delay ready time
Summary:
- Check sensor polling once before BIC pulls ready GPIO high.
To avoid BMC too early to ask for any pieces of information.

Test plan
- Build code: Pass
- Ready pin is delay: Pass

Log:
1. Check BIC ready GPIO is delay.
- Before: Due to didn't check sensor reading, BIC ready value changed too fast to get different.
root@bmc-oob:~# fw-util slot1 --force --update bic oby35-cl-2022.13.01.bin; while [ 1 ]; do date; bic-util slot1 0xe0 0x41 0x9c 0x9c 0x0 0x0 28; sleep 0.5; done;
slot_id: 1, comp: 2, intf: 0, img: oby35-cl-2022.13.01.bin, force: 1
Set fan mode to manual and set PWM to 70%
file size = 327680 bytes, slot = 1, intf = 0xff
updating fw on slot 1:
updated bic: 100 %
Elapsed time:  20   sec.

Set fan mode to auto and start fscd
Force upgrade of slot1 : bic succeeded
Fri Mar  9 04:37:43 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:37:44 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:37:44 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:37:45 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:37:45 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:37:46 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:37:47 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:37:47 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:37:48 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:37:48 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:37:49 PST 2018
9C 9C 00 1C 01

- After: Due to checking sensor are polling once, we can get BIC ready value change.
root@bmc-oob:~# fw-util slot1 --force --update bic Y35BCL.bin; while [ 1 ]; do date; bic-util slot1 0xe0 0x41 0x9c 0x9c 0x0 0x0 28; sleep 0.5; done;
slot_id: 1, comp: 2, intf: 0, img: Y35BCL.bin, force: 1
Set fan mode to manual and set PWM to 70%
file size = 296440 bytes, slot = 1, intf = 0xff
updating fw on slot 1:
updated bic: 100 %
Elapsed time:  18   sec.

Set fan mode to auto and start fscd
Force upgrade of slot1 : bic succeeded
Fri Mar  9 04:38:21 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:38:21 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:38:22 PST 2018
9C 9C 00 1C 00
Fri Mar  9 04:38:23 PST 2018
9C 9C 00 1C 00
Fri Mar  9 04:38:23 PST 2018
9C 9C 00 1C 00
Fri Mar  9 04:38:24 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:38:24 PST 2018
9C 9C 00 1C 01
Fri Mar  9 04:38:25 PST 2018
9C 9C 00 1C 01