### PR TITLE
fby3.5-cl: Improve peci read function

### DIFF
--- a/common/dev/include/intel_dimm.h
+++ b/common/dev/include/intel_dimm.h
@@ -1,0 +1,73 @@
+#ifndef DIMM_H
+#define DIMM_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define CMD_GET_CPU_MEMORY_TEMP 0x4B
+#define CMD_GET_CPU_MEMORY_TEMP_DATA_LEN 12
+#define RESPONSE_DIMM_TEMP_INDEX 3
+
+/* Get CPU and memory temperature command request */
+#define CHANNEL_0_4_DIMM_NUM_0 BIT(0)
+#define CHANNEL_0_4_DIMM_NUM_1 BIT(1)
+#define CHANNEL_0_4_DIMM_NUM_2 BIT(2)
+#define CHANNEL_0_4_DIMM_NUM_3 BIT(3)
+#define CHANNEL_1_5_DIMM_NUM_0 BIT(4)
+#define CHANNEL_1_5_DIMM_NUM_1 BIT(5)
+#define CHANNEL_1_5_DIMM_NUM_2 BIT(6)
+#define CHANNEL_1_5_DIMM_NUM_3 BIT(7)
+#define CHANNEL_2_6_DIMM_NUM_0 BIT(8)
+#define CHANNEL_2_6_DIMM_NUM_1 BIT(9)
+#define CHANNEL_2_6_DIMM_NUM_2 BIT(10)
+#define CHANNEL_2_6_DIMM_NUM_3 BIT(11)
+#define CHANNEL_3_7_DIMM_NUM_0 BIT(12)
+#define CHANNEL_3_7_DIMM_NUM_1 BIT(13)
+#define CHANNEL_3_7_DIMM_NUM_2 BIT(14)
+#define CHANNEL_3_7_DIMM_NUM_3 BIT(15)
+
+enum DIMM_CHANNEL_NUM {
+	DIMM_CHANNEL_NUM_0,
+	DIMM_CHANNEL_NUM_1,
+	DIMM_CHANNEL_NUM_2,
+	DIMM_CHANNEL_NUM_3,
+	DIMM_CHANNEL_NUM_4,
+	DIMM_CHANNEL_NUM_5,
+	DIMM_CHANNEL_NUM_6,
+	DIMM_CHANNEL_NUM_7,
+};
+
+enum DIMM_NUMBER {
+	DIMM_NUMBER_0,
+	DIMM_NUMBER_1,
+	DIMM_NUMBER_2,
+	DIMM_NUMBER_3,
+};
+
+enum CPU_USE_RANGE {
+	USE_CPU_0_TO_3 = 0x0,
+	USE_CPU_4_TO_7 = 0x1,
+	USE_CPU_8_TO_11 = 0x2,
+};
+
+enum MEMORY_CHANNEL {
+	MEMORY_CHANNEL_0_TO_3 = 0x0,
+	MEMORY_CHANNEL_4_TO_7 = 0x1,
+};
+
+typedef struct _get_cpu_memory_temp_req {
+	uint8_t intel_id[3];
+	uint8_t set_read_cpu0 : 1;
+	uint8_t set_read_cpu1 : 1;
+	uint8_t set_read_cpu2 : 1;
+	uint8_t set_read_cpu3 : 1;
+	uint8_t set_use_cpu : 2;
+	uint8_t set_memory_channel : 1;
+	uint8_t set_request_format : 1;
+	uint16_t cpu0_read_dimm_req;
+	uint16_t cpu1_read_dimm_req;
+	uint16_t cpu2_read_dimm_req;
+	uint16_t cpu3_read_dimm_req;
+} get_cpu_memory_temp_req;
+
+#endif

--- a/common/dev/include/intel_peci.h
+++ b/common/dev/include/intel_peci.h
@@ -30,5 +30,6 @@ enum {
 };
 
 bool peci_sensor_read(uint8_t sensor_num, int *reading);
+bool check_dimm_present(uint8_t dimm_channel, uint8_t dimm_num, uint8_t *present_result);
 
 #endif

