### PR TITLE
fby3.5: common: Change I2C master w/r to 0-base

### DIFF
--- a/common/hal/hal_i2c.c
+++ b/common/hal/hal_i2c.c
@@ -39,6 +39,11 @@ int i2c_master_read(I2C_MSG *msg, uint8_t retry)
 		return EMSGSIZE;
 	}
 
+	if (check_i2c_bus_valid(msg->bus) < 0) {
+		printf("i2c bus %d is invalid\n", msg->bus);
+		return -1;
+	}
+
 	do { // break while getting mutex success but tranmission fail
 		status = k_mutex_lock(&i2c_mutex[msg->bus], K_MSEC(1000));
 		if (status == osOK) {
@@ -100,6 +105,11 @@ int i2c_master_write(I2C_MSG *msg, uint8_t retry)
 		printf("\n");
 	}
 
+	if (check_i2c_bus_valid(msg->bus) < 0) {
+		printf("i2c bus %d is invalid\n", msg->bus);
+		return -1;
+	}
+
 	status = k_mutex_lock(&i2c_mutex[msg->bus], K_MSEC(1000));
 	if (status == osOK) {
 		for (i = 0; i < retry; i++) {
@@ -140,7 +150,6 @@ void i2c_scan(uint8_t bus, uint8_t *target_addr, uint8_t *target_addr_len)
 	*target_addr_len = 0;
 
 	if (check_i2c_bus_valid(bus) < 0) {
-		*slave_addr_len = 0;
 		printf("i2c bus %d is invalid\n", bus);
 		return;
 	}

--- a/common/hal/hal_i2c.c
+++ b/common/hal/hal_i2c.c
@@ -139,6 +139,12 @@ void i2c_scan(uint8_t bus, uint8_t *target_addr, uint8_t *target_addr_len)
 	uint8_t first = 0x04, last = 0x77;
 	*target_addr_len = 0;
 
+	if (check_i2c_bus_valid(bus) < 0) {
+		*slave_addr_len = 0;
+		printf("i2c bus %d is invalid\n", bus);
+		return;
+	}
+
 	for (uint8_t i = 0; i <= last; i += 16) {
 		for (uint8_t j = 0; j < 16; j++) {
 			if (i + j < first || i + j > last) {
@@ -224,4 +230,12 @@ void util_init_I2C(void)
 	if (status)
 		printf("i2c9 mutex init fail\n");
 #endif
+}
+
+int check_i2c_bus_valid(uint8_t bus)
+{
+	if (dev_i2c[bus] == NULL) {
+		return -1;
+	}
+	return 0;
 }

--- a/common/hal/hal_i2c.h
+++ b/common/hal/hal_i2c.h
@@ -4,7 +4,6 @@
 #include <drivers/i2c.h>
 #include <drivers/i2c/slave/ipmb.h>
 
-extern const uint8_t i2c_bus_to_index[];
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c0), okay)
 #define DEV_I2C_0

--- a/common/hal/hal_i2c.h
+++ b/common/hal/hal_i2c.h
@@ -65,5 +65,6 @@ int i2c_master_read(I2C_MSG *msg, uint8_t retry);
 int i2c_master_write(I2C_MSG *msg, uint8_t retry);
 void i2c_scan(uint8_t bus, uint8_t *target_addr, uint8_t *target_addr_len);
 void util_init_I2C(void);
+int check_i2c_bus_valid(uint8_t bus);
 
 #endif

--- a/common/ipmi/app_handler.c
+++ b/common/ipmi/app_handler.c
@@ -190,7 +190,7 @@ __weak void APP_MASTER_WRITE_READ(ipmi_msg *msg)
 		return;
 	}
 
-	i2c_msg.bus = i2c_bus_to_index[bus_7bit];
+	i2c_msg.bus = bus_7bit;
 	// 8 bit address to 7 bit
 	i2c_msg.target_addr = msg->data[1] >> 1;
 	i2c_msg.rx_len = msg->data[2];

--- a/common/ipmi/oem_1s_handler.c
+++ b/common/ipmi/oem_1s_handler.c
@@ -740,7 +740,7 @@ __weak void OEM_1S_I2C_DEV_SCAN(ipmi_msg *msg)
 		return;
 	}
 
-	uint8_t bus = i2c_bus_to_index[msg->data[0]];
+	uint8_t bus = msg->data[0];
 
 	i2c_scan(bus, &msg->data[0], (uint8_t *)&msg->data_len);
 

--- a/meta-facebook/yv35-bb/src/platform/plat_i2c.c
+++ b/meta-facebook/yv35-bb/src/platform/plat_i2c.c
@@ -2,4 +2,3 @@
 #include <stdbool.h>
 #include "plat_i2c.h"
 
-const uint8_t i2c_bus_to_index[] = { 0, 0, 1, 2, 0, 0, 0, 3, 4, 0 };

--- a/meta-facebook/yv35-cl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.c
@@ -8,6 +8,7 @@
 #include "hal_i2c.h"
 #include "libutil.h"
 #include "plat_gpio.h"
+#include "plat_i2c.h"
 
 #define CPLD_ADDR 0x21 // 7-bit address
 #define CPLD_CLASS_TYPE_REG 0x05
@@ -109,7 +110,7 @@ void init_platform_config()
 	rx_len = 1;
 	memset(data, 0, I2C_DATA_SIZE);
 	data[0] = CPLD_CLASS_TYPE_REG;
-	i2c_msg = construct_i2c_message(i2c_bus_to_index[1], CPLD_ADDR, tx_len, data, rx_len);
+	i2c_msg = construct_i2c_message(I2C_BUS1, CPLD_ADDR, tx_len, data, rx_len);
 	if (!i2c_master_read(&i2c_msg, retry)) {
 		class_type = i2c_msg.data[0];
 		is_1ou_present = (class_type & 0x4 ? false : true);
@@ -123,7 +124,7 @@ void init_platform_config()
 	memset(data, 0, I2C_DATA_SIZE);
 	data[0] = CPLD_CLASS_TYPE_REG;
 	data[1] = (((system_class - 1) << 4) & 0x10) | class_type;
-	i2c_msg = construct_i2c_message(i2c_bus_to_index[1], CPLD_ADDR, tx_len, data, rx_len);
+	i2c_msg = construct_i2c_message(I2C_BUS1, CPLD_ADDR, tx_len, data, rx_len);
 	if (i2c_master_write(&i2c_msg, retry)) {
 		printf("Failed to set class type to CPLD)\n");
 	}
@@ -137,7 +138,7 @@ void init_platform_config()
 	rx_len = 1;
 	memset(data, 0, I2C_DATA_SIZE);
 	data[0] = CPLD_BOARD_REV_ID_REG;
-	i2c_msg = construct_i2c_message(i2c_bus_to_index[1], CPLD_ADDR, tx_len, data, rx_len);
+	i2c_msg = construct_i2c_message(I2C_BUS1, CPLD_ADDR, tx_len, data, rx_len);
 	int ret = i2c_master_read(&i2c_msg, retry);
 	if (ret == 0) {
 		board_revision = i2c_msg.data[0] & 0xF;
@@ -153,7 +154,7 @@ void init_platform_config()
 		memset(data, 0, I2C_DATA_SIZE);
 		data[0] = CPLD_2OU_EXPANSION_CARD_REG;
 		i2c_msg =
-			construct_i2c_message(i2c_bus_to_index[1], CPLD_ADDR, tx_len, data, rx_len);
+			construct_i2c_message(I2C_BUS1, CPLD_ADDR, tx_len, data, rx_len);
 		if (!i2c_master_read(&i2c_msg, retry)) {
 			switch (i2c_msg.data[0]) {
 			case TYPE_2OU_DPV2:

--- a/meta-facebook/yv35-cl/src/platform/plat_i2c.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_i2c.c
@@ -1,5 +1,3 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include "plat_i2c.h"
-
-const uint8_t i2c_bus_to_index[] = { 0, 0, 1, 2, 3, 4, 5, 6, 7, 8 };


### PR DESCRIPTION
fby3.5: common: Change I2C master w/r to 0-base
Summary:
- Change bus of I2C master write read from 1-base to 0-base.
- Fix read/write invalid I2C bus causes BIC hang problem.

Test plan:
- Build Code: Pass
- I2C Master Write Read: Pass

Log:
1. Check I2c master write read command.
- Read CL BIC bus 4 address 0xC4
* Before change (1-base)
root@bmc-oob:~# bic-util slot1 0x18 0x52 0x09 0xC4 0x02 0x8B
BIC no response!
root@bmc-oob:~# bic-util slot1 0x18 0x52 0x0B 0xC4 0x02 0x8B
77 04

* After change (0-base)
root@bmc-oob:~# bic-util slot1 0x18 0x52 0x09 0xC4 0x02 0x8B
76 04
root@bmc-oob:~# bic-util slot1 0x18 0x52 0x0B 0xC4 0x02 0x8B
BIC no response!

- Read BB BIC bus 2 address 0x4E
* Before change (1-base)
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x00 0x10 0x18 0x52 0x05 0x4E 0x01 0x01
9C 9C 00 10 07 52 83
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x00 0x10 0x18 0x52 0x07 0x4E 0x01 0x01
9C 9C 00 10 07 52 00 C3

* After change (0-base)
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x00 0x10 0x18 0x52 0x05 0x4E 0x01 0x01
9C 9C 00 10 07 52 00 C3
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x00 0x10 0x18 0x52 0x07 0x4E 0x01 0x01
9C 9C 00 10 07 52 83