### PR TITLE
fby3.5: bb: Fix build code fail issue and correct LTC4282 sensor reading

### DIFF
--- a/common/dev/ltc4282.c
+++ b/common/dev/ltc4282.c
@@ -266,7 +266,7 @@ init_param:
 	msg.tx_len = 1;
 	msg.rx_len = 1;
 	msg.data[0] = LTC4282_ILIM_ADJUST_OFFSET;
-	if (i2c_master_write(&msg, retry) != 0) {
+	if (i2c_master_read(&msg, retry) != 0) {
 		printf("Failed to read LTC4282 register(0x%x)\n", msg.data[0]);
 		init_args->is_init = false;
 		goto error;

--- a/meta-facebook/yv35-bb/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-bb/src/platform/plat_hook.c
@@ -19,7 +19,7 @@ adm1278_init_arg adm1278_init_args[] = {
 	[0] = { .is_init = false, .config = { 0x3F1C }, .r_sense = 0.25 }
 };
 
-ltc4282_init_arg ltc4282_init_args[] = { [0] = { .is_init = true, .r_sense_mohm = 0.1 } };
+ltc4282_init_arg ltc4282_init_args[] = { [0] = { .is_init = false, .r_sense_mohm = 0.1 } };
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS
@@ -84,7 +84,7 @@ bool pre_ltc4282_read(uint8_t sensor_num, void *args)
 		return false;
 	}
 
-	if (val | ADC_16BIT_MODE_BIT) {
+	if (val & ADC_16BIT_MODE_BIT) {
 		k_msleep(ADC_16BIT_MODE_DELAY_MS);
 	} else {
 		k_msleep(ADC_12BIT_MODE_DELAY_MS);


### PR DESCRIPTION
Summary:
- Fix build code fail issue.
  - Modify LTC4282 initial argument structure member name from r_sense to r_sense_mohm.
- Correct BB BIC LTC4282 sensor reading.
  - Modify LTC4282 sensor initial flag from true to false, making LTC4282 sensor to get adjust parameter of sensor reading from register.

Test Plan:
- Build code: Pass
- LTC4282 sensor reading is correct: Pass

Log:
- Before modifying LTC4282 sensor initial flag from true to false
  LTC4282 sensor doesn't do initial function (Doesn't get adjust parameter of sensor reading from register)

[BMC console]
root@bmc-oob:~# sensor-util slot1 --thre | grep BB_MEDUSA
BB_MEDUSA_VIN                (0xDB) :    4.13 Volts | (lnr) | UCR: 13.88 | UNC: 13.75 | UNR: 14.00 | LCR: 11.12 | LNC: 11.25 | LNR: 9.25
BB_MEDUSA_VOUT               (0xD7) :    4.13 Volts | (lnr) | UCR: 13.88 | UNC: 13.75 | UNR: 14.00 | LCR: 11.12 | LNC: 11.25 | LNR: 9.25
BB_MEDUSA_CUR                (0xDF) :   17.77 Amps  | (ok) | UCR: 144.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
BB_MEDUSA_PWR                (0xD8) :   73.33 Watts | (ok) | UCR: 1800.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA

- After modifying LTC4282 sensor initial flag from true to false

[BMC console]
root@bmc-oob:~# sensor-util slot1 --thre | grep BB_MEDUSA
BB_MEDUSA_VIN                (0xDB) :   12.39 Volts | (ok) | UCR: 13.88 | UNC: 13.75 | UNR: 14.00 | LCR: 11.12 | LNC: 11.25 | LNR: 9.25
BB_MEDUSA_VOUT               (0xD7) :   12.39 Volts | (ok) | UCR: 13.88 | UNC: 13.75 | UNR: 14.00 | LCR: 11.12 | LNC: 11.25 | LNR: 9.25
BB_MEDUSA_CUR                (0xDF) :   17.58 Amps  | (ok) | UCR: 144.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
BB_MEDUSA_PWR                (0xD8) :  217.65 Watts | (ok) | UCR: 1800.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA