### PR TITLE
fby3.5: cl: Version commit for oby35-cl-2022.25.01

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_version.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_version.h
@@ -5,8 +5,8 @@
 #define PROJECT_NAME "craterlake"
 #define DEVICE_ID 0x00
 #define DEVICE_REVISION 0x80
-#define FIRMWARE_REVISION_1 0x11
-#define FIRMWARE_REVISION_2 0x13
+#define FIRMWARE_REVISION_1 0x21
+#define FIRMWARE_REVISION_2 0x01
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
 #define PRODUCT_ID 0x0000
@@ -14,7 +14,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x22
+#define BIC_FW_WEEK 0x25
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x63 // char: c
 #define BIC_FW_platform_1 0x6c // char: l


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Craterlake BIC oby35-cl-2022.25.01.

Test Plan:
- Build code: Pass
- Check BIC version is changed: Pass

Log:
root@bmc-oob:~# fw-util slot1 --version bic
SB Bridge-IC Version: oby35-cl-v2022.25.01