### PR TITLE
fby35: remove hardcode sensor number from common

### DIFF
--- a/common/service/ipmi/include/oem_handler.h
+++ b/common/service/ipmi/include/oem_handler.h
@@ -3,6 +3,8 @@
 
 #include "ipmi.h"
 
+uint8_t get_hsc_pwr_reading(int *reading);
+
 void OEM_NM_SENSOR_READ(ipmi_msg *msg);
 
 #ifdef CONFIG_ESPI

--- a/common/service/ipmi/oem_handler.c
+++ b/common/service/ipmi/oem_handler.c
@@ -7,6 +7,11 @@
 #include "plat_fan.h"
 #endif
 
+__weak uint8_t get_hsc_pwr_reading(int *reading)
+{
+	return SENSOR_NOT_FOUND;
+}
+
 #ifdef CONFIG_ESPI
 __weak void OEM_NM_SENSOR_READ(ipmi_msg *msg)
 {
@@ -14,7 +19,7 @@ __weak void OEM_NM_SENSOR_READ(ipmi_msg *msg)
 		return;
 	}
 
-	uint8_t status, sensor_num;
+	uint8_t status;
 	int reading;
 
 	// only input enable status
@@ -25,8 +30,7 @@ __weak void OEM_NM_SENSOR_READ(ipmi_msg *msg)
 
 	// Follow INTEL NM SPEC, read platform pwr from HSC
 	if (msg->data[0] == 0x00) {
-		sensor_num = SENSOR_NUM_PWR_HSCIN;
-		status = get_sensor_reading(sensor_num, &reading, GET_FROM_CACHE);
+		status = get_hsc_pwr_reading(&reading);
 	} else {
 		msg->completion_code = CC_INVALID_DATA_FIELD;
 		return;

--- a/meta-facebook/yv35-bb/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-bb/src/platform/plat_sensor_table.c
@@ -100,3 +100,8 @@ void load_sensor_config(void)
 	memcpy(sensor_config, plat_sensor_config, sizeof(plat_sensor_config));
 	sensor_config_count = ARRAY_SIZE(plat_sensor_config);
 }
+
+uint8_t get_hsc_pwr_reading(int *reading)
+{
+	return get_sensor_reading(SENSOR_NUM_PWR_HSCIN, reading, GET_FROM_CACHE);
+}

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -494,3 +494,9 @@ bool pal_is_time_to_poll(uint8_t sensor_num, int poll_time)
 	printf("[%s] can't find sensor 0x%x last accest time\n", __func__, sensor_num);
 	return true;
 }
+
+uint8_t get_hsc_pwr_reading(int *reading)
+{
+	return get_sensor_reading(SENSOR_NUM_PWR_HSCIN, reading, GET_FROM_CACHE);
+}
+


### PR DESCRIPTION
Summary:
Remove yv35 specific sensor number from common to prevent potential build fail risk.

Test plan:
Build pass on fby35.

1. Check the ipmi command is still functional.

root@bmc-oob:~# bic-util slot3 0xc0 0xe2 0 0 0
00 82 00