### PR TITLE
fby3.5: Revise the IANA ID to 0x00A015 (Meta's ID)

### DIFF
--- a/common/service/ipmi/include/ipmi.h
+++ b/common/service/ipmi/include/ipmi.h
@@ -7,6 +7,7 @@
 
 #define IPMI_THREAD_STACK_SIZE 4096
 #define IPMI_BUF_LEN 10
+#define IANA_ID 0x00A015 // Meta's IANA
 #define DEBUG_IPMI 0
 
 extern uint8_t IPMB_inf_index_map[];

--- a/meta-facebook/gt-cc/src/platform/plat_version.h
+++ b/meta-facebook/gt-cc/src/platform/plat_version.h
@@ -3,7 +3,6 @@
 
 #define PLATFORM_NAME "gt"
 #define PROJECT_NAME "cascade-creek"
-#define IANA_ID 0x00A015
 #define DEVICE_ID 0x00
 #define DEVICE_REVISION 0x80
 /*

--- a/meta-facebook/yv35-bb/src/platform/plat_version.h
+++ b/meta-facebook/yv35-bb/src/platform/plat_version.h
@@ -3,7 +3,6 @@
 
 #define PLATFORM_NAME "yv35"
 #define PROJECT_NAME "baseboard"
-#define IANA_ID 0x009c9c
 #define DEVICE_ID 0x00
 #define DEVICE_REVISION 0x80
 // Byte 0 boade: 01h CL  02h BB

--- a/meta-facebook/yv35-cl/src/platform/plat_version.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_version.h
@@ -3,7 +3,6 @@
 
 #define PLATFORM_NAME "yv35"
 #define PROJECT_NAME "craterlake"
-#define IANA_ID 0x009c9c
 #define DEVICE_ID 0x00
 #define DEVICE_REVISION 0x80
 #define FIRMWARE_REVISION_1 0x11

--- a/meta-facebook/yv35-rf/src/platform/plat_version.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_version.h
@@ -3,7 +3,6 @@
 
 #define PLATFORM_NAME "yv35"
 #define PROJECT_NAME "Rainbow Falls"
-#define IANA_ID 0x009c9c
 #define DEVICE_ID 0x00
 #define DEVICE_REVISION 0x80
 // BIT 0:3  1: CraterLake 2: Baseboard 3: Rainbow falls


### PR DESCRIPTION
Summary:
- Move IANA setting to common layer and set to Meta's IANA.

Test plans:
1. Get the card type of expansion board

Log:
root@bmc-oob:~# bic-util slot2 0xe0 0xa1 0x15 0xa0 0x0 0x0
15 A0 00 00 FE