### PR TITLE
Common: Revise the IANA ID define

### DIFF
--- a/common/service/ipmi/include/ipmi.h
+++ b/common/service/ipmi/include/ipmi.h
@@ -7,7 +7,9 @@
 
 #define IPMI_THREAD_STACK_SIZE 4096
 #define IPMI_BUF_LEN 10
+#ifndef IANA_ID
 #define IANA_ID 0x00A015 // Meta's IANA
+#endif
 #define DEBUG_IPMI 0
 
 extern uint8_t IPMB_inf_index_map[];


### PR DESCRIPTION
Summary:
- Check if IANA ID is defined because some platform use other ID.

Test plans:
1. Yv35 cl build code :pass
2. Get fw version
root@bmc-oob:~# bic-util slot1 0xe0 0xb 0x15 0xa0 0x0 0x2
15 A0 00 20 22 25 01 63 6C 00