### PR TITLE
fby3.5: cl: Adjust ADM1278 value

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_hook.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.h
@@ -27,5 +27,7 @@ bool pre_nvme_read(uint8_t sensor_num, void *args);
 bool pre_vol_bat3v_read(uint8_t sensor_num, void *args);
 bool post_vol_bat3v_read(uint8_t sensor_num, void *args, int *reading);
 bool post_cpu_margin_read(uint8_t sensor_num, void *args, int *reading);
+bool post_adm1278_power_read(uint8_t sensor_num, void *args, int *reading);
+bool post_adm1278_current_read(uint8_t sensor_num, void *args, int *reading);
 
 #endif

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -183,9 +183,11 @@ sensor_cfg adm1278_sensor_config_table[] = {
 	{ SENSOR_NUM_VOL_HSCIN, sensor_dev_adm1278, I2C_BUS2, ADI_ADM1278_ADDR, PMBUS_READ_VIN,
 	  stby_access, 0, 0, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adm1278_init_args[0] },
 	{ SENSOR_NUM_CUR_HSCOUT, sensor_dev_adm1278, I2C_BUS2, ADI_ADM1278_ADDR, PMBUS_READ_IOUT,
-	  stby_access, 0, 0, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adm1278_init_args[0] },
+	  stby_access, 0, 0, 0, SENSOR_INIT_STATUS, NULL, NULL, post_adm1278_current_read, NULL,
+	  &adm1278_init_args[0] },
 	{ SENSOR_NUM_PWR_HSCIN, sensor_dev_adm1278, I2C_BUS2, ADI_ADM1278_ADDR, PMBUS_READ_PIN,
-	  stby_access, 0, 0, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adm1278_init_args[0] },
+	  stby_access, 0, 0, 0, SENSOR_INIT_STATUS, NULL, NULL, post_adm1278_power_read, NULL,
+	  &adm1278_init_args[0] },
 };
 
 sensor_cfg evt3_class1_adi_temperature_sensor_table[] = {


### PR DESCRIPTION
fby3.5: cl: Adjust ADM1278 value
Summary:
- ADM1278 HSC telemetry.
Current = (Value*0.98)+0.1
Power = Value*0.98

Test plan:
- Build code: Pass
- Get ADM1278 sensor reading: Pass

Log:
1. Check can get ADM1278 sensor reading.
root@bmc-oob:~# sensor-util slot1 | grep HSC
HSC Temp                     (0xE) :   38.33 C     | (ok)
HSC Input Vol                (0x29) :   12.18 Volts | (ok)
HSC Output Cur               (0x30) :    8.85 Amps  | (ok)
HSC Input Pwr                (0x39) :  106.21 Watts | (ok)