### PR TITLE
common: peci: revise PECI retry to meet SPEC

### DIFF
--- a/common/hal/hal_peci.h
+++ b/common/hal/hal_peci.h
@@ -3,6 +3,16 @@
 
 #define DEBUG_PECI 0
 
+/* Completion Code mask to check retry needs */
+#define PECI_DEV_CC_RETRY_CHECK_MASK                    0xf0
+#define PECI_DEV_CC_NEED_RETRY                          0x80
+#define IS_PECI_CC_NEED_RETRY(cc) \
+		(((cc) & PECI_DEV_CC_RETRY_CHECK_MASK) == PECI_DEV_CC_NEED_RETRY) ? true : false
+#define PECI_DEV_RETRY_BIT                              0x01
+#define PECI_DEV_RETRY_TIMEOUT                          700 // ms
+#define PECI_DEV_RETRY_INTERVAL_MAX_MSEC                100
+#define PECI_DEV_RETRY_INTERVAL_MIN_MSEC                1
+
 enum peci_cmd {
 	PECI_PING_CMD = 0x00,
 	PECI_GET_TEMP0_CMD = 0x01,


### PR DESCRIPTION
Summary:
For some commands, the PECI originator may need to retry a command
if the processor PECI client responds with a 0x8x completion code.

Test plan:
Build and test pass on fby35 system.
1. Execute ACD without CC 0x80
2. PECI sensor read
root@bmc-oob:~# sensor-util slot3
slot3:
MB Inlet Temp                (0x1) :   27.00 C     | (ok)
MB Outlet Temp               (0x2) :   36.00 C     | (ok)
FIO Temp                     (0x3) :   27.00 C     | (ok)
PCH Temp                     (0x4) :   36.00 C     | (ok)
SOC CPU Temp                 (0x5) :   30.00 C     | (ok)
SOC Therm Margin             (0x14) :  -70.00 C     | (ok)
CPU TjMax                    (0x15) :  100.00 C     | (ok)
DIMMA Temp                   (0x6) :   30.00 C     | (ok)
DIMMC Temp                   (0x7) :   29.00 C     | (ok)
DIMMD Temp                   (0x9) :   29.00 C     | (ok)
DIMME Temp                   (0xA) :   30.00 C     | (ok)
DIMMG Temp                   (0xB) :   29.00 C     | (ok)
DIMMH Temp                   (0xC) :   29.00 C     | (ok)
SSD0 Temp                    (0xD) :   32.00 C     | (ok)
HSC Temp                     (0xE) :   32.14 C     | (ok)
VCCIN SPS Temp               (0xF) :   44.00 C     | (ok)
FIVRA SPS Temp               (0x10) :   40.00 C     | (ok)
EHV SPS Temp                 (0x11) :   35.00 C     | (ok)
VCCD SPS Temp                (0x12) :   35.00 C     | (ok)
FAON SPS Temp                (0x13) :   39.00 C     | (ok)
P12V_STBY Vol                (0x20) :   12.42 Volts | (ok)
P3V_BAT Vol                  (0x21) :    3.11 Volts | (ok)
P3V3_STBY Vol                (0x22) :    3.31 Volts | (ok)
P1V8_STBY Vol                (0x23) :    1.81 Volts | (ok)
P1V05_PCH Vol                (0x24) :    1.05 Volts | (ok)
P5V_STBY Vol                 (0x25) :    5.02 Volts | (ok)
P12V_DIMM Vol                (0x26) :   12.53 Volts | (ok)
P1V2_STBY Vol                (0x27) :    1.20 Volts | (ok)
P3V3_M2 Vol                  (0x28) :    3.33 Volts | (ok)
HSC Input Vol                (0x29) :   12.38 Volts | (ok)
VCCIN VR Vol                 (0x2A) :    1.77 Volts | (ok)
FIVRA VR Vol                 (0x2C) :    1.82 Volts | (ok)
EHV VR Vol                   (0x2D) :    1.80 Volts | (ok)
VCCD VR Vol                  (0x2E) :    1.14 Volts | (ok)
FAON VR Vol                  (0x2F) :    1.05 Volts | (ok)
HSC Output Cur               (0x30) :    8.21 Amps  | (ok)
VCCIN VR Cur                 (0x31) :   29.60 Amps  | (ok)
FIVRA VR Cur                 (0x32) :    2.60 Amps  | (ok)
EHV VR Cur                   (0x33) :    0.70 Amps  | (ok)
VCCD VR Cur                  (0x34) :    2.70 Amps  | (ok)
FAON VR Cur                  (0x35) :    8.50 Amps  | (ok)
CPU PWR                      (0x38) :   69.50 Watts | (ok)
HSC Input Pwr                (0x39) :  100.13 Watts | (ok)
VCCIN VR Pout                (0x3A) :   52.00 Watts | (ok)
FIVRA VR Pout                (0x3C) :    5.00 Watts | (ok)
EHV VR Pout                  (0x3D) :    1.00 Watts | (ok)
VCCD VR Pout                 (0x3E) :    2.00 Watts | (ok)
FAON VR Pout                 (0x3F) :    9.00 Watts | (ok)
DIMMA PMIC_Pout              (0x1E) :    0.38 Watts | (ok)
DIMMC PMIC_Pout              (0x1F) :    0.50 Watts | (ok)
DIMMD PMIC_Pout              (0x36) :    0.38 Watts | (ok)
DIMME PMIC_Pout              (0x37) :    0.50 Watts | (ok)
DIMMG PMIC_Pout              (0x42) :    0.38 Watts | (ok)
DIMMH PMIC_Pout              (0x47) :    0.38 Watts | (ok)
DPV2_1_12V_VIN               (0x8C) :   12.26 Volts | (ok)
DPV2_1_12V_VOUT              (0x8D) :   12.26 Volts | (ok)
DPV2_1_12V_IOUT              (0x8E) :    0.12 Amps  | (ok)
DPV2_1_EFUSETemp             (0x8F) :   22.38 C     | (ok)
DPV2_1_EFUSEPWR              (0x90) :    1.19 Watts | (ok)