### PR TITLE
fby3.5: cl: Remove ME cold reset before PMIC reading

### DIFF
--- a/common/dev/include/pmic.h
+++ b/common/dev/include/pmic.h
@@ -30,7 +30,6 @@
 #define PMIC_ENABLE_ADC_BIT BIT(7)
 
 //PMIC PMIC setting delay msec
-#define ME_COLD_RESET_DELAY_MSEC 1000
 #define PMIC_COMMAND_DELAY_MSEC 250
 
 //Send PMIC memory write read parameter

--- a/meta-facebook/yv35-cl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.c
@@ -149,21 +149,9 @@ bool pre_pmic_read(uint8_t sensor_num, void *args)
 	pmic_pre_proc_arg *pre_proc_arg =
 		sensor_config[sensor_config_index_map[sensor_num]].pre_sensor_read_args;
 	if (pre_proc_arg->pre_read_init == false) {
-		static bool is_ME_reset = false;
 		int ret = 0;
 		uint8_t seq_source = 0xFF, write_data = 0x0;
 		uint8_t *compose_memory_write_read_msg = NULL;
-
-		// ME reset to let ME regain bus setting
-		if (is_ME_reset != true) {
-			ret = pmic_ipmb_transfer(NULL, seq_source, NETFN_APP_REQ,
-						 CMD_APP_COLD_RESET, SELF, ME_IPMB, 0x0, NULL);
-			if (ret != 0) {
-				goto PMIC_IPMB_TRANSFER_ERR;
-			}
-			is_ME_reset = true;
-			k_msleep(ME_COLD_RESET_DELAY_MSEC);
-		}
 
 		// Enable PMIC ADC
 		write_data = PMIC_ENABLE_ADC_BIT;


### PR DESCRIPTION
Summary:
- Remove ME cold reset before PMIC reading
  Before reading PMIC sensors, BIC does ME cold reset.
  This causes there is "Call Trace" error message in the host dmesg after doing 12V-cycle.
  After discussing with Intel, the MC cold reset is unnecessary before reading PMIC sensors.

Test Plan:
1. Check if there is any "call trace" error in host dmesg after doing 12V-cycle - pass
2. Check PMIC sensors after stressing host - pass

Log:
root@bmc-oob:~# power-util slot1 12V-cycle
12V Power cycling fru 1...
[root@system7_slot1 ~]# dmesg |grep Call
[root@system7_slot1 ~]#
root@bmc-oob:~# sensor-util slot1|grep PMIC
DIMMA PMIC_Pout              (0x1E) :    0.00 Watts | (ok)
DIMMC PMIC_Pout              (0x1F) :    0.00 Watts | (ok)
DIMMD PMIC_Pout              (0x36) :    0.00 Watts | (ok)
DIMME PMIC_Pout              (0x37) :    0.00 Watts | (ok)
DIMMG PMIC_Pout              (0x42) :    0.00 Watts | (ok)
DIMMH PMIC_Pout              (0x47) :    0.00 Watts | (ok)

[root@system7_slot1 ~]# cd /home/tools
[root@system7_slot1 tools]# stressapptest -s 99999&
[1] 1925
2022/06/17-08:39:54(CST) Log: Commandline - stressapptest -s 99999
2022/06/17-08:39:54(CST) Stats: SAT revision 1.0.9_autoconf, 64 bit binary
2022/06/17-08:39:54(CST) Log: root @ localhost.localdomain on Thu May 13 02:05:45 CST 2021 from open source release
2022/06/17-08:39:54(CST) Log: 1 nodes, 60 cpus.
2022/06/17-08:39:54(CST) Log: Defaulting to 60 copy threads
2022/06/17-08:39:54(CST) Log: Total 96007 MB. Free 95069 MB. Hugepages 0 MB. Targeting 91015 MB (94%)
2022/06/17-08:39:54(CST) Log: Prefer plain malloc memory allocation.
2022/06/17-08:39:54(CST) Log: Using mmap() allocation at 0x7f9c77900000.
2022/06/17-08:39:54(CST) Stats: Starting SAT, 91015M, 99999 seconds
[root@system7_slot1 tools]# 2022/06/17-08:40:01(CST) Log: region number 8 exceeds region count 8
2022/06/17-08:40:02(CST) Log: Region mask: 0xff
2022/06/17-08:40:12(CST) Log: Seconds remaining: 99989
root@bmc-oob:~# sensor-util slot1|grep PMIC
DIMMA PMIC_Pout              (0x1E) :    0.88 Watts | (ok)
DIMMC PMIC_Pout              (0x1F) :    0.75 Watts | (ok)
DIMMD PMIC_Pout              (0x36) :    0.75 Watts | (ok)
DIMME PMIC_Pout              (0x37) :    0.75 Watts | (ok)
DIMMG PMIC_Pout              (0x42) :    0.75 Watts | (ok)
DIMMH PMIC_Pout              (0x47) :    0.75 Watts | (ok)