### PR TITLE
fby3.5: bb: Version commit for oby35-bb-2022.16.01

### DIFF
--- a/meta-facebook/yv35-bb/src/platform/plat_version.h
+++ b/meta-facebook/yv35-bb/src/platform/plat_version.h
@@ -6,8 +6,10 @@
 #define IANA_ID 0x009c9c
 #define DEVICE_ID 0x00
 #define DEVICE_REVISION 0x80
-#define FIRMWARE_REVISION_1 0x01
-#define FIRMWARE_REVISION_2 0x01
+// Bit 0 board: 01h CL  02h BB
+// Bit 1 stage: 00h POC 01h EVT
+#define FIRMWARE_REVISION_1 0x12
+#define FIRMWARE_REVISION_2 0x03
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
 #define PRODUCT_ID 0x0000
@@ -15,7 +17,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x01
+#define BIC_FW_WEEK 0x16
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x62 // char: b
 #define BIC_FW_platform_1 0x62 // char: b


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Baseboard BIC oby35-bb-2022.16.01.
- Modify baseboard BIC revision.

Test Plan:
- Build code: Pass
- Get version: Pass

Log:
1. Get firmware revision.
root@bmc-oob:~# bic-util slot1 0xE0 0x02 0x9C 0x9C 0x00 0x10 0x18 0x01
9C 9C 00 10 07 01 00 00 80 12 03 02 BF 9C 9C 00
00 00 00 00 00 00

2. Get firmware version.
root@bmc-oob:~# fw-util slot1 --version bb_bic
BB Bridge-IC Version: oby35-bb-v2022.16.01