### PR TITLE
fby3.5: hd: Add get card type command

### DIFF
--- a/meta-facebook/yv35-hd/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/yv35-hd/src/ipmi/include/plat_ipmi.h
@@ -1,4 +1,9 @@
 #ifndef PLAT_IPMI_H
 #define PLAT_IPMI_H
 
+enum REQ_GET_CARD_TYPE {
+	GET_1OU_CARD_TYPE = 0x0,
+	GET_2OU_CARD_TYPE,
+};
+
 #endif

--- a/meta-facebook/yv35-hd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-hd/src/ipmi/plat_ipmi.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "ipmi.h"
+#include "plat_ipmi.h"
+#include "plat_class.h"
+
+void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
+{
+	if (msg == NULL) {
+		printf("[%s] Failed due to parameter *msg is NULL\n", __func__);
+		return;
+	}
+
+	if (msg->data_len != 1) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	CARD_STATUS _1ou_status = get_1ou_status();
+	CARD_STATUS _2ou_status = get_2ou_status();
+	switch (msg->data[0]) {
+	case GET_1OU_CARD_TYPE:
+		msg->data_len = 2;
+		msg->completion_code = CC_SUCCESS;
+		msg->data[0] = GET_1OU_CARD_TYPE;
+		if (_1ou_status.present) {
+			msg->data[1] = _1ou_status.card_type;
+		} else {
+			msg->data[1] = TYPE_1OU_ABSENT;
+		}
+		break;
+	case GET_2OU_CARD_TYPE:
+		msg->data_len = 2;
+		msg->completion_code = CC_SUCCESS;
+		msg->data[0] = GET_2OU_CARD_TYPE;
+		if (_2ou_status.present) {
+			msg->data[1] = _2ou_status.card_type;
+		} else {
+			msg->data[1] = TYPE_2OU_ABSENT;
+		}
+		break;
+	default:
+		msg->data_len = 0;
+		msg->completion_code = CC_INVALID_DATA_FIELD;
+		break;
+	}
+
+	return;
+}

--- a/meta-facebook/yv35-hd/src/platform/plat_class.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_class.h
@@ -37,6 +37,13 @@ enum _1OU_CARD_TYPE_ {
 	TYPE_1OU_UNKNOWN = 0xFF,
 };
 
+enum _2OU_CARD_TYPE_ {
+	TYPE_2OU_DPV2_8 = 0x07, // DPV2x8
+	TYPE_2OU_DPV2_16 = 0x70, // DPV2x16
+	TYPE_2OU_ABSENT = 0xFE,
+	TYPE_2OU_UNKNOWN = 0xFF,
+};
+
 /* ADC channel number */
 enum ADC_CHANNEL {
 	CHANNEL_6 = 6,
@@ -49,6 +56,7 @@ enum BIC_CARD_PRESENT {
 
 uint8_t get_system_class();
 CARD_STATUS get_1ou_status();
+CARD_STATUS get_2ou_status();
 uint8_t get_board_revision();
 bool get_adc_voltage(int channel, float *voltage);
 void init_platform_config();


### PR DESCRIPTION
Summary:
- Add IPMI get card type OEM command(Netfn:0x38, cmd:0xA1).

Test Plan:
- Build code: PASS