### PR TITLE
fby3.5: cl: Version commit for oby35-cl-2022.31.01

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_version.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_version.h
@@ -6,7 +6,7 @@
 #define DEVICE_ID 0x00
 #define DEVICE_REVISION 0x80
 #define FIRMWARE_REVISION_1 0x21
-#define FIRMWARE_REVISION_2 0x02
+#define FIRMWARE_REVISION_2 0x03
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
 #define PRODUCT_ID 0x0000
@@ -14,8 +14,8 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x28
-#define BIC_FW_VER 0x02
+#define BIC_FW_WEEK 0x31
+#define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x63 // char: c
 #define BIC_FW_platform_1 0x6c // char: l
 #define BIC_FW_platform_2 0x00 // char: '\0'


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Craterlake BIC oby35-cl-2022.31.01.

Test Plan:
- Build code: Pass
- Get BIC version: Pass

Log:
root@bmc-oob:~# fw-util slot2 --version bic
SB Bridge-IC Version: oby35-cl-v2022.31.01

get firmware revision
root@bmc-oob:~# bic-util slot2 0x18 0x1
00 80 21 03 02 BF 15 A0 00 00 00 00 00 00 00

get firmware version
root@bmc-oob:~# bic-util slot2 0xE0 0xB 0x15 0xA0 0x0 0x2
15 A0 00 20 22 31 01 63 6C 00