### PR TITLE
common:modify switch bios spi mux function

### DIFF
--- a/common/lib/util_spi.c
+++ b/common/lib/util_spi.c
@@ -283,7 +283,7 @@ __weak int pal_get_bios_flash_position()
 
 __weak bool pal_switch_bios_spi_mux(int gpio_status)
 {
-	return false;
+	return true;
 }
 
 __weak int pal_get_cxl_flash_position()


### PR DESCRIPTION
Summary:
1.Some platform do not need to switch the spi mux, modify this function return true, so that the bios update can be continue.

Test plan:
Build pass on yv3-dl and yv35-cl