### PR TITLE
GT: Modify get pex function

### DIFF
--- a/meta-facebook/gt-cc/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/gt-cc/src/ipmi/plat_ipmi.c
@@ -379,10 +379,14 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 		sensor_cfg *cfg = &sensor_config[sensor_config_index_map[pex_sensor_num]];
 		pex89000_unit *p = (pex89000_unit *)cfg->priv_data;
 
-		if (k_mutex_lock(&i2c_bus10_mutex, K_MSEC(300))) {
-			printf("[%s]mutex lock fail on PEX bus\n", __func__);
-			msg->completion_code = CC_UNSPECIFIED_ERROR;
-			return;
+		if (cfg->pre_sensor_read_hook) {
+			if (cfg->pre_sensor_read_hook(cfg->num, cfg->pre_sensor_read_args) ==
+			    false) {
+				printf("[%s] pex%d pre-read failed!\n", __func__,
+				       component - GT_COMPNT_PEX0);
+				msg->completion_code = CC_UNSPECIFIED_ERROR;
+				return;
+			}
 		}
 
 		if (pex_access_engine(cfg->port, cfg->target_addr, p->idx, pex_access_flash_ver,
@@ -393,8 +397,13 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 			return;
 		}
 
-		if (k_mutex_unlock(&i2c_bus10_mutex))
-			printf("[%s]mutex unlock fail on PEX bus\n", __func__);
+		if (cfg->post_sensor_read_hook) {
+			if (cfg->post_sensor_read_hook(cfg->num, cfg->post_sensor_read_args,
+						       NULL) == false) {
+				printf("[%s] pex%d post-read failed!\n", __func__,
+				       component - GT_COMPNT_PEX0);
+			}
+		}
 
 		memcpy(&msg->data[2], &reading, sizeof(reading));
 

--- a/meta-facebook/gt-cc/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/gt-cc/src/ipmi/plat_ipmi.c
@@ -38,6 +38,7 @@ struct bridge_compnt_info_s {
 };
 
 extern struct k_mutex i2c_bus6_mutex;
+extern struct k_mutex i2c_bus10_mutex;
 struct bridge_compnt_info_s bridge_compnt_info[] = {
 	[0] = { .compnt_id = GT_COMPNT_VR0,
 		.i2c_bus = I2C_BUS6,
@@ -364,7 +365,7 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 	case GT_COMPNT_PEX2:
 	case GT_COMPNT_PEX3: {
 		/* Only can be read when DC is on */
-		if (!get_DC_status()) {
+		if (is_mb_dc_on() == false) {
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 			return;
 		}
@@ -378,11 +379,23 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 		sensor_cfg *cfg = &sensor_config[sensor_config_index_map[pex_sensor_num]];
 		pex89000_unit *p = (pex89000_unit *)cfg->priv_data;
 
-		if (pex_access_engine(cfg->port, cfg->target_addr, p->idx, pex_access_flash_ver,
-				      &reading)) {
+		if (k_mutex_lock(&i2c_bus10_mutex, K_MSEC(300))) {
+			printf("[%s]mutex lock fail on PEX bus\n", __func__);
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 			return;
 		}
+
+		if (pex_access_engine(cfg->port, cfg->target_addr, p->idx, pex_access_flash_ver,
+				      &reading)) {
+			if (k_mutex_unlock(&i2c_bus10_mutex))
+				printf("[%s]mutex unlock fail on PEX bus\n", __func__);
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+			return;
+		}
+
+		if (k_mutex_unlock(&i2c_bus10_mutex))
+			printf("[%s]mutex unlock fail on PEX bus\n", __func__);
+
 		memcpy(&msg->data[2], &reading, sizeof(reading));
 
 		msg->data[0] = component;
@@ -407,7 +420,7 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 		uint8_t buf[5] = { 0 };
 		/* Assign VR 0/1 related sensor number to get information for accessing VR */
 		uint8_t sensor_num = (component == GT_COMPNT_VR0) ? SENSOR_NUM_TEMP_PEX_1 :
-									  SENSOR_NUM_TEMP_PEX_3;
+								    SENSOR_NUM_TEMP_PEX_3;
 		if (!tca9548_select_chan(sensor_num, &mux_conf_addr_0xe0[6])) {
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 			return;
@@ -480,7 +493,7 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 	case GT_COMPNT_NIC6:
 	case GT_COMPNT_NIC7: {
 		/* Only can be read when DC is on */
-		if (!get_DC_status()) {
+		if (is_mb_dc_on() == false) {
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 			return;
 		}

--- a/meta-facebook/gt-cc/src/platform/plat_hook.c
+++ b/meta-facebook/gt-cc/src/platform/plat_hook.c
@@ -344,9 +344,8 @@ bool pre_pex89000_read(uint8_t sensor_num, void *args)
 	}
 	pex89000_pre_proc_arg *pre_read_args = (pex89000_pre_proc_arg *)args;
 
-	/* Can not access i2c mux and PEX89000 when DC off, this pin will change to low active in 
-      next SWB CPLD firmware release */
-	if (!gpio_get(SYS_PWR_READY_N))
+	/* Can not access i2c mux and PEX89000 when DC off */
+	if (is_mb_dc_on() == false)
 		return false;
 
 	if (!pre_i2c_bus_read(sensor_num, pre_read_args->mux_info_p)) {
@@ -411,4 +410,18 @@ struct k_mutex *find_bus_mutex(uint8_t sensor_num)
 		return NULL;
 
 	return mutex;
+}
+
+bool is_mb_dc_on()
+{
+	/* SYS_PWR_READY_N is low active,
+   * 0 -> power on
+   * 1 -> power off
+   */
+	return !gpio_get(SYS_PWR_READY_N);
+}
+
+bool is_dc_access(uint8_t sensor_num)
+{
+	return is_mb_dc_on();
 }

--- a/meta-facebook/gt-cc/src/platform/plat_hook.c
+++ b/meta-facebook/gt-cc/src/platform/plat_hook.c
@@ -365,7 +365,7 @@ bool pre_i2c_bus_read(uint8_t sensor_num, void *args)
 	if (!mutex)
 		return false;
 
-	if (k_mutex_lock(mutex, K_MSEC(10))) {
+	if (k_mutex_lock(mutex, K_MSEC(300))) {
 		printf("[%s] sensor number 0x%x mutex lock fail\n", __func__, sensor_num);
 		return false;
 	}

--- a/meta-facebook/gt-cc/src/platform/plat_hook.h
+++ b/meta-facebook/gt-cc/src/platform/plat_hook.h
@@ -39,4 +39,6 @@ bool pre_i2c_bus_read(uint8_t sensor_num, void *args);
 bool post_i2c_bus_read(uint8_t sensor_num, void *args, int *reading);
 
 struct k_mutex *find_bus_mutex(uint8_t sensor_num);
+bool is_mb_dc_on();
+bool is_dc_access(uint8_t sensor_num);
 #endif

--- a/meta-facebook/gt-cc/src/platform/plat_isr.c
+++ b/meta-facebook/gt-cc/src/platform/plat_isr.c
@@ -12,7 +12,7 @@
 #include "pex89000.h"
 #include "pldm.h"
 #include "plat_mctp.h"
-
+#include "plat_hook.h"
 void dc_on_init_component()
 {
 	uint8_t pex_sensor_num_table[PEX_MAX_NUMBER] = { SENSOR_NUM_BB_TEMP_PEX_0,
@@ -62,11 +62,7 @@ K_WORK_DELAYABLE_DEFINE(set_DC_on_5s_work, dc_on_init_component);
 
 void ISR_DC_ON()
 {
-	set_DC_status(SYS_PWR_READY_N);
-	set_DC_on_delayed_status();
-	/* Check whether DC on to send work to initial PEX, 
-    	 * this pin will be change in next CPLD firmware release 
-	 */
-	if (get_DC_status())
+	/* Check whether DC on to send work to initial PEX */
+	if (is_mb_dc_on())
 		k_work_schedule(&set_DC_on_5s_work, K_SECONDS(DC_ON_5_SECOND));
 }

--- a/meta-facebook/gt-cc/src/platform/plat_mctp.c
+++ b/meta-facebook/gt-cc/src/platform/plat_mctp.c
@@ -14,7 +14,8 @@
 #include "pldm.h"
 #include "ipmi.h"
 #include "plat_mctp.h"
-#include "power_status.h"
+#include "sensor.h"
+#include "plat_hook.h"
 
 LOG_MODULE_REGISTER(plat_mctp);
 
@@ -306,6 +307,6 @@ void plat_mctp_init(void)
 	}
 
 	/* Only send command to device when DC on */
-	if (get_DC_status())
+	if (is_mb_dc_on())
 		k_timer_start(&send_cmd_timer, K_MSEC(3000), K_NO_WAIT);
 }

--- a/meta-facebook/gt-cc/src/platform/plat_sensor_table.c
+++ b/meta-facebook/gt-cc/src/platform/plat_sensor_table.c
@@ -304,16 +304,16 @@ sensor_cfg plat_sensor_config[] = {
 	  &pex_p1v8_sensor_init_args[0] },
 
 	{ SENSOR_NUM_BB_TEMP_PEX_0, sensor_dev_pex89000, I2C_BUS10, PEX_SWITCH_I2C_ADDR, PEX_TEMP,
-	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, pre_pex89000_read,
+	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, pre_pex89000_read,
 	  &pex89000_pre_read_args[0], post_i2c_bus_read, NULL, &pex_sensor_init_args[0] },
 	{ SENSOR_NUM_BB_TEMP_PEX_1, sensor_dev_pex89000, I2C_BUS10, PEX_SWITCH_I2C_ADDR, PEX_TEMP,
-	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, pre_pex89000_read,
+	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, pre_pex89000_read,
 	  &pex89000_pre_read_args[1], post_i2c_bus_read, NULL, &pex_sensor_init_args[1] },
 	{ SENSOR_NUM_BB_TEMP_PEX_2, sensor_dev_pex89000, I2C_BUS10, PEX_SWITCH_I2C_ADDR, PEX_TEMP,
-	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, pre_pex89000_read,
+	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, pre_pex89000_read,
 	  &pex89000_pre_read_args[2], post_i2c_bus_read, NULL, &pex_sensor_init_args[2] },
 	{ SENSOR_NUM_BB_TEMP_PEX_3, sensor_dev_pex89000, I2C_BUS10, PEX_SWITCH_I2C_ADDR, PEX_TEMP,
-	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, pre_pex89000_read,
+	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, pre_pex89000_read,
 	  &pex89000_pre_read_args[3], post_i2c_bus_read, NULL, &pex_sensor_init_args[3] },
 
 	/* SYSTEM INLET TEMP */


### PR DESCRIPTION
Summary:
- Call pre_sensor_read_hook function before access pex to get version then call post_sensor_read_hook function.
- Increase mutex lock wait time use in pre_i2c_bus_read.

Dependency: #365 

Test plan:
- Build code: Pass