### PR TITLE
fby3.5: bb: Version commit for oby35-bb-2022.28.01

### DIFF
--- a/meta-facebook/yv35-bb/src/platform/plat_version.h
+++ b/meta-facebook/yv35-bb/src/platform/plat_version.h
@@ -8,7 +8,7 @@
 // Byte 0 boade: 01h CL  02h BB
 // Byte 1 stage: 00h POC 01h EVT
 #define FIRMWARE_REVISION_1 0x12
-#define FIRMWARE_REVISION_2 0x04
+#define FIRMWARE_REVISION_2 0x05
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
 #define PRODUCT_ID 0x0000
@@ -16,7 +16,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x19
+#define BIC_FW_WEEK 0x28
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x62 // char: b
 #define BIC_FW_platform_1 0x62 // char: b


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Baseboard BIC oby35-bb-2022.28.01.

Test plan:
- Build code: Pass
- Check BIC version is changed: Pass

Log:
1. Get version of BB BIC.
root@bmc-oob:~# fw-util slot1 --version bb_bic
BB Bridge-IC Version: oby35-bb-v2022.28.01