### PR TITLE
fby3.5: cl: Workaround to fix power on sensor fail in config B after …

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -408,7 +408,6 @@ void pal_extend_sensor_config()
 	CARD_STATUS _2ou_status = get_2ou_status();
 
 	int arg_index = (_2ou_status.present) ? 1 : 0;
-	int gpio_state = (_2ou_status.present) ? GPIO_HIGH : GPIO_LOW;
 
 	sensor_count = ARRAY_SIZE(mp5990_sensor_config_table);
 	for (int index = 0; index < sensor_count; index++) {
@@ -418,7 +417,6 @@ void pal_extend_sensor_config()
 	for (int index = 0; index < sensor_count; index++) {
 		ltc4286_sensor_config_table[index].init_args = &ltc4286_init_args[arg_index];
 	}
-	gpio_set(HSC_SET_EN_R, gpio_state);
 
 	switch (hsc_module) {
 	case HSC_MODULE_ADM1278:


### PR DESCRIPTION
…12V on

Summary:
- Signal HSC_SET_EN_R is to increase the HSC current output for 2OU configuarion.
  However it causes the GPIO ISR routine malfunction and lead to all power_on sensor fail because BIC FW doesn't get the power on event.
  Make a workaround for shorten solution for DVT build and we will keep digging out the root cause.

Test Plan:
- Build code: Pass
- Check power on sensor reading in config B after 12V on: Pass

Log:
root@bmc-oob:~# sensor-util slot1 --threshold
slot1:
MB Inlet Temp                (0x1) :   26.00 C     | (ok) | UCR: 48.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
MB Outlet Temp               (0x2) :   36.00 C     | (ok) | UCR: 93.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
FIO Temp                     (0x3) :   26.00 C     | (ok) | UCR: 40.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PCH Temp                     (0x4) :   34.00 C     | (ok) | UCR: 74.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC CPU Temp                 (0x5) :   31.00 C     | (ok) | UCR: 84.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC Therm Margin             (0x14) :  -69.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
CPU TjMax                    (0x15) :  100.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
DIMMA Temp                   (0x6) :   30.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMC Temp                   (0x7) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMD Temp                   (0x9) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME Temp                   (0xA) :   30.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMG Temp                   (0xB) :   30.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH Temp                   (0xC) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SSD0 Temp                    (0xD) :   29.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Temp                     (0xE) :   33.33 C     | (ok) | UCR: 86.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
VCCIN SPS Temp               (0xF) :   45.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
FIVRA SPS Temp               (0x10) :   40.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
EHV SPS Temp                 (0x11) :   33.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
VCCD SPS Temp                (0x12) :   35.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
FAON SPS Temp                (0x13) :   38.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
P12V_STBY Vol                (0x20) :   12.59 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
P3V_BAT Vol                  (0x21) :    3.05 Volts | (ok) | UCR: 3.51 | UNC: 3.46 | UNR: NA | LCR: 2.76 | LNC: 2.79 | LNR: NA
P3V3_STBY Vol                (0x22) :    3.33 Volts | (ok) | UCR: 3.56 | UNC: 3.53 | UNR: 4.00 | LCR: 3.04 | LNC: 3.08 | LNR: 2.30
P1V8_STBY Vol                (0x23) :    1.80 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.09 | LCR: 1.67 | LNC: 1.69 | LNR: 1.44
P1V05_PCH Vol                (0x24) :    1.05 Volts | (ok) | UCR: 1.12 | UNC: 1.10 | UNR: 1.22 | LCR: 0.97 | LNC: 0.98 | LNR: 0.84
P5V_STBY Vol                 (0x25) :    4.96 Volts | (ok) | UCR: 5.40 | UNC: 5.35 | UNR: 5.80 | LCR: 4.59 | LNC: 4.64 | LNR: 4.00
P12V_DIMM Vol                (0x26) :   12.44 Volts | (ok) | UCR: 14.21 | UNC: 14.07 | UNR: NA | LCR: 9.87 | LNC: 10.01 | LNR: NA
P1V2_STBY Vol                (0x27) :    1.19 Volts | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.39 | LCR: 1.10 | LNC: 1.12 | LNR: 0.96
P3V3_M2 Vol                  (0x28) :    3.31 Volts | (ok) | UCR: 3.71 | UNC: 3.67 | UNR: NA | LCR: 2.91 | LNC: 2.94 | LNR: NA
HSC Input Vol                (0x29) :   12.40 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
VCCIN VR Vol                 (0x2A) :    1.77 Volts | (ok) | UCR: 1.93 | UNC: 1.91 | UNR: 2.20 | LCR: 1.64 | LNC: 1.66 | LNR: 0.40
FIVRA VR Vol                 (0x2C) :    1.82 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.20 | LCR: 1.69 | LNC: 1.71 | LNR: 0.40
EHV VR Vol                   (0x2D) :    1.80 Volts | (ok) | UCR: 1.90 | UNC: 1.88 | UNR: 2.20 | LCR: 1.70 | LNC: 1.72 | LNR: 0.40
VCCD VR Vol                  (0x2E) :    1.14 Volts | (ok) | UCR: 1.23 | UNC: 1.21 | UNR: 1.50 | LCR: 1.05 | LNC: 1.06 | LNR: 0.40
FAON VR Vol                  (0x2F) :    1.05 Volts | (ok) | UCR: 1.09 | UNC: 1.07 | UNR: 1.40 | LCR: 0.90 | LNC: 0.91 | LNR: 0.40
HSC Output Cur               (0x30) :    8.16 Amps  | (ok) | UCR: 31.96 | UNC: 28.73 | UNR: 39.95 | LCR: NA | LNC: NA | LNR: NA
VCCIN VR Cur                 (0x31) :   29.20 Amps  | (ok) | UCR: 141.18 | UNC: 119.34 | UNR: 180.18 | LCR: NA | LNC: NA | LNR: NA
FIVRA VR Cur                 (0x32) :    3.40 Amps  | (ok) | UCR: 53.01 | UNC: 48.05 | UNR: 70.99 | LCR: NA | LNC: NA | LNR: NA
EHV VR Cur                   (0x33) :    0.80 Amps  | (ok) | UCR: 6.24 | UNC: 5.04 | UNR: 18.00 | LCR: NA | LNC: NA | LNR: NA
VCCD VR Cur                  (0x34) :    2.80 Amps  | (ok) | UCR: 30.02 | UNC: 26.98 | UNR: 42.94 | LCR: NA | LNC: NA | LNR: NA
FAON VR Cur                  (0x35) :    9.10 Amps  | (ok) | UCR: 46.02 | UNC: 42.12 | UNR: 60.06 | LCR: NA | LNC: NA | LNR: NA
CPU PWR                      (0x38) :   71.00 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Input Pwr                (0x39) :   99.87 Watts | (ok) | UCR: 399.28 | UNC: 360.22 | UNR: 499.10 | LCR: NA | LNC: NA | LNR: NA
VCCIN VR Pout                (0x3A) :   51.00 Watts | (ok) | UCR: 253.80 | UNC: 214.32 | UNR: 324.30 | LCR: NA | LNC: NA | LNR: NA
FIVRA VR Pout                (0x3C) :    5.00 Watts | (ok) | UCR: 95.19 | UNC: 86.64 | UNR: 127.68 | LCR: NA | LNC: NA | LNR: NA
EHV VR Pout                  (0x3D) :    1.00 Watts | (ok) | UCR: 11.25 | UNC: 8.97 | UNR: 32.38 | LCR: NA | LNC: NA | LNR: NA
VCCD VR Pout                 (0x3E) :    2.00 Watts | (ok) | UCR: 34.32 | UNC: 31.02 | UNR: 49.28 | LCR: NA | LNC: NA | LNR: NA
FAON VR Pout                 (0x3F) :   10.00 Watts | (ok) | UCR: 49.28 | UNC: 45.08 | UNR: 64.12 | LCR: NA | LNC: NA | LNR: NA
DIMMA PMIC_Pout              (0x1E) :    0.38 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMC PMIC_Pout              (0x1F) :    0.38 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMD PMIC_Pout              (0x36) :    0.50 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME PMIC_Pout              (0x37) :    1.00 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMG PMIC_Pout              (0x42) :    0.50 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH PMIC_Pout              (0x47) :    0.38 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA