### PR TITLE
fby3.5: cl: Remove redundant platform add SEL function

### DIFF
--- a/meta-facebook/yv35-cl/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/yv35-cl/src/ipmi/include/plat_ipmi.h
@@ -9,15 +9,4 @@ enum REQ_GET_CARD_TYPE {
 	GET_2OU_CARD_TYPE,
 };
 
-typedef struct addsel_msg_t {
-	uint8_t sensor_type;
-	uint8_t sensor_number;
-	uint8_t event_type;
-	uint8_t event_data1;
-	uint8_t event_data2;
-	uint8_t event_data3;
-} addsel_msg_t;
-
-bool add_sel_evt_record(addsel_msg_t *sel_msg);
-
 #endif

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -8,63 +8,6 @@
 #include "plat_class.h"
 #include "plat_ipmb.h"
 
-bool add_sel_evt_record(addsel_msg_t *sel_msg)
-{
-	ipmb_error status;
-	ipmi_msg *msg;
-	uint8_t system_event_record = 0x02; // IPMI spec definition
-	uint8_t evt_msg_version = 0x04; // IPMI spec definition
-	static uint16_t record_id = 0x1;
-
-	// According to IPMI spec, record id 0h and FFFFh is reserved for special usage
-	if ((record_id == 0) || (record_id == 0xFFFF)) {
-		record_id = 0x1;
-	}
-
-	msg = (ipmi_msg *)malloc(sizeof(ipmi_msg));
-	if (msg == NULL) {
-		printf("add_sel_evt_record malloc fail\n");
-		return false;
-	}
-	memset(msg, 0, sizeof(ipmi_msg));
-
-	msg->data_len = 16;
-	msg->InF_source = SELF;
-	msg->InF_target = BMC_IPMB;
-	msg->netfn = NETFN_STORAGE_REQ;
-	msg->cmd = CMD_STORAGE_ADD_SEL;
-
-	msg->data[0] = (record_id & 0xFF); // record id byte 0, lsb
-	msg->data[1] = ((record_id >> 8) & 0xFF); // record id byte 1
-	msg->data[2] = system_event_record; // record type
-	msg->data[3] = 0x00; // timestamp, bmc would fill up for bic
-	msg->data[4] = 0x00; // timestamp, bmc would fill up for bic
-	msg->data[5] = 0x00; // timestamp, bmc would fill up for bic
-	msg->data[6] = 0x00; // timestamp, bmc would fill up for bic
-	msg->data[7] = (SELF_I2C_ADDRESS << 1); // generator id
-	msg->data[8] = 0x00; // generator id
-	msg->data[9] = evt_msg_version; // event message format version
-	msg->data[10] = sel_msg->sensor_type; // sensor type, TBD
-	msg->data[11] = sel_msg->sensor_number; // sensor number
-	msg->data[12] = sel_msg->event_type; // event dir/event type
-	msg->data[13] = sel_msg->event_data1; // sensor data 1
-	msg->data[14] = sel_msg->event_data2; // sensor data 2
-	msg->data[15] = sel_msg->event_data3; // sensor data 3
-	record_id++;
-
-	status = ipmb_read(msg, IPMB_inf_index_map[msg->InF_target]);
-	SAFE_FREE(msg);
-	if (status == IPMB_ERROR_FAILURE) {
-		printf("Fail to post msg to txqueue for addsel\n");
-		return false;
-	} else if (status == IPMB_ERROR_GET_MESSAGE_QUEUE) {
-		printf("No response from bmc for addsel\n");
-		return false;
-	}
-
-	return true;
-}
-
 void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
 {
 	if (msg == NULL) {

--- a/meta-facebook/yv35-cl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.c
@@ -42,15 +42,16 @@ void send_gpio_interrupt(uint8_t gpio_num)
 
 static void SLP3_handler()
 {
-	addsel_msg_t sel_msg;
+	common_addsel_msg_t sel_msg;
 	if ((gpio_get(FM_SLPS3_PLD_N) == GPIO_HIGH) && (gpio_get(PWRGD_SYS_PWROK) == GPIO_LOW)) {
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_VRWATCHDOG;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		if (!add_sel_evt_record(&sel_msg)) {
+		if (!common_add_sel_evt_record(&sel_msg)) {
 			printf("VR watchdog timeout addsel fail\n");
 		}
 	}
@@ -101,14 +102,15 @@ void ISR_DC_ON()
 
 		if ((gpio_get(FM_SLPS3_PLD_N) == GPIO_HIGH) &&
 		    (gpio_get(RST_RSMRST_BMC_N) == GPIO_HIGH)) {
-			addsel_msg_t sel_msg;
+			common_addsel_msg_t sel_msg;
+			sel_msg.InF_target = BMC_IPMB;
 			sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_OEM_C3;
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 			sel_msg.sensor_number = SENSOR_NUM_POWER_ERROR;
 			sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_PWROK_FAIL;
 			sel_msg.event_data2 = 0xFF;
 			sel_msg.event_data3 = 0xFF;
-			if (!add_sel_evt_record(&sel_msg)) {
+			if (!common_add_sel_evt_record(&sel_msg)) {
 				printf("System PWROK failure addsel fail\n");
 			}
 		}
@@ -124,18 +126,18 @@ static void PROC_FAIL_handler(struct k_work *work)
 {
 	/* if have not received kcs and post code, add FRB3 event log. */
 	if ((get_kcs_ok() == false) && (get_postcode_ok() == false)) {
-		addsel_msg_t sel_msg;
+		common_addsel_msg_t sel_msg;
 		bool ret = false;
 
-		memset(&sel_msg, 0, sizeof(addsel_msg_t));
-
+		memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.sensor_type = IPMI_SENSOR_TYPE_PROCESSOR;
 		sel_msg.sensor_number = SENSOR_NUM_PROC_FAIL;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		sel_msg.event_data1 = IPMI_EVENT_OFFSET_PROCESSOR_FRB3;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		ret = add_sel_evt_record(&sel_msg);
+		ret = common_add_sel_evt_record(&sel_msg);
 		if (!ret) {
 			printf("Fail to assert FRE3 event log.\n");
 		}
@@ -167,11 +169,11 @@ void ISR_PWRGD_CPU()
 static void CAT_ERR_handler(struct k_work *work)
 {
 	if ((gpio_get(RST_PLTRST_BUF_N) == GPIO_HIGH) || (gpio_get(PWRGD_SYS_PWROK) == GPIO_HIGH)) {
-		addsel_msg_t sel_msg;
+		common_addsel_msg_t sel_msg;
 		bool ret = false;
 
-		memset(&sel_msg, 0, sizeof(addsel_msg_t));
-
+		memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.sensor_type = IPMI_SENSOR_TYPE_PROCESSOR;
 		sel_msg.sensor_number = SENSOR_NUM_CATERR;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
@@ -183,7 +185,7 @@ static void CAT_ERR_handler(struct k_work *work)
 		}
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		ret = add_sel_evt_record(&sel_msg);
+		ret = common_add_sel_evt_record(&sel_msg);
 		if (!ret) {
 			printf("Fail to assert CatErr event log.\n");
 		}
@@ -215,19 +217,21 @@ void ISR_DBP_PRSNT()
 
 void ISR_FM_THROTTLE()
 {
-	addsel_msg_t sel_msg;
+	common_addsel_msg_t sel_msg;
 	if (gpio_get(PWRGD_CPU_LVC3) == GPIO_HIGH) {
 		if (gpio_get(FM_THROTTLE_R_N) == GPIO_HIGH) {
 			sel_msg.event_type = IPMI_OEM_EVENT_TYPE_DEASSART;
 		} else {
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		}
+
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_FMTHROTTLE;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		if (!add_sel_evt_record(&sel_msg)) {
+		if (!common_add_sel_evt_record(&sel_msg)) {
 			printf("FM Throttle addsel fail\n");
 		}
 	}
@@ -235,7 +239,7 @@ void ISR_FM_THROTTLE()
 
 void ISR_HSC_THROTTLE()
 {
-	addsel_msg_t sel_msg;
+	common_addsel_msg_t sel_msg;
 	static bool is_hsc_throttle_assert = false; // Flag for filt out fake alert
 	if (gpio_get(RST_RSMRST_BMC_N) == GPIO_HIGH) {
 		if ((gpio_get(PWRGD_SYS_PWROK) == GPIO_LOW) &&
@@ -254,12 +258,13 @@ void ISR_HSC_THROTTLE()
 				return;
 			}
 
+			sel_msg.InF_target = BMC_IPMB;
 			sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 			sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 			sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_PMBUSALERT;
 			sel_msg.event_data2 = 0xFF;
 			sel_msg.event_data3 = 0xFF;
-			if (!add_sel_evt_record(&sel_msg)) {
+			if (!common_add_sel_evt_record(&sel_msg)) {
 				printf("HSC Throttle addsel fail\n");
 			}
 		}
@@ -268,19 +273,21 @@ void ISR_HSC_THROTTLE()
 
 void ISR_MB_THROTTLE()
 {
-	addsel_msg_t sel_msg;
+	common_addsel_msg_t sel_msg;
 	if (gpio_get(RST_RSMRST_BMC_N) == GPIO_HIGH) {
 		if (gpio_get(FAST_PROCHOT_N) == GPIO_HIGH) {
 			sel_msg.event_type = IPMI_OEM_EVENT_TYPE_DEASSART;
 		} else {
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		}
+
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_FIRMWAREASSERT;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		if (!add_sel_evt_record(&sel_msg)) {
+		if (!common_add_sel_evt_record(&sel_msg)) {
 			printf("MB Throttle addsel fail\n");
 		}
 	}
@@ -288,7 +295,7 @@ void ISR_MB_THROTTLE()
 
 void ISR_SOC_THMALTRIP()
 {
-	addsel_msg_t sel_msg;
+	common_addsel_msg_t sel_msg;
 	if (gpio_get(RST_PLTRST_PLD_N) == GPIO_HIGH) {
 		if (gpio_get(H_CPU_MEMTRIP_LVC3_N) ==
 		    GPIO_HIGH) { // Reference pin for memory thermal trip event
@@ -296,12 +303,14 @@ void ISR_SOC_THMALTRIP()
 		} else {
 			sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_MEMORY_THERMALTRIP;
 		}
+
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		if (!add_sel_evt_record(&sel_msg)) {
+		if (!common_add_sel_evt_record(&sel_msg)) {
 			if (sel_msg.event_data1 == IPMI_OEM_EVENT_OFFSET_SYS_THERMAL_TRIP) {
 				printf("SOC Thermal trip addsel fail\n");
 			} else {
@@ -313,19 +322,21 @@ void ISR_SOC_THMALTRIP()
 
 void ISR_SYS_THROTTLE()
 {
-	addsel_msg_t sel_msg;
+	common_addsel_msg_t sel_msg;
 	if ((gpio_get(RST_PLTRST_PLD_N) == GPIO_HIGH) && (gpio_get(PWRGD_SYS_PWROK) == GPIO_HIGH)) {
 		if (gpio_get(FM_CPU_BIC_PROCHOT_LVT3_N) == GPIO_HIGH) {
 			sel_msg.event_type = IPMI_OEM_EVENT_TYPE_DEASSART;
 		} else {
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		}
+
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_THROTTLE;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		if (!add_sel_evt_record(&sel_msg)) {
+		if (!common_add_sel_evt_record(&sel_msg)) {
 			printf("System Throttle addsel fail\n");
 		}
 	}
@@ -333,7 +344,7 @@ void ISR_SYS_THROTTLE()
 
 void ISR_PCH_THMALTRIP()
 {
-	addsel_msg_t sel_msg;
+	common_addsel_msg_t sel_msg;
 	static bool is_pch_assert = 0;
 	if (gpio_get(FM_PCHHOT_N) == GPIO_LOW) {
 		if ((gpio_get(RST_PLTRST_PLD_N) == GPIO_HIGH) && (get_post_status() == true) &&
@@ -347,31 +358,35 @@ void ISR_PCH_THMALTRIP()
 	} else {
 		return;
 	}
+
+	sel_msg.InF_target = BMC_IPMB;
 	sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 	sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 	sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_PCHHOT;
 	sel_msg.event_data2 = 0xFF;
 	sel_msg.event_data3 = 0xFF;
-	if (!add_sel_evt_record(&sel_msg)) {
+	if (!common_add_sel_evt_record(&sel_msg)) {
 		printf("PCH Thermal trip addsel fail\n");
 	}
 }
 
 void ISR_HSC_OC()
 {
-	addsel_msg_t sel_msg;
+	common_addsel_msg_t sel_msg;
 	if (gpio_get(RST_RSMRST_BMC_N) == GPIO_HIGH) {
 		if (gpio_get(FM_HSC_TIMER) == GPIO_HIGH) {
 			sel_msg.event_type = IPMI_OEM_EVENT_TYPE_DEASSART;
 		} else {
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		}
+
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_HSCTIMER;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		if (!add_sel_evt_record(&sel_msg)) {
+		if (!common_add_sel_evt_record(&sel_msg)) {
 			printf("HSC OC addsel fail\n");
 		}
 	}
@@ -379,19 +394,21 @@ void ISR_HSC_OC()
 
 void ISR_CPU_MEMHOT()
 {
-	addsel_msg_t sel_msg;
+	common_addsel_msg_t sel_msg;
 	if ((gpio_get(RST_PLTRST_PLD_N) == GPIO_HIGH) && (gpio_get(PWRGD_SYS_PWROK) == GPIO_HIGH)) {
 		if (gpio_get(H_CPU_MEMHOT_OUT_LVC3_N) == GPIO_HIGH) {
 			sel_msg.event_type = IPMI_OEM_EVENT_TYPE_DEASSART;
 		} else {
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		}
+
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_CPU_DIMM_HOT;
 		sel_msg.sensor_number = SENSOR_NUM_CPUDIMM_HOT;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_DIMM_HOT;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		if (!add_sel_evt_record(&sel_msg)) {
+		if (!common_add_sel_evt_record(&sel_msg)) {
 			printf("CPU MEM HOT addsel fail\n");
 		}
 	}
@@ -399,19 +416,21 @@ void ISR_CPU_MEMHOT()
 
 void ISR_CPUVR_HOT()
 {
-	addsel_msg_t sel_msg;
+	common_addsel_msg_t sel_msg;
 	if ((gpio_get(RST_PLTRST_PLD_N) == GPIO_HIGH) && (gpio_get(PWRGD_SYS_PWROK) == GPIO_HIGH)) {
 		if (gpio_get(IRQ_CPU0_VRHOT_N) == GPIO_HIGH) {
 			sel_msg.event_type = IPMI_OEM_EVENT_TYPE_DEASSART;
 		} else {
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		}
+
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_CPU_DIMM_VR_HOT;
 		sel_msg.sensor_number = SENSOR_NUM_VR_HOT;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_CPU_VR_HOT;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		if (!add_sel_evt_record(&sel_msg)) {
+		if (!common_add_sel_evt_record(&sel_msg)) {
 			printf("CPU VR HOT addsel fail\n");
 		}
 	}
@@ -419,15 +438,16 @@ void ISR_CPUVR_HOT()
 
 void ISR_PCH_PWRGD()
 {
-	addsel_msg_t sel_msg;
+	common_addsel_msg_t sel_msg;
 	if (gpio_get(FM_SLPS3_PLD_N) == GPIO_HIGH) {
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_OEM_C3;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		sel_msg.sensor_number = SENSOR_NUM_POWER_ERROR;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_PCH_PWROK_FAIL;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		if (!add_sel_evt_record(&sel_msg)) {
+		if (!common_add_sel_evt_record(&sel_msg)) {
 			printf("PCH PWROK failure addsel fail\n");
 		}
 	}
@@ -436,14 +456,15 @@ void ISR_PCH_PWRGD()
 void ISR_RMCA()
 {
 	if ((gpio_get(RST_PLTRST_BUF_N) == GPIO_HIGH) || (gpio_get(PWRGD_CPU_LVC3) == GPIO_HIGH)) {
-		addsel_msg_t sel_msg;
+		common_addsel_msg_t sel_msg;
+		sel_msg.InF_target = BMC_IPMB;
 		sel_msg.sensor_type = IPMI_SENSOR_TYPE_PROCESSOR;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		sel_msg.sensor_number = SENSOR_NUM_CATERR;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_MEM_RMCA;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		if (!add_sel_evt_record(&sel_msg)) {
+		if (!common_add_sel_evt_record(&sel_msg)) {
 			printf("RMCA addsel fail\n");
 		}
 	}


### PR DESCRIPTION
Summary:
- Change to use the common function to add SEL, and remove the redundant platform function of adding SEL.

Test plan:
- Build code: Pass
- Trigger event and check SEL: Pass

Log:
1. VR watchdog timeout
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_A_D 15 out
Configuring GPIO0_A_D pin 15
uart:~$ gpio set GPIO0_A_D 15 0
Writing to GPIO0_A_D pin 15
uart:~$ gpio conf GPIO0_A_D 2 out
Configuring GPIO0_A_D pin 2
uart:~$ gpio set GPIO0_A_D 2 0
Writing to GPIO0_A_D pin 2
uart:~$ gpio set GPIO0_A_D 2 1
Writing to GPIO0_A_D pin 2

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-04 23:57:31    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-04 23:57:31, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) VR Watchdog timeout Assertion

2. System power error
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_A_D 15 out
Configuring GPIO0_E_H pin 15
uart:~$ gpio set GPIO0_A_D 15 0
Writing to GPIO0_E_H pin 15

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 00:06:22    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 00:06:22, Sensor: PWR_ERR (0x56), Event Data: (01FFFF) SYS_PWROK failure, FRU:4 Assertion

3. FM throttle
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_E_H 2 out
Configuring GPIO0_E_H pin 2
uart:~$ gpio set GPIO0_E_H 2 0
Writing to GPIO0_E_H pin 2
uart:~$ gpio set GPIO0_E_H 2 1
Writing to GPIO0_E_H pin 2

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 00:29:53    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 00:29:53, Sensor: SYSTEM_STATUS (0x10), Event Data: (10FFFF) FM_Throttle throttle Assertion
4    slot4    2022-08-05 00:30:18    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 00:30:18, Sensor: SYSTEM_STATUS (0x10), Event Data: (10FFFF) FM_Throttle throttle Deassertion

4. HSC throttle
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_E_H 9 out
Configuring GPIO0_E_H pin 9
uart:~$ gpio set GPIO0_E_H 9 0
Writing to GPIO0_E_H pin 9
uart:~$ gpio set GPIO0_E_H 9 1
Writing to GPIO0_E_H pin 9

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 00:51:13    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 00:51:13, Sensor: SYSTEM_STATUS (0x10), Event Data: (05FFFF) HSC_Throttle throttle Assertion
4    slot4    2022-08-05 00:51:25    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 00:51:25, Sensor: SYSTEM_STATUS (0x10), Event Data: (05FFFF) HSC_Throttle throttle Deassertion

5. MB throttle
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_E_H 18 out
Configuring GPIO0_E_H pin 18
uart:~$ gpio set GPIO0_E_H 18 0
Writing to GPIO0_E_H pin 18
uart:~$ gpio set GPIO0_E_H 18 1
Writing to GPIO0_E_H pin 18

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 00:55:18    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 00:55:18, Sensor: SYSTEM_STATUS (0x10), Event Data: (07FFFF) MB_Throttle throttle Assertion
4    slot4    2022-08-05 00:55:29    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 00:55:29, Sensor: SYSTEM_STATUS (0x10), Event Data: (07FFFF) MB_Throttle throttle Deassertion

6. CPU/memory thermal trip
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_E_H 26 out
Configuring GPIO0_E_H pin 26
uart:~$ gpio set GPIO0_E_H 26 0
Writing to GPIO0_E_H pin 26
uart:~$ gpio conf GPIO0_A_D 20 out
Configuring GPIO0_A_D pin 20
uart:~$ gpio set GPIO0_A_D 20 0
Writing to GPIO0_A_D pin 20

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 01:17:33    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:17:33, Sensor: SYSTEM_STATUS (0x10), Event Data: (11FFFF) CPU/Memory thermal trip Assertion

7. SOC thermal trip
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_E_H 26 out
Configuring GPIO0_E_H pin 26
uart:~$ gpio set GPIO0_E_H 26 1
Writing to GPIO0_E_H pin 26
uart:~$ gpio conf GPIO0_A_D 20 out
Configuring GPIO0_A_D pin 20
uart:~$ gpio set GPIO0_A_D 20 0
Writing to GPIO0_A_D pin 20

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 01:19:34    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:19:34, Sensor: SYSTEM_STATUS (0x10), Event Data: (00FFFF) SOC thermal trip Assertion

8. System throttle
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_E_H 27 out
Configuring GPIO0_E_H pin 27
uart:~$ gpio set GPIO0_E_H 27 0
Writing to GPIO0_E_H pin 27
uart:~$ gpio set GPIO0_E_H 27 1
Writing to GPIO0_E_H pin 27

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 01:26:20    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:26:20, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Assertion
4    slot4    2022-08-05 01:26:26    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:26:26, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Deassertion

9. PCH thermal trip
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_A_D 12 out
Configuring GPIO0_A_D pin 12
uart:~$ gpio set GPIO0_A_D 12 0
Writing to GPIO0_A_D pin 12
uart:~$ gpio set GPIO0_A_D 12 1
Writing to GPIO0_A_D pin 12

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 01:34:33    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:34:33, Sensor: SYSTEM_STATUS (0x10), Event Data: (03FFFF) PCH thermal trip Assertion
4    slot4    2022-08-05 01:34:46    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:34:46, Sensor: SYSTEM_STATUS (0x10), Event Data: (03FFFF) PCH thermal trip Deassertion

10. HSC over current
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_A_D 16 out
Configuring GPIO0_A_D pin 16
uart:~$ gpio set GPIO0_A_D 16 0
Writing to GPIO0_A_D pin 16
uart:~$ gpio set GPIO0_A_D 16 1
Writing to GPIO0_A_D pin 16

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 01:38:02    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:38:02, Sensor: SYSTEM_STATUS (0x10), Event Data: (06FFFF) HSC_OC warning Deassertion
4    slot4    2022-08-05 01:38:03    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:38:03, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Assertion
4    slot4    2022-08-05 01:38:12    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:38:12, Sensor: SYSTEM_STATUS (0x10), Event Data: (06FFFF) HSC_OC warning Assertion
4    slot4    2022-08-05 01:38:12    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:38:12, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Deassertion

11. SCO memory hot
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_A_D 22 out
Configuring GPIO0_A_D pin 22
uart:~$ gpio set GPIO0_A_D 22 0
Writing to GPIO0_A_D pin 22
uart:~$ gpio set GPIO0_A_D 22 1
Writing to GPIO0_A_D pin 22

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 01:49:21    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:49:21, Sensor: CPU_DIMM_HOT (0xB3), Event Data: (01FFFF) SOC MEMHOT Assertion
4    slot4    2022-08-05 01:49:22    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:49:22, Sensor: CPU_DIMM_HOT (0xB3), Event Data: (01FFFF) SOC MEMHOT Deassertion

12. SOC VR hot
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_A_D 18 out
Configuring GPIO0_A_D pin 18
uart:~$ gpio set GPIO0_A_D 18 0
Writing to GPIO0_A_D pin 18
uart:~$ gpio set GPIO0_A_D 18 1
Writing to GPIO0_A_D pin 18

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 01:51:13    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:51:13, Sensor: VR_HOT (0xB2), Event Data: (00FFFF) SOC VR HOT warning Assertion
4    slot4    2022-08-05 01:51:13    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:51:13, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Assertion
4    slot4    2022-08-05 01:51:18    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:51:18, Sensor: VR_HOT (0xB2), Event Data: (00FFFF) SOC VR HOT warning Deassertion
4    slot4    2022-08-05 01:51:19    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 01:51:19, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Deassertion

13. PCH power error
- Set GPIO manually to trigger event
[BIC console]
uart:~$ gpio conf GPIO0_E_H 24 out
Configuring GPIO0_E_H pin 24
uart:~$ gpio set GPIO0_E_H 24 0
Writing to GPIO0_E_H pin 24

- Check BMC get SEL
[BMC console]
root@bmc-oob:~# log-util --print slot4
...
4    slot4    2022-08-05 02:07:17    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2022-08-05 02:07:17, Sensor: PWR_ERR (0x56), Event Data: (02FFFF) PCH_PWROK failure, FRU:4 Assertion