### PR TITLE
wc: mb: Improve dimm relative sensors read(follow #450)

### DIFF
--- a/meta-facebook/wc-mb/src/platform/plat_hook.h
+++ b/meta-facebook/wc-mb/src/platform/plat_hook.h
@@ -10,6 +10,10 @@ typedef struct _pmic_pre_proc_arg {
 	bool pre_read_init;
 } pmic_pre_proc_arg;
 
+typedef struct _dimm_pre_proc_arg {
+	bool is_present_checked;
+} dimm_pre_proc_arg;
+
 /**************************************************************************************************
  * INIT ARGS
 **************************************************************************************************/
@@ -25,17 +29,19 @@ extern pmic_init_arg pmic_init_args[];
 extern struct tca9548 mux_conf_addr_0xe2[];
 extern vr_pre_proc_arg vr_pre_read_args[];
 extern pmic_pre_proc_arg pmic_pre_read_args[];
+extern dimm_pre_proc_arg dimm_pre_proc_args[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK FUNC
  **************************************************************************************************/
 bool pre_vr_read(uint8_t sensor_num, void *args);
 bool pre_nvme_read(uint8_t sensor_num, void *args);
+bool pre_pmic_read(uint8_t sensor_num, void *args);
 bool pre_vol_bat3v_read(uint8_t sensor_num, void *args);
+bool pre_intel_peci_dimm_read(uint8_t sensor_num, void *args);
 bool post_vol_bat3v_read(uint8_t sensor_num, void *args, int *reading);
 bool post_cpu_margin_read(uint8_t sensor_num, void *args, int *reading);
 bool post_adm1278_power_read(uint8_t sensor_num, void *args, int *reading);
 bool post_adm1278_current_read(uint8_t sensor_num, void *args, int *reading);
-bool pre_pmic_read(uint8_t sensor_num, void *args);
 
 #endif

--- a/meta-facebook/wc-mb/src/platform/plat_sensor_table.c
+++ b/meta-facebook/wc-mb/src/platform/plat_sensor_table.c
@@ -16,6 +16,14 @@
 #include "pmbus.h"
 #include "libutil.h"
 
+dimm_pmic_mapping_cfg dimm_pmic_map_table[] = {
+	// dimm_sensor_num, mapping_pmic_sensor_num
+	{ SENSOR_NUM_TEMP_DIMM_A, SENSOR_NUM_PWR_DIMMA_PMIC },
+	{ SENSOR_NUM_TEMP_DIMM_C, SENSOR_NUM_PWR_DIMMC_PMIC },
+	{ SENSOR_NUM_TEMP_DIMM_E, SENSOR_NUM_PWR_DIMME_PMIC },
+	{ SENSOR_NUM_TEMP_DIMM_G, SENSOR_NUM_PWR_DIMMG_PMIC },
+};
+
 sensor_cfg plat_sensor_config[] = {
 	/* number,                  type,       port,      address,      offset,
 	   access check arg0, arg1, sample_count, cache, cache_status, mux_ADDRess, mux_offset,
@@ -49,16 +57,20 @@ sensor_cfg plat_sensor_config[] = {
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 	{ SENSOR_NUM_TEMP_DIMM_A, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
 	  PECI_TEMP_CHANNEL0_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read,
+	  &dimm_pre_proc_args[0], NULL, NULL, NULL },
 	{ SENSOR_NUM_TEMP_DIMM_C, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
 	  PECI_TEMP_CHANNEL2_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read,
+	  &dimm_pre_proc_args[1], NULL, NULL, NULL },
 	{ SENSOR_NUM_TEMP_DIMM_E, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
 	  PECI_TEMP_CHANNEL4_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read,
+	  &dimm_pre_proc_args[2], NULL, NULL, NULL },
 	{ SENSOR_NUM_TEMP_DIMM_G, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
 	  PECI_TEMP_CHANNEL6_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read,
+	  &dimm_pre_proc_args[3], NULL, NULL, NULL },
 	{ SENSOR_NUM_PWR_CPU, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR, PECI_PWR_CPU, post_access,
 	  0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
@@ -212,3 +224,22 @@ sensor_cfg plat_sensor_config[] = {
 };
 
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
+
+bool disable_dimm_pmic_sensor(uint8_t sensor_num)
+{
+	uint8_t table_size = ARRAY_SIZE(dimm_pmic_map_table);
+
+	for (uint8_t index = 0; index < table_size; ++index) {
+		if (sensor_num == dimm_pmic_map_table[index].dimm_sensor_num) {
+			control_sensor_polling(dimm_pmic_map_table[index].dimm_sensor_num,
+					       DISABLE_SENSOR_POLLING, SENSOR_NOT_PRESENT);
+			control_sensor_polling(dimm_pmic_map_table[index].mapping_pmic_sensor_num,
+					       DISABLE_SENSOR_POLLING, SENSOR_NOT_PRESENT);
+			return true;
+		}
+	}
+
+	printf("[%s] input sensor 0x%x can't find in dimm pmic mapping table\n", __func__,
+	       sensor_num);
+	return false;
+}

--- a/meta-facebook/wc-mb/src/platform/plat_sensor_table.h
+++ b/meta-facebook/wc-mb/src/platform/plat_sensor_table.h
@@ -2,6 +2,7 @@
 #define PLAT_SENSOR_TABLE_H
 
 #include <stdint.h>
+#include "sensor.h"
 
 /*  define config for sensors  */
 #define TMP75_IN_ADDR (0x92 >> 1)
@@ -99,7 +100,13 @@
 #define SENSOR_NUM_CATERR 0xEB
 #define SENSOR_NUM_RMCA 0xEC //TBD: BMC should know this
 
+typedef struct _dimm_pmic_mapping_cfg {
+	uint8_t dimm_sensor_num;
+	uint8_t mapping_pmic_sensor_num;
+} dimm_pmic_mapping_cfg;
+
 uint8_t plat_get_config_size();
 void load_sensor_config(void);
+bool disable_dimm_pmic_sensor(uint8_t sensor_num);
 
 #endif


### PR DESCRIPTION
Summary:
- Improve ddr relative sensors read
  - Add dimm pre-read function to check dimm present or not. BIC would not monitor dimm/pmic sensor if dimm not present.

Dependency: #450 

Test Plan:
- Build code: Pass
- Check sensor read from BMC while missing 1 DDR at DIMM_G: Pass

Log:
- BMC console
  ```
  root@bmc-oob:~# sensor-util mb |grep "MB DIMM"
  MB DIMMA Temp                (0xA) :   33.00 C     | (ok)
  MB DIMMC Temp                (0xB) :   32.00 C     | (ok)
  MB DIMME Temp                (0xC) :   39.00 C     | (ok)
  MB DIMMG Temp                (0xD) : NA | (na)
  MB DIMMA PMIC_Pout           (0x62) :    0.00 Watts | (ok)
  MB DIMMC PMIC_Pout           (0x63) :    0.12 Watts | (ok)
  MB DIMME PMIC_Pout           (0x64) :    0.00 Watts | (ok)
  MB DIMMG PMIC_Pout           (0x65) : NA | (na)
  ```