### PR TITLE
fby3.5: cl:Increase the I2C clock rate accuracy

### DIFF
--- a/fix_patch/tag_v00.01.04_edb7dc6f3cc5cde814dd10e8ec02da62f833bdaf/0006-drivers-i2c-Update-i2c-bus-calculation-formula.patch
+++ b/fix_patch/tag_v00.01.04_edb7dc6f3cc5cde814dd10e8ec02da62f833bdaf/0006-drivers-i2c-Update-i2c-bus-calculation-formula.patch
@@ -1,0 +1,143 @@
+From 306c8cdba8e802486e456fc09693bba2af10ddca Mon Sep 17 00:00:00 2001
+From: Tommy Haung <tommy_huang@aspeedtech.com>
+Date: Mon, 21 Feb 2022 13:15:17 +0800
+Subject: [PATCH 1/2] drivers: i2c: Update i2c bus calculation formula
+
+Update the i2c bus calculation. We list the bus speed calculation result
+with tbuf value. Customer could change it by themself. By the way, because
+the fixed point setting, we will do division with rounding by ourself.
+
+Signed-off-by: Tommy Haung <tommy_huang@aspeedtech.com>
+Change-Id: I1390c18fb7feae78bfbda9e68c5269b5c1552fe9
+---
+ drivers/i2c/i2c_aspeed.c        | 48 ++++++++++++++++++++-------------
+ drivers/i2c/i2c_global_aspeed.c |  9 +++++++
+ 2 files changed, 39 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/i2c/i2c_aspeed.c b/drivers/i2c/i2c_aspeed.c
+index 04bd5d2079..12b86cf0b8 100644
+--- a/drivers/i2c/i2c_aspeed.c
++++ b/drivers/i2c/i2c_aspeed.c
+@@ -482,40 +482,54 @@ static uint32_t i2c_aspeed_select_clock(const struct device *dev)
+ 	int divider_ratio = 0;
+ 	uint32_t clk_div_reg;
+ 	int inc = 0;
++	unsigned long base_clk;
+ 	unsigned long base_clk1;
+ 	unsigned long base_clk2;
+ 	unsigned long base_clk3;
+ 	unsigned long base_clk4;
+ 	uint32_t scl_low, scl_high;
+-	uint32_t hl_ratio_term = 3;
+ 
+ 	if (config->clk_div_mode) {
+ 		clk_div_reg = sys_read32(config->global_reg + ASPEED_I2CG_CLK_DIV);
+ 
++		base_clk = config->clk_src;
+ 		base_clk1 = (config->clk_src * 10) /
+ 		((((clk_div_reg & 0xff) + 2) * 10) / 2);
++		LOG_DBG("base_clk1 is %lx", base_clk1);
+ 		base_clk2 = (config->clk_src * 10) /
+ 		(((((clk_div_reg >> 8) & 0xff) + 2) * 10) / 2);
++		LOG_DBG("base_clk2 is %lx", base_clk2);
+ 		base_clk3 = (config->clk_src * 10) /
+ 		(((((clk_div_reg >> 16) & 0xff) + 2) * 10) / 2);
++		LOG_DBG("base_clk3 is %lx", base_clk3);
+ 		base_clk4 = (config->clk_src * 10) /
+ 		(((((clk_div_reg >> 24) & 0xff) + 2) * 10) / 2);
++		LOG_DBG("base_clk4 is %lx", base_clk4);
+ 
++		/* Rounding by ourself */
+ 		if ((config->clk_src / data->bus_frequency) <= 32) {
+ 			div = 0;
+-			divider_ratio = config->clk_src / data->bus_frequency;
++			divider_ratio = (base_clk / (unsigned long)(data->bus_frequency));
++			if ((base_clk / divider_ratio) > (unsigned long)(data->bus_frequency))
++				divider_ratio++;
+ 		} else if ((base_clk1 / data->bus_frequency) <= 32) {
+ 			div = 1;
+-			divider_ratio = base_clk1 / data->bus_frequency;
++			divider_ratio = (base_clk1 / (unsigned long)(data->bus_frequency));
++			if ((base_clk1 / divider_ratio) > (unsigned long)(data->bus_frequency))
++				divider_ratio++;
+ 		} else if ((base_clk2 / data->bus_frequency) <= 32) {
+ 			div = 2;
+-			divider_ratio = base_clk2 / data->bus_frequency;
++			divider_ratio = (base_clk2 / (unsigned long)(data->bus_frequency));
++			if ((base_clk2 / divider_ratio) > (unsigned long)(data->bus_frequency))
++				divider_ratio++;
+ 		} else if ((base_clk3 / data->bus_frequency) <= 32) {
+ 			div = 3;
+-			divider_ratio = base_clk3 / data->bus_frequency;
++			divider_ratio = (base_clk3 / (unsigned long)(data->bus_frequency));
++			if ((base_clk3 / divider_ratio) > (unsigned long)(data->bus_frequency))
++				divider_ratio++;
+ 		} else {
+ 			div = 4;
+-			divider_ratio = base_clk4 / data->bus_frequency;
++			divider_ratio = (base_clk4 / (unsigned long)(data->bus_frequency));
+ 			inc = 0;
+ 			while ((divider_ratio + inc) > 32) {
+ 				inc |= divider_ratio & 0x1;
+@@ -523,28 +537,26 @@ static uint32_t i2c_aspeed_select_clock(const struct device *dev)
+ 				div++;
+ 			}
+ 			divider_ratio += inc;
++			if ((base_clk4 / divider_ratio) > (unsigned long)(data->bus_frequency))
++				divider_ratio++;
+ 		}
+ 
+ 		LOG_DBG("div %d", div);
+-		LOG_DBG("ratio %x", divider_ratio);
++		LOG_DBG("divider_ratio %x", divider_ratio);
+ 
++		divider_ratio = MIN(divider_ratio, 32);
++		LOG_DBG("divider_ratio min %x", divider_ratio);
+ 		div &= 0xf;
+-		scl_low = ((divider_ratio >> 1) - 1) & 0xf;
+-		scl_high = (divider_ratio - scl_low - 2) & 0xf;
+-
+-		/* modified the H/L ratio for spec request */
+-		if (data->bus_frequency != I2C_BITRATE_STANDARD) {
+-			scl_low += hl_ratio_term;
+-			scl_high -= hl_ratio_term;
+-		}
+-
++		scl_low = ((divider_ratio * 9) / 16) - 1;
+ 		LOG_DBG("scl_low %x", scl_low);
++		scl_low = MIN(scl_low, 0xf);
++		LOG_DBG("scl_low min %x", scl_low);
++		scl_high = (divider_ratio - scl_low - 2) & 0xf;
+ 		LOG_DBG("scl_high %x", scl_high);
+ 
+ 		/*Divisor : Base Clock : tCKHighMin : tCK High : tCK Low*/
+ 		ac_timing = ((scl_high-1) << 20) | (scl_high << 16) | (scl_low << 12) | (div);
+-		ac_timing |= AST_I2CC_toutBaseCLK(I2C_TIMEOUT_CLK);
+-		ac_timing |= AST_I2CC_tTIMEOUT(I2C_TIMEOUT_COUNT);
++		LOG_DBG("ac_timing %x", ac_timing);
+ 	} else {
+ 		for (i = 0; i < ARRAY_SIZE(aspeed_old_i2c_timing_table); i++) {
+ 			if ((config->clk_src / aspeed_old_i2c_timing_table[i].divisor) <
+diff --git a/drivers/i2c/i2c_global_aspeed.c b/drivers/i2c/i2c_global_aspeed.c
+index d4270ac60a..087aabf373 100644
+--- a/drivers/i2c/i2c_global_aspeed.c
++++ b/drivers/i2c/i2c_global_aspeed.c
+@@ -47,6 +47,15 @@ struct i2c_global_config {
+ 
+ #define BASE_CLK_COUNT	4
+ 
++/*
++ * 100khz base clk3 table
++ * base clk:3250000, val:0x1d, scl:100.8Khz, tbuf:4.96us
++ * base clk:3125000, val:0x1e, scl:97.66Khz, tbuf:5.12us
++ * base clk:3040000, val:0x1f, scl: 97.85Khz, tbuf: 5.28us
++ * base clk:3000000, val:0x20, scl: 98.04Khz, tbuf: 5.44us
++ * base clk:2900000, val:0x21, scl: 98.61Khz, tbuf: 5.6us
++ * base clk:2800000, val:0x22, scl: 99.21Khz, tbuf: 5.75us
++ */
+ static uint32_t base_freq[BASE_CLK_COUNT] = {
+ 	20000000,	/* 20M */
+ 	10000000,	/* 10M */
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.04_edb7dc6f3cc5cde814dd10e8ec02da62f833bdaf/0007-Revise-the-I2C-baseclock3-to-2.8MHz-to-improve-I2C-clock-rate-accuracy.patch
+++ b/fix_patch/tag_v00.01.04_edb7dc6f3cc5cde814dd10e8ec02da62f833bdaf/0007-Revise-the-I2C-baseclock3-to-2.8MHz-to-improve-I2C-clock-rate-accuracy.patch
@@ -1,0 +1,26 @@
+From baec32a93ee1f26d9a1cb2be587ad62316efdf24 Mon Sep 17 00:00:00 2001
+From: Ren Chen <ren_chen@wiwynn.com>
+Date: Fri, 27 May 2022 10:33:12 +0800
+Subject: [PATCH 2/2] Revise the I2C baseclock3 to 2.8MHz to improve I2C clock
+ rate accuracy
+
+---
+ drivers/i2c/i2c_global_aspeed.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/i2c_global_aspeed.c b/drivers/i2c/i2c_global_aspeed.c
+index 087aabf373..a91fe62696 100644
+--- a/drivers/i2c/i2c_global_aspeed.c
++++ b/drivers/i2c/i2c_global_aspeed.c
+@@ -59,7 +59,7 @@ struct i2c_global_config {
+ static uint32_t base_freq[BASE_CLK_COUNT] = {
+ 	20000000,	/* 20M */
+ 	10000000,	/* 10M */
+-	3250000,	/* 3.25M */
++	2800000,	/* 2.8M */
+ 	1000000,	/* 1M */
+ };
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Summary:
- The clock rate of I2C bus-1/3/4 is set as 100kHz in DTS(overlay) file.
  The real clock rate(around 103kHz) is higher than 100kHz because of the AST I2C clock divider setting.
  This doesn't meet hardware's critera.
  The hardware's critera is the real clock rate should be lower than the clock rate that BIC set.
  So, BIC increases the I2C clock rate accuracy in Zephyr Kernel.
  After the modifaction, the real clock rate is around 92MHz.

Test Plan:
1. Check the I2C clock rate - pass
Log:
uart:~$ md 0x7e6e2200 1
[7e6e2200] 00000000 --> H-PLL = 1000MHz
uart:~$ md 0x7e6e2310 1
[7e6e2310] 43f90900 --> PCLK = 50MHz
uart:~$ md 0x7e7b0010 1
[7e7b0010] 62220803 --> base_divider_1 = 20MHz, base_divider_2 = 10MHz, base_divider_3 = 2.77MHz, base_divider_4 = 1MHz
[Bus 0 - is set as 400kHz in DTS]
uart:~$ md 0x7e7b0084 1
[7e7b0084] 009ad002 --> clock rate = 10M/(25) = 400kHz
[Bus 1 - is set as 100kHz in DTS]
uart:~$ md 0x7e7b0104 1
[7e7b0104] 00bce003 --> clock rate = 2.77M/28 = 99.2kHz
[Bus 2 - is set as 1MHz in DTS]
uart:~$ md 0x7e7b0184 1
[7e7b0184] 0078a001 --> clock rate = 20M/20 = 1MHz