### PR TITLE
fby3.5: common: Support shell command "platform sensor" to show senso…

### DIFF
--- a/common/shell/shell_platform.h
+++ b/common/shell/shell_platform.h
@@ -19,6 +19,9 @@
 #define REG_GPIO_BASE 0x7e780000
 #define REG_SCU 0x7E6E2000
 
+/* According to IPMI specification Table 43, length of sensor name maximum is 16 bytes. */   
+#define MAX_SENSOR_NAME_LENGTH 17 // 16 bytes sensor name and 1 byte null character
+
 int num_of_pin_in_one_group_lst[NUM_OF_GROUP] = { 32, 32, 32, 32, 32, 16 };
 char GPIO_GROUP_NAME_LST[NUM_OF_GROUP][10] = { "GPIO0_A_D", "GPIO0_E_H", "GPIO0_I_L",
 					       "GPIO0_M_P", "GPIO0_Q_T", "GPIO0_U_V" };


### PR DESCRIPTION
…r name

Summary:
- Support shell command "platform sensor" to show sensor name.
- Modify return code to a negative value if error condition occurred.

Test Plan:
- Build code: Pass
- Check platform sensor command would show sensor name with different config: Pass

Log:

-Config A
[BIC console]
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x1 ] MB Inlet Temp            : tmp75      | access[O] | 4byte_acur_read_success   | 35
[0x2 ] MB Outlet Temp           : tmp75      | access[O] | 4byte_acur_read_success   | 58
[0x3 ] FIO Temp                 : tmp75      | access[O] | 4byte_acur_read_success   | 30
[0xd ] SSD0 Temp                : nvme       | access[O] | 4byte_acur_read_success   | 37
[0x5 ] SOC CPU Temp             : peci       | access[O] | 4byte_acur_read_success   | 59
[0x14] SOC Therm Margin         : peci       | access[O] | 4byte_acur_read_success   | 41
[0x15] CPU TjMax                : peci       | access[O] | 4byte_acur_read_success   | 100
[0x6 ] DIMMA Temp               : peci       | access[O] | 4byte_acur_read_success   | 56
[0x7 ] DIMMC Temp               : peci       | access[O] | 4byte_acur_read_success   | 55
[0x9 ] DIMMD Temp               : peci       | access[O] | 4byte_acur_read_success   | 50
[0xa ] DIMME Temp               : peci       | access[O] | 4byte_acur_read_success   | 54
[0xb ] DIMMG Temp               : peci       | access[O] | 4byte_acur_read_success   | 50
[0xc ] DIMMH Temp               : peci       | access[O] | 4byte_acur_read_success   | 45
[0x38] CPU PWR                  : peci       | access[O] | 4byte_acur_read_success   | 83
[0x20] P12V_STBY Vol            : adc        | access[O] | 4byte_acur_read_success   | 51970060
[0x22] P3V3_STBY Vol            : adc        | access[O] | 4byte_acur_read_success   | 22544387
[0x24] P1V05_PCH Vol            : adc        | access[O] | 4byte_acur_read_success   | 3735553
[0x21] P3V_BAT Vol              : adc        | access[O] | 4byte_acur_read_success   | 8257539
[0x25] P5V_STBY Vol             : adc        | access[O] | 4byte_acur_read_success   | 61407236
[0x26] P12V_DIMM Vol            : adc        | access[O] | 4byte_acur_read_success   | 38404108
[0x27] P1V2_STBY Vol            : adc        | access[O] | 4byte_acur_read_success   | 12320769
[0x28] P3V3_M2 Vol              : adc        | access[O] | 4byte_acur_read_success   | 19267587
[0x23] P1V8_STBY Vol            : adc        | access[O] | 4byte_acur_read_success   | 51707905
[0x2e] VCCD VR Vol              : isl69259   | access[O] | 4byte_acur_read_success   | 9306113
[0x2f] FAON VR Vol              : isl69259   | access[O] | 4byte_acur_read_success   | 3211265
[0x2d] EHV VR Vol               : isl69259   | access[O] | 4byte_acur_read_success   | 52428801
[0x2a] VCCIN VR Vol             : isl69259   | access[O] | 4byte_acur_read_success   | 50397185
[0x2c] FIVRA VR Vol             : isl69259   | access[O] | 4byte_acur_read_success   | 53608449
[0x34] VCCD VR Cur              : isl69259   | access[O] | 4byte_acur_read_success   | 52428802
[0x35] FAON VR Cur              : isl69259   | access[O] | 4byte_acur_read_success   | 13107209
[0x33] EHV VR Cur               : isl69259   | access[O] | 4byte_acur_read_success   | 52428800
[0x31] VCCIN VR Cur             : isl69259   | access[O] | 4byte_acur_read_success   | 13107236
[0x32] FIVRA VR Cur             : isl69259   | access[O] | 4byte_acur_read_success   | 19660803
[0x12] VCCD SPS Temp            : isl69259   | access[O] | 4byte_acur_read_success   | 52
[0x13] FAON SPS Temp            : isl69259   | access[O] | 4byte_acur_read_success   | 55
[0x11] EHV SPS Temp             : isl69259   | access[O] | 4byte_acur_read_success   | 51
[0xf ] VCCIN SPS Temp           : isl69259   | access[O] | 4byte_acur_read_success   | 68
[0x10] FIVRA SPS Temp           : isl69259   | access[O] | 4byte_acur_read_success   | 64
[0x3e] VCCD VR Pout             : isl69259   | access[O] | 4byte_acur_read_success   | 2
[0x3f] FAON VR Pout             : isl69259   | access[O] | 4byte_acur_read_success   | 9
[0x3d] EHV VR Pout              : isl69259   | access[O] | 4byte_acur_read_success   | 1
[0x3a] VCCIN VR Pout            : isl69259   | access[O] | 4byte_acur_read_success   | 63
[0x3c] FIVRA VR Pout            : isl69259   | access[O] | 4byte_acur_read_success   | 6
[0x4 ] PCH Temp                 : pch        | access[O] | 4byte_acur_read_success   | 55
[0x1e] DIMMA PMIC_Pout          : pmic       | access[O] | 4byte_acur_read_success   | 8192000
[0x1f] DIMMC PMIC_Pout          : pmic       | access[O] | 4byte_acur_read_success   | 0
[0x36] DIMMD PMIC_Pout          : pmic       | access[O] | 4byte_acur_read_success   | 0
[0x37] DIMME PMIC_Pout          : pmic       | access[O] | 4byte_acur_read_success   | 0
[0x42] DIMMG PMIC_Pout          : pmic       | access[O] | 4byte_acur_read_success   | 8192000
[0x47] DIMMH PMIC_Pout          : pmic       | access[O] | 4byte_acur_read_success   | 0
[0xe ] HSC Temp                 : hsc        | access[O] | 4byte_acur_read_success   | 21823541
[0x29] HSC Input Vol            : hsc        | access[O] | 4byte_acur_read_success   | 35782668
[0x30] HSC Output Cur           : hsc        | access[O] | 4byte_acur_read_success   | 55443464
[0x39] HSC Input Pwr            : hsc        | access[O] | 4byte_acur_read_success   | 14352493
---------------------------------------------------------------------------------

