### PR TITLE
Refactored GUID Code to Remove Dependencies

### DIFF
--- a/common/dev/guid.c
+++ b/common/dev/guid.c
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <zephyr.h>
 #include "guid.h"
-#include "plat_guid.h"
 
 // size of 1 to satisfy compiler warning
 __weak const EEPROM_CFG guid_config[1] = {};
@@ -13,7 +13,7 @@ uint8_t GUID_read(EEPROM_ENTRY *entry)
 		return GUID_FAIL_TO_ACCESS;
 	}
 
-	if (entry->config.dev_id >= MAX_GUID_ID) {
+	if (entry->config.dev_id >= ARRAY_SIZE(guid_config)) {
 		printf("GUID read device ID %x not exist\n", entry->config.dev_id);
 		return GUID_INVALID_ID;
 	}
@@ -22,10 +22,6 @@ uint8_t GUID_read(EEPROM_ENTRY *entry)
 	    (GUID_START + GUID_SIZE)) { // Check data write out of range
 		printf("GUID read out of range, type: %x, ID: %x\n", entry->config.dev_type,
 		       entry->config.dev_id);
-		return GUID_OUT_OF_RANGE;
-	}
-
-	if (entry->config.dev_id >= (sizeof(guid_config) / sizeof(EEPROM_CFG))) {
 		return GUID_OUT_OF_RANGE;
 	}
 
@@ -44,7 +40,7 @@ uint8_t GUID_write(EEPROM_ENTRY *entry)
 		return GUID_FAIL_TO_ACCESS;
 	}
 
-	if (entry->config.dev_id >= MAX_GUID_ID) {
+	if (entry->config.dev_id >= ARRAY_SIZE(guid_config)) {
 		printf("GUID write device ID %x not exist\n", entry->config.dev_id);
 		return GUID_INVALID_ID;
 	}
@@ -56,10 +52,6 @@ uint8_t GUID_write(EEPROM_ENTRY *entry)
 		return GUID_OUT_OF_RANGE;
 	}
 
-	if (entry->config.dev_id >= (sizeof(guid_config) / sizeof(EEPROM_CFG))) {
-		return GUID_OUT_OF_RANGE;
-	}
-
 	memcpy(&entry->config, &guid_config[entry->config.dev_id], sizeof(EEPROM_CFG));
 
 	if (!eeprom_write(entry)) {
@@ -67,4 +59,14 @@ uint8_t GUID_write(EEPROM_ENTRY *entry)
 	}
 
 	return GUID_WRITE_SUCCESS;
+}
+
+__weak uint8_t get_system_guid(uint16_t *data_len, uint8_t *data)
+{
+	return GUID_FAIL_TO_ACCESS;
+}
+
+__weak uint8_t set_system_guid(uint16_t *data_len, uint8_t *data)
+{
+	return GUID_FAIL_TO_ACCESS;
 }

--- a/common/dev/include/guid.h
+++ b/common/dev/include/guid.h
@@ -19,4 +19,7 @@ enum {
 uint8_t GUID_read(EEPROM_ENTRY *entry);
 uint8_t GUID_write(EEPROM_ENTRY *entry);
 
+uint8_t get_system_guid(uint16_t *data_len, uint8_t *data);
+uint8_t set_system_guid(uint16_t *data_len, uint8_t *data);
+
 #endif

--- a/common/service/ipmi/app_handler.c
+++ b/common/service/ipmi/app_handler.c
@@ -5,7 +5,6 @@
 #include "guid.h"
 #include "plat_i2c.h"
 #include "plat_ipmi.h"
-#include "plat_guid.h"
 #include "util_sys.h"
 
 __weak void APP_GET_DEVICE_ID(ipmi_msg *msg)
@@ -122,30 +121,20 @@ __weak void APP_GET_SELFTEST_RESULTS(ipmi_msg *msg)
 	return;
 }
 
