### PR TITLE
fby3.5: common:Modify IPMI cold reset command reset type

### DIFF
--- a/common/lib/util_sys.c
+++ b/common/lib/util_sys.c
@@ -36,7 +36,7 @@ void bic_warm_reset()
 {
 	pal_warm_reset_prepare();
 	k_msleep(bic_warm_reset_delay);
-	sys_reboot(SYS_REBOOT_WARM);
+	sys_reboot(SOC_RESET);
 }
 
 K_WORK_DEFINE(bic_warm_reset_work, bic_warm_reset);
@@ -52,7 +52,7 @@ void bic_cold_reset()
 {
 	pal_cold_reset_prepare();
 	k_msleep(bic_cold_reset_delay);
-	sys_reboot(SYS_REBOOT_COLD);
+	sys_reboot(SOC_RESET);
 }
 
 K_WORK_DEFINE(bic_cold_reset_work, bic_cold_reset);

--- a/common/lib/util_sys.h
+++ b/common/lib/util_sys.h
@@ -1,6 +1,7 @@
 #ifndef UTIL_SYS_H
 #define UTIL_SYS_H
 
+#include <sys/reboot.h>
 #include "stdbool.h"
 #include "stdint.h"
 
@@ -22,6 +23,12 @@ enum ME_MODE {
 enum FORCE_ME_RECOVERY_CMD {
 	ME_FW_RECOVERY = 0x01,
 	ME_FW_RESTORE = 0x02,
+};
+
+enum SYSTEM_RESET_TYPE {
+	// Aspeed system warm reset default setting is SOC reset, and system cold reset is full chip reset
+	SOC_RESET = SYS_REBOOT_WARM,
+	FULL_CHIP_RESET = SYS_REBOOT_COLD,
 };
 
 void submit_bic_cold_reset();


### PR DESCRIPTION
Summary:
- Modify IPMI cold reset command reset type from full chip reset to SOC reset.

Note:
BIC would do full chip reset before modifying cold reset command reset type.
Full chip reset would cause SUART disabled between BIC and host, and BMC can't connect to host through SOL after cold reset.
Cold reset needs to go back to the original firmware environment by definition, so SOC reset is enough in cold reset case.

Test Plan:
- Build code: Pass
- Check the connection between BIC and host by IPMI cold/warm reset command: Pass

Log:
[Host console]

[root@Stream8_211112 ~]#
[root@Stream8_211112 ~]# ipmitool raw 0x6 0x1  // test the connection between BIC and host before doing BIC cold reset
 20 81 01 03 02 bf 15 a0 00 46 31 00 00 00 00
[root@Stream8_211112 ~]# ipmitool raw 0x6 0x1  // test the connection between BIC and host after doing BIC cold reset
 20 81 01 03 02 bf 15 a0 00 46 31 00 00 00 00
[root@Stream8_211112 ~]# ipmitool raw 0x6 0x1  // test the connection between BIC and host after doing BIC warm reset
 20 81 01 03 02 bf 15 a0 00 46 31 00 00 00 00
[root@Stream8_211112 ~]#