### PR TITLE
fby3.5: rf: Enable the CXL controller power LED.

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_isr.c
@@ -96,9 +96,11 @@ void ISR_DC_STATE()
 
 	// Set a access flag after DC on 5 secs
 	if (get_DC_status() == true) {
+		gpio_set(LED_CXL_POWER, GPIO_HIGH);
 		k_work_schedule(&set_DC_on_5s_work, K_SECONDS(DC_ON_5_SECOND));
 
 	} else {
+		gpio_set(LED_CXL_POWER, GPIO_LOW);
 		if (k_work_cancel_delayable(&set_DC_on_5s_work) != 0) {
 			printf("Cancel set dc off delay work fail\n");
 		}


### PR DESCRIPTION
Associate the CXL power LED with the PWRGD_CARD_PWROK(GPIOE1).

Tested:
- Applied patches in this testing:
    1. Use the IANA: 00 9C 9C
    2. Remove the unused variable in the xdpe12284c c file.
- Test plan:
    1. Rainbow Falls build platform: Pass.
    2. Check GPIO state on the BMC side. When PWRGD_CARD_PWROK(33) is
       high, the CXL power LED(66) is bright, and vice versa.
```
root@bmc-oob:~# power-util slot1 status
Power status for fru 1 : ON
root@bmc-oob:~# power-util slot1 off
Powering fru 1 to OFF state...
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x00 0x5 0xE0 0x41 0x9C 0x9c 0x00 0 33
9C 9C 00 05 39 41 00 9C 9C 00 21 00
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x00 0x5 0xE0 0x41 0x9C 0x9c 0x00 0 66
9C 9C 00 05 39 41 00 9C 9C 00 5A 00
root@bmc-oob:~# power-util slot1 on
Powering fru 1 to ON state...
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x00 0x5 0xE0 0x41 0x9C 0x9c 0x00 0 33
9C 9C 00 05 39 41 00 9C 9C 00 21 01
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x9c 0x9c 0x00 0x5 0xE0 0x41 0x9C 0x9c 0x00 0 66
9C 9C 00 05 39 41 00 9C 9C 00 5A 01
root@bmc-oob:~#
```

Signed-off-by: Scron Chang <Scron.Chang@quantatw.com>