### PR TITLE
fby3.5: cl:Support IPMI command - Get card type

### DIFF
--- a/common/dev/max16550a.c
+++ b/common/dev/max16550a.c
@@ -1,0 +1,89 @@
+#include <stdio.h>
+#include <string.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "pmbus.h"
+
+uint8_t max16550a_read(uint8_t sensor_num, int *reading)
+{
+	if (reading == NULL) {
+		printf("[%s] input parameter reading is NULL\n", __func__);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	if ((sensor_num > SENSOR_NUM_MAX) ||
+	    (sensor_config[sensor_config_index_map[sensor_num]].init_args == NULL)) {
+		printf("[%s] sensor 0x%x input parameter is invalid\n", __func__, sensor_num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	*reading = 0;
+	uint8_t retry = 5;
+	uint8_t offset = sensor_config[sensor_config_index_map[sensor_num]].offset;
+	int ret = 0;
+	float val = 0, r_load = 0;
+	I2C_MSG msg;
+	memset(&msg, 0, sizeof(I2C_MSG));
+
+	max16550a_init_arg *init_arg =
+		(max16550a_init_arg *)sensor_config[sensor_config_index_map[sensor_num]].init_args;
+	// R_load is the value of resistance connected to EFUSE , and EFUSE would adjust the reading accuracy according to r_load
+	r_load = init_arg->r_load;
+
+	msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
+	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = offset;
+
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		printf("[%s] i2c read fail  sensor number 0x%x  ret: %d\n", __func__, sensor_num,
+		       ret);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	switch (offset) {
+	case PMBUS_READ_VIN:
+		// m = +7578, b = +0, R = -2
+		val = (float)((msg.data[1] << 8) | msg.data[0]) * 100 / 7578;
+		break;
+	case PMBUS_READ_VOUT:
+		// m = +7578, b = +0, R = -2
+		val = (float)((msg.data[1] << 8) | msg.data[0]) * 100 / 7578;
+		break;
+	case PMBUS_READ_IOUT:
+		// m = +3.824 * Rload, b = -4300, R = -3
+		val = (float)(((msg.data[1] << 8) | msg.data[0]) * 1000 + 4300) / (3.824 * r_load);
+		break;
+	case PMBUS_READ_TEMPERATURE_1:
+		// m = +199, b = +7046, R = -2
+		val = (float)(((msg.data[1] << 8) | msg.data[0]) * 100 - 7046) / 199;
+		break;
+	case PMBUS_READ_PIN:
+		// m = +0.895 * Rload, b = -9100, R = -2
+		val = (float)(((msg.data[1] << 8) | msg.data[0]) * 100 + 9100) / (0.895 * r_load);
+		break;
+	default:
+		printf("[%s] not support sensor number 0x%x  offset: 0x%x\n", __func__, sensor_num,
+		       offset);
+		return SENSOR_NOT_FOUND;
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	sval->integer = (int)val & 0xFFFF;
+	sval->fraction = (val - sval->integer) * 1000;
+
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t max16550a_init(uint8_t sensor_num)
+{
+	if (sensor_num > SENSOR_NUM_MAX) {
+		printf("[%s] input sensor number 0x%x is invalid\n", __func__, sensor_num);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	sensor_config[sensor_config_index_map[sensor_num]].read = max16550a_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/service/ipmi/include/ipmi.h
+++ b/common/service/ipmi/include/ipmi.h
@@ -198,6 +198,8 @@ enum { CMD_OEM_1S_MSG_IN = 0x1,
 
        CMD_OEM_1S_PEX_FLASH_READ = 0x72,
        CMD_OEM_1S_GET_FPGA_USER_CODE = 0x73,
+
+       CMD_OEM_1S_GET_CARD_TYPE = 0xA1,
 };
 
 enum { INDEX_SLOT1 = 0x01,

--- a/common/service/ipmi/include/oem_1s_handler.h
+++ b/common/service/ipmi/include/oem_1s_handler.h
@@ -62,6 +62,7 @@ void OEM_1S_WRITE_BIC_REGISTER(ipmi_msg *msg);
 void OEM_1S_INFORM_PEER_SLED_CYCLE(ipmi_msg *msg);
 void OEM_1S_PEX_FLASH_READ(ipmi_msg *msg);
 void OEM_1S_GET_FPGA_USER_CODE(ipmi_msg *msg);
+void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg);
 
 #ifdef CONFIG_IPMI_KCS_ASPEED
 void OEM_1S_GET_POST_CODE(ipmi_msg *msg);

--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -1201,6 +1201,18 @@ __weak void OEM_1S_GET_FPGA_USER_CODE(ipmi_msg *msg)
 	return;
 }
 
+__weak void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
+{
+	if (msg == NULL) {
+		printf("%s failed due to parameter *msg is NULL\n", __func__);
+		return;
+	}
+
+	msg->data_len = 0;
+	msg->completion_code = CC_INVALID_CMD;
+	return;
+}
+
 void IPMI_OEM_1S_handler(ipmi_msg *msg)
 {
 	if (msg == NULL) {
@@ -1301,6 +1313,9 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 		break;
 	case CMD_OEM_1S_GET_FPGA_USER_CODE:
 		OEM_1S_GET_FPGA_USER_CODE(msg);
+		break;
+	case CMD_OEM_1S_GET_CARD_TYPE:
+		OEM_1S_GET_CARD_TYPE(msg);
 		break;
 	default:
 		printf("Invalid OEM message, netfn(0x%x) cmd(0x%x)\n", msg->netfn, msg->cmd);

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -57,6 +57,7 @@ SENSOR_DRIVE_INIT_DECLARE(tmp431);
 SENSOR_DRIVE_INIT_DECLARE(pmic);
 SENSOR_DRIVE_INIT_DECLARE(ina233);
 SENSOR_DRIVE_INIT_DECLARE(isl69254iraz_t);
+SENSOR_DRIVE_INIT_DECLARE(max16550a);
 
 struct sensor_drive_api {
 	enum SENSOR_DEV dev;
@@ -79,6 +80,7 @@ struct sensor_drive_api {
 	SENSOR_DRIVE_TYPE_INIT_MAP(pmic),
 	SENSOR_DRIVE_TYPE_INIT_MAP(ina233),
 	SENSOR_DRIVE_TYPE_INIT_MAP(isl69254iraz_t),
+	SENSOR_DRIVE_TYPE_INIT_MAP(max16550a),
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -56,6 +56,7 @@ enum SENSOR_DEV {
 	sensor_dev_pmic = 0x19,
 	sensor_dev_ina233 = 0x20,
 	sensor_dev_isl69254iraz_t = 0x21,
+	sensor_dev_max16550a = 0x22,
 	sensor_dev_max
 };
 
@@ -94,18 +95,20 @@ static inline float convert_MBR_to_reading(uint8_t sensor_num, uint8_t val)
 	return (val - round_add(sensor_num, val)) * SDR_M(sensor_num) / SDR_Rexp(sensor_num);
 }
 
-enum { SENSOR_READ_SUCCESS,
-       SENSOR_READ_ACUR_SUCCESS,
-       SENSOR_NOT_FOUND,
-       SENSOR_NOT_ACCESSIBLE,
-       SENSOR_FAIL_TO_ACCESS,
-       SENSOR_INIT_STATUS,
-       SENSOR_UNSPECIFIED_ERROR,
-       SENSOR_POLLING_DISABLE,
-       SENSOR_PRE_READ_ERROR,
-       SENSOR_POST_READ_ERROR,
-       SENSOR_READ_API_UNREGISTER,
-       SENSOR_READ_4BYTE_ACUR_SUCCESS };
+enum {
+	SENSOR_READ_SUCCESS,
+	SENSOR_READ_ACUR_SUCCESS,
+	SENSOR_NOT_FOUND,
+	SENSOR_NOT_ACCESSIBLE,
+	SENSOR_FAIL_TO_ACCESS,
+	SENSOR_INIT_STATUS,
+	SENSOR_UNSPECIFIED_ERROR,
+	SENSOR_POLLING_DISABLE,
+	SENSOR_PRE_READ_ERROR,
+	SENSOR_POST_READ_ERROR,
+	SENSOR_READ_API_UNREGISTER,
+	SENSOR_READ_4BYTE_ACUR_SUCCESS
+};
 
 enum { SENSOR_INIT_SUCCESS, SENSOR_INIT_UNSPECIFIED_ERROR };
 
@@ -220,6 +223,10 @@ typedef struct _pmic_init_arg {
 typedef struct _ina233_init_arg_ {
 	bool is_init;
 } ina233_init_arg;
+
+typedef struct _max16550a_init_arg_ {
+	float r_load;
+} max16550a_init_arg;
 
 extern bool enable_sensor_poll_thread;
 extern uint8_t SDR_NUM;

--- a/meta-facebook/yv35-cl/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/yv35-cl/src/ipmi/include/plat_ipmi.h
@@ -4,6 +4,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+enum REQ_GET_CARD_TYPE {
+	GET_1OU_CARD_TYPE = 0x0,
+	GET_2OU_CARD_TYPE,
+};
+
 typedef struct addsel_msg_t {
 	uint8_t sensor_type;
 	uint8_t sensor_number;

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -5,6 +5,7 @@
 
 #include "libutil.h"
 #include "ipmi.h"
+#include "plat_class.h"
 #include "plat_ipmb.h"
 
 bool add_sel_evt_record(addsel_msg_t *sel_msg)
@@ -62,4 +63,48 @@ bool add_sel_evt_record(addsel_msg_t *sel_msg)
 	}
 
 	return true;
+}
+
+void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
+{
+	if (msg == NULL) {
+		printf("[%s] Failed due to parameter *msg is NULL\n", __func__);
+		return;
+	}
+
+	if (msg->data_len != 1) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	CARD_STATUS _1ou_status = get_1ou_status();
+	CARD_STATUS _2ou_status = get_2ou_status();
+	switch (msg->data[0]) {
+	case GET_1OU_CARD_TYPE:
+		msg->data_len = 2;
+		msg->completion_code = CC_SUCCESS;
+		msg->data[0] = GET_1OU_CARD_TYPE;
+		if (_1ou_status.present) {
+			msg->data[1] = _1ou_status.card_type;
+		} else {
+			msg->data[1] = TYPE_1OU_ABSENT;
+		}
+		break;
+	case GET_2OU_CARD_TYPE:
+		msg->data_len = 2;
+		msg->completion_code = CC_SUCCESS;
+		msg->data[0] = GET_2OU_CARD_TYPE;
+		if (_2ou_status.present) {
+			msg->data[1] = _2ou_status.card_type;
+		} else {
+			msg->data[1] = TYPE_2OU_ABSENT;
+		}
+		break;
+	default:
+		msg->data_len = 0;
+		msg->completion_code = CC_INVALID_DATA_FIELD;
+		break;
+	}
+
+	return;
 }

--- a/meta-facebook/yv35-cl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.c
@@ -14,28 +14,29 @@
 #define CPLD_CLASS_TYPE_REG 0x05
 #define CPLD_2OU_EXPANSION_CARD_REG 0x06
 #define CPLD_BOARD_REV_ID_REG 0x08
+#define CPLD_1OU_CARD_DETECTION 0x09
 #define I2C_DATA_SIZE 5
+#define NUMBER_OF_ADC_CHANNEL 16
+#define AST1030_ADC_BASE_ADDR 0x7e6e9000
 
 static uint8_t system_class = SYS_CLASS_1;
-static bool is_1ou_present = false;
-static bool is_2ou_present = false;
-static uint8_t __attribute__((unused)) card_type_1ou = 0;
-static uint8_t card_type_2ou = TYPE_UNKNOWN;
 static uint8_t board_revision = 0x0F;
+static CARD_STATUS _1ou_status = { false, TYPE_1OU_UNKNOWN };
+static CARD_STATUS _2ou_status = { false, TYPE_2OU_UNKNOWN };
 
 uint8_t get_system_class()
 {
 	return system_class;
 }
 
-bool get_1ou_status()
+CARD_STATUS get_1ou_status()
 {
-	return is_1ou_present;
+	return _1ou_status;
 }
 
-bool get_2ou_status()
+CARD_STATUS get_2ou_status()
 {
-	return is_2ou_present;
+	return _2ou_status;
 }
 
 uint8_t get_board_revision()
@@ -43,42 +44,95 @@ uint8_t get_board_revision()
 	return board_revision;
 }
 
-uint8_t get_2ou_cardtype()
-{
-	return card_type_2ou;
-}
+/* ADC information for each channel
+ * offset: register offset
+ * shift: data of channel
+ */
+struct ADC_INFO {
+	long unsigned int offset;
+	int shift;
+};
 
-float get_hsc_type_adc_voltage()
+struct ADC_INFO adc_info[NUMBER_OF_ADC_CHANNEL] = {
+	{ 0x10, 0 },  { 0x10, 16 },  { 0x14, 0 },  { 0x14, 16 },  { 0x18, 0 },	{ 0x18, 16 },
+	{ 0x1C, 0 },  { 0x1C, 16 },  { 0x110, 0 }, { 0x110, 16 }, { 0x114, 0 }, { 0x114, 16 },
+	{ 0x118, 0 }, { 0x118, 16 }, { 0x11C, 0 }, { 0x11C, 16 }
+};
+
+enum ADC_REF_VOL_SELECTION {
+	REF_VOL_2_5V = 0x0, // 2.5V reference voltage selection
+	REF_VOL_1_2V = 0x40 // 1.2V reference voltage selection
+};
+
+struct _1OU_CARD_MAPPING_TABLE {
+	float voltage;
+	uint8_t condition;
+	uint8_t card_type;
+};
+
+/* The condition is used for 1OU card mapping table
+ * "LOWER" means the voltage is lower than the setting value
+ * "HIGHER" means the voltage is higher than the setting value
+ * "RANGE" means the voltage is within a range
+ */
+enum CONDITION {
+	LOWER = 0x0,
+	HIGHER = 0x01,
+	RANGE = 0x02,
+};
+
+struct _1OU_CARD_MAPPING_TABLE _1ou_card_mapping_table[] = {
+	{ 0.3, LOWER, TYPE_1OU_SI_TEST_CARD },
+	{ 0.5, RANGE, TYPE_1OU_EXP_WITH_6_M2 },
+	{ 0.75, RANGE, TYPE_1OU_RAINBOW_FALLS },
+	{ 1.0, RANGE, TYPE_1OU_VERNAL_FALLS_WITH_TI },
+	{ 1.26, RANGE, TYPE_1OU_WAIMANO_FALLS },
+	{ 1.5, RANGE, TYPE_1OU_EXP_WITH_NIC },
+	{ 1.75, RANGE, TYPE_1OU_VERNAL_FALLS_WITH_AST },
+	{ 2.0, RANGE, TYPE_1OU_KAHUNA_FALLS },
+};
+
+bool get_adc_voltage(int channel, float *voltage)
 {
-	uint32_t adc_base_address = 0x7e6e9000, adc7_raw, reg_val;
-	long unsigned int engine_control = 0x0, adc_data_of_ch7_and_6 = 0x1C;
+	if (!voltage) {
+		return false;
+	}
+
+	if (channel >= NUMBER_OF_ADC_CHANNEL) {
+		printf("Invalid ADC channel-%d\n", channel);
+		return false;
+	}
+
+	uint32_t raw_value, reg_value;
+	long unsigned int engine_control = 0x0;
 	float reference_voltage = 0.0f;
-	uint8_t reference_voltage_selection;
 
 	/* Get ADC reference voltage from Aspeed chip
 	 * ADC000: Engine Control
 	 * [7:6] Reference Voltage Selection
 	 * 00b - 2.5V / 01b - 1.2V / 10b and 11b - External Voltage
 	 */
-	reg_val = sys_read32(adc_base_address + engine_control);
-	reference_voltage_selection = (reg_val >> 6) & 0x3;
-	if (reference_voltage_selection == 0b00) {
+	reg_value = sys_read32(AST1030_ADC_BASE_ADDR + engine_control);
+	switch (reg_value & (BIT(7) | BIT(6))) {
+	case REF_VOL_2_5V:
 		reference_voltage = 2.5;
-	} else if (reference_voltage_selection == 0b01) {
+		break;
+	case REF_VOL_1_2V:
 		reference_voltage = 1.2;
-	} else {
-		printf("Not supported the external reference voltage\n");
+		break;
+	default:
+		printf("Unsupported the external reference voltage\n");
+		return false;
 	}
 
-	/* Read ADC channel-7 raw value
-	 * ADC01C: Data of Channel 7 and 6
-	 * [25:16] Data of channel 7
-	 */
-	reg_val = sys_read32(adc_base_address + adc_data_of_ch7_and_6);
-	adc7_raw = (reg_val & 0x3FF0000) >> 16;
+	// Read ADC raw value
+	reg_value = sys_read32(AST1030_ADC_BASE_ADDR + adc_info[channel].offset);
+	raw_value = (reg_value >> adc_info[channel].shift) & 0x3FF; // 10-bit(0x3FF) resolution
 
 	// Real voltage = raw data * reference voltage / 2 ^ resolution(10)
-	return ((adc7_raw * reference_voltage) / (1024));
+	*voltage = (raw_value * reference_voltage) / 1024;
+
+	return true;
 }
 
 void init_platform_config()
@@ -113,8 +167,8 @@ void init_platform_config()
 	i2c_msg = construct_i2c_message(I2C_BUS1, CPLD_ADDR, tx_len, data, rx_len);
 	if (!i2c_master_read(&i2c_msg, retry)) {
 		class_type = i2c_msg.data[0];
-		is_1ou_present = (class_type & 0x4 ? false : true);
-		is_2ou_present = (class_type & 0x8 ? false : true);
+		_1ou_status.present = ((class_type & BIT(2)) ? false : true);
+		_2ou_status.present = ((class_type & BIT(3)) ? false : true);
 	} else {
 		printf("Failed to read expansion present from CPLD\n");
 	}
@@ -146,9 +200,85 @@ void init_platform_config()
 		printf("Failed to read board ID from CPLD\n");
 	}
 	printk("BIC class type(class-%d), 1ou present status(%d), 2ou present status(%d), board revision(0x%x)\n",
-	       system_class, (int)is_1ou_present, (int)is_2ou_present, board_revision);
+	       system_class, (int)_1ou_status.present, (int)_2ou_status.present, board_revision);
 
-	if (is_2ou_present) {
+	/* BIC judges the 1OU card type according the ADC-6(0-based) voltage.
+	 * The 1OU card type is
+	 *  - "SI test board" if voltage is lower than 0.3V
+	 *  - "Expansion with 6 M.2" if the voltage is 0.5V(+/- 5%)
+	 *  - "Rainbow falls ( CXL with 4 DDR4 DIMMs)" if the voltage is 0.75V(+/- 5%)
+	 *  - "Vernal falls (4 E1S, with TI chip)" if the voltage is 1.0V(+/- 5%)
+	 *  - "Waimano falls (CXL with 2 DDR4 DIMMs+2 E1S)" if the voltage is 1.26V(+/- 5%)
+	 *  - "Expansion with NIC" if the voltage is 1.5V(+/- 5%)
+	 * And then, BIC sets the type to CL CPLD register(slave address 21h, register 09h)
+	 * CPLD register 09h - 1OU Card Detection
+	 *  - 00h: 1OU SI test card
+	 *  - 01h: Expansion with 6 M.2
+	 *  - 02h: Rainbow falls ( CXL with 4 DDR4 DIMMs)
+	 *  - 03h: Vernal falls (with TI chip)
+	 *  - 04h: Vernal falls (with AST1030 chip)
+	 *  - 05h: Kahuna Falls
+	 *  - 06h: Waimano falls (CXL with 2 DDR4 DIMMs+2 E1S)
+	 *  - 07h: Expansion with NIC
+	 */
+	if (_1ou_status.present) {
+		float voltage;
+		bool success = get_adc_voltage(CHANNEL_6, &voltage);
+		if (success) {
+			for (int cnt = 0; cnt < ARRAY_SIZE(_1ou_card_mapping_table); cnt++) {
+				float typical_voltage = _1ou_card_mapping_table[cnt].voltage;
+				switch (_1ou_card_mapping_table[cnt].condition) {
+				case LOWER:
+					if (voltage <= typical_voltage) {
+						_1ou_status.card_type =
+							_1ou_card_mapping_table[cnt].card_type;
+					}
+					break;
+				case HIGHER:
+					if (voltage >= typical_voltage) {
+						_1ou_status.card_type =
+							_1ou_card_mapping_table[cnt].card_type;
+					}
+					break;
+				case RANGE:
+					if ((voltage >
+					     typical_voltage - (typical_voltage * 0.05)) &&
+					    (voltage <
+					     typical_voltage + (typical_voltage * 0.05))) {
+						_1ou_status.card_type =
+							_1ou_card_mapping_table[cnt].card_type;
+					}
+					break;
+				default:
+					printf("[%s] Unknown condition 0x%x", __func__,
+					       _1ou_card_mapping_table[cnt].condition);
+					break;
+				}
+
+				if (_1ou_status.card_type != TYPE_1OU_UNKNOWN) {
+					tx_len = 2;
+					rx_len = 0;
+					memset(data, 0, I2C_DATA_SIZE);
+					data[0] = CPLD_1OU_CARD_DETECTION;
+					data[1] = _1ou_status.card_type;
+					i2c_msg = construct_i2c_message(I2C_BUS1, CPLD_ADDR, tx_len,
+									data, rx_len);
+					if (i2c_master_write(&i2c_msg, retry)) {
+						printf("Failed to set 1OU card detection to CPLD register(0x%x)\n",
+						       data[0]);
+					}
+					break;
+				}
+				if ((cnt == ARRAY_SIZE(_1ou_card_mapping_table)) &&
+				    (_1ou_status.card_type == TYPE_1OU_UNKNOWN)) {
+					printf("Unknown the 1OU card type, the voltage of ADC channel-6 is %fV\n",
+					       voltage);
+				}
+			}
+		}
+	}
+
+	if (_2ou_status.present) {
 		tx_len = 1;
 		rx_len = 1;
 		memset(data, 0, I2C_DATA_SIZE);
@@ -156,24 +286,15 @@ void init_platform_config()
 		i2c_msg = construct_i2c_message(I2C_BUS1, CPLD_ADDR, tx_len, data, rx_len);
 		if (!i2c_master_read(&i2c_msg, retry)) {
 			switch (i2c_msg.data[0]) {
-			case TYPE_2OU_SPE:
-				card_type_2ou = TYPE_2OU_SPE;
-				break;
-			case TYPE_2OU_EXP:
-				card_type_2ou = TYPE_2OU_EXP;
-				break;
 			case TYPE_2OU_DPV2_8:
-				card_type_2ou = TYPE_2OU_DPV2_8;
-				break;
 			case TYPE_2OU_DPV2_16:
-				card_type_2ou = TYPE_2OU_DPV2_16;
-				break;
 			case (TYPE_2OU_DPV2_8 | TYPE_2OU_DPV2_16):
-				// Case is 2ou_DPV2_8 and 2ou_DPV2_16 are present
-				card_type_2ou = (TYPE_2OU_DPV2_8 | TYPE_2OU_DPV2_16);
+				_2ou_status.card_type = i2c_msg.data[0];
 				break;
 			default:
-				card_type_2ou = TYPE_UNKNOWN;
+				_2ou_status.card_type = TYPE_2OU_UNKNOWN;
+				printf("Unknown the 2OU card type, the card type read from CPLD is 0x%x\n",
+				       i2c_msg.data[0]);
 				break;
 			}
 		}

--- a/meta-facebook/yv35-cl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.c
@@ -156,9 +156,6 @@ void init_platform_config()
 		i2c_msg = construct_i2c_message(I2C_BUS1, CPLD_ADDR, tx_len, data, rx_len);
 		if (!i2c_master_read(&i2c_msg, retry)) {
 			switch (i2c_msg.data[0]) {
-			case TYPE_2OU_DPV2:
-				card_type_2ou = TYPE_2OU_DPV2;
-				break;
 			case TYPE_2OU_SPE:
 				card_type_2ou = TYPE_2OU_SPE;
 				break;
@@ -170,6 +167,10 @@ void init_platform_config()
 				break;
 			case TYPE_2OU_DPV2_16:
 				card_type_2ou = TYPE_2OU_DPV2_16;
+				break;
+			case (TYPE_2OU_DPV2_8 | TYPE_2OU_DPV2_16):
+				// Case is 2ou_DPV2_8 and 2ou_DPV2_16 are present
+				card_type_2ou = (TYPE_2OU_DPV2_8 | TYPE_2OU_DPV2_16);
 				break;
 			default:
 				card_type_2ou = TYPE_UNKNOWN;

--- a/meta-facebook/yv35-cl/src/platform/plat_class.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.h
@@ -22,10 +22,14 @@ enum BIC_BOARD_REVISION {
 enum BIC_CLASS_TYPE {
 	TYPE_2OU_EXP = 0x1,
 	TYPE_2OU_SPE = 0x2,
-	TYPE_2OU_DPV2 = 0x77,
 	TYPE_2OU_DPV2_8 = 0x7,
 	TYPE_2OU_DPV2_16 = 0x70,
 	TYPE_UNKNOWN = 0xFF,
+};
+
+enum BIC_CARD_PRESENT {
+	CARD_UNPRESENT = false,
+	CARD_PRESENT = true,
 };
 
 uint8_t get_system_class();

--- a/meta-facebook/yv35-cl/src/platform/plat_class.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.h
@@ -19,25 +19,42 @@ enum BIC_BOARD_REVISION {
 	SYS_BOARD_MP_EFUSE,
 };
 
-enum BIC_CLASS_TYPE {
-	TYPE_2OU_EXP = 0x1,
-	TYPE_2OU_SPE = 0x2,
-	TYPE_2OU_DPV2_8 = 0x7,
-	TYPE_2OU_DPV2_16 = 0x70,
-	TYPE_UNKNOWN = 0xFF,
+typedef struct _CARD_STATUS_ {
+	bool present;
+	uint8_t card_type;
+} CARD_STATUS;
+
+enum _1OU_CARD_TYPE_ {
+	TYPE_1OU_SI_TEST_CARD = 0x0,
+	TYPE_1OU_EXP_WITH_6_M2,
+	TYPE_1OU_RAINBOW_FALLS,
+	TYPE_1OU_VERNAL_FALLS_WITH_TI, // TI BIC
+	TYPE_1OU_VERNAL_FALLS_WITH_AST, // AST1030 BIC
+	TYPE_1OU_KAHUNA_FALLS,
+	TYPE_1OU_WAIMANO_FALLS,
+	TYPE_1OU_EXP_WITH_NIC,
+	TYPE_1OU_ABSENT = 0xFE,
+	TYPE_1OU_UNKNOWN = 0xFF,
 };
 
-enum BIC_CARD_PRESENT {
-	CARD_UNPRESENT = false,
-	CARD_PRESENT = true,
+enum _2OU_CARD_TYPE_ {
+	TYPE_2OU_DPV2_8 = 0x07, // DPV2x8
+	TYPE_2OU_DPV2_16 = 0x70, // DPV2x16
+	TYPE_2OU_ABSENT = 0xFE,
+	TYPE_2OU_UNKNOWN = 0xFF,
+};
+
+/* ADC channel number */
+enum ADC_CHANNEL {
+	CHANNEL_6 = 6,
+	CHANNEL_7 = 7,
 };
 
 uint8_t get_system_class();
-bool get_1ou_status();
-bool get_2ou_status();
+CARD_STATUS get_1ou_status();
+CARD_STATUS get_2ou_status();
 uint8_t get_board_revision();
-uint8_t get_2ou_cardtype();
-float get_hsc_type_adc_voltage();
+bool get_adc_voltage(int channel, float *voltage);
 
 void init_platform_config();
 

--- a/meta-facebook/yv35-cl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.c
@@ -35,6 +35,9 @@ pmic_init_arg pmic_init_args[] = {
 	[5] = { .is_init = false, .smbus_bus_identifier = 0x01, .smbus_addr = 0x98 }
 };
 
+// R_load is the value of resistance connected to EFUSE , and EFUSE would adjust the reading accuracy according to r_load
+max16550a_init_arg max16550a_init_args[] = { [0] = { .r_load = 14000 } };
+
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS
  **************************************************************************************************/

--- a/meta-facebook/yv35-cl/src/platform/plat_hook.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.h
@@ -13,6 +13,7 @@ extern adc_asd_init_arg adc_asd_init_args[];
 extern adm1278_init_arg adm1278_init_args[];
 extern mp5990_init_arg mp5990_init_args[];
 extern pmic_init_arg pmic_init_args[];
+extern max16550a_init_arg max16550a_init_args[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS

--- a/meta-facebook/yv35-cl/src/platform/plat_ipmb.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_ipmb.c
@@ -43,9 +43,8 @@ bool pal_load_ipmb_config(void)
 		card_type_2ou = get_2ou_cardtype();
 
 		// for dpv2 sku, disable ipmb and set i2c freq to 400Khz for target devices reading
-		// for reset of expansion board, enable ipmb and set i2c freq to 1Mhz
-		if ((card_type_2ou == TYPE_2OU_DPV2) || (card_type_2ou == TYPE_2OU_DPV2_8) ||
-		    (card_type_2ou == TYPE_2OU_DPV2_16)) {
+		// for rest of expansion board, enable ipmb
+		if ((card_type_2ou & TYPE_2OU_DPV2_16) == TYPE_2OU_DPV2_16) {
 			i2c_freq_set(pal_IPMB_config_table[EXP2_IPMB_IDX].bus, I2C_SPEED_FAST);
 			pal_IPMB_config_table[EXP2_IPMB_IDX].enable_status = DISABLE;
 		} else {

--- a/meta-facebook/yv35-cl/src/platform/plat_ipmb.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_ipmb.c
@@ -26,25 +26,33 @@ bool pal_load_ipmb_config(void)
 	uint8_t bic_class = get_system_class();
 
 	// class1 1ou ipmi bus and class2 bb ipmi bus shared same i2c bus
-	if (get_1ou_status() && (bic_class == SYS_CLASS_1)) {
-		pal_IPMB_config_table[EXP1_IPMB_IDX].enable_status = ENABLE;
-	} else if (get_1ou_status() && (bic_class == SYS_CLASS_2)) {
-		pal_IPMB_config_table[EXP1_IPMB_IDX].index = BB_IPMB_IDX;
-		pal_IPMB_config_table[BB_IPMB_IDX].channel = BB_IPMB;
-		pal_IPMB_config_table[BB_IPMB_IDX].bus = IPMB_BB_BIC_BUS;
-		pal_IPMB_config_table[BB_IPMB_IDX].channel_target_address = BB_BIC_I2C_ADDRESS;
-		pal_IPMB_config_table[BB_IPMB_IDX].rx_thread_name = "RX_BB_BIC_IPMB_TASK";
-		pal_IPMB_config_table[BB_IPMB_IDX].tx_thread_name = "TX_BB_BIC_IPMB_TASK";
-		pal_IPMB_config_table[BB_IPMB_IDX].enable_status = ENABLE;
+	CARD_STATUS _1ou_status = get_1ou_status();
+	if (_1ou_status.present) {
+		switch (bic_class) {
+		case SYS_CLASS_1:
+			pal_IPMB_config_table[EXP1_IPMB_IDX].enable_status = ENABLE;
+			break;
+		case SYS_CLASS_2:
+			pal_IPMB_config_table[EXP1_IPMB_IDX].index = BB_IPMB_IDX;
+			pal_IPMB_config_table[BB_IPMB_IDX].channel = BB_IPMB;
+			pal_IPMB_config_table[BB_IPMB_IDX].bus = IPMB_BB_BIC_BUS;
+			pal_IPMB_config_table[BB_IPMB_IDX].channel_target_address =
+				BB_BIC_I2C_ADDRESS;
+			pal_IPMB_config_table[BB_IPMB_IDX].rx_thread_name = "RX_BB_BIC_IPMB_TASK";
+			pal_IPMB_config_table[BB_IPMB_IDX].tx_thread_name = "TX_BB_BIC_IPMB_TASK";
+			pal_IPMB_config_table[BB_IPMB_IDX].enable_status = ENABLE;
+			break;
+		default:
+			printf("[%s] Unknown system class(0x%x)\n", __func__, bic_class);
+			break;
+		}
 	}
 
-	if (get_2ou_status()) { // check present status
-		uint8_t card_type_2ou;
-		card_type_2ou = get_2ou_cardtype();
-
-		// for dpv2 sku, disable ipmb and set i2c freq to 400Khz for target devices reading
-		// for rest of expansion board, enable ipmb
-		if ((card_type_2ou & TYPE_2OU_DPV2_16) == TYPE_2OU_DPV2_16) {
+	CARD_STATUS _2ou_status = get_2ou_status();
+	if (_2ou_status.present) {
+		// for dpv2 sku, disable ipmb and set i2c freq to 400Khz for slave devices reading
+		// for reset of expansion board, enable ipmb and set i2c freq to 1Mhz
+		if ((_2ou_status.card_type & TYPE_2OU_DPV2_16) == TYPE_2OU_DPV2_16) {
 			i2c_freq_set(pal_IPMB_config_table[EXP2_IPMB_IDX].bus, I2C_SPEED_FAST);
 			pal_IPMB_config_table[EXP2_IPMB_IDX].enable_status = DISABLE;
 		} else {

--- a/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
@@ -3634,6 +3634,7 @@ uint8_t load_sdr_table(void)
 void pal_fix_full_sdr_table()
 {
 	// Fix sdr table according to bic type.
+	bool ret = false;
 	uint8_t fix_array_num;
 	uint8_t array_max_num = MAX_SENSOR_SIZE;
 	float voltage_hsc_type_adc;
@@ -3655,7 +3656,11 @@ void pal_fix_full_sdr_table()
 			 * If the voltage of ADC-7 is 1.0V(+/- 15%), the hotswap model is LTC4282.
 			 * If the voltage of ADC-7 is 1.5V(+/- 15%), the hotswap model is LTC4286.
 			 */
-			voltage_hsc_type_adc = get_hsc_type_adc_voltage();
+			ret = get_adc_voltage(CHANNEL_7, &voltage_hsc_type_adc);
+			if (!ret) {
+				break;
+			}
+
 			if ((voltage_hsc_type_adc > 0.5 - (0.5 * 0.15)) &&
 			    (voltage_hsc_type_adc < 0.5 + (0.5 * 0.15))) {
 				fix_array_num = ARRAY_SIZE(hotswap_sdr_table);
@@ -3699,9 +3704,10 @@ void pal_fix_full_sdr_table()
 	}
 
 	// Fix sdr table if 2ou card is present
-	if (get_2ou_status() == CARD_PRESENT) {
+	CARD_STATUS _2ou_status = get_2ou_status();
+	if (_2ou_status.present) {
 		// Add DPV2 sdr if DPV2_16 is present
-		if ((get_2ou_cardtype() & TYPE_2OU_DPV2_16) == TYPE_2OU_DPV2_16) {
+		if ((_2ou_status.card_type & TYPE_2OU_DPV2_16) == TYPE_2OU_DPV2_16) {
 			fix_array_num = ARRAY_SIZE(dpv2_sdr_table);
 			// Check sdr table max size before adding new sdr, avoiding over sdr table max size after adding new sdr
 			if ((SDR_NUM + fix_array_num) > array_max_num) {

--- a/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "sdr.h"
+#include "sensor.h"
 #include "plat_class.h"
 #include "plat_ipmb.h"
 #include "plat_sensor_table.h"
@@ -3317,8 +3318,311 @@ uint8_t fix_class2_sdr_table[][10] = {
 SDR_Full_sensor fix_1ou_sdr_table[] = {
 	// SDR_Full_sensor struct member
 };
-SDR_Full_sensor fix_dvp_sdr_table[] = {
-	// SDR_Full_sensor struct member
+SDR_Full_sensor dpv2_sdr_table[] = {
+	{
+		// DPV2_2_12V Voltage in
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_DPV2_12VIN, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LNCT | IPMI_SDR_ASSERT_MASK_UNCT_HI |
+			IPMI_SDR_ASSERT_MASK_LNCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UNCT | IPMI_SDR_DEASSERT_MASK_UNCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LNCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UNCT_SETTABLE | IPMI_SDR_LNCT_SETTABLE | IPMI_SDR_UNCT_READABLE |
+			IPMI_SDR_LNCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x41, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xD0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0xD8, // UNRT
+		0xCB, // UCT
+		0xC7, // UNCT
+		0x9A, // LNRT
+		0xA6, // LCT
+		0xAA, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"DPV2_2_12V_Vin",
+	},
+	{
+		// DPV2_2_12V Voltage out
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_DPV2_12VOUT, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LNCT | IPMI_SDR_ASSERT_MASK_UNCT_HI |
+			IPMI_SDR_ASSERT_MASK_LNCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UNCT | IPMI_SDR_DEASSERT_MASK_UNCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LNCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UNCT_SETTABLE | IPMI_SDR_LNCT_SETTABLE | IPMI_SDR_UNCT_READABLE |
+			IPMI_SDR_LNCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x41, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xD0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0xD8, // UNRT
+		0xCB, // UCT
+		0xC7, // UNCT
+		0x9A, // LNRT
+		0xA6, // LCT
+		0xAA, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"DPV2_2_12V_Vout",
+	},
+	{
+		// DPV2_2_12V Current out
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_CUR_DPV2OUT, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_CURRENT, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LNCT | IPMI_SDR_ASSERT_MASK_UNCT_HI |
+			IPMI_SDR_ASSERT_MASK_LNCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UNCT | IPMI_SDR_DEASSERT_MASK_UNCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LNCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UNCT_SETTABLE | IPMI_SDR_LNCT_SETTABLE | IPMI_SDR_UNCT_READABLE |
+			IPMI_SDR_LNCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x57, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xD0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0xD9, // UNRT
+		0xB2, // UCT
+		0xAE, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"DPV2_2_12V_Iout",
+	},
+	{
+		// DPV2_2_EFUSE Temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_DPV2_EFUSE, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x96, // UNRT
+		0x64, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"DPV2_2_EFUSETemp",
+	},
+	{
+		// DPV2_2 EFUSE Power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_PWR_DPV2, // sensor number
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LNCT | IPMI_SDR_ASSERT_MASK_UNCT_HI |
+			IPMI_SDR_ASSERT_MASK_LNCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UNCT | IPMI_SDR_DEASSERT_MASK_UNCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LNCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UNCT_SETTABLE | IPMI_SDR_LNCT_SETTABLE | IPMI_SDR_UNCT_READABLE |
+			IPMI_SDR_LNCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0xE3, // UNRT
+		0xBA, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"DPV2_2_EFUSEPWR",
+	},
 };
 
 uint8_t load_sdr_table(void)
@@ -3331,6 +3635,7 @@ void pal_fix_full_sdr_table()
 {
 	// Fix sdr table according to bic type.
 	uint8_t fix_array_num;
+	uint8_t array_max_num = MAX_SENSOR_SIZE;
 	float voltage_hsc_type_adc;
 	if (get_system_class() == SYS_CLASS_1) {
 		uint8_t board_revision = get_board_revision();
@@ -3390,6 +3695,23 @@ void pal_fix_full_sdr_table()
 							  fix_class2_sdr_table[index][i + 1]);
 				}
 			}
+		}
+	}
+
+	// Fix sdr table if 2ou card is present
+	if (get_2ou_status() == CARD_PRESENT) {
+		// Add DPV2 sdr if DPV2_16 is present
+		if ((get_2ou_cardtype() & TYPE_2OU_DPV2_16) == TYPE_2OU_DPV2_16) {
+			fix_array_num = ARRAY_SIZE(dpv2_sdr_table);
+			// Check sdr table max size before adding new sdr, avoiding over sdr table max size after adding new sdr
+			if ((SDR_NUM + fix_array_num) > array_max_num) {
+				printf("[%s] over sdr table max size after adding DPV2_16 sdr, sdr table max size: %d  sdr table size after adding: %d\n",
+				       __func__, array_max_num, SDR_NUM + fix_array_num);
+				return;
+			}
+			memcpy(&full_sdr_table[SDR_NUM], &dpv2_sdr_table[0],
+			       fix_array_num * sizeof(SDR_Full_sensor));
+			SDR_NUM += fix_array_num;
 		}
 	}
 };

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.h
@@ -38,6 +38,7 @@
 #define TEMP_DIMM_E_PARAM 0x0004
 #define TEMP_DIMM_G_PARAM 0x0006
 #define TEMP_DIMM_H_PARAM 0x0007
+#define DPV2_16_ADDR 0x50
 
 /*  threshold sensor number, 1 based  */
 #define SENSOR_NUM_TEMP_TMP75_IN 0x01
@@ -104,6 +105,13 @@
 #define SENSOR_NUM_VR_HOT 0xB2
 #define SENSOR_NUM_CPUDIMM_HOT 0xB3
 #define SENSOR_NUM_CATERR 0xEB
+
+/*  threshold sensor number, DPV2  */
+#define SENSOR_NUM_VOL_DPV2_12VIN 0x91
+#define SENSOR_NUM_VOL_DPV2_12VOUT 0x92
+#define SENSOR_NUM_CUR_DPV2OUT 0x93
+#define SENSOR_NUM_TEMP_DPV2_EFUSE 0x94
+#define SENSOR_NUM_PWR_DPV2 0x95
 
 uint8_t load_sensor_config(void);
 


### PR DESCRIPTION
Summary:
- Support 1OU card type detection (by SB BIC firmware)
  Follow hardware design, BIC can judge 1OU card type according the ADC-6(0-based) voltage if 1OU is present.
  BIC should set the type to SB CPLD register "1OU Card Detection" to let SB CPLD powers on the SI test card.
- Support IPMI command - "Get card type"
  NetFn: 38h / Cmd: A1h
  Request Data:
    Byte[3:1] - Manufacturer ID
    Byte4 - Get 1OU/2OU card type(00h for 1OU and 01h for 2OU)
  Response Data:
    Byte1 - Completion code
            00h - Successfully
            C7h - Request data length invalid
            CCh - Invalid data field in Request
    Byte2 - 1OU/2OU(00h for 1OU and 01h for 2OU)
    Byte3 - card type
            1OU -
                * 00h: 1OU SI test card
	        * 01h: Expansion with 6 M.2
	        * 02h: Rainbow falls ( CXL with 4 DDR4 DIMMs)
	        * 03h: Vernal falls (with TI chip)
	        * 04h: Vernal falls (with AST1030 chip)
	        * 05h: Kahuna Falls
	        * 06h: Waimano falls (CXL with 2 DDR4 DIMMs+2 E1S)
	        * 07h: Expansion with NIC
                * FEh: 1OU card is absent
                * FFh: Unknown 1OU card type
            2OU -
                * 07h: DPV2 x8
                * 70h: DPV2 x16
                * FEh: 2OU card is absent
                * FFh: Unknown 2OU card type

Dependency: #303 

TODO:
The manufacture ID should be changed to Meta's IANA.

Test Plan:
1. Check the IPMI command "Get card type" - pass
   ==> Get 1OU card type: bic-util ${slot} 0xe0 0xa1 0x9c 0x9c 0x0 0x0
   ==> Get 2OU card type: bic-util ${slot} 0xe0 0xa1 0x9c 0x9c 0x0 0x1
2. Check SB CPLD register 09h - pass
   ==> bic-util ${slot} 0x18 0x52 0x1 0x42 0x1 0x9
Log:
[1OU - SI test card]
root@bmc-oob:~# bic-util slot1 0xe0 0xa1 0x9c 0x9c 0x0 0x0
9C 9C 00 00 00
[1OU - Rainbow falls]
root@bmc-oob:~# bic-util slot2 0xe0 0xa1 0x9c 0x9c 0x0 0x0
9C 9C 00 00 02
root@bmc-oob:~# bic-util slot2 0x18 0x52 0x1 0x42 0x1 0x9
02
[2OU - DPV2 x8]
root@bmc-oob:~# bic-util slot1 0xe0 0xa1 0x9c 0x9c 0x0 0x1
9C 9C 00 01 07
[2OU - DPV2 x16]
root@bmc-oob:~# bic-util slot1 0xe0 0xa1 0x9c 0x9c 0x0 0x1
9C 9C 00 01 70
[2OU - DPV2 x8 and DPV2 x16]
root@bmc-oob:~# bic-util slot1 0xe0 0xa1 0x9c 0x9c 0x0 0x1
9C 9C 00 01 77
[No 1OU/2OU card]
root@bmc-oob:~# bic-util slot1 0xe0 0xa1 0x9c 0x9c 0x0 0x0
9C 9C 00 00 FE
root@bmc-oob:~# bic-util slot1 0xe0 0xa1 0x9c 0x9c 0x0 0x1
9C 9C 00 01 FE