### PR TITLE
Common: Fix all sensors and SDRs lost

### DIFF
--- a/common/service/sensor/sdr.c
+++ b/common/service/sensor/sdr.c
@@ -222,6 +222,6 @@ uint8_t plat_get_sdr_size()
 
 __weak void load_sdr_table(void)
 {
-	memcpy(full_sdr_table, plat_sdr_table, SDR_TABLE_SIZE);
+	memcpy(full_sdr_table, plat_sdr_table, sizeof(SDR_Full_sensor) * SDR_TABLE_SIZE);
 	sdr_count = SDR_TABLE_SIZE;
 }

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -556,6 +556,6 @@ uint8_t plat_get_config_size()
 
 __weak void load_sensor_config(void)
 {
-	memcpy(sensor_config, plat_sensor_config, SENSOR_CONFIG_SIZE);
+	memcpy(sensor_config, plat_sensor_config, sizeof(sensor_cfg) * SENSOR_CONFIG_SIZE);
 	sensor_config_count = SENSOR_CONFIG_SIZE;
 }


### PR DESCRIPTION
The memcpy should consider the size of the structure.

Tested:
Tested on yv35-rf and all sensors work well.

Signed-off-by: Scron Chang <Scron.Chang@quantatw.com>