### PR TITLE
fby3: dl: Fixed the building failed of yv3-dl

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_sdr_table.c
@@ -1,5 +1,3 @@
-#include "plat_sdr_table.h"
-
 #include <stdio.h>
 #include <string.h>
 

--- a/meta-facebook/yv3-dl/src/platform/plat_sdr_table.h
+++ b/meta-facebook/yv3-dl/src/platform/plat_sdr_table.h
@@ -1,9 +1,4 @@
 #ifndef PLAT_SDR_TABLE_H
 #define PLAT_SDR_TABLE_H
 
-#include <stdint.h>
-
-uint8_t plat_get_sdr_size();
-uint8_t load_sdr_table(void);
-
 #endif


### PR DESCRIPTION
Summry:
- Since commit 10e23f1935e6977462e7d7f353a12c46f1324675 refactor plat_sdr to extract common functions, removed plat_get_sdr_size(...) and load_sdr_table(...) function.

Test Plan:
- Built passed on yv3-dl.