### PR TITLE
wc: mb: Add postcode led control

### DIFF
--- a/meta-facebook/wc-mb/src/platform/plat_fru.h
+++ b/meta-facebook/wc-mb/src/platform/plat_fru.h
@@ -7,11 +7,10 @@
 #define IOM_FRU_PORT 0x07
 #define IOM_FRU_ADDR 0x50
 
-enum {
-	MB_FRU_ID,
-	IOM_FRU_ID,
-	// OTHER_FRU_ID,
-	MAX_FRU_ID,
+enum { MB_FRU_ID,
+       IOM_FRU_ID,
+       // OTHER_FRU_ID,
+       MAX_FRU_ID,
 };
 
 #endif

--- a/meta-facebook/wc-mb/src/platform/plat_guid.h
+++ b/meta-facebook/wc-mb/src/platform/plat_guid.h
@@ -1,10 +1,9 @@
 #ifndef PLAT_GUID_H
 #define PLAT_GUID_H
 
-enum {
-	MB_SYS_GUID_ID,
-	// OTHER_GUID_ID
-	MAX_GUID_ID,
+enum { MB_SYS_GUID_ID,
+       // OTHER_GUID_ID
+       MAX_GUID_ID,
 };
 
 #endif

--- a/meta-facebook/wc-mb/src/platform/plat_init.c
+++ b/meta-facebook/wc-mb/src/platform/plat_init.c
@@ -23,11 +23,44 @@ SCU_CFG scu_cfg[] = {
 	{ 0x7e6e2634, 0x0000007D },
 };
 
+/* port80 bypass signal to GPIOF(postcode led) */
+static void postcode_led_ctl()
+{
+	uint32_t val = 0;
+
+	/* LPC config - set address */
+	val = sys_read32(0x7e789090);
+	sys_write32((val & 0xFFFFFF00) | 0x80, 0x7e789090);
+
+	/* LPC config - enable snoop */
+	val = sys_read32(0x7e789080);
+	sys_write32((val & 0xFFFFFFFE) | 0x1, 0x7e789080);
+
+	/* GPIO config - set GPIOF to output */
+	val = sys_read32(0x7e780024);
+	sys_write32((val & 0xFFFF00FF) | 0xFF00, 0x7e780024);
+
+	/* GPIO config - set GPIOF source #0 */
+	val = sys_read32(0x7e780068);
+	sys_write32((val & 0xFFFFFEFF) | 0x100, 0x7e780068);
+
+	/* GPIO config - set GPIOF source #1 */
+	val = sys_read32(0x7e78006C);
+	sys_write32((val & 0xFFFFFEFF) | 0x0, 0x7e78006C);
+
+	/* Super IO config - set SIOR7_30h to 0x80 */
+	// These configs should set by BIOS
+
+	/* Super IO config - set SIOR7_38h to 0x5(GPIOF) */
+	// These configs should set by BIOS
+}
+
 void pal_pre_init()
 {
 	init_platform_config();
 	disable_PRDY_interrupt();
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
+	postcode_led_ctl();
 }
 
 void pal_post_init()

--- a/meta-facebook/wc-mb/src/platform/plat_ipmb.h
+++ b/meta-facebook/wc-mb/src/platform/plat_ipmb.h
@@ -14,10 +14,9 @@
 #define SELF_I2C_ADDRESS 0x20
 #define MAX_IPMB_IDX 3
 
-enum {
-	BMC_IPMB_IDX,
-	ME_IPMB_IDX,
-	PEER_BMC_IPMB_IDX,
+enum { BMC_IPMB_IDX,
+       ME_IPMB_IDX,
+       PEER_BMC_IPMB_IDX,
 };
 
 extern IPMB_config pal_IPMB_config_table[];


### PR DESCRIPTION
Summary:
- Control 8 postcode led(GPIOF0~GPIOF7) via bypass method, which means directly transfer signals from port80 to gpio port.

Test Plan:
- Build code: PASS
- GPIO signal change during host bring up: PASS