### PR TITLE
GT: Add shell command to stress E1.S power

### DIFF
--- a/meta-facebook/gt-cc/CMakeLists.txt
+++ b/meta-facebook/gt-cc/CMakeLists.txt
@@ -6,14 +6,14 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gt-cc)
 
 set(common_path ../../common)
-FILE(GLOB app_sources src/ipmi/*.c src/platform/*.c src/lib/*.c)
+FILE(GLOB app_sources src/ipmi/*.c src/platform/*.c src/lib/*.c src/shell/*.c)
 FILE(GLOB common_sources ${common_path}/service/*.c ${common_path}/service/*/*.c ${common_path}/hal/*.c ${common_path}/dev/*.c ${common_path}/lib/*.c ${common_path}/shell/*.c)
 
 target_sources(app PRIVATE ${app_sources})
 target_sources(app PRIVATE ${common_sources})
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/include/portability)
 target_include_directories(app PRIVATE ${common_path} ${common_path}/service/ipmi/include ${common_path}/service/host ${common_path}/service/sensor ${common_path}/service/usb ${common_path}/service/ipmb ${common_path}/service/mctp ${common_path}/service/pldm ${common_path}/hal ${common_path}/dev/include ${common_path}/lib ${common_path}/shell)
-target_include_directories(app PRIVATE src/ipmi/include src/lib src/platform)
+target_include_directories(app PRIVATE src/ipmi/include src/lib src/platform src/shell)
 
 # Fail build if there are any warnings 
 target_compile_options(app PRIVATE -Werror)

--- a/meta-facebook/gt-cc/src/shell/plat_shell.c
+++ b/meta-facebook/gt-cc/src/shell/plat_shell.c
@@ -1,0 +1,17 @@
+#include <zephyr.h>
+#include <shell/shell.h>
+#include "plat_shell_e1s.h"
+
+/* Sub-command Level 2 of command test */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_e1s_cmds,
+			       SHELL_CMD(power, NULL, "Stress E1S power consumption",
+					 cmd_stress_e1s_pwr),
+			       SHELL_SUBCMD_SET_END);
+
+/* Sub-command Level 1 of command test */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_test_cmds,
+			       SHELL_CMD(e1s, &sub_e1s_cmds, "E1S related command", NULL),
+			       SHELL_SUBCMD_SET_END);
+
+/* Root of command test */
+SHELL_CMD_REGISTER(test, &sub_test_cmds, "Test commands for GT", NULL);

--- a/meta-facebook/gt-cc/src/shell/plat_shell_e1s.c
+++ b/meta-facebook/gt-cc/src/shell/plat_shell_e1s.c
@@ -1,0 +1,136 @@
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <shell/shell.h>
+
+#include "sensor.h"
+#include "plat_gpio.h"
+#include "plat_sensor_table.h"
+
+#define MAX_E1S_NUMBER 16
+#define E1S_POWER_CLOCK_PERIOD 2
+#define E1S_POWER_AVG_PERIOD 250
+
+struct stress_e1s_pwr_s {
+	uint8_t e1s_idx;
+	uint32_t time_count_ms;
+	struct k_timer timer;
+	struct k_work work;
+	struct k_work stop_work;
+	const struct shell *shell;
+};
+
+uint8_t e1s_power_sensor_table[MAX_E1S_NUMBER] = {
+	SENSOR_NUM_POUT_E1S_0,	SENSOR_NUM_POUT_E1S_1,	SENSOR_NUM_POUT_E1S_2,
+	SENSOR_NUM_POUT_E1S_3,	SENSOR_NUM_POUT_E1S_4,	SENSOR_NUM_POUT_E1S_5,
+	SENSOR_NUM_POUT_E1S_6,	SENSOR_NUM_POUT_E1S_7,	SENSOR_NUM_POUT_E1S_8,
+	SENSOR_NUM_POUT_E1S_9,	SENSOR_NUM_POUT_E1S_10, SENSOR_NUM_POUT_E1S_11,
+	SENSOR_NUM_POUT_E1S_12, SENSOR_NUM_POUT_E1S_13, SENSOR_NUM_POUT_E1S_14,
+	SENSOR_NUM_POUT_E1S_15,
+};
+
+uint8_t e1s_present_pin_table[MAX_E1S_NUMBER] = {
+	PRSNT_SSD0_R_N,	 PRSNT_SSD1_R_N,  PRSNT_SSD2_R_N,  PRSNT_SSD3_R_N,
+	PRSNT_SSD4_R_N,	 PRSNT_SSD5_R_N,  PRSNT_SSD6_R_N,  PRSNT_SSD7_R_N,
+	PRSNT_SSD8_R_N,	 PRSNT_SSD9_R_N,  PRSNT_SSD10_R_N, PRSNT_SSD11_R_N,
+	PRSNT_SSD12_R_N, PRSNT_SSD13_R_N, PRSNT_SSD14_R_N, PRSNT_SSD15_R_N,
+};
+
+void e1s_pwr_work_handler(struct k_work *work)
+{
+	static uint16_t period_count = E1S_POWER_AVG_PERIOD;
+	static float avg = 0.0;
+	int reading = 0;
+
+	struct stress_e1s_pwr_s *data = CONTAINER_OF(work, struct stress_e1s_pwr_s, work);
+
+	if (period_count > 0) {
+		if (!get_sensor_reading(e1s_power_sensor_table[data->e1s_idx], &reading,
+					GET_FROM_SENSOR))
+			shell_warn(data->shell, "[%s] Reading E1S dev%d power failed \n", __func__,
+				   data->e1s_idx);
+		period_count--;
+		sensor_val *sval = (sensor_val *)(&reading);
+		avg += (sval->integer) + (sval->fraction * 0.001);
+	} else if (period_count == 0) {
+		period_count = E1S_POWER_AVG_PERIOD;
+		avg /= E1S_POWER_AVG_PERIOD;
+		shell_print(data->shell, "E1S dev%d power avg = %.2f Watts\n", data->e1s_idx, avg);
+		avg = 0.0;
+	}
+}
+
+void e1s_pwr_stop_work_handler(struct k_work *work)
+{
+	struct stress_e1s_pwr_s *data = CONTAINER_OF(work, struct stress_e1s_pwr_s, stop_work);
+
+	if (data) {
+		shell_print(data->shell, "==== Stop stress E1S dev%d power consumption ==== \n",
+			    data->e1s_idx);
+		free(data);
+		data = NULL;
+	}
+}
+
+static void e1s_pwr_timer_stop_handler(struct k_timer *timer)
+{
+	struct stress_e1s_pwr_s *data = CONTAINER_OF(timer, struct stress_e1s_pwr_s, timer);
+	k_work_submit(&data->stop_work);
+}
+
+static void e1s_pwr_timer_handler(struct k_timer *timer)
+{
+	struct stress_e1s_pwr_s *data = CONTAINER_OF(timer, struct stress_e1s_pwr_s, timer);
+
+	if (data->time_count_ms > 0) {
+		data->time_count_ms--;
+		k_work_submit(&data->work);
+	} else if (data->time_count_ms == 0) {
+		k_timer_stop(timer);
+	}
+}
+
+int cmd_stress_e1s_pwr(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc != 3) {
+		shell_warn(shell, "Usage: test e1s power [device index] [duration (minute)]");
+		return -1;
+	}
+
+	uint8_t e1s_idx = strtoul(argv[1], NULL, 10);
+	uint16_t duration = strtoul(argv[2], NULL, 10);
+
+	if (e1s_idx >= MAX_E1S_NUMBER) {
+		shell_warn(shell, "Device index out of range \n");
+		return -1;
+	}
+
+	if (gpio_get(e1s_present_pin_table[e1s_idx])) {
+		shell_warn(shell, "E1S dev%d not present \n", e1s_idx);
+		return -1;
+	}
+	struct stress_e1s_pwr_s *data = malloc(sizeof(struct stress_e1s_pwr_s));
+
+	if (!data) {
+		shell_warn(shell, "Malloc fail\n");
+		return -1;
+	}
+
+	data->e1s_idx = e1s_idx;
+	data->time_count_ms = (duration * 60 * 1000) / E1S_POWER_CLOCK_PERIOD;
+	data->shell = shell;
+
+	k_timer_init(&data->timer, e1s_pwr_timer_handler, e1s_pwr_timer_stop_handler);
+
+	k_work_init(&data->work, e1s_pwr_work_handler);
+	k_work_init(&data->stop_work, e1s_pwr_stop_work_handler);
+
+	shell_print(shell, "==== Start stress E1S dev%d power consumption %d minutes =====\n",
+		    e1s_idx, duration);
+
+	k_timer_start(&data->timer, K_NO_WAIT, K_MSEC(E1S_POWER_CLOCK_PERIOD));
+
+	return 0;
+}