--- a/common/lib/libutil.h
+++ b/common/lib/libutil.h
@@ -15,6 +15,16 @@
 #define GETBIT(x, y) ((x & (1ULL << y)) > y)
 #define CLEARBIT(x, y) (x & (~(1ULL << y)))
 
+enum BIT_SETTING_READING {
+	BIT_SET = 1,
+	BIT_CLEAR = 0,
+};
+
+enum BIT_SETTING_READING_N {
+	BIT_SET_N = 0,
+	BIT_CLEAR_N = 1,
+};
+
 ipmi_msg construct_ipmi_message(uint8_t seq_source, uint8_t netFn, uint8_t command,
 				uint8_t source_inft, uint8_t target_inft, uint16_t data_len,
 				uint8_t *data);

--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -778,6 +778,7 @@ __weak void OEM_1S_ACCURACY_SENSOR_READING(ipmi_msg *msg)
 		break;
 	case SENSOR_NOT_ACCESSIBLE:
 	case SENSOR_INIT_STATUS:
+	case SENSOR_NOT_PRESENT:
 		res->decimal = 0;
 		res->fraction = 0;
 		// notice BMC about sensor temporary in not accessible status

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -196,6 +196,9 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 				cfg->cache_status = SENSOR_PRE_READ_ERROR;
 				return cfg->cache_status;
 			}
+			if (cfg->cache_status == SENSOR_NOT_PRESENT) {
+				return cfg->cache_status;
+			}
 		}
 
 		if (cfg->read) {
@@ -263,6 +266,7 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 			return cfg->cache_status;
 			;
 		case SENSOR_INIT_STATUS:
+		case SENSOR_NOT_PRESENT:
 			cfg->cache = SENSOR_FAIL;
 			return cfg->cache_status;
 		default:
@@ -309,8 +313,12 @@ void sensor_poll_handler(void *arug0, void *arug1, void *arug2)
 				break;
 			}
 
-			// Check whether monitoring sensor is enabled
 			sensor_cfg *config = &sensor_config[sensor_config_index_map[sensor_num]];
+			if (config->cache_status == SENSOR_NOT_PRESENT) {
+				continue;
+			}
+
+			// Check whether monitoring sensor is enabled
 			if (config->is_enable_polling == DISABLE_SENSOR_POLLING) {
 				config->cache = SENSOR_FAIL;
 				config->cache_status = SENSOR_POLLING_DISABLE;
@@ -566,4 +574,21 @@ __weak void load_sensor_config(void)
 {
 	memcpy(sensor_config, plat_sensor_config, sizeof(sensor_cfg) * SENSOR_CONFIG_SIZE);
 	sensor_config_count = SENSOR_CONFIG_SIZE;
+}
+
+void control_sensor_polling(uint8_t sensor_num, uint8_t optional, uint8_t cache_status)
+{
+	if ((sensor_num == SENSOR_NOT_SUPPORT) ||
+	    (sensor_config_index_map[sensor_num] == SENSOR_FAIL)) {
+		return;
+	}
+
+	if ((optional != DISABLE_SENSOR_POLLING) && (optional != ENABLE_SENSOR_POLLING)) {
+		printf("[%s] input optional is not support, optional: %d\n", __func__, optional);
+		return;
+	}
+
+	sensor_cfg *config = &sensor_config[sensor_config_index_map[sensor_num]];
+	config->is_enable_polling = optional;
+	config->cache_status = cache_status;
 }

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -18,6 +18,8 @@
 #define SENSOR_NULL 0xFF
 #define SENSOR_FAIL 0xFF
 #define SENSOR_NUM_MAX 0xFF
+#define SENSOR_NOT_SUPPORT 0xFF
+#define DIMM_NOT_PRESENT 0xFF
 
 #define DEBUG_SENSOR 0
 
@@ -128,18 +130,21 @@ static inline float convert_MBR_to_reading(uint8_t sensor_num, uint8_t val)
 	return (val - round_add(sensor_num, val)) * SDR_M(sensor_num) / SDR_Rexp(sensor_num);
 }
 
-enum { SENSOR_READ_SUCCESS,
-       SENSOR_READ_ACUR_SUCCESS,
-       SENSOR_NOT_FOUND,
-       SENSOR_NOT_ACCESSIBLE,
-       SENSOR_FAIL_TO_ACCESS,
-       SENSOR_INIT_STATUS,
-       SENSOR_UNSPECIFIED_ERROR,
-       SENSOR_POLLING_DISABLE,
-       SENSOR_PRE_READ_ERROR,
-       SENSOR_POST_READ_ERROR,
-       SENSOR_READ_API_UNREGISTER,
-       SENSOR_READ_4BYTE_ACUR_SUCCESS };
+enum {
+	SENSOR_READ_SUCCESS,
+	SENSOR_READ_ACUR_SUCCESS,
+	SENSOR_NOT_FOUND,
+	SENSOR_NOT_ACCESSIBLE,
+	SENSOR_FAIL_TO_ACCESS,
+	SENSOR_INIT_STATUS,
+	SENSOR_UNSPECIFIED_ERROR,
+	SENSOR_POLLING_DISABLE,
+	SENSOR_PRE_READ_ERROR,
+	SENSOR_POST_READ_ERROR,
+	SENSOR_READ_API_UNREGISTER,
+	SENSOR_READ_4BYTE_ACUR_SUCCESS,
+	SENSOR_NOT_PRESENT
+};
 
 enum { SENSOR_INIT_SUCCESS, SENSOR_INIT_UNSPECIFIED_ERROR };
 
@@ -367,5 +372,6 @@ bool check_is_sensor_ready();
 bool pal_is_time_to_poll(uint8_t sensor_num, int poll_time);
 uint8_t plat_get_config_size();
 void load_sensor_config(void);
+void control_sensor_polling(uint8_t sensor_num, uint8_t optional, uint8_t cache_status);
 
 #endif

--- a/common/shell/shell_platform.h
+++ b/common/shell/shell_platform.h
@@ -87,6 +87,7 @@ const char *const sensor_status_name[] = {
 				sensor_name_to_num(post_read_error)
 					sensor_name_to_num(api_unregister)
 						sensor_name_to_num(4byte_acur_read_success)
+							sensor_name_to_num(sensor_not_present)
 };
 
 enum SENSOR_ACCESS { SENSOR_READ, SENSOR_WRITE };

--- a/meta-facebook/yv35-cl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.c
@@ -8,6 +8,9 @@
 #include "plat_hook.h"
 #include "plat_sensor_table.h"
 #include "pmbus.h"
+#include "intel_peci.h"
+#include "intel_dimm.h"
+#include "power_status.h"
 
 #include "i2c-mux-tca9548.h"
 
