### PR TITLE
Add Grand Teton : Clear Creek to CI

### DIFF
--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # This job matrix will generate a separate job for all platforms listed.
-        platform: [yv35-cl, yv35-bb]
+        platform: [yv35-cl, yv35-bb, gt-cc]
         # Need to set this to false otherwise it will cancel all platform builds if one fails.
       fail-fast: false
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ OpenBIC is an open software framework to build a complete firmware image for a B
 |-------|--------|-------------|
 oby35-cl | ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/goldenbug/62fb115c4fa43a02acad226534e10932/raw/yv35-cl.json) | Yosemite v3.5 Crater Lake Board
 oby35-bb | ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/goldenbug/62fb115c4fa43a02acad226534e10932/raw/yv35-bb.json) | Yosemite v3.5 Baseboard
+obgt-cc | ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/goldenbug/62fb115c4fa43a02acad226534e10932/raw/gt-cc.json) | Grand Teton Clear Creek
 
 ## Contents
 

--- a/meta-facebook/gt-cc/src/platform/plat_version.h
+++ b/meta-facebook/gt-cc/src/platform/plat_version.h
@@ -28,10 +28,10 @@
 #define PRODUCT_ID 0x0000
 #define AUXILIARY_FW_REVISION 0x00000000
 
-#define BIC_FW_YEAR_MSB 0x00
-#define BIC_FW_YEAR_LSB 0x00
-#define BIC_FW_WEEK 0x00
-#define BIC_FW_VER 0x00
+#define BIC_FW_YEAR_MSB 0x20
+#define BIC_FW_YEAR_LSB 0x22
+#define BIC_FW_WEEK 0x22
+#define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x47 // char: G
 #define BIC_FW_platform_1 0x54 // char: T
 #define BIC_FW_platform_2 0x00 // char: '\0'


### PR DESCRIPTION
Summary:
- Onboard Grand Teton platform to GitHub actions CI.
- Add GT to the Readme and the release script constants files.
- set "first" version of GT to 2022.22.01

Differential Revision: D36833901

