### PR TITLE
fby3.5: common:Fix mapping wrong issue in drive init function

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -372,7 +372,7 @@ void add_sensor_config(sensor_cfg config)
 static inline bool init_drive_type(sensor_cfg *p, uint16_t current_drive)
 {
 	int ret = -1;
-	if (p->type == sensor_drive_tbl[current_drive].dev) {
+	if (p->type != sensor_drive_tbl[current_drive].dev) {
 		return false;
 	}
 


### PR DESCRIPTION
Summary:
- Fix mapping wrong init function causing BIC crash in drive init function

Test Plan:
- Build code: Pass
- Check BIC can workable: Pass
- Check BIC can get sensor reading successfully: Pass

Log:
Before fixing

[BIC console]

Hello, welcome to yv35 craterlake 2022.22.1
BIC class type(class-1), 1ou present status(0), 2ou present status(0), board revision(0x3)
[init_drive_type] sensor_num 0x1
<error> ADC init args not provide!
sensor num 1 initial fail, ret 1
[init_drive_type] sensor_num 0x3
<error> ADC init args not provide!
sensor num 3 initial fail, ret 1
[init_drive_type] sensor 0x14 post sensor read failed!

[init_drive_type] sensor 0x30 post sensor read failed!
[init_drive_type] sensor 0x39 post sensor read failed!
ipmi_init
[set_DC_status] gpio number(15) status(1)
[set_post_status] gpio number(1) status(1)
uart:~$ [get_sensor_reading]sensor number 0x14 reading and post_read fail
[00:00:00.517,000] <inf> usb_cdc_acm: Device resumed
[00:00:00.517,000] <inf> usb_cdc_acm: from suspend
[00:00:00.834,000] <inf> usb_cdc_acm: Device configured
00:00.[00:00:00.517,000] <inf> usb_cdc_acm: from suspend
[00:00:00.834,000] <inf> usb_cdc_acm: Device configured
[00:00:01.553,000] <err> os: ***** MPU FAULT *****
[00:00:01.553,000] <err> os: ***** MPU FAULT *****
[00:00:01.553,000] <err> os:   Instruction Access Violation
[00:00:01.553,000] <err> os:   Instruction Access Violation
[00:00:01.553,000] <err> os: r0/a1:  0xbeef1030  r1/a2:  0x40031a1c  r2/a3:  0x0006c152
[00:00:01.553,000] <err> os: r0/a1:  0xbeef1030  r1/a2:  0x40031a1c  r2/a3:  0x0006c152
[00:00:01.553,000] <err> os: r3/a4:  0xbeef1030 r12/ip:  0xa0000000 r14/lr:  0x00012acf
[00:00:01.553,000] <err> os: r3/a4:  0xbeef1030 r12/ip:  0xa0000000 r14/lr:  0x00012acf
[00:00:01.553,000] <err> os:  xpsr:  0x00000018
[00:00:01.553,000] <err> os:  xpsr:  0x00000018
[00:00:01.553,000] <err> os: Faulting instruction address (r15/pc): 0xbeef1030
[00:00:01.553,000] <err> os: Faulting instruction address (r15/pc): 0xbeef1030
[00:00:01.553,000] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
[00:00:01.553,000] <err> os: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
[00:00:01.553,000] <err> os: Fault during interrupt handling
[00:00:01.553,000] <err> os: Current thread: 0x4f750 (shell_uart)
[00:00:01.553,000] <err> os: Current thread: 0x4f750 (shell_uart)
[00:00:01.554,000] <err> os: Halting system
[00:00:01.554,000] <err> os: Halting system

After fixing

[BIC console]

Hello, welcome to yv35 craterlake 2022.22.1
BIC class type(class-1), 1ou present status(0), 2ou present status(0), board revision(0x3)
[00:00:00.001,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint
[00:00:00.056,000] <inf> kcs_aspeed: KCS3: addr=0xca2, idr=0x2c, odAdded ADM1278 sensor configuration
Replace the sensor[0x02] configuration
Replace the sensor[0x0e] configuration
[00:00:00.437,000] <inf> usb_cdc_acm: from suspend
[00:00:00.739,000] <inf> usb_cdc_acm: Device configured
[00:00:00.437,000] <inf> usb_cdc_acm: Device resumed
[00:00:00.437,000] <inf> usb_cdc_acm: from suspend
[00:00:00.739,000] <inf> usb_cdc_acm: Device configured
uart:~$ BIC Ready

uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x1 ] Unsupported name                   : tmp75 | access[O] | vr                   | 27
[0x2 ] Unsupported name                   :       | access[O] | vr                   | 45023265
[0x3 ] Unsupported name                   : tmp75 | access[O] | vr                   | 28
[0xd ] Unsupported name                   : nvme  | access[O] | vr                   | 30
[0x5 ] Unsupported name                   : peci  | access[O] | vr                   | 27
[0x14] Unsupported name                   : peci  | access[O] | vr                   | 73
[0x15] Unsupported name                   : peci  | access[O] | vr                   | 100
[0x6 ] Unsupported name                   : peci  | access[O] | vr                   | 31
[0x7 ] Unsupported name                   : peci  | access[O] | vr                   | 30
[0x9 ] Unsupported name                   : peci  | access[O] | vr                   | 29
[0xa ] Unsupported name                   : peci  | access[O] | vr                   | 30
[0xb ] Unsupported name                   : peci  | access[O] | vr                   | 29
[0xc ] Unsupported name                   : peci  | access[O] | vr                   | 28
[0x38] Unsupported name                   : peci  | access[O] | vr                   | 40960054
[0x20] Unsupported name                   : adc   | access[O] | vr                   | 34865164
[0x22] Unsupported name                   : adc   | access[O] | vr                   | 20578307
[0x24] Unsupported name                   : adc   | access[O] | vr                   | 3080193
[0x21] Unsupported name                   : adc   | access[O] | vr                   | 6881283
[0x25] Unsupported name                   : adc   | access[O] | vr                   | 1507333
[0x26] Unsupported name                   : adc   | access[O] | vr                   | 41418764
[0x27] Unsupported name                   : adc   | access[O] | vr                   | 13172737
[0x28] Unsupported name                   : adc   | access[O] | vr                   | 19922947
[0x23] Unsupported name                   : adc   | access[O] | vr                   | 52690945
[0x2e] Unsupported name                   : vr    | access[O] | vr                   | 9371649
[0x2f] Unsupported name                   : vr    | access[O] | vr                   | 3407873
[0x2d] Unsupported name                   : vr    | access[O] | vr                   | 52428801
[0x2a] Unsupported name                   : vr    | access[O] | vr                   | 50921473
[0x2c] Unsupported name                   : vr    | access[O] | vr                   | 53608449
[0x34] Unsupported name                   : vr    | access[O] | vr                   | 52428802
[0x35] Unsupported name                   : vr    | access[O] | vr                   | 26214407
[0x33] Unsupported name                   : vr    | access[O] | vr                   | 52428800
[0x31] Unsupported name                   : vr    | access[O] | vr                   | 13107213
[0x32] Unsupported name                   : vr    | access[O] | vr                   | 32768003
[0x12] Unsupported name                   : vr    | access[O] | vr                   | 34
[0x13] Unsupported name                   : vr    | access[O] | vr                   | 36
[0x11] Unsupported name                   : vr    | access[O] | vr                   | 34
[0xf ] Unsupported name                   : vr    | access[O] | vr                   | 41
[0x10] Unsupported name                   : vr    | access[O] | vr                   | 38
[0x3e] Unsupported name                   : vr    | access[O] | vr                   | 2
[0x3f] Unsupported name                   : vr    | access[O] | vr                   | 8
[0x3d] Unsupported name                   : vr    | access[O] | vr                   | 1
[0x3a] Unsupported name                   : vr    | access[O] | vr                   | 46
[0x3c] Unsupported name                   : vr    | access[O] | vr                   | 7
[0x4 ] Unsupported name                   : pch   | access[O] | vr                   | 38
[0x1e] Unsupported name                   :  | access[O] | vr                   | 49152000
[0x1f] Unsupported name                   :  | access[O] | vr                   | 32768000
[0x36] Unsupported name                   :  | access[O] | vr                   | 32768000
[0x37] Unsupported name                   :  | access[O] | vr                   | 40960000
[0x42] Unsupported name                   :  | access[O] | vr                   | 32768000
[0x47] Unsupported name                   :  | access[O] | vr                   | 32768000
[0xe ] Unsupported name                   :       | access[O] | vr                   | 45023263
[0x29] Unsupported name                   : hsc   | access[O] | vr                   | 35127308
[0x30] Unsupported name                   : hsc   | access[O] | vr                   | 29097990
[0x39] Unsupported name                   : hsc   | access[O] | vr                   | 19857481
---------------------------------------------------------------------------------