### PR TITLE
fby3.5: cl: Remove PMIC initial setting

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.c
@@ -73,12 +73,6 @@ isl69259_pre_proc_arg isl69259_pre_read_args[] = {
 	[1] = { 0x1 },
 };
 
-pmic_pre_proc_arg pmic_pre_read_args[] = {
-	[0] = { .pre_read_init = false }, [1] = { .pre_read_init = false },
-	[2] = { .pre_read_init = false }, [3] = { .pre_read_init = false },
-	[4] = { .pre_read_init = false }, [5] = { .pre_read_init = false }
-};
-
 dimm_pre_proc_arg dimm_pre_proc_args[] = {
 	[0] = { .is_present_checked = false }, [1] = { .is_present_checked = false },
 	[2] = { .is_present_checked = false }, [3] = { .is_present_checked = false },
@@ -160,95 +154,6 @@ bool pre_vol_bat3v_read(uint8_t sensor_num, void *args)
 		k_msleep(1);
 	}
 
-	return true;
-}
-
-bool pre_pmic_read(uint8_t sensor_num, void *args)
-{
-	ARG_UNUSED(args);
-
-	pmic_init_arg *init_arg = sensor_config[sensor_config_index_map[sensor_num]].init_args;
-	if (init_arg->is_init == false) {
-		return true;
-	}
-
-	pmic_pre_proc_arg *pre_proc_arg =
-		sensor_config[sensor_config_index_map[sensor_num]].pre_sensor_read_args;
-	if (pre_proc_arg->pre_read_init == false) {
-		int ret = 0;
-		uint8_t seq_source = 0xFF, write_data = 0x0;
-		uint8_t *compose_memory_write_read_msg = NULL;
-
-		// Enable PMIC ADC
-		write_data = PMIC_ENABLE_ADC_BIT;
-		compose_memory_write_read_msg =
-			compose_memory_write_read_req(init_arg->smbus_bus_identifier,
-						      init_arg->smbus_addr, PMIC_ADC_ADDR_VAL,
-						      &write_data, 0x1);
-		if (compose_memory_write_read_msg == NULL) {
-			goto COMPOSE_MSG_ERR;
-		}
-
-		ret = pmic_ipmb_transfer(NULL, seq_source, NETFN_NM_REQ, CMD_SMBUS_WRITE_MEMORY,
-					 SELF, ME_IPMB, PMIC_WRITE_DATA_LEN,
-					 compose_memory_write_read_msg);
-		if (ret != 0) {
-			goto PMIC_IPMB_TRANSFER_ERR;
-		}
-		k_msleep(PMIC_COMMAND_DELAY_MSEC);
-
-		// Initialize PMIC to report total mode (could be total power, total current, etc.)
-		write_data = SET_DEV_REPORT_TOTAL;
-		compose_memory_write_read_msg =
-			compose_memory_write_read_req(init_arg->smbus_bus_identifier,
-						      init_arg->smbus_addr,
-						      PMIC_TOTAL_INDIV_ADDR_VAL, &write_data, 0x1);
-		if (compose_memory_write_read_msg == NULL) {
-			goto COMPOSE_MSG_ERR;
-		}
-
-		ret = pmic_ipmb_transfer(NULL, seq_source, NETFN_NM_REQ, CMD_SMBUS_WRITE_MEMORY,
-					 SELF, ME_IPMB, PMIC_WRITE_DATA_LEN,
-					 compose_memory_write_read_msg);
-		if (ret != 0) {
-			goto PMIC_IPMB_TRANSFER_ERR;
-		}
-		k_msleep(PMIC_COMMAND_DELAY_MSEC);
-
-		// Initialize PMIC to report power mode
-		write_data = SET_DEV_REPORT_POWER;
-		compose_memory_write_read_msg =
-			compose_memory_write_read_req(init_arg->smbus_bus_identifier,
-						      init_arg->smbus_addr, PMIC_PWR_CURR_ADDR_VAL,
-						      &write_data, 0x1);
-		if (compose_memory_write_read_msg == NULL) {
-			goto COMPOSE_MSG_ERR;
-		}
-
-		ret = pmic_ipmb_transfer(NULL, seq_source, NETFN_NM_REQ, CMD_SMBUS_WRITE_MEMORY,
-					 SELF, ME_IPMB, PMIC_WRITE_DATA_LEN,
-					 compose_memory_write_read_msg);
-		if (ret != 0) {
-			goto PMIC_IPMB_TRANSFER_ERR;
-		}
-		k_msleep(PMIC_COMMAND_DELAY_MSEC);
-
-		pre_proc_arg->pre_read_init = true;
-		return true;
-
-	PMIC_IPMB_TRANSFER_ERR:
-		if (write_data == 0x0) {
-			printf("[%s] PMIC ipmb transfer me reset command error\n", __func__);
-		} else {
-			printf("[%s] PMIC ipmb transfer command error write_data: 0x%x\n", __func__,
-			       write_data);
-		}
-		return false;
-
-	COMPOSE_MSG_ERR:
-		printf("[%s] compose msg error write_data: 0x%x\n", __func__, write_data);
-		return false;
-	}
 	return true;
 }
 

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -202,22 +202,22 @@ sensor_cfg plat_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 	{ SENSOR_NUM_PWR_DIMMA0_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
-	  pre_pmic_read, &pmic_pre_read_args[0], NULL, NULL, &pmic_init_args[0] },
+	  NULL, NULL, NULL, NULL, &pmic_init_args[0] },
 	{ SENSOR_NUM_PWR_DIMMA2_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
-	  pre_pmic_read, &pmic_pre_read_args[1], NULL, NULL, &pmic_init_args[1] },
+	  NULL, NULL, NULL, NULL, &pmic_init_args[1] },
 	{ SENSOR_NUM_PWR_DIMMA3_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
-	  pre_pmic_read, &pmic_pre_read_args[2], NULL, NULL, &pmic_init_args[2] },
+	  NULL, NULL, NULL, NULL, &pmic_init_args[2] },
 	{ SENSOR_NUM_PWR_DIMMA4_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
-	  pre_pmic_read, &pmic_pre_read_args[3], NULL, NULL, &pmic_init_args[3] },
+	  NULL, NULL, NULL, NULL, &pmic_init_args[3] },
 	{ SENSOR_NUM_PWR_DIMMA6_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
-	  pre_pmic_read, &pmic_pre_read_args[4], NULL, NULL, &pmic_init_args[4] },
+	  NULL, NULL, NULL, NULL, &pmic_init_args[4] },
 	{ SENSOR_NUM_PWR_DIMMA7_PMIC, sensor_dev_pmic, I2C_BUS3, PCH_ADDR, NONE, me_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
-	  pre_pmic_read, &pmic_pre_read_args[5], NULL, NULL, &pmic_init_args[5] },
+	  NULL, NULL, NULL, NULL, &pmic_init_args[5] },
 };
 
 sensor_cfg mp5990_sensor_config_table[] = {
@@ -464,14 +464,16 @@ void pal_extend_sensor_config()
 	case HSC_MODULE_LTC4286:
 		sensor_count = ARRAY_SIZE(ltc4286_sensor_config_table);
 		for (int index = 0; index < sensor_count; index++) {
-			ltc4286_sensor_config_table[index].init_args = &ltc4286_init_args[arg_index];
+			ltc4286_sensor_config_table[index].init_args =
+				&ltc4286_init_args[arg_index];
 			add_sensor_config(ltc4286_sensor_config_table[index]);
 		}
 		break;
 	case HSC_MODULE_LTC4282:
 		sensor_count = ARRAY_SIZE(ltc4282_sensor_config_table);
 		for (int index = 0; index < sensor_count; index++) {
-			ltc4282_sensor_config_table[index].init_args = &ltc4282_init_args[arg_index];
+			ltc4282_sensor_config_table[index].init_args =
+				&ltc4282_init_args[arg_index];
 			add_sensor_config(ltc4282_sensor_config_table[index]);
 		}
 		break;


### PR DESCRIPTION
Summary:
- Remove PMIC initial setting.
  - Remove the enable ADC, report total and report power settings by writing to PMIC register.

Note:
- PMIC write protection is enabled by default, so PMIC initial setting would fail if BIOS doesn't disable PMIC secure mode.
  The PMIC initial setting is changed to be set by the BIOS.

Test Plan:
- Build code: Pass
- PMIC power reading is correct with BIOS test firmware after removing PMIC initial setting: Pass
- PMIC power reading is correct in host reset/reboot 330 times: Pass
- PMIC power reading is correct in DC cycle 300 times: Pass

Log:
root@bmc-oob:~# sensor-util slot2 --thre | grep PMIC
DIMMA PMIC_Pout              (0x1E) :    0.75 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMC PMIC_Pout              (0x1F) :    0.50 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMD PMIC_Pout              (0x36) :    0.62 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME PMIC_Pout              (0x37) :    0.50 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMG PMIC_Pout              (0x42) :    0.75 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH PMIC_Pout              (0x47) :    0.50 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA