### PR TITLE
Common: Support MUX PCA9846

### DIFF
--- a/common/dev/i2c-mux-pca984x.c
+++ b/common/dev/i2c-mux-pca984x.c
@@ -1,0 +1,122 @@
+#include <stdio.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "i2c-mux-pca984x.h"
+
+/** 
+ * PCA9846 usage:
+ * PCA9846 only recieves the last byte unless special condition.
+ * The byte data[0] refer to below bit-map; 1 = Enable, 0 = Disable
+ *     Bit 7 6 5 4 3 2 1 0
+ * Channel X X X X 3 2 1 0
+ * 
+ * Example:
+ * File1: plat_i2c.c
+ * K_MUTEX_DEFINE(i2c_bus9_mutex);
+ * 
+ * File2: plat_i2c.h
+ * extern struct k_mutex i2c_bus9_mutex;
+ *
+ * File3: Application
+ * I2C_MSG *msg;
+ * msg->data[0] = 0x1;	// Enable Channel 0 only
+ * msg->data[0] = 0x3;	// Enable Channel 0 + 1
+ * msg->data[0] = 0x4;	// Enable Channel 2 only
+ * msg->data[0] = 0x8;	// Enable Channel 3 only
+ * msg->lock = &i2c_bus9_mutex;
+ * i2c_mux_pca9846_lock(msg);
+ * // Accessing device code here //
+ * i2c_mux_pca9846_unlock(msg);
+ */
+
+/**
+ * @brief lock the specific mutex then enable mux channel.
+ * 
+ * Check lock_count before enable channel.
+ * Set 5 seconds timeout if wait for unlock failed.
+ * After timeout, the mutex will be force re-init to unlock for preventing infinte lock.
+ * Once lock the mutex, switch the channel based on i2c data.
+ * 
+ * @param msg                   i2c message structure.
+ * @param msg->bus              bus number where mux locate.
+ * @param msg->target_addr      slave addr where mux locate.
+ * @param msg->lock             the mutex addr for kernel reference.
+ * @param msg->lock->lock_count number of lock using
+ * 
+ * @retval true  mutex lock and enable mux channel successfully.
+ * @retval false mutex lock or i2c send failed.
+ */
+bool i2c_mux_pca9846_lock(I2C_MSG *msg)
+{
+	if (!msg) {
+		printf("[%s] Received null pointer\n", __func__);
+		return false;
+	}
+
+	uint8_t retry = 3;
+	for (uint8_t i = 1; i <= retry; ++i) {
+		if (msg->lock->lock_count) {
+			k_sleep(K_SECONDS(I2C_MUX_RETRY_INTERVAL));
+			if (i >= retry) {
+				printf("[%s] Failed to wait for unlock, retry: %u times in %u seconds. Force re-init the mutex\n",
+				       __func__, retry, I2C_MUX_RETRY_INTERVAL * retry);
+				k_mutex_init(msg->lock);
+			}
+		} else {
+			break;
+		}
+	}
+
+	/* k_mutex_lock return zero or -ERRNO */
+	if (k_mutex_lock(msg->lock, K_NO_WAIT)) {
+		/* Re-init Mutex for preventing infinite lock */
+		printf("[%s] Failed to lock bus%u mux0x%x\n", __func__, msg->bus, msg->target_addr);
+		return false;
+	}
+
+	if (i2c_master_write(msg, retry)) {
+		printf("[%s] i2c sent failed\n", __func__);
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * @brief disable all mux channels then unlock the mutex
+ * 
+ * Function disable all mux channels directly.
+ * No matter the disable result, it will unlock the mutex.
+ * Unlock can be failed by incorrect thread owner or lock_count already zero.
+ * 
+ * @param msg              i2c message structure
+ * @param msg->bus         bus number where mux locate
+ * @param msg->target_addr slave addr where mux locate
+ * @param msg->lock        the mutex addr for kernel reference
+ * 
+ * @retval true  mutex unlock successfully
+ * @retval false mutex unlock failed
+ */
+bool i2c_mux_pca9846_unlock(I2C_MSG *msg)
+{
+	if (!msg) {
+		printf("[%s] Received null pointer\n", __func__);
+		return false;
+	}
+
+	/* Disable all channels */
+	uint8_t retry = 5;
+	msg->data[0] = I2C_MUX_PCA9846_DEFAULT_CHANNEL;
+	if (i2c_master_write(msg, retry)) {
+		printf("[%s] i2c sent failed, mux did not disable all channels\n", __func__);
+	}
+
+	/* k_mutex_unlock return zero or -ERRNO */
+	if (k_mutex_unlock(msg->lock)) {
+		printf("[%s] Failed to unlock bus%u mux0x%x\n", __func__, msg->bus,
+		       msg->target_addr);
+		return false;
+	}
+
+	return true;
+}

--- a/common/dev/include/i2c-mux-pca984x.h
+++ b/common/dev/include/i2c-mux-pca984x.h
@@ -1,0 +1,12 @@
+#ifndef I2C_MUX_PCA984X_H
+#define I2C_MUX_PCA984X_H
+#include "hal_i2c.h"
+
+#define I2C_MUX_RETRY_INTERVAL 1
+#define I2C_MUX_PCA9846_DEFAULT_CHANNEL 0x00
+
+/* i2c-mux pca9846 */
+bool i2c_mux_pca9846_lock(I2C_MSG *msg);
+bool i2c_mux_pca9846_unlock(I2C_MSG *msg);
+
+#endif

--- a/common/hal/hal_i2c.h
+++ b/common/hal/hal_i2c.h
@@ -79,7 +79,7 @@ typedef struct _I2C_MSG_ {
 	uint8_t rx_len;
 	uint8_t tx_len;
 	uint8_t data[I2C_BUFF_SIZE];
-	struct k_mutex lock;
+	struct k_mutex *lock;
 } I2C_MSG;
 
 void i2c_freq_set(uint8_t i2c_bus, uint8_t i2c_speed_mode);


### PR DESCRIPTION
[Summary]
- Add common device i2c-mux-pca984x (x for these series), using kernel mutex lock and unlock functions
- k_mutex is only work for different threads; lock_count check used for avoiding same thread race condition
- Currently, set 3 seconds timeout to lock the mutex. If it fails, force re-init the mutex to unlock for preventing infinte lock

[Test Plan & Log]
1. Build code:	Y35 CL BIC			[ Pass ]
		Y35 BB BIC			[ Pass ]
		Y35 RF BIC			[ Pass ]
		GT  SW BIC			[ Pass ]

2. Mutex lock & Force re-init:			[ Pass ]
	--------------- BMC Console ---------------
	root@bmc-oob:~# bic-util slot4 0xe0 0x99 0x15 0xa0 0x00 0x02 0x00	// Trigger IPMI thread lock the mutex
	15 A0 00 02 00
	root@bmc-oob:~# bic-util slot4 --set_gpio 0 0				// Trigger GPIO thread lock the mutex
	slot 4: setting [0]FM_BMC_PCH_SCI_LPC_R_N to 0

	--------------- BIC Console ---------------
	[i2c_mux_pca9846_lock] Before Lock count: 1
	[i2c_mux_pca9846_lock] Failed to wait for unlock, retry: 3 times in 3 seconds. Force re-init the mutex
	[i2c_mux_pca9846_lock] Re-init Lock count: 0
	[i2c_mux_pca9846_lock] After Lock count: 1

3. Mutex unlock:				[ Pass ]
	A. Unlock by non-owner:
	--------------- BMC Console ---------------
	root@bmc-oob:~# bic-util slot4 0xe0 0x99 0x15 0xa0 0x00 0x02 0x00	// Trigger IPMI thread lock the mutex
	15 A0 00 02 00
	root@bmc-oob:~# bic-util slot4 --set_gpio 0 1				// Trigger GPIO thread unlock the mutex
	slot 4: setting [0]FM_BMC_PCH_SCI_LPC_R_N to 1

	--------------- BIC Console ---------------
	[i2c_mux_pca9846_unlock] Failed to unlock Mutex of bus8 addr0x71

	B. Unlock by owner:
	--------------- BMC Console ---------------
	root@bmc-oob:~# bic-util slot4 0xe0 0x99 0x15 0xa0 0x00 0x01 0x00	// Trigger IPMI thread lock the mutex
	15 A0 00 01 00
	root@bmc-oob:~# bic-util slot4 0xe0 0x99 0x15 0xa0 0x00 0x01 0x01	// Trigger IPMI thread unlock the mutex
	15 A0 00 01 01

	--------------- BIC Console ---------------
	// Note: BIC console does not pop up any error (means work fine)

4. Mutex queue waiting without timeout:		[ Pass ]
	--------------- BIC Console ---------------
	uart:~$ i2c scan I2C_8
	     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
	00:             -- -- -- -- -- -- -- -- -- -- -- --
	10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	70: -- 71 -- -- -- -- -- --
	1 devices found on I2C_8

	--------------- BMC Console ---------------
	root@bmc-oob:~# bic-util slot4 0xe0 0x99 0x15 0xa0 0x00 0x2 0	// Trigger IPMI thread lock the mutex and enable to channel 1
	15 A0 00 02 00

	--------------- BIC Console ---------------
	uart:~$ i2c scan I2C_8
	     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
	00:             -- -- -- -- -- -- -- -- -- -- -- --
	10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	40: 40 41 -- 43 -- -- -- -- -- -- -- -- -- -- -- --
	50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	70: -- 71 -- -- -- -- -- --
	4 devices found on I2C_8

	--------------- BMC Console ---------------
	root@bmc-oob:~# bic-util slot4 --set_gpio 0 0			// Trigger GPIO thread enter queue for locking the mutex
	slot 4: setting [0]FM_BMC_PCH_SCI_LPC_R_N to 0

	--------------- BIC Console ---------------
	uart:~$ i2c scan I2C_8
	     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
	00:             -- -- -- -- -- -- -- -- -- -- -- --
	10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	40: 40 41 -- 43 -- -- -- -- -- -- -- -- -- -- -- --
	50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	70: -- 71 -- -- -- -- -- --
	4 devices found on I2C_8

	--------------- BMC Console ---------------
	root@bmc-oob:~# bic-util slot4 0xe0 0x99 0x15 0xa0 0x00 0x2 1	// Trigger IPMI thread unlock the mutex and disable channel
	15 A0 00 02 01

	--------------- BIC Console ---------------
	uart:~$ i2c scan I2C_8
	     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
	00:             -- -- -- -- -- -- -- -- -- -- -- --
	10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	40: -- -- -- -- -- 45 -- -- -- -- -- -- -- -- -- --		// GPIO thread lock and switch channel successfully after unlock
	50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	70: -- 71 -- -- -- -- -- --
	2 devices found on I2C_8

5. Lock_count check function:			[ Pass ]
	--------------- BIC Console ---------------
	uart:~$ i2c scan I2C_8
	     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
	00:             -- -- -- -- -- -- -- -- -- -- -- --
	10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	70: -- 71 -- -- -- -- -- --
	1 devices found on I2C_8

	--------------- BMC Console ---------------
	root@bmc-oob:~# bic-util slot4 0xe0 0x99 0x15 0xa0 0x00 1 0	// Trigger IPMI thread lock the mutex and enable channel 0
	15 A0 00 02 00

	--------------- BIC Console ---------------
	[i2c_mux_pca9846_lock] Before Lock count: 0
	[i2c_mux_pca9846_lock] After Lock count: 1

	uart:~$ i2c scan I2C_8
	     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
	00:             -- -- -- -- -- -- -- -- -- -- -- --
	10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	40: -- -- -- -- -- 45 -- -- -- -- -- -- -- -- -- --
	50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	70: -- 71 -- -- -- -- -- --
	2 devices found on I2C_8

	--------------- BMC Console ---------------
	root@bmc-oob:~# bic-util slot4 0xe0 0x99 0x15 0xa0 0x00 2 0	// Trigger IPMI thread lock the mutex and enable channel 1
	15 A0 00 02 00

	--------------- BIC Console ---------------
	[i2c_mux_pca9846_lock] Before Lock count: 1
	[i2c_mux_pca9846_lock] Failed to wait for unlock, retry: 3 times in 3 seconds. Force re-init the mutex
	[i2c_mux_pca9846_lock] Re-init Lock count: 0
	[i2c_mux_pca9846_lock] After Lock count: 1

6. Stress:					[ Pass ]
	Pass with 58548 times of Mux sequential switch

7. Experiment on same thread using k_mutex without lock_count judgement:
	--------------- BIC Console ---------------
	uart:~$ i2c scan I2C_8
	     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
	00:             -- -- -- -- -- -- -- -- -- -- -- --
	10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	70: -- 71 -- -- -- -- -- --
	1 devices found on I2C_8

	--------------- BMC Console ---------------
	root@bmc-oob:~# bic-util slot4 0xe0 0x99 0x15 0xa0 0x0 0x1 0x0	// Trigger IPMI thread lock the mutex and enable channel 0
	15 A0 00 01 00

	--------------- BIC Console ---------------
	[i2c_mux_pca9846_lock] msg->lock->owner: 0x4dce0
	[i2c_mux_pca9846_lock] msg->lock->lock_count: 1
	uart:~$ i2c scan I2C_8
	     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
	00:             -- -- -- -- -- -- -- -- -- -- -- --
	10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	40: -- -- -- -- -- 45 -- -- -- -- -- -- -- -- -- --
	50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	70: -- 71 -- -- -- -- -- --
	2 devices found on I2C_8

	--------------- BMC Console ---------------
	root@bmc-oob:~# bic-util slot4 0xe0 0x98 0x15 0xa0 0x0 0x2 0x0	// Trigger IPMI thread with different in-band command
	15 A0 00 02 00							// lock the mutex and enable channel 1

	--------------- BIC Console ---------------
	[i2c_mux_pca9846_lock] msg->lock->owner: 0x4dce0
	[i2c_mux_pca9846_lock] msg->lock->lock_count: 2
	uart:~$ i2c scan I2C_8
	     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
	00:             -- -- -- -- -- -- -- -- -- -- -- --
	10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	40: 40 41 -- 43 -- -- -- -- -- -- -- -- -- -- -- --		// Switch channel and lock mutex again successfully
	50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	70: -- 71 -- -- -- -- -- --
	4 devices found on I2C_8