### PR TITLE
fby3.5: Modify ADC average sensor delay time

### DIFF
--- a/common/dev/ast_adc.c
+++ b/common/dev/ast_adc.c
@@ -23,7 +23,7 @@ enum adc_device_idx { adc0, adc1, ADC_NUM };
 #define ADC_REFERENCE ADC_REF_INTERNAL
 #define ADC_ACQUISITION_TIME ADC_ACQ_TIME_DEFAULT
 
-#define ADC_AVERAGE_DELAY_MSEC 50
+#define ADC_AVERAGE_DELAY_MSEC 1
 
 static const struct device *dev_adc[ADC_NUM];
 static int16_t sample_buffer[BUFFER_SIZE];


### PR DESCRIPTION
Summary:
- Modify ADC average sensor delay time from 50ms to 1ms.
Due to sampling 100 times and sleeping 50ms (total need to sleep 5s) is too long.

Test plan:
- Build code: Pass
- Get sensor reading: Pass

Log:
1. Check can get sensor reading.
root@bmc-oob:~# sensor-util slot1 --force
slot1:
MB Inlet Temp                (0x1) :   30.00 C     | (ok)
MB Outlet Temp               (0x2) :   41.00 C     | (ok)
FIO Temp                     (0x3) :   25.00 C     | (ok)
PCH Temp                     (0x4) :   47.00 C     | (ok)
SOC CPU Temp                 (0x5) :   39.00 C     | (ok)
SOC Therm Margin             (0x14) :  -61.00 C     | (ok)
CPU TjMax                    (0x15) :  100.00 C     | (ok)
DIMMA Temp                   (0x6) :   38.00 C     | (ok)
DIMMC Temp                   (0x7) :   37.00 C     | (ok)
DIMMD Temp                   (0x9) :   36.00 C     | (ok)
DIMME Temp                   (0xA) :   38.00 C     | (ok)
DIMMG Temp                   (0xB) :   36.00 C     | (ok)
DIMMH Temp                   (0xC) :   34.00 C     | (ok)
SSD0 Temp                    (0xD) :   29.00 C     | (ok)
HSC Temp                     (0xE) :   36.90 C     | (ok)
VCCIN SPS Temp               (0xF) :   50.00 C     | (ok)
FIVRA SPS Temp               (0x10) :   47.00 C     | (ok)
EHV SPS Temp                 (0x11) :   39.00 C     | (ok)
VCCD SPS Temp                (0x12) :   41.00 C     | (ok)
FAON SPS Temp                (0x13) :   44.00 C     | (ok)
P12V_STBY Vol                (0x20) :   12.16 Volts | (ok)
P3V_BAT Vol                  (0x21) :    3.12 Volts | (ok)
P3V3_STBY Vol                (0x22) :    3.34 Volts | (ok)
P1V8_STBY Vol                (0x23) :    1.79 Volts | (ok)
P1V05_PCH Vol                (0x24) :    1.05 Volts | (ok)
P5V_STBY Vol                 (0x25) :    4.96 Volts | (ok)
P12V_DIMM Vol                (0x26) :   12.08 Volts | (ok)
P1V2_STBY Vol                (0x27) :    1.19 Volts | (ok)
P3V3_M2 Vol                  (0x28) :    3.29 Volts | (ok)
HSC Input Vol                (0x29) :   12.01 Volts | (ok)
VCCIN VR Vol                 (0x2A) :    1.78 Volts | (ok)
FIVRA VR Vol                 (0x2C) :    1.82 Volts | (ok)
EHV VR Vol                   (0x2D) :    1.80 Volts | (ok)
VCCD VR Vol                  (0x2E) :    1.14 Volts | (ok)
FAON VR Vol                  (0x2F) :    1.05 Volts | (ok)
HSC Output Cur               (0x30) :    9.14 Amps  | (ok)
VCCIN VR Cur                 (0x31) :   26.60 Amps  | (ok)
FIVRA VR Cur                 (0x32) :    3.60 Amps  | (ok)
EHV VR Cur                   (0x33) :    0.90 Amps  | (ok)
VCCD VR Cur                  (0x34) :    2.60 Amps  | (ok)
FAON VR Cur                  (0x35) :    8.70 Amps  | (ok)
CPU PWR                      (0x38) :   65.70 Watts | (ok)
HSC Input Pwr                (0x39) :  108.26 Watts | (ok)
VCCIN VR Pout                (0x3A) :   45.00 Watts | (ok)
FIVRA VR Pout                (0x3C) :    6.00 Watts | (ok)
EHV VR Pout                  (0x3D) :    2.00 Watts | (ok)
VCCD VR Pout                 (0x3E) :    2.00 Watts | (ok)
FAON VR Pout                 (0x3F) :    8.00 Watts | (ok)
BB_INLET_TEMP                (0xD1) :   25.99 C     | (ok)
BB_OUTLET_TEMP               (0xD2) :   28.99 C     | (ok)
BB_HSC_TEMP                  (0xD3) :   24.52 C     | (ok)
BB_P5V_STBY                  (0xD4) :    5.14 Volts | (ok)
BB_P12V_STBY                 (0xD5) :   12.18 Volts | (ok)
BB_P3V3_STBY                 (0xD6) :    3.36 Volts | (ok)
BB_P5V_USB                   (0xE9) :    5.14 Volts | (ok)
BB_P1V2_STBY                 (0xD9) :    1.21 Volts | (ok)
BB_P1V0_STBY                 (0xDA) :    1.01 Volts | (ok)
BB_MEDUSA_VIN                (0xDB) :   12.05 Volts | (ok)
BB_MEDUSA_VOUT               (0xD7) :   12.05 Volts | (ok)
BB_HSC_VIN                   (0xDC) :   12.02 Volts | (ok)
BB_MEDUSA_CUR                (0xDF) :   12.69 Amps  | (ok)
BB_HSC_IOUT                  (0xDE) :    6.12 Amps  | (ok)
BB_FAN_IOUT                  (0xE8) :    2.75 Amps  | (ok)
BB_MEDUSA_PWR                (0xD8) :  152.86 Watts | (ok)
BB_HSC_PIN                   (0xDD) :   73.23 Watts | (ok)
BB_HSC_EIN                   (0xEA) :   71.52 Watts | (ok)
BB_HSC_PEAK_IOUT             (0xEB) :    8.88 Amps  | (ok)
BB_HSC_PEAK_PIN              (0xEC) :  107.99 Watts | (ok)

root@bmc-oob:~# sensor-util slot1 | grep FAN
BB_FAN_IOUT                  (0xE8) :    2.73 Amps  | (ok)