### PR TITLE
fby3.5: cl:Adjust VR current reading

### DIFF
--- a/common/dev/include/isl69259.h
+++ b/common/dev/include/isl69259.h
@@ -1,0 +1,7 @@
+#ifndef isl69259_H
+#define isl69259_H
+
+#define TWO_COMPLEMENT_NEGATIVE_BIT BIT(15)
+#define ADJUST_IOUT_RANGE 2
+
+#endif


### PR DESCRIPTION
Summary:
- Because VR VCCD sensor would receive negative current value during DC cycle , BIC adjust current value according to vendor Renesas.

Test Plan:
- Build code: Pass
- Add debug message to confirm reading value before/after adjust: Pass

Log:
Add debug message to confirm reading value before/after adjusting result
Current val: 0x1
Adjust Current val: 0x0

Current val: 0x8
Adjust Current val: 0x8

Current val: 0xffff
Adjust Current val: 0x0

root@bmc-oob:~# sensor-util slot2 --threshold | grep "VR Cur"
VCCIN VR Cur                 (0x31) :   28.70 Amps  | (ok) | UCR: 141.18 | UNC: 119.34 | UNR: 180.18 | LCR: NA | LNC: NA | LNR: NA
FIVRA VR Cur                 (0x32) :    3.50 Amps  | (ok) | UCR: 53.01 | UNC: 48.05 | UNR: 70.99 | LCR: NA | LNC: NA | LNR: NA
EHV VR Cur                   (0x33) :    0.80 Amps  | (ok) | UCR: 6.24 | UNC: 5.04 | UNR: 18.00 | LCR: NA | LNC: NA | LNR: NA
VCCD VR Cur                  (0x34) :    2.70 Amps  | (ok) | UCR: 30.02 | UNC: 26.98 | UNR: 42.94 | LCR: NA | LNC: NA | LNR: NA
FAON VR Cur                  (0x35) :    8.50 Amps  | (ok) | UCR: 46.02 | UNC: 42.12 | UNR: 60.06 | LCR: NA | LNC: NA | LNR: NA