### PR TITLE
fby3.5-cl: Fix sensor config table of YV35 CL LTC4286 sensor

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -247,17 +247,18 @@ sensor_cfg ltc4286_sensor_config_table[] = {
 	   access check arg0, arg1, sample_count, cache, cache_status, mux_address, mux_offset,
 	   pre_sensor_read_fn, pre_sensor_read_args, post_sensor_read_fn, post_sensor_read_fn  */
 	{ SENSOR_NUM_TEMP_HSC, sensor_dev_ltc4286, I2C_BUS2, ADI_LTC4286_ADDR,
-	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS,
-	  NULL, NULL, NULL, NULL, &ltc4286_init_args[0] },
-	{ SENSOR_NUM_VOL_HSCIN, sensor_dev_ltc4286, I2C_BUS2, ADI_LTC4286_ADDR, PMBUS_READ_VIN,
-	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ltc4286_init_args[0] },
+	{ SENSOR_NUM_VOL_HSCIN, sensor_dev_ltc4286, I2C_BUS2, ADI_LTC4286_ADDR, PMBUS_READ_VIN,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &ltc4286_init_args[0] },
 	{ SENSOR_NUM_CUR_HSCOUT, sensor_dev_ltc4286, I2C_BUS2, ADI_LTC4286_ADDR, PMBUS_READ_IOUT,
-	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, NULL, NULL,
-	  post_ltc4286_read, NULL, &ltc4286_init_args[0] },
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, post_ltc4286_read, NULL, &ltc4286_init_args[0] },
 	{ SENSOR_NUM_PWR_HSCIN, sensor_dev_ltc4286, I2C_BUS2, ADI_LTC4286_ADDR, PMBUS_READ_PIN,
-	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, 0, SENSOR_INIT_STATUS, NULL, NULL,
-	  post_ltc4286_read, NULL, &ltc4286_init_args[0] },
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, post_ltc4286_read, NULL, &ltc4286_init_args[0] },
 };
 
 sensor_cfg evt3_class1_adi_temperature_sensor_table[] = {


### PR DESCRIPTION
Summary:
- Add individual sensor polling time and polling status to sensor config table of YV35 CL LTC4286 sensor.

Test Plan:
- Build code: Pass
- Check BIC status is workable: Pass

Log:
[BIC console]
Hello, welcome to yv35 craterlake 2022.28.1
BIC class type(class-1), 1ou present status(1), 2ou present status(0), board revision(0x4)
[00:00:00.003,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint
[00:00:00.059,000] <inf> kcs_aspeed: KCS3: addr=0xca2, idr=0x2c, odr=0x38, str=0x44

[set_DC_status] gpio number(15) status(0)
[set_post_status] gpio number(1) status(0)
[00:00:00.200,000] <inf> usb_cdc_acm: Device suspended

uart:~$ [00:00:00.637,000] <inf> usb_cdc_acm: Device resumed
[00:00:00.637,000] <inf> usb_cdc_acm: from suspend
[00:00:00.949,000] <inf> usb_cdc_acm: Device configured
[00:00:00.637,000] <inf> usb_cdc_acm: Device resumed
[00:00:00.637,000] <inf> usb_cdc_acm: from suspend
BIC Ready
uart:~$