### PR TITLE
Modify sensor related function and device pex89000

### DIFF
--- a/common/dev/include/pex89000.h
+++ b/common/dev/include/pex89000.h
@@ -36,5 +36,6 @@ typedef struct {
 
 /* Note: Could be used only after pex89000 sensor init successed */
 uint8_t pex_access_engine(uint8_t bus, uint8_t addr, uint8_t idx, pex_access_t key, uint32_t *resp);
+uint8_t pex89000_init(uint8_t sensor_num);
 
 #endif

--- a/common/dev/pex89000.c
+++ b/common/dev/pex89000.c
@@ -486,19 +486,21 @@ uint8_t pex89000_init(uint8_t sensor_num)
 			return SENSOR_INIT_UNSPECIFIED_ERROR;
 		}
 
+		sys_slist_append(&pex89000_list, &p->node);
+
 		if (pex_dev_get(sensor_config[sensor_config_index_map[sensor_num]].port,
 				sensor_config[sensor_config_index_map[sensor_num]].target_addr,
 				p->idx, &p->pex_type)) {
 			printf("%s: get pex type failed!\n", __func__);
+			sys_slist_remove(&pex89000_list, NULL, &p->node);
 			SAFE_FREE(p);
 			return SENSOR_INIT_UNSPECIFIED_ERROR;
 		}
-
-		sys_slist_append(&pex89000_list, &p->node);
 	}
 
 	sensor_config[sensor_config_index_map[sensor_num]].priv_data = p;
 	sensor_config[sensor_config_index_map[sensor_num]].read = pex89000_read;
+	init_arg->is_init = true;
 
 	return SENSOR_INIT_SUCCESS;
 }


### PR DESCRIPTION
Summary:
- Move sys_slist_append above to the pex_dev_get because the latter function will use the slist in pex89000 initial function.
- Add sys_slist_remove then free the pointer if pex_dev_get fails to avoid the latter coming in and can't find the corresponding node.
- If sensor read fails in get_sensor_reading, call the post_sensor_read_hook which is defined in each platform code to do the corresponding thing like mutex_unlock.

Test plan:
Build code - Pass