### PR TITLE
fby3.5: bb: Adjust medusa sensor reading

### DIFF
--- a/common/dev/ltc4282.c
+++ b/common/dev/ltc4282.c
@@ -34,12 +34,13 @@ uint8_t ltc4282_read(uint8_t sensor_num, int *reading)
 	if (i2c_master_read(&msg, retry) != 0)
 		return SENSOR_FAIL_TO_ACCESS;
 
+	// Refer to LTC4282 datasheet page 23.
 	switch (cfg->offset) {
 	case LTC4282_VSENSE_OFFSET:
-		val = (((msg.data[0] << 8) | msg.data[1]) * 0.4 / 65535 / Rsense);
+		val = (((msg.data[0] << 8) | msg.data[1]) * 0.04 / 65535 / Rsense);
 		break;
 	case LTC4282_POWER_OFFSET:
-		val = (((msg.data[0] << 8) | msg.data[1]) * 16.64 * 0.4 / 65535 / Rsense);
+		val = (((msg.data[0] << 8) | msg.data[1]) * 16.64 * 0.04 * 65536 / 65535 / 65535 / Rsense);
 		break;
 	case LTC4282_VSOURCE_OFFSET:
 		val = (((msg.data[0] << 8) | msg.data[1]) * 16.64 / 65535);

--- a/meta-facebook/yv35-bb/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-bb/src/platform/plat_hook.c
@@ -19,7 +19,7 @@ adm1278_init_arg adm1278_init_args[] = {
 	[0] = { .is_init = false, .config = { 0x3F1C }, .r_sense = 0.25 }
 };
 
-ltc4282_init_arg ltc4282_init_args[] = { [0] = { .r_sense = 0.0001875 } };
+ltc4282_init_arg ltc4282_init_args[] = { [0] = { .r_sense = 0.0001 } };
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS


### PR DESCRIPTION
Summary:
- Correct LTC4282 power and current conversion formula.
Refer from ltc4282 datasheet page 23.
- Modify BB BIC medusa RSENSE value.

Test plan:
- Build code: Pass
- Get medusa power: Pass
- Get medusa current: Pass

Log:
1. Check medusa sensor reading is correctly.
- Before modify
root@bmc-oob:~# sensor-util slot1 | grep MEDUSA
BB_MEDUSA_VIN                (0xDB) :   11.55 Volts | (ok)
BB_MEDUSA_VOUT               (0xD7) :   11.55 Volts | (ok)
BB_MEDUSA_CUR                (0xDF) :   75.52 Amps  | (ok)
BB_MEDUSA_PWR                (0xD8) :  866.14 Watts | (ok)

- After modify
root@bmc-oob:~# sensor-util slot1 | grep MEDUSA
BB_MEDUSA_VIN                (0xDB) :   11.57 Volts | (ok)
BB_MEDUSA_VOUT               (0xD7) :   11.57 Volts | (ok)
BB_MEDUSA_CUR                (0xDF) :   14.06 Amps  | (ok)
BB_MEDUSA_PWR                (0xD8) :  162.61 Watts | (ok)