### PR TITLE
yv3.5: cl: Prevent false GPIO interrupt alert for IRQ_SML1_PMBUS_ALERT_N

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.c
@@ -230,16 +230,24 @@ void ISR_FM_THROTTLE()
 void ISR_HSC_THROTTLE()
 {
 	addsel_msg_t sel_msg;
+	static bool is_hsc_throttle_assert = false; // Flag for filt out fake alert
 	if (gpio_get(RST_RSMRST_BMC_N) == GPIO_HIGH) {
 		if ((gpio_get(PWRGD_SYS_PWROK) == GPIO_LOW) &&
 		    (get_DC_off_delayed_status() == false)) {
 			return;
 		} else {
-			if (gpio_get(IRQ_SML1_PMBUS_ALERT_N) == GPIO_HIGH) {
+			if ((gpio_get(IRQ_SML1_PMBUS_ALERT_N) == GPIO_HIGH) &&
+			    (is_hsc_throttle_assert == true)) {
 				sel_msg.event_type = IPMI_OEM_EVENT_TYPE_DEASSART;
-			} else {
+				is_hsc_throttle_assert = false;
+			} else if ((gpio_get(IRQ_SML1_PMBUS_ALERT_N) == GPIO_LOW) &&
+				   (is_hsc_throttle_assert == false)) {
 				sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPEC;
+				is_hsc_throttle_assert = true;
+			} else { // Fake alert
+				return;
 			}
+
 			sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 			sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 			sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_PMBUSALERT;


### PR DESCRIPTION
[Summary]
- Prevent false GPIO interrupt alert for IRQ_SML1_PMBUS_ALERT_N in each 12V-cycle

[Test Plan & Log]
1. Build code: Pass

2. 12V-cycle: Pass
	root@bmc-oob:~# power-util slot3 12V-cycle			# Try to duplicate issue, expect no abnormal SEL after 12V-cycle
	12V Power cycling fru 3...

	root@bmc-oob:~# log-util all --print
	2022 Apr 15 02:43:27 log-util: User cleared all logs
	3    slot3    2022-04-15 02:43:59    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-04-15 02:43:59, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
	3    slot3    2022-04-15 02:44:01    power-util       SERVER_12V_CYCLE successful for FRU: 3
	3    slot3    2022-04-15 02:44:04    gpiod            FRU: 3, System powered ON

3. Trigger GPIO: Pass
	root@bmc-oob:~# bic-util slot3 --get_gpio | egrep 41
	41 IRQ_SML1_PMBUS_ALERT_N: 1

	root@bmc-oob:~# bic-util slot3 --set_gpio 41 0			# Set LOW for falling assertion
	slot 3: setting [41]IRQ_SML1_PMBUS_ALERT_N to 0

	root@bmc-oob:~# log-util all --print
	2022 Apr 15 02:47:01 log-util: User cleared all logs
	3    slot3    2022-04-15 02:47:32    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-04-15 02:47:32, Sensor: SYSTEM_STATUS (0x10), Event Data: (05FFFF) HSC_Throttle throttle Assertion
	3    slot3    2022-04-15 02:47:32    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-04-15 02:47:32, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Assertion
	3    slot3    2022-04-15 02:47:32    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-04-15 02:47:32, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PR

	root@bmc-oob:~# bic-util slot3 --get_gpio | egrep 41
	41 IRQ_SML1_PMBUS_ALERT_N: 0

	root@bmc-oob:~# bic-util slot3 --set_gpio 41 1			# Set HIGH for rising deassertion
	slot 3: setting [41]IRQ_SML1_PMBUS_ALERT_N to 1

	root@bmc-oob:~# log-util all --print
	2022 Apr 15 02:47:01 log-util: User cleared all logs
	3    slot3    2022-04-15 02:47:32    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-04-15 02:47:32, Sensor: SYSTEM_STATUS (0x10), Event Data: (05FFFF) HSC_Throttle throttle Assertion
	3    slot3    2022-04-15 02:47:32    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-04-15 02:47:32, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Assertion
	3    slot3    2022-04-15 02:47:32    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-04-15 02:47:32, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Assertion
	3    slot3    2022-04-15 02:47:50    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-04-15 02:47:50, Sensor: SYSTEM_STATUS (0x10), Event Data: (05FFFF) HSC_Throttle throttle Deassertion
	3    slot3    2022-04-15 02:47:50    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-04-15 02:47:50, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Deassertion
	3    slot3    2022-04-15 02:47:50    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-04-15 02:47:50, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Deassertion