### PR TITLE
fby3.5: cl:Adjust VR power reading

### DIFF
--- a/common/dev/isl69259.c
+++ b/common/dev/isl69259.c
@@ -5,24 +5,41 @@
 #include "pmbus.h"
 #include "isl69259.h"
 
-void adjust_of_two_complement(uint8_t offset, int *val)
+bool adjust_of_twos_complement(uint8_t offset, int *val)
 {
 	if (val == NULL) {
 		printf("[%s] input value is NULL\n", __func__);
-		return;
+		return false;
 	}
 	int adjust_val = *val;
-	if ((adjust_val & TWO_COMPLEMENT_NEGATIVE_BIT) != 0) {
-		// Convert two's complement to usigned integer
-		adjust_val = ~(adjust_val - 1);
-	}
+	bool is_negative_val = ((adjust_val & TWO_COMPLEMENT_NEGATIVE_BIT) == 0 ? false : true);
+	bool ret = true;
 
-	if (offset == PMBUS_READ_IOUT) {
-		// Set reading value to 0 if reading value in adjust range
+	switch (offset) {
+	case PMBUS_READ_IOUT:
+		// Convert two's complement to usigned integer
+		if (is_negative_val == true) {
+			adjust_val = ~(adjust_val - 1);
+		}
+
+		// Set reading value to 0 if reading value in range -0.2A ~ 0.2A
+		// Because register report unit is 0.1A , set reading value to 0 if register report value is lower than 2 units
 		if (adjust_val < ADJUST_IOUT_RANGE) {
 			*val = 0;
 		}
+		break;
+	case PMBUS_READ_POUT:
+		// Set reading value to 0 if reading value is negative
+		if (is_negative_val == true) {
+			*val = 0;
+		}
+		break;
+	default:
+		printf("[%s] not support offset: 0x%x\n", __func__, offset);
+		ret = false;
+		break;
 	}
+	return ret;
 }
 
 uint8_t isl69259_read(uint8_t sensor_num, int *reading)
@@ -31,6 +48,7 @@ uint8_t isl69259_read(uint8_t sensor_num, int *reading)
 		return SENSOR_UNSPECIFIED_ERROR;
 	}
 
+	bool ret = false;
 	uint8_t retry = 5;
 	int val = 0;
 	sensor_val *sval = (sensor_val *)reading;
@@ -50,23 +68,44 @@ uint8_t isl69259_read(uint8_t sensor_num, int *reading)
 
 	uint8_t offset = sensor_config[sensor_config_index_map[sensor_num]].offset;
 	val = (msg.data[1] << 8) | msg.data[0];
-	if (offset == PMBUS_READ_VOUT) {
+
+	switch (offset) {
+	case PMBUS_READ_VOUT:
 		/* 1 mV/LSB, unsigned integer */
 		sval->integer = val / 1000;
 		sval->fraction = val % 1000;
-	} else if (offset == PMBUS_READ_IOUT) {
+		break;
+	case PMBUS_READ_IOUT:
 		/* 0.1 A/LSB, 2's complement */
-		adjust_of_two_complement(PMBUS_READ_IOUT, &val);
+		ret = adjust_of_twos_complement(offset, &val);
+		if (ret == false) {
+			printf("[%s] adjust reading value fail  sensor number: 0x%x\n", __func__,
+			       sensor_num);
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+
 		sval->integer = (int16_t)val / 10;
 		sval->fraction = (int16_t)(val - (sval->integer * 10)) * 100;
-	} else if (offset == PMBUS_READ_TEMPERATURE_1) {
+		break;
+	case PMBUS_READ_TEMPERATURE_1:
 		/* 1 Degree C/LSB, 2's complement */
 		sval->integer = val;
-	} else if (offset == PMBUS_READ_POUT) {
+		break;
+	case PMBUS_READ_POUT:
 		/* 1 Watt/LSB, 2's complement */
+		ret = adjust_of_twos_complement(offset, &val);
+		if (ret == false) {
+			printf("[%s] adjust reading value fail  sensor number: 0x%x\n", __func__,
+			       sensor_num);
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+
 		sval->integer = val;
-	} else {
+		break;
+	default:
+		printf("[%s] not support offset: 0x%x\n", __func__, offset);
 		return SENSOR_FAIL_TO_ACCESS;
+		break;
 	}
 
 	return SENSOR_READ_SUCCESS;


### PR DESCRIPTION
Summary:
- Because VR VCCD sensor would receive negative power value during DC cycle, BIC adjust power value according to the recommendation of vendor Renesas.

Test Plan:
- Build code: Pass
- VR sensor would report negative power value during DC cycle, add debug message to confirm the reading value is adjusted: Pass

Log:
Add debug message to confirm the reading value is adjusted
power 0xffff
adjust power 0x0

power 0xb
adjust power 0xb

root@bmc-oob:~# sensor-util slot1 --threshold | grep "VR Pout"
VCCIN VR Pout                (0x3A) :   47.00 Watts | (ok) | UCR: 253.80 | UNC: 214.32 | UNR: 324.30 | LCR: NA | LNC: NA | LNR: NA
FIVRA VR Pout                (0x3C) :    5.00 Watts | (ok) | UCR: 95.19 | UNC: 86.64 | UNR: 127.68 | LCR: NA | LNC: NA | LNR: NA
EHV VR Pout                  (0x3D) :    2.00 Watts | (ok) | UCR: 11.25 | UNC: 8.97 | UNR: 32.38 | LCR: NA | LNC: NA | LNR: NA
VCCD VR Pout                 (0x3E) :    2.00 Watts | (ok) | UCR: 34.32 | UNC: 31.02 | UNR: 49.28 | LCR: NA | LNC: NA | LNR: NA
FAON VR Pout                 (0x3F) :    9.00 Watts | (ok) | UCR: 49.28 | UNC: 45.08 | UNR: 64.12 | LCR: NA | LNC: NA | LNR: NA