@@ -64,6 +67,12 @@ pmic_pre_proc_arg pmic_pre_read_args[] = {
 	[0] = { .pre_read_init = false }, [1] = { .pre_read_init = false },
 	[2] = { .pre_read_init = false }, [3] = { .pre_read_init = false },
 	[4] = { .pre_read_init = false }, [5] = { .pre_read_init = false }
+};
+
+dimm_pre_proc_arg dimm_pre_proc_args[] = {
+	[0] = { .is_present_checked = false }, [1] = { .is_present_checked = false },
+	[2] = { .is_present_checked = false }, [3] = { .is_present_checked = false },
+	[4] = { .is_present_checked = false }, [5] = { .is_present_checked = false }
 };
 
 /**************************************************************************************************
@@ -231,6 +240,59 @@ bool pre_pmic_read(uint8_t sensor_num, void *args)
 		return false;
 	}
 	return true;
+}
+
+bool pre_intel_peci_dimm_read(uint8_t sensor_num, void *args)
+{
+	if (get_post_status() == false) {
+		// BIC can't check DIMM temperature by ME, return true to keep do sensor initial
+		return true;
+	}
+
+	dimm_pre_proc_arg *pre_proc_args = (dimm_pre_proc_arg *)args;
+	if (pre_proc_args->is_present_checked == true) {
+		return true;
+	}
+
+	bool ret = false;
+	uint8_t dimm_present_result = 0;
+	sensor_cfg cfg = sensor_config[sensor_config_index_map[sensor_num]];
+	switch (cfg.offset) {
+	case PECI_TEMP_CHANNEL0_DIMM0:
+		ret = check_dimm_present(DIMM_CHANNEL_NUM_0, DIMM_NUMBER_0, &dimm_present_result);
+		break;
+	case PECI_TEMP_CHANNEL2_DIMM0:
+		ret = check_dimm_present(DIMM_CHANNEL_NUM_2, DIMM_NUMBER_0, &dimm_present_result);
+		break;
+	case PECI_TEMP_CHANNEL3_DIMM0:
+		ret = check_dimm_present(DIMM_CHANNEL_NUM_3, DIMM_NUMBER_0, &dimm_present_result);
+		break;
+	case PECI_TEMP_CHANNEL4_DIMM0:
+		ret = check_dimm_present(DIMM_CHANNEL_NUM_4, DIMM_NUMBER_0, &dimm_present_result);
+		break;
+	case PECI_TEMP_CHANNEL6_DIMM0:
+		ret = check_dimm_present(DIMM_CHANNEL_NUM_6, DIMM_NUMBER_0, &dimm_present_result);
+		break;
+	case PECI_TEMP_CHANNEL7_DIMM0:
+		ret = check_dimm_present(DIMM_CHANNEL_NUM_7, DIMM_NUMBER_0, &dimm_present_result);
+		break;
+	default:
+		printf("[%s] input sensor 0x%x offset is invalid, offset: 0x%x\n", __func__,
+		       sensor_num, cfg.offset);
+		return ret;
+	}
+
+	if (ret == false) {
+		return ret;
+	}
+
+	// Check dimm temperature result, report 0xFF if dimm not present
+	if (dimm_present_result == DIMM_NOT_PRESENT) {
+		ret = disable_dimm_pmic_sensor(sensor_num);
+	}
+
+	pre_proc_args->is_present_checked = true;
+	return ret;
 }
 
 /* AST ADC post read function

--- a/meta-facebook/yv35-cl/src/platform/plat_hook.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.h
@@ -10,6 +10,10 @@ typedef struct _pmic_pre_proc_arg {
 	bool pre_read_init;
 } pmic_pre_proc_arg;
 
+typedef struct _dimm_pre_proc_arg {
+	bool is_present_checked;
+} dimm_pre_proc_arg;
+
 /**************************************************************************************************
  * INIT ARGS
 **************************************************************************************************/
@@ -26,6 +30,7 @@ extern ltc4286_init_arg ltc4286_init_args[];
 extern struct tca9548 mux_conf_addr_0xe2[];
 extern isl69259_pre_proc_arg isl69259_pre_read_args[];
 extern pmic_pre_proc_arg pmic_pre_read_args[];
+extern dimm_pre_proc_arg dimm_pre_proc_args[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK FUNC
@@ -34,6 +39,7 @@ bool pre_isl69259_read(uint8_t sensor_num, void *args);
 bool pre_nvme_read(uint8_t sensor_num, void *args);
 bool pre_pmic_read(uint8_t sensor_num, void *args);
 bool pre_vol_bat3v_read(uint8_t sensor_num, void *args);
+bool pre_intel_peci_dimm_read(uint8_t sensor_num, void *args);
 bool post_vol_bat3v_read(uint8_t sensor_num, void *args, int *reading);
 bool post_cpu_margin_read(uint8_t sensor_num, void *args, int *reading);
 bool post_adm1278_power_read(uint8_t sensor_num, void *args, int *reading);

--- a/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
@@ -377,7 +377,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"CPU TjMax",
 	},
 	{
-		// DIMM A on board temperature
+		// DIMM A0 on board temperature
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -386,7 +386,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_TEMP_DIMM_A, // sensor number
+		SENSOR_NUM_TEMP_DIMM_A0, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance
@@ -438,7 +438,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"DIMMA Temp",
 	},
 	{
-		// DIMM C on board temperature
+		// DIMM A2 on board temperature
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -447,7 +447,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_TEMP_DIMM_C, // sensor number
+		SENSOR_NUM_TEMP_DIMM_A2, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance
@@ -499,7 +499,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"DIMMC Temp",
 	},
 	{
-		// DIMM D on board temperature
+		// DIMM A3 on board temperature
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -508,7 +508,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_TEMP_DIMM_D, // sensor number
+		SENSOR_NUM_TEMP_DIMM_A3, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance
@@ -560,7 +560,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"DIMMD Temp",
 	},
 	{
-		// DIMM E on board temperature
+		// DIMM A4 on board temperature
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -569,7 +569,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_TEMP_DIMM_E, // sensor number
+		SENSOR_NUM_TEMP_DIMM_A4, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance
@@ -621,7 +621,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"DIMME Temp",
 	},
 	{
-		// DIMM G on board temperature
+		// DIMM A6 on board temperature
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -630,7 +630,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_TEMP_DIMM_G, // sensor number
+		SENSOR_NUM_TEMP_DIMM_A6, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance
@@ -682,7 +682,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"DIMMG Temp",
 	},
 	{
-		// DIMM H on board temperature
+		// DIMM A7 on board temperature
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -691,7 +691,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_TEMP_DIMM_H, // sensor number
+		SENSOR_NUM_TEMP_DIMM_A7, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance
@@ -2695,7 +2695,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"FAON VR Pout",
 	},
 	{
-		// DIMMA power
+		// DIMMA0 power
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -2704,7 +2704,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_PWR_DIMMA_PMIC, // sensor number
+		SENSOR_NUM_PWR_DIMMA0_PMIC, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance
@@ -2756,7 +2756,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"DIMMA PMIC_Pout",
 	},
 	{
-		// DIMMC power
+		// DIMMA2 power
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -2765,7 +2765,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_PWR_DIMMC_PMIC, // sensor number
+		SENSOR_NUM_PWR_DIMMA2_PMIC, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance
@@ -2817,7 +2817,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"DIMMC PMIC_Pout",
 	},
 	{
-		// DIMMD power
+		// DIMMA3 power
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -2826,7 +2826,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_PWR_DIMMD_PMIC, // sensor number
+		SENSOR_NUM_PWR_DIMMA3_PMIC, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance
@@ -2878,7 +2878,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"DIMMD PMIC_Pout",
 	},
 	{
-		// DIMME power
+		// DIMMA4 power
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -2887,7 +2887,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_PWR_DIMME_PMIC, // sensor number
+		SENSOR_NUM_PWR_DIMMA4_PMIC, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance
@@ -2939,7 +2939,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"DIMME PMIC_Pout",
 	},
 	{
-		// DIMMG power
+		// DIMMA6 power
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -2948,7 +2948,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_PWR_DIMMG_PMIC, // sensor number
+		SENSOR_NUM_PWR_DIMMA6_PMIC, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance
@@ -3000,7 +3000,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"DIMMG PMIC_Pout",
 	},
 	{
-		// DIMMH power
+		// DIMMA7 power
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -3009,7 +3009,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_PWR_DIMMH_PMIC, // sensor number
+		SENSOR_NUM_PWR_DIMMA7_PMIC, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
 		0x00, // entity instance

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -25,6 +25,16 @@ sensor_poll_time_cfg diff_poll_time_sensor_table[] = {
 	{ SENSOR_NUM_VOL_BAT3V, 0 },
 };
 
+dimm_pmic_mapping_cfg dimm_pmic_map_table[] = {
+	// dimm_sensor_num, mapping_pmic_sensor_num
+	{ SENSOR_NUM_TEMP_DIMM_A0, SENSOR_NUM_PWR_DIMMA0_PMIC },
+	{ SENSOR_NUM_TEMP_DIMM_A2, SENSOR_NUM_PWR_DIMMA2_PMIC },
+	{ SENSOR_NUM_TEMP_DIMM_A3, SENSOR_NUM_PWR_DIMMA3_PMIC },
+	{ SENSOR_NUM_TEMP_DIMM_A4, SENSOR_NUM_PWR_DIMMA4_PMIC },
+	{ SENSOR_NUM_TEMP_DIMM_A6, SENSOR_NUM_PWR_DIMMA6_PMIC },
+	{ SENSOR_NUM_TEMP_DIMM_A7, SENSOR_NUM_PWR_DIMMA7_PMIC },
+};
+
 sensor_cfg plat_sensor_config[] = {
 	/* number,                  type,       port,      address,      offset,
 	   access check arg0, arg1, sample_count, cache, cache_status, mux_ADDRess, mux_offset,
@@ -57,24 +67,30 @@ sensor_cfg plat_sensor_config[] = {
 	{ SENSOR_NUM_TEMP_CPU_TJMAX, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
 	  PECI_TEMP_CPU_TJMAX, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_TEMP_DIMM_A, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
+	{ SENSOR_NUM_TEMP_DIMM_A0, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
 	  PECI_TEMP_CHANNEL0_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_TEMP_DIMM_C, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read,
+	  &dimm_pre_proc_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_DIMM_A2, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
 	  PECI_TEMP_CHANNEL2_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_TEMP_DIMM_D, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read,
+	  &dimm_pre_proc_args[1], NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_DIMM_A3, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
 	  PECI_TEMP_CHANNEL3_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_TEMP_DIMM_E, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read,
+	  &dimm_pre_proc_args[2], NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_DIMM_A4, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
 	  PECI_TEMP_CHANNEL4_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_TEMP_DIMM_G, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read,
+	  &dimm_pre_proc_args[3], NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_DIMM_A6, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
 	  PECI_TEMP_CHANNEL6_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_TEMP_DIMM_H, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read,
+	  &dimm_pre_proc_args[4], NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_DIMM_A7, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
 	  PECI_TEMP_CHANNEL7_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read,
+	  &dimm_pre_proc_args[5], NULL, NULL, NULL },
 	{ SENSOR_NUM_PWR_CPU, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR, PECI_PWR_CPU, post_access,
 	  0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
@@ -184,22 +200,22 @@ sensor_cfg plat_sensor_config[] = {
 	{ SENSOR_NUM_TEMP_PCH, sensor_dev_pch, I2C_BUS3, PCH_ADDR, ME_SENSOR_NUM_TEMP_PCH,
 	  me_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_PWR_DIMMA_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
+	{ SENSOR_NUM_PWR_DIMMA0_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  pre_pmic_read, &pmic_pre_read_args[0], NULL, NULL, &pmic_init_args[0] },
-	{ SENSOR_NUM_PWR_DIMMC_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
+	{ SENSOR_NUM_PWR_DIMMA2_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  pre_pmic_read, &pmic_pre_read_args[1], NULL, NULL, &pmic_init_args[1] },
-	{ SENSOR_NUM_PWR_DIMMD_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
+	{ SENSOR_NUM_PWR_DIMMA3_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  pre_pmic_read, &pmic_pre_read_args[2], NULL, NULL, &pmic_init_args[2] },
-	{ SENSOR_NUM_PWR_DIMME_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
+	{ SENSOR_NUM_PWR_DIMMA4_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  pre_pmic_read, &pmic_pre_read_args[3], NULL, NULL, &pmic_init_args[3] },
-	{ SENSOR_NUM_PWR_DIMMG_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
+	{ SENSOR_NUM_PWR_DIMMA6_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  pre_pmic_read, &pmic_pre_read_args[4], NULL, NULL, &pmic_init_args[4] },
-	{ SENSOR_NUM_PWR_DIMMH_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
+	{ SENSOR_NUM_PWR_DIMMA7_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  pre_pmic_read, &pmic_pre_read_args[5], NULL, NULL, &pmic_init_args[5] },
 };
@@ -502,4 +518,23 @@ bool pal_is_time_to_poll(uint8_t sensor_num, int poll_time)
 uint8_t get_hsc_pwr_reading(int *reading)
 {
 	return get_sensor_reading(SENSOR_NUM_PWR_HSCIN, reading, GET_FROM_CACHE);
+}
+
+bool disable_dimm_pmic_sensor(uint8_t sensor_num)
+{
+	uint8_t table_size = ARRAY_SIZE(dimm_pmic_map_table);
+
+	for (uint8_t index = 0; index < table_size; ++index) {
+		if (sensor_num == dimm_pmic_map_table[index].dimm_sensor_num) {
+			control_sensor_polling(dimm_pmic_map_table[index].dimm_sensor_num,
+					       DISABLE_SENSOR_POLLING, SENSOR_NOT_PRESENT);
+			control_sensor_polling(dimm_pmic_map_table[index].mapping_pmic_sensor_num,
+					       DISABLE_SENSOR_POLLING, SENSOR_NOT_PRESENT);
+			return true;
+		}
+	}
+
+	printf("[%s] input sensor 0x%x can't find in dimm pmic mapping table\n", __func__,
+	       sensor_num);
+	return false;
 }

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.h
@@ -2,6 +2,7 @@
 #define PLAT_SENSOR_TABLE_H
 
 #include <stdint.h>
+#include "sensor.h"
 
 /*  define config for sensors  */
 #define TMP75_IN_ADDR (0x92 >> 1)
@@ -33,12 +34,12 @@
 #define TEMP_CPU_TJMAX_INDEX 0x10
 #define TEMP_CPU_TJMAX_PARAM 0x0000
 #define TEMP_DIMM_INDEX 0x0E
-#define TEMP_DIMM_A_PARAM 0x0000
-#define TEMP_DIMM_C_PARAM 0x0002
-#define TEMP_DIMM_D_PARAM 0x0003
-#define TEMP_DIMM_E_PARAM 0x0004
-#define TEMP_DIMM_G_PARAM 0x0006
-#define TEMP_DIMM_H_PARAM 0x0007
+#define TEMP_DIMM_A0_PARAM 0x0000
+#define TEMP_DIMM_A2_PARAM 0x0002
+#define TEMP_DIMM_A3_PARAM 0x0003
+#define TEMP_DIMM_A4_PARAM 0x0004
+#define TEMP_DIMM_A6_PARAM 0x0006
+#define TEMP_DIMM_A7_PARAM 0x0007
 #define DPV2_16_ADDR 0x50
 
 /*  threshold sensor number, 1 based  */
@@ -47,12 +48,12 @@
 #define SENSOR_NUM_TEMP_TMP75_FIO 0x03
 #define SENSOR_NUM_TEMP_PCH 0x04
 #define SENSOR_NUM_TEMP_CPU 0x05
-#define SENSOR_NUM_TEMP_DIMM_A 0x06
-#define SENSOR_NUM_TEMP_DIMM_C 0x07
-#define SENSOR_NUM_TEMP_DIMM_D 0x09
-#define SENSOR_NUM_TEMP_DIMM_E 0x0A
-#define SENSOR_NUM_TEMP_DIMM_G 0x0B
-#define SENSOR_NUM_TEMP_DIMM_H 0x0C
+#define SENSOR_NUM_TEMP_DIMM_A0 0x06
+#define SENSOR_NUM_TEMP_DIMM_A2 0x07
+#define SENSOR_NUM_TEMP_DIMM_A3 0x09
+#define SENSOR_NUM_TEMP_DIMM_A4 0x0A
+#define SENSOR_NUM_TEMP_DIMM_A6 0x0B
+#define SENSOR_NUM_TEMP_DIMM_A7 0x0C
 #define SENSOR_NUM_TEMP_SSD0 0x0D
 #define SENSOR_NUM_TEMP_HSC 0x0E
 #define SENSOR_NUM_TEMP_CPU_MARGIN 0x14
@@ -93,12 +94,12 @@
 #define SENSOR_NUM_PWR_PVCCFA_EHV 0x3D
 #define SENSOR_NUM_PWR_PVCCD_HV 0x3E
 #define SENSOR_NUM_PWR_PVCCINFAON 0x3F
-#define SENSOR_NUM_PWR_DIMMA_PMIC 0x1E
-#define SENSOR_NUM_PWR_DIMMC_PMIC 0x1F
-#define SENSOR_NUM_PWR_DIMMD_PMIC 0x36
-#define SENSOR_NUM_PWR_DIMME_PMIC 0x37
-#define SENSOR_NUM_PWR_DIMMG_PMIC 0x42
-#define SENSOR_NUM_PWR_DIMMH_PMIC 0x47
+#define SENSOR_NUM_PWR_DIMMA0_PMIC 0x1E
+#define SENSOR_NUM_PWR_DIMMA2_PMIC 0x1F
+#define SENSOR_NUM_PWR_DIMMA3_PMIC 0x36
+#define SENSOR_NUM_PWR_DIMMA4_PMIC 0x37
+#define SENSOR_NUM_PWR_DIMMA6_PMIC 0x42
+#define SENSOR_NUM_PWR_DIMMA7_PMIC 0x47
 
 #define SENSOR_NUM_SYSTEM_STATUS 0x10
 #define SENSOR_NUM_POWER_ERROR 0x56
@@ -116,8 +117,14 @@
 
 #define POLL_TIME_BAT3V 3600 // sec
 
+typedef struct _dimm_pmic_mapping_cfg {
+	uint8_t dimm_sensor_num;
+	uint8_t mapping_pmic_sensor_num;
+} dimm_pmic_mapping_cfg;
+
 uint8_t plat_get_config_size();
 uint8_t pal_get_extend_sensor_config();
 void load_sensor_config(void);
+bool disable_dimm_pmic_sensor(uint8_t sensor_num);
 
 #endif


### PR DESCRIPTION
Summary:
- Ipmrove peci read function
  - Add dimm pre-read function to check dimm present or not.
    BIC would not monitor dimm/pmic sensor if dimm not present.

Test Plan:
- Build code: Pass
- BIC doesn't monitor dimm/pmic sensor if dimm A/E is not present: Pass

Log:
[BMC console]
root@bmc-oob:~# sensor-util slot2 --thre | grep "DIMM"
DIMMA Temp                   (0x6) : NA | (na)
DIMMC Temp                   (0x7) :   49.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMD Temp                   (0x9) :   46.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME Temp                   (0xA) : NA | (na)
DIMMG Temp                   (0xB) :   44.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH Temp                   (0xC) :   40.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
P12V_DIMM Vol                (0x26) :   12.77 Volts | (ok) | UCR: 14.21 | UNC: 14.07 | UNR: NA | LCR: 9.87 | LNC: 10.01 | LNR: NA
DIMMA PMIC_Pout              (0x1E) : NA | (na)
DIMMC PMIC_Pout              (0x1F) :    0.50 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMD PMIC_Pout              (0x36) :    0.62 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME PMIC_Pout              (0x37) : NA | (na)
DIMMG PMIC_Pout              (0x42) :    0.75 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH PMIC_Pout              (0x47) :    0.50 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA

[BIC console]
uart:~$ platform sensor get 0x6
[0x6 ] DIMMA Temp               : peci       | access[O] | sensor_not_present        | 255
uart:~$ platform sensor get 0xa
[0xa ] DIMME Temp               : peci       | access[O] | sensor_not_present        | 255
uart:~$ platform sensor get 0x1e
[0x1e] DIMMA PMIC_Pout          : pmic       | access[O] | sensor_not_present        | 255
uart:~$ platform sensor get 0x37
[0x37] DIMME PMIC_Pout          : pmic       | access[O] | sensor_not_present        | 255