### PR TITLE
GT: Close i2c mux channel after reading sensor on BUS9

### DIFF
--- a/meta-facebook/gt-cc/src/platform/plat_version.h
+++ b/meta-facebook/gt-cc/src/platform/plat_version.h
@@ -21,7 +21,7 @@
  *    Count of release firmware at each stage.
  */
 #define FIRMWARE_REVISION_1 0x01
-#define FIRMWARE_REVISION_2 0x00
+#define FIRMWARE_REVISION_2 0x07
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
 #define PRODUCT_ID 0x0000
@@ -29,7 +29,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x22
+#define BIC_FW_WEEK 0x28
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x47 // char: G
 #define BIC_FW_platform_1 0x54 // char: T


### PR DESCRIPTION
Summary:
- Because BUS9 has two mux behind 16 E1.S with the same i2c address, so close all mux channels after the sensor read  to avoid conflict with other devices reading.

Test Plan:
- Build code on project GT: Pass
- Check to see if the temperature rises as the hair dryer heat up: Pass

Log:
1. Before heat test
root@bmc-oob:~# sensor-util swb | grep "GT_SWB_E1S_*" | grep "TEMP"
GT_SWB_E1S_0_TEMP_C          (0x80) :   41.00 C     | (ok)
GT_SWB_E1S_1_TEMP_C          (0x84) :   40.00 C     | (ok)
GT_SWB_E1S_2_TEMP_C          (0x88) :   40.00 C     | (ok)
GT_SWB_E1S_3_TEMP_C          (0x8C) :   38.00 C     | (ok)
GT_SWB_E1S_4_TEMP_C          (0x90) :   40.00 C     | (ok)
GT_SWB_E1S_5_TEMP_C          (0x94) :   40.00 C     | (ok)
GT_SWB_E1S_6_TEMP_C          (0x98) :   39.00 C     | (ok)
GT_SWB_E1S_7_TEMP_C          (0x9C) :   35.00 C     | (ok)
GT_SWB_E1S_8_TEMP_C          (0xA0) :   33.00 C     | (ok)
GT_SWB_E1S_9_TEMP_C          (0xA4) :   33.00 C     | (ok)
GT_SWB_E1S_10_TEMP_C         (0xA8) :   37.00 C     | (ok)
GT_SWB_E1S_11_TEMP_C         (0xAC) :   37.00 C     | (ok)
GT_SWB_E1S_12_TEMP_C         (0xB0) :   42.00 C     | (ok)
GT_SWB_E1S_13_TEMP_C         (0xB4) :   44.00 C     | (ok)
GT_SWB_E1S_14_TEMP_C         (0xB8) :   44.00 C     | (ok)
GT_SWB_E1S_15_TEMP_C         (0xBC) :   40.00 C     | (ok)

2. Heat test on E1S 15
root@bmc-oob:~# sensor-util swb | grep "GT_SWB_E1S_*" | grep "TEMP"
GT_SWB_E1S_0_TEMP_C          (0x80) :   41.00 C     | (ok)
GT_SWB_E1S_1_TEMP_C          (0x84) :   40.00 C     | (ok)
GT_SWB_E1S_2_TEMP_C          (0x88) :   39.00 C     | (ok)
GT_SWB_E1S_3_TEMP_C          (0x8C) :   38.00 C     | (ok)
GT_SWB_E1S_4_TEMP_C          (0x90) :   40.00 C     | (ok)
GT_SWB_E1S_5_TEMP_C          (0x94) :   40.00 C     | (ok)
GT_SWB_E1S_6_TEMP_C          (0x98) :   39.00 C     | (ok)
GT_SWB_E1S_7_TEMP_C          (0x9C) :   35.00 C     | (ok)
GT_SWB_E1S_8_TEMP_C          (0xA0) :   33.00 C     | (ok)
GT_SWB_E1S_9_TEMP_C          (0xA4) :   34.00 C     | (ok)
GT_SWB_E1S_10_TEMP_C         (0xA8) :   37.00 C     | (ok)
GT_SWB_E1S_11_TEMP_C         (0xAC) :   38.00 C     | (ok)
GT_SWB_E1S_12_TEMP_C         (0xB0) :   43.00 C     | (ok)
GT_SWB_E1S_13_TEMP_C         (0xB4) :   47.00 C     | (ok)
GT_SWB_E1S_14_TEMP_C         (0xB8) :   55.00 C     | (ok)
**GT_SWB_E1S_15_TEMP_C         (0xBC) :   57.00 C     | (ok)**