### PR TITLE
fby3.5: rf: Correct ADC config of P5V_STBY

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
@@ -20,7 +20,7 @@ sensor_cfg plat_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
 	// ADC
-	{ SENSOR_NUM_VOL_STBY5V, sensor_dev_ast_adc, ADC_PORT9, NONE, NONE, stby_access, 711, 200,
+	{ SENSOR_NUM_VOL_STBY5V, sensor_dev_ast_adc, ADC_PORT14, NONE, NONE, stby_access, 711, 200,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 	{ SENSOR_NUM_VOL_STBY1V2, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, stby_access, 1, 1,


### PR DESCRIPTION
The ADC port number of P5V_STBY should be 14.

Tested:
```
root@bmc-oob:~# sensor-util slot1 0x5F
slot1:
RF P5V_STBY Vol              (0x5F) :    5.10 Volts | (ok)
root@bmc-oob:~#
```

Signed-off-by: Scron Chang <Scron.Chang@quantatw.com>