-#ifdef CONFIG_ESPI
 __weak void APP_GET_SYSTEM_GUID(ipmi_msg *msg)
 {
 	if (msg == NULL) {
 		return;
 	}
 
-	uint8_t status;
-	EEPROM_ENTRY guid_entry;
-
 	if (msg->data_len != 0) {
 		msg->completion_code = CC_INVALID_LENGTH;
 		return;
 	}
 
-	guid_entry.offset = 0;
-	guid_entry.data_len = 16;
-	guid_entry.config.dev_id = MB_SYS_GUID_ID;
-	status = GUID_read(&guid_entry);
-
+	uint8_t status = get_system_guid(&msg->data_len, &msg->data[0]);
 	switch (status) {
 	case GUID_READ_SUCCESS:
-		msg->data_len = guid_entry.data_len;
-		memcpy(&msg->data[0], &guid_entry.data, guid_entry.data_len);
 		msg->completion_code = CC_SUCCESS;
 		break;
 	case GUID_INVALID_ID:
@@ -164,7 +153,6 @@ __weak void APP_GET_SYSTEM_GUID(ipmi_msg *msg)
 
 	return;
 }
-#endif
 
 __weak void APP_MASTER_WRITE_READ(ipmi_msg *msg)
 {

--- a/common/service/ipmi/oem_handler.c
+++ b/common/service/ipmi/oem_handler.c
@@ -3,7 +3,6 @@
 #include "sensor.h"
 #include "plat_sensor_table.h"
 #include "guid.h"
-#include "plat_guid.h"
 #ifdef ENABLE_FAN
 #include "plat_fan.h"
 #endif
@@ -65,6 +64,7 @@ __weak void OEM_NM_SENSOR_READ(ipmi_msg *msg)
 	}
 	return;
 }
+#endif
 
 __weak void OEM_SET_SYSTEM_GUID(ipmi_msg *msg)
 {
@@ -77,14 +77,7 @@ __weak void OEM_SET_SYSTEM_GUID(ipmi_msg *msg)
 		return;
 	}
 
-	uint8_t status;
-	EEPROM_ENTRY guid_entry;
-
-	guid_entry.offset = 0;
-	guid_entry.data_len = msg->data_len;
-	guid_entry.config.dev_id = MB_SYS_GUID_ID;
-	memcpy(&guid_entry.data[0], &msg->data, guid_entry.data_len);
-	status = GUID_write(&guid_entry);
+	uint8_t status = set_system_guid(&msg->data_len, &msg->data[0]);
 
 	switch (status) {
 	case GUID_WRITE_SUCCESS:
@@ -107,7 +100,6 @@ __weak void OEM_SET_SYSTEM_GUID(ipmi_msg *msg)
 	msg->data_len = 0;
 	return;
 }
-#endif
 
 #ifdef ENABLE_FAN
 __weak void OEM_SET_FAN_DUTY_MANUAL(ipmi_msg *msg)

