### PR TITLE
fby3.5: wf: support fru

### DIFF
--- a/meta-facebook/yv35-wf/src/platform/plat_fru.c
+++ b/meta-facebook/yv35-wf/src/platform/plat_fru.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <string.h>
+#include "plat_fru.h"
+#include "fru.h"
+
+const EEPROM_CFG plat_fru_config[] = {
+	{
+		NV_ATMEL_24C128,
+		WF_FRU_ID,
+		WF_FRU_PORT,
+		WF_FRU_ADDR,
+		FRU_DEV_ACCESS_BYTE,
+		FRU_START,
+		FRU_SIZE,
+	},
+};
+
+void pal_load_fru_config(void)
+{
+	memcpy(&fru_config, &plat_fru_config, sizeof(plat_fru_config));
+}


### PR DESCRIPTION
Summary:

Support read and write FRU.
Dependency: #343 

Test plan:

- Build code: Pass
- Read FRU: Pass
- Write FRU: Pass

Log:

1. Write test FRU data
    root@bmc-oob:~# fruid-util slot1 1U --write WF_test_fru.bin

2. Read FRU
    root@bmc-oob:~# fruid-util slot1 1U
    
    FRU Information           : Server board 1 1U
    ---------------           : ------------------
    Chassis Type              : Rack Mount Chassis
    Board Mfg Date            : Mon Jun 20 00:03:00 2022
    Board Mfg                 : Quanta
    Board Product             : Waimano Falls Bridge BD
    Board Serial              : test_1234567890
    Board Part Number         : 3EF0EGB00L0
    Board FRU ID              : FRU Ver 0.01
    Board Custom Data 2       : test_1234567890
    Board Custom Data 3       : Power On
    Product Manufacturer      : Quanta
    Product Name              : Waimano Falls
    Product Version           : 3EF0EGB00L0
    Product Custom Data 2     : Power On