### PR TITLE
fby3:dl:remove unused variable and revise event sensor nubmer

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_isr.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_isr.c
@@ -454,8 +454,6 @@ static void SMI_handler(struct k_work *work)
 {
 	if (gpio_get(IRQ_SMI_ACTIVE_BMC_N) == GPIO_LOW) {
 		common_addsel_msg_t sel_msg;
-		bool ret = false;
-
 		memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
 
 		sel_msg.InF_target = BMC_IPMB;
@@ -485,7 +483,6 @@ void ISR_SMI()
 		} else {
 			if (is_smi_assert == true) {
 				common_addsel_msg_t sel_msg;
-				bool ret = false;
 				memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
 
 				sel_msg.InF_target = BMC_IPMB;

--- a/meta-facebook/yv3-dl/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv3-dl/src/platform/plat_sensor_table.h
@@ -94,7 +94,7 @@
 /**********************Event**********************/
 
 #define SENSOR_NUM_SYS_STA 0x46
-#define SENSOR_NUM_POWER_ERROR 0x56
+#define SENSOR_NUM_POWER_ERR 0x56
 #define SENSOR_NUM_PROC_FAIL 0x65
 #define SENSOR_NUM_VR_HOT 0xB4
 #define SENSOR_NUM_CPUDIMM_HOT 0xB3


### PR DESCRIPTION
Summary:
- Remove unused variable in plat_isr.c
- Revise SENSOR_NUM_POWER_ERROR to SENSOR_NUM_POWER_ERR

Test Plan:
Build code : pass