### PR TITLE
yv3.5: cl: Remove set ME enter recovery mode during BIC reset

### DIFF
--- a/meta-facebook/yv35-cl/src/lib/plat_sys.c
+++ b/meta-facebook/yv35-cl/src/lib/plat_sys.c
@@ -4,16 +4,6 @@
 #include "hal_gpio.h"
 #include "plat_gpio.h"
 
-void pal_warm_reset_prepare()
-{
-	set_me_firmware_mode(ME_FW_RECOVERY);
-}
-
-void pal_cold_reset_prepare()
-{
-	set_me_firmware_mode(ME_FW_RECOVERY);
-}
-
 /* BMC reset */
 void BMC_reset_handler()
 {


### PR DESCRIPTION
[Summary]
- Fix issue PTS#0530550	[QE] BIC FW update + slot DC power cycle make SEL record critical CATERR(F/R around 20%)
- In previous commit, we supported system can re-init flash at any time after booting up.
  The BIOS SPI selection pin is set to "H"(to BIC) only while updating BIOS firmware.
  And then BIC sets to default status(to PCH) after updating successfully.
- The ME recovery mode setting before BIC cold/warm reset isn't needed, because the BIOS SPI selection pin is always set to PCH during BIC reset

[Test Plan & Log]
1. Build CL code:		[ Pass ]
2. Build BB code:		[ Pass ]
3. Duplicate issue:		[ Pass ] (No unexpected SEL recorded)
	---------- CL BIC flash + sleep 5 + power cycle ----------
	This image is not for Yv3.5 platform
	There is no valid platform signature in image.
	file size = 307216 bytes, slot = 4, intf = 0xff
	updating fw on slot 4:
	updated bic: 1 %This image is not for Yv3.5 platform
	There is no valid platform signature in image.
	file size = 307216 bytes, slot = 2, intf = 0xff
	updating fw on slot 2:
	updated bic: 1 %This image is not for Yv3.5 platform
	There is no valid platform signature in image.
	file size = 307216 bytes, slot = 3, intf = 0xff
	updating fw on slot 3:
	updated bic: 1 %This image is not for Yv3.5 platform
	There is no valid platform signature in image.
	file size = 307216 bytes, slot = 1, intf = 0xff
	updating fw on slot 1:
	updated bic: 100 %
	Elapsed time:  13   sec.

	Force upgrade of slot3 : bic succeeded
	updated bic: 100 %
	Elapsed time:  13   sec.

	Force upgrade of slot2 : bic succeeded
	updated bic: 100 %
	Elapsed time:  13   sec.

	Force upgrade of slot4 : bic succeeded
	updated bic: 100 %
	Elapsed time:  14   sec.

	Force upgrade of slot1 : bic succeeded
	Power cycling fru 2...
	Power cycling fru 3...
	Power cycling fru 4...
	Power cycling fru 1...
	
	---------- SEL ----------
	2022 Jun 10 03:32:18 log-util: User cleared all logs
	0    all      2022-06-10 03:32:24    fw-util          Updating SB BIC on slot1. File: /tmp/CL-BIC_2022.23.98_Fix_ME_crash_after_CL_BIC_Flash_then_DC_with_PMIC.bin
	0    all      2022-06-10 03:32:24    fw-util          Updating SB BIC on slot4. File: /tmp/CL-BIC_2022.23.98_Fix_ME_crash_after_CL_BIC_Flash_then_DC_with_PMIC.bin
	0    all      2022-06-10 03:32:24    fw-util          Updating SB BIC on slot3. File: /tmp/CL-BIC_2022.23.98_Fix_ME_crash_after_CL_BIC_Flash_then_DC_with_PMIC.bin
	0    all      2022-06-10 03:32:24    fw-util          Updating SB BIC on slot2. File: /tmp/CL-BIC_2022.23.98_Fix_ME_crash_after_CL_BIC_Flash_then_DC_with_PMIC.bin
	0    all      2022-06-10 03:32:38    fw-util          Updated SB BIC on slot2. File: /tmp/CL-BIC_2022.23.98_Fix_ME_crash_after_CL_BIC_Flash_then_DC_with_PMIC.bin. Result: Success
	0    all      2022-06-10 03:32:38    fw-util          Updated SB BIC on slot1. File: /tmp/CL-BIC_2022.23.98_Fix_ME_crash_after_CL_BIC_Flash_then_DC_with_PMIC.bin. Result: Success
	0    all      2022-06-10 03:32:38    fw-util          Updated SB BIC on slot4. File: /tmp/CL-BIC_2022.23.98_Fix_ME_crash_after_CL_BIC_Flash_then_DC_with_PMIC.bin. Result: Success
	0    all      2022-06-10 03:32:38    fw-util          Updated SB BIC on slot3. File: /tmp/CL-BIC_2022.23.98_Fix_ME_crash_after_CL_BIC_Flash_then_DC_with_PMIC.bin. Result: Success
	2    slot2    2022-06-10 03:32:40    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2022-06-10 03:32:40, Sensor: ME_POWER_STATE (0x16), Event Data: (020000) POWER_OFF Assertion
	1    slot1    2022-06-10 03:32:40    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-06-10 03:32:40, Sensor: ME_POWER_STATE (0x16), Event Data: (020000) POWER_OFF Assertion
	4    slot4    2022-06-10 03:32:40    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-06-10 03:32:40, Sensor: ME_POWER_STATE (0x16), Event Data: (020000) POWER_OFF Assertion
	3    slot3    2022-06-10 03:32:40    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-06-10 03:32:40, Sensor: ME_POWER_STATE (0x16), Event Data: (020000) POWER_OFF Assertion
	2    slot2    2022-06-10 03:32:42    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2022-06-10 03:32:42, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
	1    slot1    2022-06-10 03:32:42    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-06-10 03:32:42, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
	4    slot4    2022-06-10 03:32:42    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-06-10 03:32:42, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
	3    slot3    2022-06-10 03:32:42    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-06-10 03:32:42, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
	1    slot1    2022-06-10 03:32:51    gpiod            FRU: 1, System powered OFF
	2    slot2    2022-06-10 03:32:51    gpiod            FRU: 2, System powered OFF
	3    slot3    2022-06-10 03:32:51    gpiod            FRU: 3, System powered OFF
	4    slot4    2022-06-10 03:32:51    gpiod            FRU: 4, System powered OFF
	3    slot3    2022-06-10 03:32:54    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-06-10 03:32:54, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
	2    slot2    2022-06-10 03:32:54    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2022-06-10 03:32:54, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
	1    slot1    2022-06-10 03:32:54    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-06-10 03:32:54, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
	4    slot4    2022-06-10 03:32:54    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-06-10 03:32:54, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
	2    slot2    2022-06-10 03:32:55    power-util       SERVER_POWER_CYCLE successful for FRU: 2
	4    slot4    2022-06-10 03:32:55    power-util       SERVER_POWER_CYCLE successful for FRU: 4
	1    slot1    2022-06-10 03:32:55    power-util       SERVER_POWER_CYCLE successful for FRU: 1
	3    slot3    2022-06-10 03:32:55    power-util       SERVER_POWER_CYCLE successful for FRU: 3
	1    slot1    2022-06-10 03:32:58    gpiod            FRU: 1, System powered ON
	2    slot2    2022-06-10 03:32:58    gpiod            FRU: 2, System powered ON
	4    slot4    2022-06-10 03:32:58    gpiod            FRU: 4, System powered ON
	3    slot3    2022-06-10 03:32:59    gpiod            FRU: 3, System powered ON

4. Reset BIC and check ME/SDR:	[ Pass ]
	---------- Warm Reset in CMD prompt ----------
	root@bmc-oob:~# me-util slot1 0x18 0x04
	55 00
	root@bmc-oob:~# sensor-util slot1
	slot1:
	MB Inlet Temp                (0x1) :   30.00 C     | (ok)
	MB Outlet Temp               (0x2) :   54.00 C     | (ok)
	FIO Temp                     (0x3) :   24.00 C     | (ok)
	PCH Temp                     (0x4) :   51.00 C     | (ok)
	SOC CPU Temp                 (0x5) :   54.00 C     | (ok)
	SOC Therm Margin             (0x14) :  -45.00 C     | (ok)
	CPU TjMax                    (0x15) :  100.00 C     | (ok)
	DIMMA Temp                   (0x6) :   51.00 C     | (ok)
	DIMMC Temp                   (0x7) :   50.00 C     | (ok)
	DIMMD Temp                   (0x9) :   48.00 C     | (ok)
	DIMME Temp                   (0xA) :   50.00 C     | (ok)
	DIMMG Temp                   (0xB) :   45.00 C     | (ok)
	DIMMH Temp                   (0xC) :   40.00 C     | (ok)
	SSD0 Temp                    (0xD) :   25.00 C     | (ok)
	HSC Temp                     (0xE) :   48.81 C     | (ok)
	VCCIN SPS Temp               (0xF) :   64.00 C     | (ok)
	FIVRA SPS Temp               (0x10) :   59.00 C     | (ok)
	EHV SPS Temp                 (0x11) :   46.00 C     | (ok)
	VCCD SPS Temp                (0x12) :   45.00 C     | (ok)
	FAON SPS Temp                (0x13) :   49.00 C     | (ok)
	P12V_STBY Vol                (0x20) :   12.57 Volts | (ok)
	P3V_BAT Vol                  (0x21) :    3.08 Volts | (ok)
	P3V3_STBY Vol                (0x22) :    3.32 Volts | (ok)
	P1V8_STBY Vol                (0x23) :    1.82 Volts | (ok)
	P1V05_PCH Vol                (0x24) :    1.05 Volts | (ok)
	P5V_STBY Vol                 (0x25) :    5.02 Volts | (ok)
	P12V_DIMM Vol                (0x26) :   12.62 Volts | (ok)
	P1V2_STBY Vol                (0x27) :    1.21 Volts | (ok)
	P3V3_M2 Vol                  (0x28) :    3.34 Volts | (ok)
	HSC Input Vol                (0x29) :   12.45 Volts | (ok)
	VCCIN VR Vol                 (0x2A) :    1.77 Volts | (ok)
	FIVRA VR Vol                 (0x2C) :    1.82 Volts | (ok)
	EHV VR Vol                   (0x2D) :    1.80 Volts | (ok)
	VCCD VR Vol                  (0x2E) :    1.14 Volts | (ok)
	FAON VR Vol                  (0x2F) :    1.05 Volts | (ok)
	HSC Output Cur               (0x30) :    8.36 Amps  | (ok)
	VCCIN VR Cur                 (0x31) :   34.60 Amps  | (ok)
	FIVRA VR Cur                 (0x32) :    3.10 Amps  | (ok)
	EHV VR Cur                   (0x33) :    0.80 Amps  | (ok)
	VCCD VR Cur                  (0x34) :    2.80 Amps  | (ok)
	FAON VR Cur                  (0x35) :    8.90 Amps  | (ok)
	CPU PWR                      (0x38) :   78.00 Watts | (ok)
	HSC Input Pwr                (0x39) :  102.56 Watts | (ok)
	VCCIN VR Pout                (0x3A) :   61.00 Watts | (ok)
	FIVRA VR Pout                (0x3C) :    4.00 Watts | (ok)
	EHV VR Pout                  (0x3D) :    1.00 Watts | (ok)
	VCCD VR Pout                 (0x3E) :    2.00 Watts | (ok)
	FAON VR Pout                 (0x3F) :    9.00 Watts | (ok)
	DIMMA PMIC_Pout              (0x1E) :    0.00 Watts | (ok)
	DIMMC PMIC_Pout              (0x1F) :    0.00 Watts | (ok)
	DIMMD PMIC_Pout              (0x36) :    0.00 Watts | (ok)
	DIMME PMIC_Pout              (0x37) :    0.00 Watts | (ok)
	DIMMG PMIC_Pout              (0x42) :    0.00 Watts | (ok)
	DIMMH PMIC_Pout              (0x47) :    0.00 Watts | (ok)

	---------- Cold Reset in CMD prompt ----------
	root@bmc-oob:~# me-util slot1 0x18 0x04
	55 00
	root@bmc-oob:~# sensor-util slot1
	slot1:
	MB Inlet Temp                (0x1) :   30.00 C     | (ok)
	MB Outlet Temp               (0x2) :   54.00 C     | (ok)
	FIO Temp                     (0x3) :   24.00 C     | (ok)
	PCH Temp                     (0x4) :   50.00 C     | (ok)
	SOC CPU Temp                 (0x5) :   54.00 C     | (ok)
	SOC Therm Margin             (0x14) :  -46.00 C     | (ok)
	CPU TjMax                    (0x15) :  100.00 C     | (ok)
	DIMMA Temp                   (0x6) :   51.00 C     | (ok)
	DIMMC Temp                   (0x7) :   51.00 C     | (ok)
	DIMMD Temp                   (0x9) :   48.00 C     | (ok)
	DIMME Temp                   (0xA) :   50.00 C     | (ok)
	DIMMG Temp                   (0xB) :   44.00 C     | (ok)
	DIMMH Temp                   (0xC) :   40.00 C     | (ok)
	SSD0 Temp                    (0xD) :   25.00 C     | (ok)
	HSC Temp                     (0xE) :   48.81 C     | (ok)
	VCCIN SPS Temp               (0xF) :   64.00 C     | (ok)
	FIVRA SPS Temp               (0x10) :   59.00 C     | (ok)
	EHV SPS Temp                 (0x11) :   46.00 C     | (ok)
	VCCD SPS Temp                (0x12) :   44.00 C     | (ok)
	FAON SPS Temp                (0x13) :   49.00 C     | (ok)
	P12V_STBY Vol                (0x20) :   12.59 Volts | (ok)
	P3V_BAT Vol                  (0x21) :    3.08 Volts | (ok)
	P3V3_STBY Vol                (0x22) :    3.33 Volts | (ok)
	P1V8_STBY Vol                (0x23) :    1.82 Volts | (ok)
	P1V05_PCH Vol                (0x24) :    1.05 Volts | (ok)
	P5V_STBY Vol                 (0x25) :    5.02 Volts | (ok)
	P12V_DIMM Vol                (0x26) :   12.62 Volts | (ok)
	P1V2_STBY Vol                (0x27) :    1.21 Volts | (ok)
	P3V3_M2 Vol                  (0x28) :    3.34 Volts | (ok)
	HSC Input Vol                (0x29) :   12.45 Volts | (ok)
	VCCIN VR Vol                 (0x2A) :    1.77 Volts | (ok)
	FIVRA VR Vol                 (0x2C) :    1.82 Volts | (ok)
	EHV VR Vol                   (0x2D) :    1.80 Volts | (ok)
	VCCD VR Vol                  (0x2E) :    1.14 Volts | (ok)
	FAON VR Vol                  (0x2F) :    1.05 Volts | (ok)
	HSC Output Cur               (0x30) :    8.31 Amps  | (ok)
	VCCIN VR Cur                 (0x31) :   34.10 Amps  | (ok)
	FIVRA VR Cur                 (0x32) :    3.10 Amps  | (ok)
	EHV VR Cur                   (0x33) :    0.70 Amps  | (ok)
	VCCD VR Cur                  (0x34) :    2.80 Amps  | (ok)
	FAON VR Cur                  (0x35) :    8.90 Amps  | (ok)
	CPU PWR                      (0x38) :   78.00 Watts | (ok)
	HSC Input Pwr                (0x39) :  101.92 Watts | (ok)
	VCCIN VR Pout                (0x3A) :   60.00 Watts | (ok)
	FIVRA VR Pout                (0x3C) :    3.00 Watts | (ok)
	EHV VR Pout                  (0x3D) :    1.00 Watts | (ok)
	VCCD VR Pout                 (0x3E) :    2.00 Watts | (ok)
	FAON VR Pout                 (0x3F) :    9.00 Watts | (ok)
	DIMMA PMIC_Pout              (0x1E) :    0.00 Watts | (ok)
	DIMMC PMIC_Pout              (0x1F) :    0.00 Watts | (ok)
	DIMMD PMIC_Pout              (0x36) :    0.00 Watts | (ok)
	DIMME PMIC_Pout              (0x37) :    0.00 Watts | (ok)
	DIMMG PMIC_Pout              (0x42) :    0.00 Watts | (ok)
	DIMMH PMIC_Pout              (0x47) :    0.00 Watts | (ok)

	---------- Reset via bic-util ----------
	root@bmc-oob:~# bic-util slot1 --reset
	Performing BIC reset, status 0
	root@bmc-oob:~# me-util slot1 0x18 0x04
	55 00
	root@bmc-oob:~# sensor-util slot1
	slot1:
	MB Inlet Temp                (0x1) :   29.00 C     | (ok)
	MB Outlet Temp               (0x2) :   54.00 C     | (ok)
	FIO Temp                     (0x3) :   24.00 C     | (ok)
	PCH Temp                     (0x4) :   50.00 C     | (ok)
	SOC CPU Temp                 (0x5) :   53.00 C     | (ok)
	SOC Therm Margin             (0x14) :  -47.00 C     | (ok)
	CPU TjMax                    (0x15) :  100.00 C     | (ok)
	DIMMA Temp                   (0x6) :   51.00 C     | (ok)
	DIMMC Temp                   (0x7) :   50.00 C     | (ok)
	DIMMD Temp                   (0x9) :   48.00 C     | (ok)
	DIMME Temp                   (0xA) :   49.00 C     | (ok)
	DIMMG Temp                   (0xB) :   44.00 C     | (ok)
	DIMMH Temp                   (0xC) :   40.00 C     | (ok)
	SSD0 Temp                    (0xD) :   25.00 C     | (ok)
	HSC Temp                     (0xE) :   48.81 C     | (ok)
	VCCIN SPS Temp               (0xF) :   64.00 C     | (ok)
	FIVRA SPS Temp               (0x10) :   59.00 C     | (ok)
	EHV SPS Temp                 (0x11) :   46.00 C     | (ok)
	VCCD SPS Temp                (0x12) :   44.00 C     | (ok)
	FAON SPS Temp                (0x13) :   49.00 C     | (ok)
	P12V_STBY Vol                (0x20) :   12.59 Volts | (ok)
	P3V_BAT Vol                  (0x21) :    3.08 Volts | (ok)
	P3V3_STBY Vol                (0x22) :    3.32 Volts | (ok)
	P1V8_STBY Vol                (0x23) :    1.82 Volts | (ok)
	P1V05_PCH Vol                (0x24) :    1.05 Volts | (ok)
	P5V_STBY Vol                 (0x25) :    5.02 Volts | (ok)
	P12V_DIMM Vol                (0x26) :   12.62 Volts | (ok)
	P1V2_STBY Vol                (0x27) :    1.21 Volts | (ok)
	P3V3_M2 Vol                  (0x28) :    3.34 Volts | (ok)
	HSC Input Vol                (0x29) :   12.44 Volts | (ok)
	VCCIN VR Vol                 (0x2A) :    1.77 Volts | (ok)
	FIVRA VR Vol                 (0x2C) :    1.82 Volts | (ok)
	EHV VR Vol                   (0x2D) :    1.80 Volts | (ok)
	VCCD VR Vol                  (0x2E) :    1.14 Volts | (ok)
	FAON VR Vol                  (0x2F) :    1.05 Volts | (ok)
	HSC Output Cur               (0x30) :    8.45 Amps  | (ok)
	VCCIN VR Cur                 (0x31) :   34.60 Amps  | (ok)
	FIVRA VR Cur                 (0x32) :    3.10 Amps  | (ok)
	EHV VR Cur                   (0x33) :    0.80 Amps  | (ok)
	VCCD VR Cur                  (0x34) :    2.80 Amps  | (ok)
	FAON VR Cur                  (0x35) :    8.90 Amps  | (ok)
	CPU PWR                      (0x38) :   78.00 Watts | (ok)
	HSC Input Pwr                (0x39) :  102.24 Watts | (ok)
	VCCIN VR Pout                (0x3A) :   61.00 Watts | (ok)
	FIVRA VR Pout                (0x3C) :    5.00 Watts | (ok)
	EHV VR Pout                  (0x3D) :    2.00 Watts | (ok)
	VCCD VR Pout                 (0x3E) :    2.00 Watts | (ok)
	FAON VR Pout                 (0x3F) :    9.00 Watts | (ok)
	DIMMA PMIC_Pout              (0x1E) :    0.00 Watts | (ok)
	DIMMC PMIC_Pout              (0x1F) :    0.00 Watts | (ok)
	DIMMD PMIC_Pout              (0x36) :    0.00 Watts | (ok)
	DIMME PMIC_Pout              (0x37) :    0.00 Watts | (ok)
	DIMMG PMIC_Pout              (0x42) :    0.00 Watts | (ok)
	DIMMH PMIC_Pout              (0x47) :    0.00 Watts | (ok)