### PR TITLE
fby3.5: cl: Version commit for oby35-cl-2022.19.01

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_version.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_version.h
@@ -7,7 +7,7 @@
 #define DEVICE_ID 0x00
 #define DEVICE_REVISION 0x80
 #define FIRMWARE_REVISION_1 0x11
-#define FIRMWARE_REVISION_2 0x11
+#define FIRMWARE_REVISION_2 0x12
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
 #define PRODUCT_ID 0x0000
@@ -15,7 +15,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x17
+#define BIC_FW_WEEK 0x19
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x63 // char: c
 #define BIC_FW_platform_1 0x6c // char: l


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Craterlake BIC oby35-cl-2022.19.01.

Test Plan:
- Build code: Pass
- Get CraterLake revision/version: Pass

Log:
root@bmc-oob:~# bic-util slot1 0x18 0x01
00 80 11 12 02 BF 9C 9C 00 00 00 00 00 00 00
root@bmc-oob:~# bic-util slot1 0xE0 0xB 0x9c 0x9c 0x0 0x2
9C 9C 00 20 22 19 01 63 6C 00