### PR TITLE
fby3.5: cl: Version commit for oby35-cl-2022.28.02

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_version.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_version.h
@@ -15,7 +15,7 @@
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
 #define BIC_FW_WEEK 0x28
-#define BIC_FW_VER 0x01
+#define BIC_FW_VER 0x02
 #define BIC_FW_platform_0 0x63 // char: c
 #define BIC_FW_platform_1 0x6c // char: l
 #define BIC_FW_platform_2 0x00 // char: '\0'


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Craterlake BIC oby35-cl-2022.28.02.

Test Plan:
- Build code: Pass
- Check BIC version: Pass

Log:
root@bmc-oob:~# fw-util slot1 --version bic
SB Bridge-IC Version: oby35-cl-v2022.28.02