### PR TITLE
fby3.5: rf: Version commit for oby35-rf-2022.25.01

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_version.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_version.h
@@ -8,7 +8,7 @@
 // BIT 0:3  1: CraterLake 2: Baseboard 3: Rainbow falls
 // BIT 4:7  0: POC 1: EVT 2: DVT
 #define FIRMWARE_REVISION_1 0x03
-#define FIRMWARE_REVISION_2 0x01
+#define FIRMWARE_REVISION_2 0x02
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
 #define PRODUCT_ID 0x0000
@@ -16,7 +16,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x22
+#define BIC_FW_WEEK 0x25
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x72 // char: r
 #define BIC_FW_platform_1 0x66 // char: f


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Rainbow falls BIC oby35-rf-2022.25.01.

Test Plan:
- Build code: Pass
- Check BIC version is changed: Pass

Log:
root@bmc-oob:~# fw-util slot3 --version 1ou_bic
1OU Bridge-IC Version: oby35-rf-v2022.25.01