--- a/meta-facebook/gt-cc/src/shell/plat_shell_e1s.h
+++ b/meta-facebook/gt-cc/src/shell/plat_shell_e1s.h
@@ -1,0 +1,14 @@
+#ifndef _PLAT_SHELL_E1S_H
+#define _PLAT_SHELL_E1S_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int cmd_stress_e1s_pwr(const struct shell *shell, size_t argc, char **argv);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PLAT_SHELL_E1S_H */


### PR DESCRIPTION
Summary:
- Add command to stress E1.S power according to SIT testing requirements.
- Follow by NVME cloud ssd specification v1.0.3 chapter 9.2 as below link:
https://www.opencompute.org/documents/nvme-cloud-ssd-specification-v1-0-3-pdf
- Print the average value of the power consumption on a given device id in a 250 ms window with a sampling rate of 2 ms in a given duration.
- Usage in BIC console:
	test e1s power [device index] [duration (minute)]

Test plan:
- Build code: Pass

Log:
uart:\~$  test e1s power 0 1
==== Start stress E1S dev0 power consumption 1 minutes =====
uart:\~$ E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.29 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.28 Watts
E1S dev0 power avg = 3.28 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.28 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.30 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.22 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.23 Watts
E1S dev0 power avg = 3.22 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.23 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.20 Watts
E1S dev0 power avg = 3.22 Watts
E1S dev0 power avg = 3.28 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.21 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.21 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.29 Watts
E1S dev0 power avg = 3.30 Watts
E1S dev0 power avg = 3.28 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.22 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.19 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.30 Watts
E1S dev0 power avg = 3.23 Watts
E1S dev0 power avg = 3.21 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.19 Watts
E1S dev0 power avg = 3.21 Watts
E1S dev0 power avg = 3.28 Watts
E1S dev0 power avg = 3.31 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.29 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.23 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.19 Watts
E1S dev0 power avg = 3.21 Watts
E1S dev0 power avg = 3.20 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.30 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.30 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.28 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.23 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.21 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.29 Watts
E1S dev0 power avg = 3.27 Watts
E1S dev0 power avg = 3.23 Watts
E1S dev0 power avg = 3.22 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.22 Watts
E1S dev0 power avg = 3.26 Watts
E1S dev0 power avg = 3.28 Watts
E1S dev0 power avg = 3.25 Watts
E1S dev0 power avg = 3.28 Watts
E1S dev0 power avg = 3.22 Watts
E1S dev0 power avg = 3.24 Watts
E1S dev0 power avg = 3.23 Watts
E1S dev0 power avg = 3.20 Watts
==== Stop stress E1S dev0 power consumption ====