### PR TITLE
common: fixed many of VR Vol sensors (xdpe12284c) showing LCR on yv3-dl

### DIFF
--- a/common/dev/xdpe12284c.c
+++ b/common/dev/xdpe12284c.c
@@ -197,6 +197,7 @@ uint8_t xdpe12284c_read(uint8_t sensor_num, int *reading)
 			return SENSOR_FAIL_TO_ACCESS;
 		}
 
+		actual_value /= 1000; // mV to V
 		sval->integer = actual_value;
 		sval->fraction = (actual_value - sval->integer) * 1000;
 		break;


### PR DESCRIPTION
Summary:
- Fixed VCCIN VR Vol (0x27), P3V3_STBY VR Vol (0x2A), VDDQ_ABC VR Vol (0x2C),
  VDDQ_DEF VR Vol (0x2D) showing LCR. It's caused by mV did not turn to V.

Test Plan:
- sensor-util showed normal sensor value. - passed

Log:
```
root@bmc-oob:~# sensor-util slot4 | grep "VR Vol"
VCCIN VR Vol                 (0x27) :    1.70 Volts | (ok)
VCCSA VR Vol                 (0x28) :    0.83 Volts | (ok)
VCCIO VR Vol                 (0x29) :    1.01 Volts | (ok)
P3V3_STBY VR Vol             (0x2A) :    3.30 Volts | (ok)
VDDQ_ABC VR Vol              (0x2C) :    1.24 Volts | (ok)
VDDQ_DEF VR Vol              (0x2D) :    1.24 Volts | (ok)
root@bmc-oob:~#
```