--- a/common/service/sensor/sdr.h
+++ b/common/service/sensor/sdr.h
@@ -446,8 +446,8 @@ extern const int negative_ten_power[16];
 static inline uint8_t round_add(uint8_t sensor_num, int val)
 {
 	return (SDR_R(sensor_num) > 0) ?
-		       (((negative_ten_power[((SDR_R(sensor_num) + 1) & 0xF)] * val) % 10) > 5 ?
-				1 :
+			     (((negative_ten_power[((SDR_R(sensor_num) + 1) & 0xF)] * val) % 10) > 5 ?
+				      1 :
 				      0) :
 			     0;
 }

--- a/meta-facebook/gt-cc/src/platform/plat_guid.c
+++ b/meta-facebook/gt-cc/src/platform/plat_guid.c
@@ -1,4 +1,0 @@
-#include <stdio.h>
-#include "guid.h"
-#include "plat_guid.h"
-#include "fru.h"

--- a/meta-facebook/gt-cc/src/platform/plat_guid.h
+++ b/meta-facebook/gt-cc/src/platform/plat_guid.h
@@ -1,9 +1,0 @@
-#ifndef PLAT_GUID_H
-#define PLAT_GUID_H
-
-/* For build guid.c in common code */
-enum {
-	MAX_GUID_ID,
-};
-
-#endif

--- a/meta-facebook/wc-mb/src/platform/plat_fru.h
+++ b/meta-facebook/wc-mb/src/platform/plat_fru.h
@@ -1,10 +1,11 @@
 #ifndef PLAT_FRU_H
 #define PLAT_FRU_H
 
-enum { MB_FRU_ID,
-       IOM_FRU_ID,
-       // OTHER_FRU_ID,
-       MAX_FRU_ID,
+enum {
+	MB_FRU_ID,
+	IOM_FRU_ID,
+	// OTHER_FRU_ID,
+	MAX_FRU_ID,
 };
 
 #endif

--- a/meta-facebook/wc-mb/src/platform/plat_guid.h
+++ b/meta-facebook/wc-mb/src/platform/plat_guid.h
@@ -1,9 +1,10 @@
 #ifndef PLAT_GUID_H
 #define PLAT_GUID_H
 
-enum { MB_SYS_GUID_ID,
-       // OTHER_GUID_ID
-       MAX_GUID_ID,
+enum {
+	MB_SYS_GUID_ID,
+	// OTHER_GUID_ID
+	MAX_GUID_ID,
 };
 
 #endif

--- a/meta-facebook/yv3-dl/src/platform/plat_guid.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_guid.c
@@ -2,6 +2,7 @@
 #include "guid.h"
 #include "plat_guid.h"
 #include "fru.h"
+#include <string.h>
 
 #define MB_GUID_BUS 0x05
 #define MB_GUID_ADDR 0x54
@@ -17,3 +18,31 @@ const EEPROM_CFG guid_config[] = {
 		GUID_SIZE,
 	},
 };
+
+uint8_t get_system_guid(uint16_t *data_len, uint8_t *data)
+{
+	EEPROM_ENTRY guid_entry;
+
+	guid_entry.offset = 0;
+	guid_entry.data_len = 16;
+	guid_entry.config.dev_id = MB_SYS_GUID_ID;
+
+	uint8_t status = GUID_read(&guid_entry);
+	if (status == GUID_READ_SUCCESS) {
+		*data_len = guid_entry.data_len;
+		memcpy(data, &guid_entry.data, guid_entry.data_len);
+	}
+
+	return status;
+}
+
+uint8_t set_system_guid(uint16_t *data_len, uint8_t *data)
+{
+	EEPROM_ENTRY guid_entry;
+
+	guid_entry.offset = 0;
+	guid_entry.data_len = *data_len;
+	guid_entry.config.dev_id = MB_SYS_GUID_ID;
+	memcpy(&guid_entry.data[0], data, guid_entry.data_len);
+	return GUID_write(&guid_entry);
+}

--- a/meta-facebook/yv35-bb/src/platform/plat_def.h
+++ b/meta-facebook/yv35-bb/src/platform/plat_def.h
@@ -1,9 +1,10 @@
 #ifndef PLAT_DEF_H
 #define PLAT_DEF_H
 
-#define BMC_USB_PORT "CDC_ACM_0"
 #define ENABLE_FAN
+#define ENABLE_GUID
 
+#define BMC_USB_PORT "CDC_ACM_0"
 #define HSC_DEVICE_READY_DELAY_MS 2000
 
 #endif

--- a/meta-facebook/yv35-cl/src/platform/plat_def.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_def.h
@@ -2,6 +2,7 @@
 #define PLAT_DEF_H
 
 #define ENABLE_ASD
+#define ENABLE_GUID
 #define ENABLE_ISL69260
 #define ENABLE_FIX_SENSOR
 

--- a/meta-facebook/yv35-cl/src/platform/plat_guid.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_guid.c
@@ -2,6 +2,7 @@
 #include "guid.h"
 #include "plat_guid.h"
 #include "fru.h"
+#include <string.h>
 
 #define MB_GUID_PORT 0x01
 #define MB_GUID_ADDR 0x54
@@ -17,3 +18,31 @@ const EEPROM_CFG guid_config[] = {
 		GUID_SIZE,
 	},
 };
+
+uint8_t get_system_guid(uint16_t *data_len, uint8_t *data)
+{
+	EEPROM_ENTRY guid_entry;
+
+	guid_entry.offset = 0;
+	guid_entry.data_len = 16;
+	guid_entry.config.dev_id = MB_SYS_GUID_ID;
+
+	uint8_t status = GUID_read(&guid_entry);
+	if (status == GUID_READ_SUCCESS) {
+		*data_len = guid_entry.data_len;
+		memcpy(data, &guid_entry.data, guid_entry.data_len);
+	}
+
+	return status;
+}
+
+uint8_t set_system_guid(uint16_t *data_len, uint8_t *data)
+{
+	EEPROM_ENTRY guid_entry;
+
+	guid_entry.offset = 0;
+	guid_entry.data_len = *data_len;
+	guid_entry.config.dev_id = MB_SYS_GUID_ID;
+	memcpy(&guid_entry.data[0], data, guid_entry.data_len);
+	return GUID_write(&guid_entry);
+}

--- a/meta-facebook/yv35-rf/src/platform/plat_guid.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_guid.h
@@ -1,8 +1,0 @@
-#ifndef PLAT_GUID_H
-#define PLAT_GUID_H
-
-enum {
-	MAX_GUID_ID,
-};
-
-#endif

--- a/meta-facebook/yv35-wf/src/platform/plat_guid.h
+++ b/meta-facebook/yv35-wf/src/platform/plat_guid.h
@@ -1,8 +1,0 @@
-#ifndef PLAT_GUID_H
-#define PLAT_GUID_H
-
-enum {
-	MAX_GUID_ID,
-};
-
-#endif


### PR DESCRIPTION
Summary:
Because of dependencies on plat_guid we were forced to include empty
plat_guid files in platforms that didn't actually use that
functionality. Now GUID functionality can be enabled by defining
"ENABLE_GUID" instead.

Differential Revision: D37543999

