### PR TITLE
fby3.5: common:Improve sensor monitor

### DIFF
--- a/common/service/sensor/sdr.c
+++ b/common/service/sensor/sdr.c
@@ -12,7 +12,7 @@ bool is_sdr_not_init = true;
 
 SDR_Full_sensor full_sdr_table[MAX_SENSOR_SIZE];
 
-uint8_t SDR_NUM = 0;
+uint8_t SDR_COUNT = 0;
 
 void SDR_clear_ID(void)
 {
@@ -60,10 +60,10 @@ uint8_t get_sdr_index(uint8_t sensor_num)
 {
 	uint8_t i, j;
 	for (i = 0; i < SENSOR_NUM_MAX; i++) {
-		for (j = 0; j < SDR_NUM; ++j) {
+		for (j = 0; j < SDR_COUNT; ++j) {
 			if (sensor_num == full_sdr_table[j].sensor_num) {
 				return j;
-			} else if (i == SDR_NUM) {
+			} else if (i == SDR_COUNT) {
 				return SENSOR_NUM_MAX;
 			} else {
 				continue;
@@ -79,7 +79,7 @@ void add_full_sdr_table(SDR_Full_sensor add_item)
 	if (get_sdr_index(add_item.sensor_num) != SENSOR_NUM_MAX) {
 		printf("add sensor num [0x%x] - sensor already exists\n", add_item.sensor_num);
 	} else {
-		full_sdr_table[SDR_NUM++] = add_item;
+		full_sdr_table[SDR_COUNT++] = add_item;
 	}
 }
 
@@ -154,12 +154,12 @@ uint8_t sdr_init(void)
 {
 	int i;
 
-	SDR_NUM = load_sdr_table();
+	SDR_COUNT = load_sdr_table();
 	pal_fix_full_sdr_table();
 	sdr_info.start_ID = 0x0000;
 	sdr_info.current_ID = sdr_info.start_ID;
 
-	for (i = 0; i < SDR_NUM; i++) {
+	for (i = 0; i < SDR_COUNT; i++) {
 		full_sdr_table[i].record_id_h = (i >> 8) & 0xFF;
 		full_sdr_table[i].record_id_l = (i & 0xFF);
 		full_sdr_table[i].ID_len += strlen(full_sdr_table[i].ID_str);
@@ -172,13 +172,9 @@ uint8_t sdr_init(void)
 		}
 	}
 
-	i--;
-	sdr_info.last_ID = (full_sdr_table[i].record_id_h << 8) | (full_sdr_table[i].record_id_l);
-	if (DEBUG_SENSOR) {
-		printf("%s ID: 0x%x%x, size: %d, recordlen: %d\n", full_sdr_table[i].ID_str,
-		       full_sdr_table[i].record_id_h, full_sdr_table[i].record_id_l,
-		       full_sdr_table[i].ID_len, full_sdr_table[i].record_len);
-	}
+	// Record last SDR record ID to sdr_info
+	sdr_info.last_ID = (full_sdr_table[SDR_COUNT - 1].record_id_h << 8) |
+			   (full_sdr_table[SDR_COUNT - 1].record_id_l);
 
 	is_sdr_not_init = false;
 	return true;

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -98,21 +98,21 @@ void map_sensor_num_to_sdr_cfg(void)
 	uint8_t i, j;
 
 	for (i = 0; i < SENSOR_NUM_MAX; i++) {
-		for (j = 0; j < SDR_NUM; j++) {
+		for (j = 0; j < SDR_COUNT; j++) {
 			if (i == full_sdr_table[j].sensor_num) {
 				sdr_index_map[i] = j;
 				break;
-			} else if (i == SDR_NUM) {
+			} else if (i == SDR_COUNT) {
 				sdr_index_map[i] = SENSOR_NULL;
 			} else {
 				continue;
 			}
 		}
-		for (j = 0; j < SDR_NUM; j++) {
+		for (j = 0; j < SDR_COUNT; j++) {
 			if (i == sensor_config[j].num) {
 				sensor_config_index_map[i] = j;
 				break;
-			} else if (i == SDR_NUM) {
+			} else if (i == SDR_COUNT) {
 				sensor_config_index_map[i] = SENSOR_NULL;
 			} else {
 				continue;
@@ -142,6 +142,7 @@ void clear_unaccessible_sensor_cache(uint8_t sensor_num)
 uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 {
 	if (reading == NULL) {
+		printf("[%s] input pointer reading is NULL\n", __func__);
 		return SENSOR_UNSPECIFIED_ERROR;
 	}
 
@@ -149,12 +150,16 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 		return SENSOR_NOT_FOUND;
 	}
 
+	*reading = 0; // Initial return reading value
+	uint8_t current_status = SENSOR_UNSPECIFIED_ERROR;
+	sensor_cfg *cfg = &sensor_config[sensor_config_index_map[sensor_num]];
+
 	if (!access_check(sensor_num)) { // sensor not accessable
 		clear_unaccessible_sensor_cache(sensor_num);
-		return SENSOR_NOT_ACCESSIBLE;
+		current_status = SENSOR_NOT_ACCESSIBLE;
+		goto return_cache_status;
 	}
 
-	sensor_cfg *cfg = &sensor_config[sensor_config_index_map[sensor_num]];
 	switch (read_mode) {
 	case GET_FROM_SENSOR:
 		if (cfg->pre_sensor_read_hook) {
@@ -162,21 +167,23 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 			    false) {
 				printf("Failed to do pre sensor read function, sensor number: 0x%x\n",
 				       sensor_num);
-				return SENSOR_PRE_READ_ERROR;
+				current_status = SENSOR_PRE_READ_ERROR;
+				goto return_cache_status;
 			}
 		}
 
-		int status = SENSOR_READ_API_UNREGISTER;
 		if (cfg->read) {
-			status = cfg->read(sensor_num, reading);
+			current_status = cfg->read(sensor_num, reading);
 		}
 
-		if (status == SENSOR_READ_SUCCESS || status == SENSOR_READ_ACUR_SUCCESS) {
+		if (current_status == SENSOR_READ_SUCCESS ||
+		    current_status == SENSOR_READ_ACUR_SUCCESS) {
 			cfg->retry = 0;
 			if (!access_check(
 				    sensor_num)) { // double check access to avoid not accessible read at same moment status change
 				clear_unaccessible_sensor_cache(sensor_num);
-				return SENSOR_NOT_ACCESSIBLE;
+				current_status = SENSOR_NOT_ACCESSIBLE;
+				goto return_cache_status;
 			}
 
 			if (cfg->post_sensor_read_hook) {
@@ -185,14 +192,13 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 							       reading) == false) {
 					printf("Failed to do post sensor read function, sensor number: 0x%x\n",
 					       sensor_num);
-					cfg->cache_status = SENSOR_POST_READ_ERROR;
-					return SENSOR_POST_READ_ERROR;
+					current_status = SENSOR_POST_READ_ERROR;
+					goto return_cache_status;
 				}
 			}
 			memcpy(&cfg->cache, reading, sizeof(*reading));
-			status = SENSOR_READ_4BYTE_ACUR_SUCCESS;
-			cfg->cache_status = status;
-			return cfg->cache_status;
+			current_status = SENSOR_READ_4BYTE_ACUR_SUCCESS;
+			goto return_cache_status;
 		} else {
 			/* If sensor read fails, let the reading argument in the
        * post_sensor_read_hook function to NULL.
@@ -208,34 +214,35 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 				}
 			}
 			/* common retry */
-			if (cfg->retry >= SENSOR_READ_RETRY_MAX)
-				cfg->cache_status = status;
-			else
+			// Return current status if retry reach max retry count, otherwise return cache status instead of current status
+			if (cfg->retry >= SENSOR_READ_RETRY_MAX) {
+				goto return_cache_status;
+			} else {
 				cfg->retry++;
-
-			return cfg->cache_status;
+				return cfg->cache_status;
+			}
 		}
 		break;
 	case GET_FROM_CACHE:
-		switch (sensor_config[sensor_config_index_map[sensor_num]].cache_status) {
+		switch (cfg->cache_status) {
 		case SENSOR_READ_SUCCESS:
 		case SENSOR_READ_ACUR_SUCCESS:
 		case SENSOR_READ_4BYTE_ACUR_SUCCESS:
-			*reading = sensor_config[sensor_config_index_map[sensor_num]].cache;
+			*reading = cfg->cache;
 			if (!access_check(
 				    sensor_num)) { // double check access to avoid not accessible read at same moment status change
-				return SENSOR_NOT_ACCESSIBLE;
+				cfg->cache_status = SENSOR_NOT_ACCESSIBLE;
 			}
-			return sensor_config[sensor_config_index_map[sensor_num]].cache_status;
+			return cfg->cache_status;
+			;
 		case SENSOR_INIT_STATUS:
-			sensor_config[sensor_config_index_map[sensor_num]].cache = SENSOR_FAIL;
-			return sensor_config[sensor_config_index_map[sensor_num]].cache_status;
+			cfg->cache = SENSOR_FAIL;
+			return cfg->cache_status;
 		default:
-			sensor_config[sensor_config_index_map[sensor_num]].cache = SENSOR_FAIL;
+			cfg->cache = SENSOR_FAIL;
 			printf("Failed to read sensor value from cache, sensor number: 0x%x\n, cache status: 0x%x",
-			       sensor_num,
-			       sensor_config[sensor_config_index_map[sensor_num]].cache_status);
-			return sensor_config[sensor_config_index_map[sensor_num]].cache_status;
+			       sensor_num, cfg->cache_status);
+			return cfg->cache_status;
 		}
 		break;
 	default:
@@ -243,7 +250,9 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 		break;
 	}
 
-	return SENSOR_UNSPECIFIED_ERROR; // should not reach here
+return_cache_status:
+	cfg->cache_status = current_status;
+	return cfg->cache_status;
 }
 
 void disable_sensor_poll()
@@ -258,7 +267,7 @@ void enable_sensor_poll()
 
 void sensor_poll_handler(void *arug0, void *arug1, void *arug2)
 {
-	uint8_t poll_num;
+	uint8_t index = 0, sensor_num = 0;
 	int sensor_poll_interval_ms;
 	int reading;
 	k_msleep(1000); // delay 1 second to wait for drivers ready before start sensor polling
@@ -266,17 +275,18 @@ void sensor_poll_handler(void *arug0, void *arug1, void *arug2)
 	pal_set_sensor_poll_interval(&sensor_poll_interval_ms);
 
 	while (1) {
-		for (poll_num = 0; poll_num < SENSOR_NUM_MAX; poll_num++) {
+		for (index = 0; index < sensor_config_num; index++) {
+			// Perform sensor polling according to the sensor number of the sensor config table
+			sensor_num = sensor_config[index].num;
 			if (sensor_poll_enable_flag == false) { /* skip if disable sensor poll */
-
-				// Due to except skip sensor polling
-				is_sensor_ready_flag = true;
 				break;
 			}
-			if (sensor_config_index_map[poll_num] == SENSOR_NULL) { // sensor not exist
+			if (sdr_index_map[sensor_num] == SENSOR_NULL) { // Check sensor info
+				printf("[%s] fail to find sensor SDR info, sensor number: 0x%x\n",
+				       __func__, sensor_num);
 				continue;
 			}
-			get_sensor_reading(poll_num, &reading, GET_FROM_SENSOR);
+			get_sensor_reading(sensor_num, &reading, GET_FROM_SENSOR);
 
 			k_yield();
 		}
@@ -342,19 +352,12 @@ void sensor_poll_init()
 
 uint8_t get_sensor_config_index(uint8_t sensor_num)
 {
-	uint8_t i, j;
-	for (i = 0; i < SENSOR_NUM_MAX; i++) {
-		for (j = 0; j < sensor_config_num; ++j) {
-			if (sensor_num == sensor_config[j].num) {
-				return j;
-			} else if (i == sensor_config_num) {
-				return SENSOR_NUM_MAX;
-			} else {
-				continue;
-			}
+	uint8_t i = 0;
+	for (i = 0; i < sensor_config_num; ++i) {
+		if (sensor_num == sensor_config[i].num) {
+			return i;
 		}
 	}
-
 	return SENSOR_NUM_MAX;
 }
 
@@ -402,7 +405,7 @@ static void drive_init(void)
 	const uint16_t max_drive_num = ARRAY_SIZE(sensor_drive_tbl);
 	uint16_t current_drive;
 
-	for (int i = 0; i < SDR_NUM; i++) {
+	for (int i = 0; i < SDR_COUNT; i++) {
 		sensor_cfg *p = sensor_config + i;
 		for (current_drive = 0; current_drive < max_drive_num; current_drive++) {
 			if (init_drive_type(p, current_drive)) {
@@ -422,8 +425,8 @@ bool sensor_init(void)
 	init_sensor_num();
 	sdr_init();
 
-	if (SDR_NUM != 0) {
-		sensor_config = (sensor_cfg *)malloc(SDR_NUM * sizeof(sensor_cfg));
+	if (SDR_COUNT != 0) {
+		sensor_config = (sensor_cfg *)malloc(SDR_COUNT * sizeof(sensor_cfg));
 		if (sensor_config != NULL) {
 			sensor_config_num = load_sensor_config();
 		} else {

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -54,19 +54,19 @@ enum SENSOR_DEV {
 	sensor_dev_adm1278 = 0x04,
 	sensor_dev_nvme = 0x05,
 	sensor_dev_pch = 0x06,
-	sensor_dev_mp5990 = 0x10,
-	sensor_dev_isl28022 = 0x11,
-	sensor_dev_pex89000 = 0x12,
-	sensor_dev_tps53689 = 0x13,
-	sensor_dev_xdpe15284 = 0x14,
-	sensor_dev_ltc4282 = 0x15,
-	sensor_dev_ast_fan = 0x16,
-	sensor_dev_tmp431 = 0x18,
-	sensor_dev_pmic = 0x19,
-	sensor_dev_ina233 = 0x20,
-	sensor_dev_isl69254iraz_t = 0x21,
-	sensor_dev_max16550a = 0x22,
-	sensor_dev_ina230 = 0x23,
+	sensor_dev_mp5990 = 0x07,
+	sensor_dev_isl28022 = 0x08,
+	sensor_dev_pex89000 = 0x09,
+	sensor_dev_tps53689 = 0x0A,
+	sensor_dev_xdpe15284 = 0x0B,
+	sensor_dev_ltc4282 = 0x0C,
+	sensor_dev_ast_fan = 0x0D,
+	sensor_dev_tmp431 = 0x0E,
+	sensor_dev_pmic = 0x0F,
+	sensor_dev_ina233 = 0x10,
+	sensor_dev_isl69254iraz_t = 0x11,
+	sensor_dev_max16550a = 0x12,
+	sensor_dev_ina230 = 0x13,
 	sensor_dev_max
 };
 
@@ -294,7 +294,7 @@ typedef struct _ina230_init_arg {
 } ina230_init_arg;
 
 extern bool enable_sensor_poll_thread;
-extern uint8_t SDR_NUM;
+extern uint8_t SDR_COUNT;
 extern sensor_cfg *sensor_config;
 // Mapping sensor number to sensor config index
 extern uint8_t sensor_config_index_map[SENSOR_NUM_MAX];

--- a/common/shell/shell_platform.c
+++ b/common/shell/shell_platform.c
@@ -199,7 +199,7 @@ static bool sensor_access_check(uint8_t sensor_num)
 
 static int sensor_get_idx_by_sensor_num(uint16_t sensor_num)
 {
-	for (int sen_idx = 0; sen_idx < SDR_NUM; sen_idx++) {
+	for (int sen_idx = 0; sen_idx < SDR_COUNT; sen_idx++) {
 		if (sensor_num == sensor_config[sen_idx].num)
 			return sen_idx;
 	}
@@ -227,7 +227,7 @@ static int sensor_access(const struct shell *shell, int sensor_num, enum SENSOR_
 		}
 		char *check_access =
 			(sensor_access_check(sensor_config[sen_idx].num) == true) ? "O" : "X";
-		shell_print(shell, "[0x%-2x] %-35s: %-5s | access[%s] | %-20s | %-8d",
+		shell_print(shell, "[0x%-2x] %-35s: %-10s | access[%s] | %-30s | %-8d",
 			    sensor_config[sen_idx].num, "Unsupported name",
 			    sensor_type_name[sensor_config[sen_idx].type], check_access,
 			    sensor_status_name[sensor_config[sen_idx].cache_status],
@@ -449,7 +449,7 @@ static void cmd_sensor_cfg_list_all(const struct shell *shell, size_t argc, char
 	shell_print(
 		shell,
 		"---------------------------------------------------------------------------------");
-	for (int sen_idx = 0; sen_idx < SDR_NUM; sen_idx++)
+	for (int sen_idx = 0; sen_idx < SDR_COUNT; sen_idx++)
 		sensor_access(shell, sensor_config[sen_idx].num, SENSOR_READ);
 
 	shell_print(

--- a/common/shell/shell_platform.h
+++ b/common/shell/shell_platform.h
@@ -59,16 +59,27 @@ gpio_flags_t int_type_table[] = { GPIO_INT_DISABLE,   GPIO_INT_EDGE_RISING, GPIO
 enum GPIO_ACCESS { GPIO_READ, GPIO_WRITE };
 
 /* Declare SENSOR */
-const char *const sensor_type_name[] = { sensor_name_to_num(tmp75) sensor_name_to_num(
-	adc) sensor_name_to_num(peci) sensor_name_to_num(vr) sensor_name_to_num(hsc)
-						 sensor_name_to_num(nvme) sensor_name_to_num(pch) };
+const char *const sensor_type_name[] = {
+	sensor_name_to_num(tmp75) sensor_name_to_num(adc) sensor_name_to_num(
+		peci) sensor_name_to_num(isl69259) sensor_name_to_num(hsc) sensor_name_to_num(nvme)
+		sensor_name_to_num(pch) sensor_name_to_num(mp5990) sensor_name_to_num(isl28022)
+			sensor_name_to_num(pex89000) sensor_name_to_num(tps53689)
+				sensor_name_to_num(xdpe15284) sensor_name_to_num(ltc4282)
+					sensor_name_to_num(fan) sensor_name_to_num(tmp431)
+						sensor_name_to_num(pmic) sensor_name_to_num(ina233)
+							sensor_name_to_num(isl69254)
+								sensor_name_to_num(max16550a)
+									sensor_name_to_num(ina230)
+};
 
 const char *const sensor_status_name[] = {
-	sensor_name_to_num(read_success) sensor_name_to_num(read_acur_success)
-		sensor_name_to_num(not_found) sensor_name_to_num(not_accesible)
-			sensor_name_to_num(fail_to_access) sensor_name_to_num(init_status)
-				sensor_name_to_num(unspecified_err)
-					sensor_name_to_num(polling_disable)
+	sensor_name_to_num(read_success) sensor_name_to_num(read_acur_success) sensor_name_to_num(
+		not_found) sensor_name_to_num(not_accesible) sensor_name_to_num(fail_to_access)
+		sensor_name_to_num(init_status) sensor_name_to_num(unspecified_err)
+			sensor_name_to_num(polling_disable) sensor_name_to_num(pre_read_error)
+				sensor_name_to_num(post_read_error)
+					sensor_name_to_num(api_unregister)
+						sensor_name_to_num(4byte_acur_read_success)
 };
 
 enum SENSOR_ACCESS { SENSOR_READ, SENSOR_WRITE };

--- a/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
@@ -3710,14 +3710,14 @@ void pal_fix_full_sdr_table()
 		if ((_2ou_status.card_type & TYPE_2OU_DPV2_16) == TYPE_2OU_DPV2_16) {
 			fix_array_num = ARRAY_SIZE(dpv2_sdr_table);
 			// Check sdr table max size before adding new sdr, avoiding over sdr table max size after adding new sdr
-			if ((SDR_NUM + fix_array_num) > array_max_num) {
+			if ((SDR_COUNT + fix_array_num) > array_max_num) {
 				printf("[%s] over sdr table max size after adding DPV2_16 sdr, sdr table max size: %d  sdr table size after adding: %d\n",
-				       __func__, array_max_num, SDR_NUM + fix_array_num);
+				       __func__, array_max_num, SDR_COUNT + fix_array_num);
 				return;
 			}
-			memcpy(&full_sdr_table[SDR_NUM], &dpv2_sdr_table[0],
+			memcpy(&full_sdr_table[SDR_COUNT], &dpv2_sdr_table[0],
 			       fix_array_num * sizeof(SDR_Full_sensor));
-			SDR_NUM += fix_array_num;
+			SDR_COUNT += fix_array_num;
 		}
 	}
 };

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -313,7 +313,7 @@ void pal_fix_sensor_config()
 {
 	uint8_t sensor_count;
 	// Sensor config table max size is set according to sdr table size
-	uint8_t sensor_max_num = SDR_NUM;
+	uint8_t sensor_max_num = SDR_COUNT;
 	float voltage_hsc_type_adc;
 
 	/* Check the VR sensor type */
@@ -426,7 +426,7 @@ void pal_fix_sensor_config()
 		}
 	}
 
-	if (sensor_config_num != SDR_NUM) {
+	if (sensor_config_num != SDR_COUNT) {
 		printf("fix sensor SDR and config table not match\n");
 	}
 }


### PR DESCRIPTION
Summary:
- Improve sensor monitor
  - Function sdr_init: the index used to store the SDR last id is represented by SDR count.
  - Function sdr_init: remove redundant debug messages.
  - Function get_sensor_config_index: remove unnecessary 'for' loop.
  - Function sensor_poll_handler: remove redundancy flag.
  - Function get_sensor_reading: update cache status in all cases.
  - Function sensor_polling_handler: sensor monitor check sensor number according to sensor config table.
  - Enum device_init_type: modify device type to increase sequentially.
  - Variable SDR_NUM: modify variable name to SDR_COUNT making name more readable.
  - Command platform: add sensor type/sensor status mapping table to get current sensor infomation in BIC console.

Test Plan:
- Build code: Pass
- Check sensor-util get sensor value is normal after optimizing sensor monitor architecture in different board: Pass
- Check sensor-util get sensor value is normal after AC/DC cycle 50 times: Pass

Test Board                                             Test result
------------------------------------------------------------------
Config A Craterlake BIC EVT2                           Pass
Config A Craterlake BIC EVT3_ADI                       Pass
Config A Craterlake BIC EVT3_MP5990                    Pass
Config B Craterlake BIC EVT2 + DPV2                    Pass
Config B Craterlake BIC EVT3_ADI + DPV2                Pass
Config B Craterlake BIC EVT3_MP5990 + DPV2             Pass
Config C Craterlake BIC EVT2 + Rainbow falls BIC       Pass
Config C Craterlake BIC EVT3_ADI + Rainbow falls BIC   Pass
COnfig D Craterlake BIC EVT2 + Baseboard BIC           Pass

Log:
[BMC console]

EVT2/EVT3 ADI/EVT3 MP5990
root@bmc-oob:~# sensor-util slot2 --threshold
slot2:
MB Inlet Temp                (0x1) :   33.00 C     | (ok) | UCR: 48.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
MB Outlet Temp               (0x2) :   50.00 C     | (ok) | UCR: 93.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
FIO Temp                     (0x3) :   31.00 C     | (ok) | UCR: 40.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PCH Temp                     (0x4) :   47.00 C     | (ok) | UCR: 74.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC CPU Temp                 (0x5) :   44.00 C     | (ok) | UCR: 84.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC Therm Margin             (0x14) :  -56.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
CPU TjMax                    (0x15) :  100.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
DIMMA Temp                   (0x6) :   47.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMC Temp                   (0x7) :   47.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMD Temp                   (0x9) :   44.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME Temp                   (0xA) :   46.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMG Temp                   (0xB) :   42.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH Temp                   (0xC) :   39.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SSD0 Temp                    (0xD) :   35.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Temp                     (0xE) :   46.67 C     | (ok) | UCR: 86.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
VCCIN SPS Temp               (0xF) :   57.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
FIVRA SPS Temp               (0x10) :   54.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
EHV SPS Temp                 (0x11) :   46.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
VCCD SPS Temp                (0x12) :   43.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
FAON SPS Temp                (0x13) :   48.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
P12V_STBY Vol                (0x20) :   12.68 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
P3V_BAT Vol                  (0x21) :    3.13 Volts | (ok) | UCR: 3.51 | UNC: 3.46 | UNR: NA | LCR: 2.76 | LNC: 2.79 | LNR: NA
P3V3_STBY Vol                (0x22) :    3.34 Volts | (ok) | UCR: 3.56 | UNC: 3.53 | UNR: 4.00 | LCR: 3.04 | LNC: 3.08 | LNR: 2.30
P1V8_STBY Vol                (0x23) :    1.81 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.09 | LCR: 1.67 | LNC: 1.69 | LNR: 1.44
P1V05_PCH Vol                (0x24) :    1.06 Volts | (ok) | UCR: 1.12 | UNC: 1.10 | UNR: 1.22 | LCR: 0.97 | LNC: 0.98 | LNR: 0.84
P5V_STBY Vol                 (0x25) :    5.02 Volts | (ok) | UCR: 5.40 | UNC: 5.35 | UNR: 5.80 | LCR: 4.59 | LNC: 4.64 | LNR: 4.00
P12V_DIMM Vol                (0x26) :   12.73 Volts | (ok) | UCR: 14.21 | UNC: 14.07 | UNR: NA | LCR: 9.87 | LNC: 10.01 | LNR: NA
P1V2_STBY Vol                (0x27) :    1.20 Volts | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.39 | LCR: 1.10 | LNC: 1.12 | LNR: 0.96
P3V3_M2 Vol                  (0x28) :    3.33 Volts | (ok) | UCR: 3.71 | UNC: 3.67 | UNR: NA | LCR: 2.91 | LNC: 2.94 | LNR: NA
HSC Input Vol                (0x29) :   12.51 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
VCCIN VR Vol                 (0x2A) :    1.77 Volts | (ok) | UCR: 1.93 | UNC: 1.91 | UNR: 2.20 | LCR: 1.64 | LNC: 1.66 | LNR: 0.40
FIVRA VR Vol                 (0x2C) :    1.82 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.20 | LCR: 1.69 | LNC: 1.71 | LNR: 0.40
EHV VR Vol                   (0x2D) :    1.80 Volts | (ok) | UCR: 1.90 | UNC: 1.88 | UNR: 2.20 | LCR: 1.70 | LNC: 1.72 | LNR: 0.40
VCCD VR Vol                  (0x2E) :    1.14 Volts | (ok) | UCR: 1.23 | UNC: 1.21 | UNR: 1.50 | LCR: 1.05 | LNC: 1.06 | LNR: 0.40
FAON VR Vol                  (0x2F) :    1.05 Volts | (ok) | UCR: 1.09 | UNC: 1.07 | UNR: 1.40 | LCR: 0.90 | LNC: 0.91 | LNR: 0.40
HSC Output Cur               (0x30) :    6.10 Amps  | (ok) | UCR: 31.96 | UNC: 28.73 | UNR: 39.95 | LCR: NA | LNC: NA | LNR: NA
VCCIN VR Cur                 (0x31) :   14.50 Amps  | (ok) | UCR: 141.18 | UNC: 119.34 | UNR: 180.18 | LCR: NA | LNC: NA | LNR: NA
FIVRA VR Cur                 (0x32) :    3.60 Amps  | (ok) | UCR: 53.01 | UNC: 48.05 | UNR: 70.99 | LCR: NA | LNC: NA | LNR: NA
EHV VR Cur                   (0x33) :    0.80 Amps  | (ok) | UCR: 6.24 | UNC: 5.04 | UNR: 18.00 | LCR: NA | LNC: NA | LNR: NA
VCCD VR Cur                  (0x34) :    2.70 Amps  | (ok) | UCR: 30.02 | UNC: 26.98 | UNR: 42.94 | LCR: NA | LNC: NA | LNR: NA
FAON VR Cur                  (0x35) :    7.60 Amps  | (ok) | UCR: 46.02 | UNC: 42.12 | UNR: 60.06 | LCR: NA | LNC: NA | LNR: NA
CPU PWR                      (0x38) :   58.00 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Input Pwr                (0x39) :   81.69 Watts | (ok) | UCR: 399.28 | UNC: 360.22 | UNR: 499.10 | LCR: NA | LNC: NA | LNR: NA
VCCIN VR Pout                (0x3A) :   23.00 Watts | (ok) | UCR: 253.80 | UNC: 214.32 | UNR: 324.30 | LCR: NA | LNC: NA | LNR: NA
FIVRA VR Pout                (0x3C) :    6.00 Watts | (ok) | UCR: 95.19 | UNC: 86.64 | UNR: 127.68 | LCR: NA | LNC: NA | LNR: NA
EHV VR Pout                  (0x3D) :    1.00 Watts | (ok) | UCR: 11.25 | UNC: 8.97 | UNR: 32.38 | LCR: NA | LNC: NA | LNR: NA
VCCD VR Pout                 (0x3E) :    2.00 Watts | (ok) | UCR: 34.32 | UNC: 31.02 | UNR: 49.28 | LCR: NA | LNC: NA | LNR: NA
FAON VR Pout                 (0x3F) :    7.00 Watts | (ok) | UCR: 49.28 | UNC: 45.08 | UNR: 64.12 | LCR: NA | LNC: NA | LNR: NA
DIMMA PMIC_Pout              (0x1E) :    0.38 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMC PMIC_Pout              (0x1F) :    0.62 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMD PMIC_Pout              (0x36) :    0.50 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME PMIC_Pout              (0x37) :    0.62 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMG PMIC_Pout              (0x42) :    0.50 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH PMIC_Pout              (0x47) :    0.75 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA

Baseboard BIC
root@bmc-oob:~# sensor-util slot1 --threshold | grep BB
BB_INLET_TEMP                (0xD1) :   23.76 C     | (ok) | UCR: 50.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
BB_OUTLET_TEMP               (0xD2) :   25.76 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
BB_HSC_TEMP                  (0xD3) :   22.14 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
BB_P5V_STBY                  (0xD4) :    5.14 Volts | (ok) | UCR: 5.55 | UNC: 5.50 | UNR: 5.65 | LCR: 4.45 | LNC: 4.50 | LNR: 4.15
BB_P12V_STBY                 (0xD5) :   12.71 Volts | (ok) | UCR: 13.29 | UNC: 13.17 | UNR: 14.30 | LCR: 10.71 | LNC: 10.77 | LNR: 10.08
BB_P3V3_STBY                 (0xD6) :    3.36 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.73 | LCR: 3.04 | LNC: 3.07 | LNR: 2.74
BB_P5V_USB                   (0xE9) :    5.14 Volts | (ok) | UCR: 5.40 | UNC: 5.35 | UNR: 5.65 | LCR: 4.60 | LNC: 4.65 | LNR: 4.15
BB_P1V2_STBY                 (0xD9) :    1.21 Volts | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.36 | LCR: 1.10 | LNC: 1.12 | LNR: 1.00
BB_P1V0_STBY                 (0xDA) :    1.01 Volts | (ok) | UCR: 1.08 | UNC: 1.07 | UNR: 1.13 | LCR: 0.92 | LNC: 0.93 | LNR: 0.83
BB_MEDUSA_VIN                (0xDB) :   12.55 Volts | (ok) | UCR: 13.88 | UNC: 13.75 | UNR: 14.00 | LCR: 11.12 | LNC: 11.25 | LNR: 9.25
BB_MEDUSA_VOUT               (0xD7) :   12.55 Volts | (ok) | UCR: 13.88 | UNC: 13.75 | UNR: 14.00 | LCR: 11.12 | LNC: 11.25 | LNR: 9.25
BB_HSC_VIN                   (0xDC) :   12.52 Volts | (ok) | UCR: 13.29 | UNC: 13.17 | UNR: 14.30 | LCR: 10.71 | LNC: 10.77 | LNR: 10.08
BB_MEDUSA_CUR                (0xDF) :   13.18 Amps  | (ok) | UCR: 144.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
BB_HSC_IOUT                  (0xDE) :    5.97 Amps  | (ok) | UCR: 22.96 | UNC: NA | UNR: 31.92 | LCR: NA | LNC: NA | LNR: NA
BB_FAN_IOUT                  (0xE8) :    2.69 Amps  | (ok) | UCR: 14.56 | UNC: NA | UNR: 39.26 | LCR: NA | LNC: NA | LNR: NA
BB_MEDUSA_PWR                (0xD8) :  165.45 Watts | (ok) | UCR: 1800.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
BB_HSC_PIN                   (0xDD) :   74.34 Watts | (ok) | UCR: 287.10 | UNC: NA | UNR: 398.46 | LCR: NA | LNC: NA | LNR: NA
BB_HSC_EIN                   (0xEA) :   72.65 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
BB_HSC_PEAK_IOUT             (0xEB) :   15.23 Amps  | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
BB_HSC_PEAK_PIN              (0xEC) :  190.76 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA

DPV2
root@bmc-oob:~# sensor-util slot1 --threshold | grep DPV2
DPV2_1_12V_VIN               (0x8C) :   12.40 Volts | (ok) | UCR: 13.20 | UNC: 12.96 | UNR: 14.00 | LCR: 10.80 | LNC: 11.04 | LNR: 10.00
DPV2_1_12V_VOUT              (0x8D) :   12.42 Volts | (ok) | UCR: 13.20 | UNC: 12.96 | UNR: 14.00 | LCR: 10.80 | LNC: 11.04 | LNR: 10.00
DPV2_1_12V_IOUT              (0x8E) :    0.14 Amps  | (ok) | UCR: 15.47 | UNC: 15.17 | UNR: 18.90 | LCR: NA | LNC: NA | LNR: NA
DPV2_1_EFUSETemp             (0x8F) :   22.38 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
DPV2_1_EFUSEPWR              (0x90) :    1.19 Watts | (ok) | UCR: 186.00 | UNC: NA | UNR: 226.80 | LCR: NA | LNC: NA | LNR: NA

[BIC console]

EVT3 ADI
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x1 ] Unsupported name                   : tmp75      | access[O] | 4byte_acur_read_success        | 31
[0x2 ] Unsupported name                   : tmp431     | access[O] | 4byte_acur_read_success        | 24576048
[0x3 ] Unsupported name                   : tmp75      | access[O] | 4byte_acur_read_success        | 29
[0xd ] Unsupported name                   : nvme       | access[O] | 4byte_acur_read_success        | 32
[0x5 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 41
[0x14] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 59
[0x15] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 100
[0x6 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 45
[0x7 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 45
[0x9 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 43
[0xa ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 44
[0xb ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 42
[0xc ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 38
[0x38] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 56
[0x20] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 34865164
[0x22] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 20578307
[0x24] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 3080193
[0x21] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 5898243
[0x25] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 1507333
[0x26] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 41418764
[0x27] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 13172737
[0x28] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 19922947
[0x23] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 52822017
[0x2e] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 9306113
[0x2f] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 3473409
[0x2d] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 52428801
[0x2a] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 40435713
[0x2c] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 53608449
[0x34] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 52428802
[0x35] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 19660807
[0x33] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 52428800
[0x31] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 26214414
[0x32] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 4
[0x12] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 43
[0x13] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 47
[0x11] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 43
[0xf ] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 55
[0x10] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 52
[0x3e] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 2
[0x3f] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 8
[0x3d] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 1
[0x3a] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 33
[0x3c] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 6
[0x4 ] Unsupported name                   : pch        | access[O] | 4byte_acur_read_success        | 48
[0x1e] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 49152000
[0x1f] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 32768000
[0x36] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 49152000
[0x37] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 40960000
[0x42] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 32768000
[0x47] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 32768000
[0xe ] Unsupported name                   : tmp431     | access[O] | 4byte_acur_read_success        | 24576045
[0x29] Unsupported name                   : hsc        | access[O] | 4byte_acur_read_success        | 34144268
[0x30] Unsupported name                   : hsc        | access[O] | 4byte_acur_read_success        | 1572869
[0x39] Unsupported name                   : hsc        | access[O] | 4byte_acur_read_success        | 21692477
---------------------------------------------------------------------------------

EVT3 MP5990
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x1 ] Unsupported name                   : tmp75      | access[O] | 4byte_acur_read_success        | 26
[0x2 ] Unsupported name                   : tmp75      | access[O] | 4byte_acur_read_success        | 30
[0x3 ] Unsupported name                   : tmp75      | access[O] | 4byte_acur_read_success        | 27
[0xd ] Unsupported name                   : nvme       | access[O] | 4byte_acur_read_success        | 23
[0x5 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 31
[0x14] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 69
[0x15] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 100
[0x6 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 27
[0x7 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 27
[0x9 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 26
[0xa ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 27
[0xb ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 26
[0xc ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 27
[0x38] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 74
[0x20] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 34865164
[0x22] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 21889027
[0x24] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 3538945
[0x21] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 2949123
[0x25] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 61407236
[0x26] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 25296908
[0x27] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 12320769
[0x28] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 19922947
[0x23] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 51707905
[0x2e] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 9371649
[0x2f] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 3276801
[0x2d] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 52428801
[0x2a] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 50593793
[0x2c] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 53608449
[0x34] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 52428802
[0x35] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 58982408
[0x33] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 52428800
[0x31] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 6553632
[0x32] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 45875203
[0x12] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 33
[0x13] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 37
[0x11] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 32
[0xf ] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 39
[0x10] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 36
[0x3e] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 2
[0x3f] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 9
[0x3d] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 1
[0x3a] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 56
[0x3c] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 7
[0x4 ] Unsupported name                   : pch        | access[O] | 4byte_acur_read_success        | 36
[0x1e] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 32768000
[0x1f] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 32768000
[0x36] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 24576000
[0x37] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 40960000
[0x42] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 24576000
[0x47] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 32768000
[0xe ] Unsupported name                   : mp5990     | access[O] | 4byte_acur_read_success        | 31
[0x29] Unsupported name                   : mp5990     | access[O] | 4byte_acur_read_success        | 26607628
[0x30] Unsupported name                   : mp5990     | access[O] | 4byte_acur_read_success        | 32768007
[0x39] Unsupported name                   : mp5990     | access[O] | 4byte_acur_read_success        | 93

EVT2 + DPV2
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x1 ] Unsupported name                   : tmp75      | access[O] | 4byte_acur_read_success        | 26
[0x2 ] Unsupported name                   : tmp75      | access[O] | 4byte_acur_read_success        | 36
[0x3 ] Unsupported name                   : tmp75      | access[O] | 4byte_acur_read_success        | 25
[0xd ] Unsupported name                   : nvme       | access[O] | 4byte_acur_read_success        | 30
[0x5 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 34
[0x14] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 66
[0x15] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 100
[0x6 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 29
[0x7 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 28
[0x9 ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 28
[0xa ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 29
[0xb ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 29
[0xc ] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 29
[0x38] Unsupported name                   : peci       | access[O] | 4byte_acur_read_success        | 79
[0x20] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 34865164
[0x22] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 21626883
[0x24] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 3211265
[0x21] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 6291459
[0x25] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 63045636
[0x26] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 31850508
[0x27] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 12648449
[0x28] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 20578307
[0x23] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 52494337
[0x2e] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 9306113
[0x2f] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 3211265
[0x2d] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 52428801
[0x2a] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 50397185
[0x2c] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 53608449
[0x34] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 52428802
[0x35] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 6553609
[0x33] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 58982400
[0x31] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 6553634
[0x32] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 6553604
[0x12] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 35
[0x13] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 38
[0x11] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 34
[0xf ] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 46
[0x10] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 40
[0x3e] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 2
[0x3f] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 9
[0x3d] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 1
[0x3a] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 60
[0x3c] Unsupported name                   : isl69259   | access[O] | 4byte_acur_read_success        | 6
[0x4 ] Unsupported name                   : pch        | access[O] | 4byte_acur_read_success        | 36
[0x1e] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 32768000
[0x1f] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 32768000
[0x36] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 24576000
[0x37] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 40960000
[0x42] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 24576000
[0x47] Unsupported name                   : pmic       | access[O] | 4byte_acur_read_success        | 32768000
[0xe ] Unsupported name                   : hsc        | access[O] | 4byte_acur_read_success        | 40566816
[0x29] Unsupported name                   : hsc        | access[O] | 4byte_acur_read_success        | 25755660
[0x30] Unsupported name                   : hsc        | access[O] | 4byte_acur_read_success        | 29687816
[0x39] Unsupported name                   : hsc        | access[O] | 4byte_acur_read_success        | 63504487
[0x91] Unsupported name                   : max16550a  | access[O] | 4byte_acur_read_success        | 25624588
[0x92] Unsupported name                   : max16550a  | access[O] | 4byte_acur_read_success        | 24707084
[0x93] Unsupported name                   : max16550a  | access[O] | 4byte_acur_read_success        | 7667712
[0x94] Unsupported name                   : max16550a  | access[O] | 4byte_acur_read_success        | 24969238
[0x95] Unsupported name                   : max16550a  | access[O] | 4byte_acur_read_success        | 12386305
---------------------------------------------------------------------------------

Rainbow falls BIC
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x50] Unsupported name                   : tmp75      | access[O] | 4byte_acur_read_success        | 29
[0x52] Unsupported name                   : tmp75      | access[O] | 4byte_acur_read_success        | 30
[0x5f] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 7798789
[0x60] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 12648449
[0x61] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 52166657
[0x68] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 32571394
[0x69] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 32571394
[0x6a] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 39190528
[0x6b] Unsupported name                   : adc        | access[O] | 4byte_acur_read_success        | 39190528
[0x5d] Unsupported name                   : ina233     | access[O] | 4byte_acur_read_success        | 34078732
[0x5e] Unsupported name                   : ina233     | access[O] | 4byte_acur_read_success        | 21102595
[0x6c] Unsupported name                   : ina233     | access[O] | 4byte_acur_read_success        | 17629184
[0x6d] Unsupported name                   : ina233     | access[O] | 4byte_acur_read_success        | 9895936
[0x73] Unsupported name                   : ina233     | access[O] | 4byte_acur_read_success        | 4915203
[0x74] Unsupported name                   : ina233     | access[O] | 4byte_acur_read_success        | 32768000
[0x58] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 39
[0x59] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 36
[0x5a] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 32
[0x5b] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 36
[0x5c] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 39
[0x62] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 3014657
[0x64] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 53673984
[0x65] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 53673984
[0x66] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 13041665
[0x67] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 12976129
[0x6e] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | -6553600
[0x6f] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 13107200
[0x70] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 19660800
[0x71] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | -6553600
[0x72] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | -26214400
[0x75] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 65534
[0x76] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 0
[0x77] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 0
[0x78] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 65535
[0x79] Unsupported name                   : isl69254   | access[O] | 4byte_acur_read_success        | 0
---------------------------------------------------------------------------------