### PR TITLE
fby3.5: wf: Support IPMB

### DIFF
--- a/meta-facebook/yv35-wf/src/platform/plat_ipmb.c
+++ b/meta-facebook/yv35-wf/src/platform/plat_ipmb.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include "cmsis_os2.h"
+#include <string.h>
+#include "ipmb.h"
+#include "plat_i2c.h"
+#include "plat_ipmb.h"
+#include "plat_ipmi.h"
+
+IPMB_config pal_IPMB_config_table[] = {
+	// index, interface, channel, bus, channel_target_address, enable_status, self_address,
+	// rx_thread_name, tx_thread_name
+	{ CL_BIC_IPMB_IDX, I2C_IF, CL_BIC_IPMB, IPMB_CL_BIC_BUS, CL_BIC_I2C_ADDRESS, ENABLE,
+	  SELF_I2C_ADDRESS, "RX_CL_BIC_IPMB_TASK", "TX_CL_BIC_IPMB_TASK" },
+	{ RESERVED_IDX, RESERVED_IF, RESERVED, RESERVED_BUS, RESERVED_ADDRESS, DISABLE,
+	  RESERVED_ADDRESS, "RESERVED_ATTR", "RESERVED_ATTR" },
+};
+
+bool pal_load_ipmb_config(void)
+{
+	memcpy(&IPMB_config_table[0], &pal_IPMB_config_table[0], sizeof(pal_IPMB_config_table));
+	return true;
+};


### PR DESCRIPTION
Summary:

Support IPMB handler.
Dependency: #341 

Test plan:

- Build code: Pass
- Boot successfully: Pass
- Check IPMB is workable: Pass

Log:

1. Check RF BIC can boot successful.

    [BIC console]
    *** Booting Zephyr OS build v00.01.04-10-ge194e1cc6cf8  ***
    Hello, welcome to yv35 Waimano Falls 2022.22.0
    Function pal_fix_full_sdr_table is not implemented
    The SDR number is equal to 0
    ipmi_init

2. Check IPMB is workable via IPMI command.

    [BMC console]
    root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x9c 0x9c 0x00 0x05 0x18 0x01
    9C 9C 00 05 07 01 00 00 80 04 01 02 BF 15 A0 00
    00 00 00 00 00 00