### PR TITLE
common: shell: Modify shell info command

### DIFF
--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -21,7 +21,7 @@ jobs:
         # Add platforms in alphabetical order.
         platform: [
           gt-cc,
-          wf-mb,
+          wc-mb,
           yv3-dl,
           yv35-bb, 
           yv35-cl, 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OpenBIC is an open software framework to build a complete firmware image for a B
 | Platform | Status | Description |
 |-------|--------|-------------|
 obgt-cc | ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/goldenbug/62fb115c4fa43a02acad226534e10932/raw/gt-cc.json) | Grand Teton Clear Creek
-obwc-mb | ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/goldenbug/62fb115c4fa43a02acad226534e10932/raw/wf-mb.json) | Waimea Canyon Mainboard
+obwc-mb | ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/goldenbug/62fb115c4fa43a02acad226534e10932/raw/wc-mb.json) | Waimea Canyon Mainboard
 oby3-dl | ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/goldenbug/62fb115c4fa43a02acad226534e10932/raw/y3-dl.json) | Yosemite v3 Delta Lake
 oby35-bb | ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/goldenbug/62fb115c4fa43a02acad226534e10932/raw/yv35-bb.json) | Yosemite v3.5 Baseboard
 oby35-cl | ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/goldenbug/62fb115c4fa43a02acad226534e10932/raw/yv35-cl.json) | Yosemite v3.5 Crater Lake

--- a/common/shell/shell_platform.c
+++ b/common/shell/shell_platform.c
@@ -35,6 +35,9 @@
 #include <device.h>
 #include <devicetree.h>
 
+/* Include VERSION */
+#include "plat_version.h"
+
 /* Include GPIO */
 #include <drivers/gpio.h>
 #include "plat_gpio.h"
@@ -283,6 +286,11 @@ static int cmd_info_print(const struct shell *shell, size_t argc, char **argv)
 	shell_print(shell, "* DATE/VERSION:  none");
 	shell_print(shell, "* CHIP/OS:       AST1030 - Zephyr");
 	shell_print(shell, "* Note:          none");
+	shell_print(shell, "------------------------------------------------------------------");
+	shell_print(shell, "* PLATFORM:      %s-%s", PLATFORM_NAME, PROJECT_NAME);
+	shell_print(shell, "* FW VERSION:    %d.%d", FIRMWARE_REVISION_1, FIRMWARE_REVISION_2);
+	shell_print(shell, "* FW DATE:       %x%x.%x.%x", BIC_FW_YEAR_MSB, BIC_FW_YEAR_LSB,
+		    BIC_FW_WEEK, BIC_FW_VER);
 	shell_print(
 		shell,
 		"========================{SHELL COMMAND INFO}========================================");
@@ -521,7 +529,7 @@ static void cmd_control_sensor_polling(const struct shell *shell, size_t argc, c
 
 	sensor_config[sensor_index].is_enable_polling =
 		((operation == DISABLE_SENSOR_POLLING) ? DISABLE_SENSOR_POLLING :
-							       ENABLE_SENSOR_POLLING);
+							 ENABLE_SENSOR_POLLING);
 	shell_print(shell, "Sensor number 0x%x %s sensor polling success", sensor_num,
 		    ((operation == DISABLE_SENSOR_POLLING) ? "disable" : "enable"));
 	return;
@@ -577,7 +585,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_sensor_cmds,
 
 /* MAIN command */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_platform_cmds,
-			       SHELL_CMD(note, NULL, "Note list.", cmd_info_print),
+			       SHELL_CMD(info, NULL, "Platform/Commands info.", cmd_info_print),
 			       SHELL_CMD(gpio, &sub_gpio_cmds, "GPIO relative command.", NULL),
 			       SHELL_CMD(sensor, &sub_sensor_cmds, "SENSOR relative command.",
 					 NULL),

--- a/common/shell/shell_platform.c
+++ b/common/shell/shell_platform.c
@@ -291,6 +291,7 @@ static int cmd_info_print(const struct shell *shell, size_t argc, char **argv)
 	shell_print(shell, "* FW VERSION:    %d.%d", FIRMWARE_REVISION_1, FIRMWARE_REVISION_2);
 	shell_print(shell, "* FW DATE:       %x%x.%x.%x", BIC_FW_YEAR_MSB, BIC_FW_YEAR_LSB,
 		    BIC_FW_WEEK, BIC_FW_VER);
+	shell_print(shell, "* FW IMAGE:      %s.bin", CONFIG_KERNEL_BIN_NAME);
 	shell_print(
 		shell,
 		"========================{SHELL COMMAND INFO}========================================");

--- a/scripts/common/constants.py
+++ b/scripts/common/constants.py
@@ -52,7 +52,7 @@ TITLE_TAGS = {
     "hd",
     "mb",
     "rf:",
-    "wf",
+    "wc",
 }
 
 

--- a/scripts/signing/sign_bic_image.py
+++ b/scripts/signing/sign_bic_image.py
@@ -17,7 +17,7 @@ stage_map = {
 # Supported boards for each platform.
 valid_projects = {
     "gt": {"cc", }
-    "wf": {"mb", }
+    "wc": {"mb", }
     "yv3": {"dl", }
     "yv35": {"cl", "bb", "rf", "hd", },
 }
@@ -26,8 +26,8 @@ valid_projects = {
 board_map = {
     # GT
     "cc": "00001",
-    # WF
-    "wf": "00001",
+    # WC
+    "wc": "00001",
     # Yv3
     "dl": "00001",
     # Yv3.5
@@ -40,7 +40,7 @@ board_map = {
 # Mapping between short and full project names.
 project_name_mapping = {
     "gt": "Grand Teton",
-    "wf": "Waimea Canyon",
+    "wc": "Waimea Canyon",
     "yv3": "Yosemite V3",
     "yv35": "Yosemite V3.5",
 }


### PR DESCRIPTION
Summary:
- Modify shell info command from "platform note" to "platform info".
- Add platform and firmware relative info to shell info command.

Dependency: #426

Test Plan:
- Build code: PASS
- Print log in BIC console: PASS

Log:
- BIC console
  ```
  uart:~$ platform info
  ========================{SHELL COMMAND INFO}========================================
  * NAME:          Platform command
  * DESCRIPTION:   Commands that could be used to debug or validate.
  * DATE/VERSION:  none
  * CHIP/OS:       AST1030 - Zephyr
  * Note:          none
  ------------------------------------------------------------------
  * PLATFORM:      wc-mainboard
  * FW VERSION:    1.1
  * FW DATE:       2022.25.0
  ========================{SHELL COMMAND INFO}========================================
  ```