### PR TITLE
wc: mb: Add mb power led control

### DIFF
--- a/meta-facebook/wc-mb/src/platform/plat_init.c
+++ b/meta-facebook/wc-mb/src/platform/plat_init.c
@@ -55,6 +55,15 @@ static void postcode_led_ctl()
 	// These configs should set by BIOS
 }
 
+/* control mb host status led */
+static void mb_pwr_led_ctl()
+{
+	if (get_DC_status())
+		gpio_set(BMC_PWR_LED, GPIO_HIGH);
+	else
+		gpio_set(BMC_PWR_LED, GPIO_LOW);
+}
+
 void pal_pre_init()
 {
 	init_platform_config();
@@ -77,6 +86,7 @@ void pal_set_sys_status()
 	set_CPU_power_status(PWRGD_CPU_LVC3);
 	set_post_thread();
 	set_sys_ready_pin(FM_BIC_READY);
+	mb_pwr_led_ctl();
 }
 
 #define DEF_PROJ_GPIO_PRIORITY 78

--- a/meta-facebook/wc-mb/src/platform/plat_isr.c
+++ b/meta-facebook/wc-mb/src/platform/plat_isr.c
@@ -89,6 +89,7 @@ void ISR_DC_ON()
 	set_DC_status(PWRGD_SYS_PWROK);
 
 	if (get_DC_status() == true) {
+		gpio_set(BMC_PWR_LED, GPIO_HIGH);
 		k_work_schedule(&set_DC_on_5s_work, K_SECONDS(DC_ON_5_SECOND));
 
 		if (k_work_cancel_delayable(&set_DC_off_10s_work) != 0) {
@@ -96,6 +97,7 @@ void ISR_DC_ON()
 		}
 		set_DC_off_delayed_status();
 	} else {
+		gpio_set(BMC_PWR_LED, GPIO_LOW);
 		set_DC_on_delayed_status();
 		k_work_schedule(&set_DC_off_10s_work, K_SECONDS(DC_OFF_10_SECOND));
 


### PR DESCRIPTION
Summary:
- Add  mother board host power led control.

Test Plan:
- Build Code: PASS
- Check led: PASS

Log:
- HOST on
  - BMC console:
    ```
    root@bmc-oob:~# power-util mb status                   
    Power status for fru 2 : ON
    ```
  - BIC console:
    ```
    uart:~$ platform gpio get 163
    [163] PWRGD_SYS_PWROK                    : PP  | input (I) | 1(1)
    uart:~$ platform gpio get 0
    [0  ] BMC_PWR_LED                        : PP  | output(O) | 1(1)
    ```

- HOST off
  - BMC console:
    ```
    root@bmc-oob:~# power-util mb status                   
    Power status for fru 2 : OFF
    ```
  - BIC console:
    ```
    uart:~$ platform gpio get 163
    [163] PWRGD_SYS_PWROK                    : PP  | input (I) | 0(0)
    uart:~$ platform gpio get 0
    [0  ] BMC_PWR_LED                        : PP  | output(O) | 0(0)