### PR TITLE
wc: mb: Improve ME access sensor reading(follow #449)

### DIFF
--- a/meta-facebook/wc-mb/src/platform/plat_init.c
+++ b/meta-facebook/wc-mb/src/platform/plat_init.c
@@ -63,7 +63,7 @@ void pal_pre_init()
 	postcode_led_ctl();
 }
 
-void pal_post_init()
+void pal_device_init()
 {
 	init_me_firmware();
 }

--- a/meta-facebook/wc-mb/src/platform/plat_isr.c
+++ b/meta-facebook/wc-mb/src/platform/plat_isr.c
@@ -71,13 +71,13 @@ void ISR_SLP3()
 
 void ISR_POST_COMPLETE()
 {
-	set_post_status(FM_BIOS_POST_CMPLT_BIC_N);
-
 	if (gpio_get(FM_BIOS_POST_CMPLT_BIC_N) == GPIO_LOW) { // Post complete
 		if (get_me_mode() == ME_INIT_MODE) {
 			init_me_firmware();
 		}
 	}
+
+	set_post_status(FM_BIOS_POST_CMPLT_BIC_N);
 }
 
 K_WORK_DELAYABLE_DEFINE(set_DC_on_5s_work, set_DC_on_delayed_status);


### PR DESCRIPTION
Summary:
- Improve ME access sensor reading.
  - Modify check ME status timing to improve ME access sensor reading fail after post complete.
    BIC should get ME status before post complete, otherwise ME access sensor reading would fail because BIC can't get ME status.
    Error message of sensor not accessible would make user confuse in BIC console.

Dependency: #449 

Test Plan:
- Build code: Pass