### PR TITLE
fby3.5: cl: Switch pages before querying PMBUS_IC_DEVICE_ID

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -305,6 +305,18 @@ void check_vr_type(uint8_t index)
 	uint8_t retry = 5;
 	I2C_MSG msg;
 
+	isl69259_pre_proc_arg *args = sensor_config[index].pre_sensor_read_args;
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = sensor_config[index].port;
+	msg.target_addr = sensor_config[index].target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = 0x00;
+	msg.data[1] = args->vr_page;
+	if (i2c_master_write(&msg, retry)) {
+		printf("Failed to switch to VR page %d\n", args->vr_page);
+		return;
+	}
+
 	/* Get IC Device ID from VR chip
 	 * - Command code: 0xAD
 	 * - The response data 


### PR DESCRIPTION
Summary:
We're querying the voltage regulators for their IC_DEVICE_ID, but we're
not selecting the page of the PMBUS device beforehand. This can
manifest in weird behavior, but ultimately it would be a "Unknown VR
type".

Test Plan:
In QEMU I verified that with this fix, and a fix in QEMU's pmbus, that the VR ID is read successfully for every VR.

I used the following experimental QEMU branch:

https://github.com/peterdelevoryas/qemu/tree/i2c

And this is the output I get before the fix:

```
$ ./build/qemu-system-arm -machine ast1030-evb -kernel Y35BCL.elf -nographic -device fby35-cpld,bus=aspeed.i2c.bus.0,address=0x21 -device isl69259,bus=aspeed.i2c.bus.4,address=0x76
 -device isl69259,bus=aspeed.i2c.bus.4,address=0x62 -device isl69259,bus=aspeed.i2c.bus.4,address=0x60
[00:00:00.010,000] <inf> usb_dc_aspeed: select ep[0x81] as IN endpoint
[00:00:00.010,000] <inf> usb_dc_aspeed: select ep[0x82] as IN endpoint
[00:00:00.010,000] <wrn> usb_dc_aspeed: pre-selected ep[0x1] as IN endpoint
[00:00:00.010,000] <wrn> usb_dc_aspeed: pre-selected ep[0x2] as IN endpoint
[00:00:00.010,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint
*** Booting Zephyr OS build v00.01.05  ***
Hello, welcome to yv35 craterlake 2022.25.1
BIC class type(class-1), 1ou present status(0), 2ou present status(0), board revision(0x1)
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
Unknown VR type
I2C 1 master write retry reach max
[init_drive_type] sensor 0xd pre sensor read failed!
sensor 3, type = 5 is not supported!
[init_drive_type] sensor 0x14 post sensor read failed!
I2C 1 master write retry reach max
<error> ADM1278 initial failed while i2c writing
sensor num 14 initial fail, ret 1
I2C 1 master write retry reach max
<error> ADM1278 initial failed while i2c writing
sensor num 41 initial fail, ret 1
```

And after the fix (no Unknown VR type logs):

```
$ ./build/qemu-system-arm -machine ast1030-evb -kernel Y35BCL.elf -nographic -device fby35-cpld,bus=aspeed.i2c.bus.0,address=0x21 -device isl69259,bus=aspeed.i2c.bus.4,address=0x76
 -device isl69259,bus=aspeed.i2c.bus.4,address=0x62 -device isl69259,bus=aspeed.i2c.bus.4,address=0x60
[00:00:00.006,000] <inf> usb_dc_aspeed: select ep[0x81] as IN endpoint
[00:00:00.007,000] <inf> usb_dc_aspeed: select ep[0x82] as IN endpoint
[00:00:00.007,000] <wrn> usb_dc_aspeed: pre-selected ep[0x1] as IN endpoint
[00:00:00.007,000] <wrn> usb_dc_aspeed: pre-selected ep[0x2] as IN endpoint
[00:00:00.007,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint
*** Booting Zephyr OS build v00.01.05  ***
Hello, welcome to yv35 craterlake 2022.25.1
BIC class type(class-1), 1ou present status(0), 2ou present status(0), board revision(0x1)
I2C 1 master write retry reach max
[init_drive_type] sensor 0xd pre sensor read failed!
sensor 3, type = 5 is not supported!
[init_drive_type] sensor 0x14 post sensor read failed!
I2C 1 master write retry reach max
<error> ADM1278 initial failed while i2c writing
sensor num 14 initial fail, ret 1
I2C 1 master write retry reach max
<error> ADM1278 initial failed while i2c writing
sensor num 41 initial fail, ret 1
I2C 1 master write retry reach max
<error> ADM1278 initial failed while i2c writing
sensor num 48 initial fail, ret 1
[init_drive_type] sensor 0x30 post sensor read failed!
I2C 1 master write retry reach max
<error> ADM1278 initial failed while i2c writing
sensor num 57 initial fail, ret 1
[init_drive_type] sensor 0x39 post sensor read failed!
ipmi_init
[set_DC_status] gpio number(15) status(0)
[set_post_status] gpio number(1) status(1)
```