### PR TITLE
Add the --force option to cppcheck

### DIFF
--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -189,6 +189,7 @@ jobs:
         cat /tmp/cppcheck_file_list.log
 
         options=( "-j2"
+          "--force"
           "--inconclusive"
           "--enable=performance,style,portability,information"
           "--library=scripts/linters/cppcheck/cppcheck.cfg"


### PR DESCRIPTION
Summary:
CPPCheck doesn't check all the configs by default. Add the force option
so it will check all the different possible code paths resulting from
various #ifdefs

Differential Revision: D36419663

