### PR TITLE
fby3.5: cl: Remove useless code

### DIFF
--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -734,12 +734,6 @@ __weak void OEM_1S_ACCURACY_SENSOR_READING(ipmi_msg *msg)
 		msg->completion_code = CC_SUCCESS;
 		break;
 	case SENSOR_READ_4BYTE_ACUR_SUCCESS:
-		res->decimal = (int32_t)reading;
-		if (reading < 0) {
-			res->fraction = (int32_t)((res->decimal - reading + 0.0005) * 1000);
-		} else {
-			res->fraction = (int32_t)((reading - res->decimal + 0.0005) * 1000);
-		}
 		memcpy(msg->data, &reading, sizeof(reading));
 		msg->data[4] = sensor_report_status;
 		msg->data_len = 5;


### PR DESCRIPTION
Summary:
- Remove useless code
  The sensor reading buffer in IPMI command handler is float type in previous codebase.
  But the type is changed to int type for new sensor reading architecture.
  So, the code for floating-point-to-integer conversion is useless.

Test Plan:
- Check sensor value - pass

Log:
root@bmc-oob:~# sensor-util slot3
slot3:
MB Inlet Temp                (0x1) :   23.25 C     | (ok)
MB Outlet Temp               (0x2) :   32.25 C     | (ok)
FIO Temp                     (0x3) :   24.25 C     | (ok)
PCH Temp                     (0x4) :   31.00 C     | (ok)
SOC CPU Temp                 (0x5) :   32.00 C     | (ok)
SOC Therm Margin             (0x14) :  -50.00 C     | (ok)
CPU TjMax                    (0x15) :   82.00 C     | (ok)
DIMMA Temp                   (0x6) :   25.00 C     | (ok)
DIMMC Temp                   (0x7) :   25.00 C     | (ok)
DIMMD Temp                   (0x9) :   25.00 C     | (ok)
DIMME Temp                   (0xA) :   25.00 C     | (ok)
DIMMG Temp                   (0xB) :   25.00 C     | (ok)
DIMMH Temp                   (0xC) :   25.00 C     | (ok)
SSD0 Temp                    (0xD) :   27.00 C     | (ok)
HSC Temp                     (0xE) :   28.81 C     | (ok)
VCCIN SPS Temp               (0xF) :   40.00 C     | (ok)
FIVRA SPS Temp               (0x10) :   38.00 C     | (ok)
EHV SPS Temp                 (0x11) :   30.00 C     | (ok)
VCCD SPS Temp                (0x12) :   34.00 C     | (ok)
FAON SPS Temp                (0x13) :   38.00 C     | (ok)
P12V_STBY Vol                (0x20) :   12.34 Volts | (ok)
P3V_BAT Vol                  (0x21) :    3.12 Volts | (ok)
P3V3_STBY Vol                (0x22) :    3.35 Volts | (ok)
P1V8_STBY Vol                (0x23) :    1.81 Volts | (ok)
P1V05_PCH Vol                (0x24) :    1.05 Volts | (ok)
P5V_STBY Vol                 (0x25) :    5.01 Volts | (ok)
P12V_DIMM Vol                (0x26) :   12.21 Volts | (ok)
P1V2_STBY Vol                (0x27) :    1.20 Volts | (ok)
P3V3_M2 Vol                  (0x28) :    3.33 Volts | (ok)
HSC Input Vol                (0x29) :   12.15 Volts | (ok)
VCCIN VR Vol                 (0x2A) :    1.77 Volts | (ok)
FIVRA VR Vol                 (0x2C) :    1.80 Volts | (ok)
EHV VR Vol                   (0x2D) :    1.80 Volts | (ok)
VCCD VR Vol                  (0x2E) :    1.14 Volts | (ok)
FAON VR Vol                  (0x2F) :    1.02 Volts | (ok)
HSC Output Cur               (0x30) :   10.81 Amps  | (ok)
VCCIN VR Cur                 (0x31) :   37.90 Amps  | (ok)
FIVRA VR Cur                 (0x32) :    3.80 Amps  | (ok)
EHV VR Cur                   (0x33) :    1.20 Amps  | (ok)
VCCD VR Cur                  (0x34) :    2.60 Amps  | (ok)
FAON VR Cur                  (0x35) :   20.60 Amps  | (ok)
CPU PWR                      (0x38) :   97.00 Watts | (ok)
HSC Input Pwr                (0x39) :  130.03 Watts | (ok)
VCCIN VR Pout                (0x3A) :   66.00 Watts | (ok)
FIVRA VR Pout                (0x3C) :    6.00 Watts | (ok)
EHV VR Pout                  (0x3D) :    2.00 Watts | (ok)
VCCD VR Pout                 (0x3E) :    2.00 Watts | (ok)
FAON VR Pout                 (0x3F) :   20.00 Watts | (ok)
DIMMA PMIC_Pout              (0x1E) :    0.25 Watts | (ok)
DIMMC PMIC_Pout              (0x1F) :    0.25 Watts | (ok)
DIMMD PMIC_Pout              (0x36) :    0.38 Watts | (ok)
DIMME PMIC_Pout              (0x37) :    0.00 Watts | (ok)
DIMMG PMIC_Pout              (0x42) :    0.50 Watts | (ok)
DIMMH PMIC_Pout              (0x47) :    0.12 Watts | (ok)