### PR TITLE
fby3.5-rf: Correct units in SDR table 

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_sdr_table.c
@@ -709,7 +709,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x1F, // [7:0] M bits
@@ -770,7 +770,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x07, // [7:0] M bits
@@ -831,7 +831,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x23, // [7:0] M bits
@@ -892,7 +892,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x11, // [7:0] M bits
@@ -953,7 +953,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x01, // [7:0] M bits
@@ -1014,7 +1014,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x01, // [7:0] M bits
@@ -1075,7 +1075,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x01, // [7:0] M bits
@@ -1136,7 +1136,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x01, // [7:0] M bits
@@ -1197,7 +1197,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x01, // [7:0] M bits
@@ -1563,7 +1563,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x18, // [7:0] M bits
@@ -1624,7 +1624,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x18, // [7:0] M bits
@@ -1685,7 +1685,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x41, // [7:0] M bits
@@ -1746,7 +1746,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x41, // [7:0] M bits
@@ -1807,7 +1807,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x41, // [7:0] M bits
@@ -1868,7 +1868,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x16, // [7:0] M bits
@@ -1929,7 +1929,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x16, // [7:0] M bits
@@ -1990,7 +1990,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x2B, // [7:0] M bits
@@ -2051,7 +2051,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x41, // [7:0] M bits
@@ -2112,7 +2112,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x41, // [7:0] M bits

--- a/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
@@ -20,7 +20,7 @@ sensor_cfg plat_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
 	// ADC
-	{ SENSOR_NUM_VOL_STBY5V, sensor_dev_ast_adc, ADC_PORT9, NONE, NONE, stby_access, 711, 200,
+	{ SENSOR_NUM_VOL_STBY5V, sensor_dev_ast_adc, ADC_PORT14, NONE, NONE, stby_access, 711, 200,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 	{ SENSOR_NUM_VOL_STBY1V2, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, stby_access, 1, 1,


### PR DESCRIPTION
Currently, all sensor units are set as "Voltage".

Tested:
Fixed all sensor units in this commit:
```
root@bmc-oob:~# sensor-util slot1 | grep RF | wc -l
35
root@bmc-oob:~# sensor-util slot1 | grep RF
RF MB Inlet Temp             (0x50) :   35.00 C     | (ok)
RF CXL_cntr_Temp             (0x52) :   36.00 C     | (ok)
RF P0V9_A Temp               (0x58) :   40.00 C     | (ok)
RF P0V8_A Temp               (0x59) :   41.00 C     | (ok)
RF P0V8_D Temp               (0x5A) :   40.00 C     | (ok)
RF PVDDQ_AB Temp             (0x5B) :   39.00 C     | (ok)
RF PVDDQ_CD Temp             (0x5C) :   40.00 C     | (ok)
RF P12V_STBY Vol             (0x5D) :   11.55 Volts | (ok)
RF P3V3_STBY Vol             (0x5E) :    3.33 Volts | (ok)
RF P5V_STBY Vol              (0x5F) :    5.10 Volts | (ok)
RF P1V2_STBY Vol             (0x60) :    1.22 Volts | (ok)
RF P1V8_ASIC Vol             (0x61) :    1.82 Volts | (ok)
RF P0V9_A Vol                (0x62) :    0.95 Volts | (ok)
RF P0V8_A Vol                (0x64) :    0.82 Volts | (ok)
RF P0V8_D Vol                (0x65) :    0.82 Volts | (ok)
RF PVDDQ_AB Vol              (0x66) :    1.20 Volts | (ok)
RF PVDDQ_CD Vol              (0x67) :    1.20 Volts | (ok)
RF PVPP_AB Vol               (0x68) :    2.51 Volts | (ok)
RF PVPP_CD Vol               (0x69) :    2.50 Volts | (ok)
RF PVTT_AB Vol               (0x6A) :    0.60 Volts | (ok)
RF PVTT_CD Vol               (0x6B) :    0.61 Volts | (ok)
RF P12V_STBY Cur             (0x6C) :    0.94 Amps  | (ok)
RF P3V3_STBY Cur             (0x6D) :    0.14 Amps  | (ok)
RF P0V9_A Cur                (0x6E) :    3.60 Amps  | (ok)
RF P0V8_A Cur                (0x6F) :    2.80 Amps  | (ok)
RF P0V8_D Cur                (0x70) :    2.90 Amps  | (ok)
RF PVDDQ_AB Cur              (0x71) :    1.10 Amps  | (ok)
RF PVDDQ_CD Cur              (0x72) :    0.40 Amps  | (ok)
RF P12V_STBY_PWR             (0x73) :   10.85 Watts | (ok)
RF P3V3_STBY_PWR             (0x74) :    0.50 Watts | (ok)
RF P0V9_A_PWR                (0x75) :    3.00 Watts | (ok)
RF P0V8_A_PWR                (0x76) :    2.00 Watts | (ok)
RF P0V8_D_PWR                (0x77) :    2.00 Watts | (ok)
RF PVDDQ_AB_PWR              (0x78) :    1.00 Watts | (ok)
RF PVDDQ_CD_PWR              (0x79) :    2.00 Watts | (ok)
root@bmc-oob:~#
```

Signed-off-by: Scron Chang <Scron.Chang@quantatw.com>