### PR TITLE
fby3.5: common: Fix GPIO return wrong value

### DIFF
--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -139,6 +139,10 @@ __weak void OEM_1S_GET_GPIO(ipmi_msg *msg)
 		gpio_value =
 			(i >= gpio_ind_to_num_table_cnt) ? 0 : gpio_get(gpio_ind_to_num_table[i]);
 
+		// clear temporary variable to avoid return wrong GPIO value
+		if (i % 8 == 0) {
+			eight_bit_value = 0;
+		}
 		eight_bit_value = eight_bit_value | (gpio_value << (i % 8));
 		msg->data[i / 8] = eight_bit_value;
 	}


### PR DESCRIPTION
Summary:
- GPIO returns wrong value and it causes host delays power on because host BIOS is waiting for BMC ready bit until time out.
- The root cause is that we didn't clean temporary variable value.

Test plan:
- Build code: Pass
- Host power on: Pass

Log:
1. Check host can power on successfully.
- Before fix
root@bmc-oob:~# power-util slot1 on
Powering fru 1 to ON state...
root@bmc-oob:~# power-util slot1 status
Power status for fru 1 : ON

root@bmc-oob:~# sol-util slot1 --history

root@bmc-oob:~#

- After fix
root@bmc-oob:~# power-util slot1 on
Powering fru 1 to ON state...

root@bmc-oob:~# power-util slot1 status
Power status for fru 1 : ON

root@bmc-oob:~# sol-util slot1 --history

Mon Apr 25 19:34:32 2022 0004237 [19][A1][A3][A3][A7][A9][A9][A2][A2][AA][AF][E0][E0][B0][BF][B5][7E][CF][7E][CD][B0][7E][C1][70][B1][B1][7E][C2][7E][70][7E][7E][AF][AF][19][A1][A3][A3][A7][A9][A9][A2][A2][A7][A7][A7][A9][A9][A8][AA][AE][E0][E0][E0][E1][E4][E3][E5][AF][AF][B0][BF][B5][7E][CF][7E][CD][B0][7E][C1][70][B1][B1][7E][C2][7E][70][7E][7E][B1][B1][B1][B6][7E][B4][7E][B8][C5][B2][C6][B3][B3][B3][B3][B3][B3][B3][B6][B6][B6][B0][B7][B6][B7][B6][B6][7E][7E][7E][B7][B7][B6][B6][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][D8][7E][B7][B7][70][7E][70][70][B7][7E][B7][B7][BE][BE][7E][7E][D2][7E][D2][D6][70][B9][7E][B7][B7][B7][B7][B7][B7][B7][B7][B8][B8][B8][B8][B8][B8][B8][B8][B8][D7][C9][DA][D9][DB][BA][B9][70][70][70][7E][7E][CB][BB][BB][BB][BB][BB][BB][BB][BB][BB][BB][7E][7E][D0][7E][D0][7E][D0][7E][D1][7E][D1][7E][70][7E][B7][CA][CA][DC][7E][CC][BC][BC][BC][BC][BC][CE][C6][7E][BF][AF][AF][AF][AF][19][A1][A3][A3][A7][A9][A9][A2][A2][A7][A7][A7][A9][A9][A8][AA][AE][E0][E0][E0][E1][E4][E3][E5][AF][AF][B0][BF][B5][7E][CF][7E][CD][B0][7E][C1][70][B1][B1][7E][C2][7E][70][7E][7E][B1][B1][B1][B6][7E][B4][7E][B8][C5][B2][C6][B3][B3][B3][B3][B3][B3][B3][B6][B6][B6][B0][B7][B6][B7][B6][B6][7E][7E][7E][B7][B7][B6][B6][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][B7][D8][7E][B7][B7][70][7E][70][70][B7][7E][B7][B7][BE][BE][7E][7E][D2][7E][D2][D6][70][B9][7E][B7][B7][B7][B7][B7][B7][B7][B7][B8][B8][B8][B8][B8][B8][B8][B8][B8][D7][C9][DA][D9][DB][BA][B9][70][70][70][7E][7E][CB][BB][BB][BB][BB][BB][BB][BB][BB][BB][BB][7E][7E][D0][7E][D0][7E][D0][7E][D1][7E][D1][7E][70][7E][B7][CA][CA][DC][7E][CC][BC][BC][BC][BC][BC][CE][C6][7E][BF][AF][AF][AF][E6][E7][E9][EB][EC][ED][EE][4F][61][68][70][91][92][94][94][94][94][94][94][94][94][95][96][92][92][92][92][92][99][91][92][92][92][92][92][92][97]
Version 2.22.1283. Copyright (C) 2022 AMI
BIOS Date: 04/18/2022 11:24:25 Ver: F0ES_1A16
...