### PR TITLE
common: fix BIC reset timing after update BIC

### DIFF
--- a/common/lib/util_sys.c
+++ b/common/lib/util_sys.c
@@ -30,7 +30,7 @@ bool is_ac_lost()
 }
 
 /* bic warm reset work */
-#define bic_warm_reset_delay 100
+#define bic_warm_reset_delay 200
 
 void bic_warm_reset()
 {


### PR DESCRIPTION
Summary:
- Sometimes BMC can't receive the last package response after update BIC image,
  because BIC didn't send out the response yet before BIC reset

Test Plan:
- Build code: Pass

Before extending the time to reset
Failed Rate:
SLOT1: 1/441 loops
SLOT2: 2/433 loops
SLOT3: 1/444 loops
SLOT4: 5/449 loop

After extending the time to reset
Total 4 slots 7720 loops pass