### PR TITLE
Check data length and IANA for OEM commands

### DIFF
--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -163,7 +163,8 @@ void IPMI_handler(void *arug0, void *arug1, void *arug2)
 			IPMI_OEM_handler(&msg_cfg.buffer);
 			break;
 		case NETFN_OEM_1S_REQ:
-			if ((msg_cfg.buffer.data[0] | (msg_cfg.buffer.data[1] << 8) |
+			if (msg_cfg.buffer.data_len >= 3 &&
+			    (msg_cfg.buffer.data[0] | (msg_cfg.buffer.data[1] << 8) |
 			     (msg_cfg.buffer.data[2] << 16)) == IANA_ID) {
 				msg_cfg.buffer.data_len -= 3;
 				memcpy(&msg_cfg.buffer.data[0], &msg_cfg.buffer.data[3],


### PR DESCRIPTION
Summary:
- BIC will hang if OEM command with no data is received, as following
bic-util slot1 0xe0 0x60

- IPMI message have indeterminate default data, if current data length
is zero but default data is the same as IANA, the check will still pass.
- Fixed it by checking data length and IANA.

Test plan:
- Build code: PASS