### PR TITLE
fby3.5: rf: Version commit for oby35-rf-2022.22.01

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_version.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_version.h
@@ -17,8 +17,8 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x20
-#define BIC_FW_VER 0xE3
+#define BIC_FW_WEEK 0x22
+#define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x72 // char: r
 #define BIC_FW_platform_1 0x66 // char: f
 #define BIC_FW_platform_2 0x00 // char: '\0'


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Rainbow falls BIC oby35-rf-2022.22.01.

Test Plan:
- Build code: Pass
- Check BIC version is changed: Pass

Log:
root@bmc-oob:~# fw-util slot2 --version 1ou_bic
1OU Bridge-IC Version: oby35-rf-v2022.22.01