- Config C
[BIC console]
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x50] RF MB Inlet Temp         : tmp75      | access[O] | 4byte_acur_read_success   | 30
[0x52] RF CXL_cntr_Temp         : tmp75      | access[O] | 4byte_acur_read_success   | 31
[0x5f] RF P5V_STBY Vol          : adc        | access[O] | 4byte_acur_read_success   | 7798789
[0x60] RF P1V2_STBY Vol         : adc        | access[O] | 4byte_acur_read_success   | 12845057
[0x61] RF P1V8_ASIC Vol         : adc        | access[O] | 4byte_acur_read_success   | 52035585
[0x68] RF PVPP_AB Vol           : adc        | access[O] | 4byte_acur_read_success   | 32571394
[0x69] RF PVPP_CD Vol           : adc        | access[O] | 4byte_acur_read_success   | 32571394
[0x6a] RF PVTT_AB Vol           : adc        | access[O] | 4byte_acur_read_success   | 39190528
[0x6b] RF PVTT_CD Vol           : adc        | access[O] | 4byte_acur_read_success   | 38993920
[0x5d] RF P12V_STBY Vol         : ina233     | access[O] | 4byte_acur_read_success   | 35127308
[0x5e] RF P3V3_STBY Vol         : ina233     | access[O] | 4byte_acur_read_success   | 21299203
[0x6c] RF P12V_STBY Cur         : ina233     | access[O] | 4byte_acur_read_success   | 17039360
[0x6d] RF P3V3_STBY Cur         : ina233     | access[O] | 4byte_acur_read_success   | 10289152
[0x73] RF P12V_STBY_PWR         : ina233     | access[O] | 4byte_acur_read_success   | 18022403
[0x74] RF P3V3_STBY_PWR         : ina233     | access[O] | 4byte_acur_read_success   | 34406400
[0x58] RF P0V9_A Temp           : isl69254   | access[O] | 4byte_acur_read_success   | 40
[0x59] RF P0V8_A Temp           : isl69254   | access[O] | 4byte_acur_read_success   | 38
[0x5a] RF P0V8_D Temp           : isl69254   | access[O] | 4byte_acur_read_success   | 34
[0x5b] RF PVDDQ_AB Temp         : isl69254   | access[O] | 4byte_acur_read_success   | 38
[0x5c] RF PVDDQ_CD Temp         : isl69254   | access[O] | 4byte_acur_read_success   | 40
[0x62] RF P0V9_A Vol            : isl69254   | access[O] | 4byte_acur_read_success   | 4849665
[0x64] RF P0V8_A Vol            : isl69254   | access[O] | 4byte_acur_read_success   | 53673984
[0x65] RF P0V8_D Vol            : isl69254   | access[O] | 4byte_acur_read_success   | 53673984
[0x66] RF PVDDQ_AB Vol          : isl69254   | access[O] | 4byte_acur_read_success   | 13107201
[0x67] RF PVDDQ_CD Vol          : isl69254   | access[O] | 4byte_acur_read_success   | 13041665
[0x6e] RF P0V9_A Cur            : isl69254   | access[O] | 4byte_acur_read_success   | 0
[0x6f] RF P0V8_A Cur            : isl69254   | access[O] | 4byte_acur_read_success   | 13107200
[0x70] RF P0V8_D Cur            : isl69254   | access[O] | 4byte_acur_read_success   | 13107200
[0x71] RF PVDDQ_AB Cur          : isl69254   | access[O] | 4byte_acur_read_success   | -6553600
[0x72] RF PVDDQ_CD Cur          : isl69254   | access[O] | 4byte_acur_read_success   | -26214400
[0x75] RF P0V9_A_PWR            : isl69254   | access[O] | 4byte_acur_read_success   | 0
[0x76] RF P0V8_A_PWR            : isl69254   | access[O] | 4byte_acur_read_success   | 0
[0x77] RF P0V8_D_PWR            : isl69254   | access[O] | 4byte_acur_read_success   | 0
[0x78] RF PVDDQ_AB_PWR          : isl69254   | access[O] | 4byte_acur_read_success   | 65535
[0x79] RF PVDDQ_CD_PWR          : isl69254   | access[O] | 4byte_acur_read_success   | 0
---------------------------------------------------------------------------------

-Config D
[BIC console]
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0xd1] BB_INLET_TEMP            : tmp75      | access[O] | 4byte_acur_read_success   | 26
[0xd2] BB_OUTLET_TEMP           : tmp75      | access[O] | 4byte_acur_read_success   | 28
[0xd4] BB_P5V_STBY              : adc        | access[O] | 4byte_acur_read_success   | 9437189
[0xd5] BB_P12V_STBY             : adc        | access[O] | 4byte_acur_read_success   | 28966924
[0xd6] BB_P3V3_STBY             : adc        | access[O] | 4byte_acur_read_success   | 23724035
[0xe9] BB_P5V_USB               : adc        | access[O] | 4byte_acur_read_success   | 8978437
[0xd9] BB_P1V2_STBY             : adc        | access[O] | 4byte_acur_read_success   | 13959169
[0xda] BB_P1V0_STBY             : adc        | access[O] | 4byte_acur_read_success   | 655361
[0xe8] BB_FAN_IOUT              : adc        | access[O] | 4byte_acur_read_success   | 65208321
[0xdb] BB_MEDUSA_VIN            : ltc4282    | access[O] | 4byte_acur_read_success   | 19464204
[0xd7] BB_MEDUSA_VOUT           : ltc4282    | access[O] | 4byte_acur_read_success   | 17563660
[0xdf] BB_MEDUSA_CUR            : ltc4282    | access[O] | 4byte_acur_read_success   | 64225284
[0xd8] BB_MEDUSA_PWR            : ltc4282    | access[O] | 4byte_acur_read_success   | 2621501
[0xd3] BB_HSC_TEMP              : hsc        | access[O] | 4byte_acur_read_success   | 49872920
[0xdc] BB_HSC_VIN               : hsc        | access[O] | 4byte_acur_read_success   | 16056332
[0xde] BB_HSC_IOUT              : hsc        | access[O] | 4byte_acur_read_success   | 57344005
[0xdd] BB_HSC_PIN               : hsc        | access[O] | 4byte_acur_read_success   | 7929928
[0xea] BB_HSC_EIN               : hsc        | access[O] | 4byte_acur_read_success   | 50987079
[0xeb] BB_HSC_PEAK_IOUT         : hsc        | access[O] | 4byte_acur_read_success   | 34340881
[0xec] BB_HSC_PEAK_PIN          : hsc        | access[O] | 4byte_acur_read_success   | 48562422
---------------------------------------------------------------------------------