### PR TITLE
fby3.5: Support get board id

### DIFF
--- a/common/service/ipmi/include/ipmi.h
+++ b/common/service/ipmi/include/ipmi.h
@@ -198,6 +198,7 @@ enum { CMD_OEM_1S_MSG_IN = 0x1,
 
        CMD_OEM_1S_PEX_FLASH_READ = 0x72,
        CMD_OEM_1S_GET_FPGA_USER_CODE = 0x73,
+       CMD_OEM_1S_GET_BOARD_ID = 0xA0,
 };
 
 enum { INDEX_SLOT1 = 0x01,

--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -1201,6 +1201,24 @@ __weak void OEM_1S_GET_FPGA_USER_CODE(ipmi_msg *msg)
 	return;
 }
 
+__weak void OEM_1S_GET_BOARD_ID(ipmi_msg *msg)
+{
+	if (msg == NULL) {
+		printf("%s failed due to parameter *msg is NULL\n", __func__);
+		return;
+	}
+
+	if (msg->data_len != 0) {
+		msg->data_len = 0;
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	msg->data_len = 0;
+	msg->completion_code = CC_INVALID_CMD;
+	return;
+}
+
 void IPMI_OEM_1S_handler(ipmi_msg *msg)
 {
 	if (msg == NULL) {
@@ -1301,6 +1319,9 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 		break;
 	case CMD_OEM_1S_GET_FPGA_USER_CODE:
 		OEM_1S_GET_FPGA_USER_CODE(msg);
+		break;
+	case CMD_OEM_1S_GET_BOARD_ID:
+		OEM_1S_GET_BOARD_ID(msg);
 		break;
 	default:
 		printf("Invalid OEM message, netfn(0x%x) cmd(0x%x)\n", msg->netfn, msg->cmd);

--- a/meta-facebook/yv35-rf/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-rf/src/ipmi/plat_ipmi.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "ipmi.h"
+#include "libutil.h"
+#include "plat_ipmi.h"
+#include "plat_ipmb.h"
+#include "plat_class.h"
+
+void OEM_1S_GET_BOARD_ID(ipmi_msg *msg)
+{
+	if (msg == NULL) {
+		printf("%s failed due to parameter *msg is NULL\n", __func__);
+		return;
+	}
+
+	if (msg->data_len != 0) {
+		msg->data_len = 0;
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	msg->data_len = 1;
+	msg->data[0] = get_board_id();
+	msg->completion_code = CC_SUCCESS;
+	return;
+}

--- a/meta-facebook/yv35-rf/src/platform/plat_class.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_class.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include "hal_gpio.h"
+#include "plat_class.h"
+
+static uint8_t system_board_id = 0;
+
+void init_sys_board_id(uint8_t board_id)
+{
+	switch (board_id) {
+	case RAINBOW_FALLS:
+		system_board_id = RAINBOW_FALLS;
+		break;
+	case WAIMANO_FALLS:
+		system_board_id = WAIMANO_FALLS;
+		break;
+	case VERNAL_FALLS:
+		system_board_id = VERNAL_FALLS;
+		break;
+	default:
+		printf("[%s] input board id not support: 0x%x\n", __func__, board_id);
+		system_board_id = UNKNOWN_BOARD;
+		break;
+	}
+}
+
+void init_platform_config()
+{
+	uint8_t board_id = 0;
+	board_id = ((gpio_get(BOARD_ID_BIT_3) << 3) | (gpio_get(BOARD_ID_BIT_2) << 2) |
+		    (gpio_get(BOARD_ID_BIT_1) << 1) | (gpio_get(BOARD_ID_BIT_0) << 0));
+
+	init_sys_board_id(board_id);
+	printf("[%s] board id 0x%x\n", __func__, system_board_id);
+	return;
+}
+
+uint8_t get_board_id()
+{
+	return system_board_id;
+}

--- a/meta-facebook/yv35-rf/src/platform/plat_class.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_class.h
@@ -1,0 +1,25 @@
+#ifndef PLAT_CLASS_H
+#define PLAT_CLASS_H
+
+#include "hal_gpio.h"
+#include "plat_gpio.h"
+
+enum BOARD_ID {
+	RAINBOW_FALLS = 0x0A,
+	WAIMANO_FALLS = 0x0C,
+	VERNAL_FALLS = 0x0E,
+	UNKNOWN_BOARD = 0xFF,
+};
+
+enum BOARD_ID_BIT_MAPPING {
+	BOARD_ID_BIT_0 = BOARD_ID0,
+	BOARD_ID_BIT_1 = BOARD_ID1,
+	BOARD_ID_BIT_2 = BOARD_ID2,
+	BOARD_ID_BIT_3 = BOARD_ID3,
+};
+
+void init_platform_config();
+void init_sys_board_id(uint8_t board_id);
+uint8_t get_board_id();
+
+#endif

--- a/meta-facebook/yv35-rf/src/platform/plat_init.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_init.c
@@ -1,0 +1,13 @@
+#include "hal_gpio.h"
+#include "plat_gpio.h"
+#include "plat_class.h"
+
+void pal_pre_init()
+{
+	init_platform_config();
+}
+
+#define DEF_PROJ_GPIO_PRIORITY 61
+
+DEVICE_DEFINE(PRE_DEF_PROJ_GPIO, "PRE_DEF_PROJ_GPIO_NAME", &gpio_init, NULL, NULL, NULL,
+	      POST_KERNEL, DEF_PROJ_GPIO_PRIORITY, NULL);


### PR DESCRIPTION
Summary:
- Support get and store system board id.
- Support get board id OEM command.

Dependency: #302 

Test plans:
- Build code: Pass
- Get board id: pass

Log:
1. Check system get board id is correct.
[RF BIC console]
*** Booting Zephyr OS build v00.01.04-5-g70b0b6ecc605  ***
Hello, welcome to yv35 Rainbow Falls 2022.20.e3
[init_platform_config] board id 0xa
Function pal_fix_full_sdr_table is not implemented
The SDR number is equal to 0
ipmi_init

2. Check BMC can get 1U board id.
[BMC console]
root@bmc-oob:~# bic-util slot2 0xe0 0x2 0x9c 0x9c 0x0 0x5 0xe0 0xa0 0x9c 0x9c 0x0
9C 9C 00 05 39 A0 00 9C 9C 00 0A