### PR TITLE
fby3: dl: set kcs port for bios

### DIFF
--- a/meta-facebook/yv3-dl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv3-dl/boards/ast1030_evb.overlay
@@ -134,7 +134,7 @@
 	status = "okay";
 };
 
-&kcs3 {
+&kcs4 {
   status = "okay";
   addr = <0xca2>;
 };

--- a/meta-facebook/yv3-dl/src/platform/plat_def.h
+++ b/meta-facebook/yv3-dl/src/platform/plat_def.h
@@ -1,7 +1,7 @@
 #ifndef PLAT_DEF_H
 #define PLAT_DEF_H
 
-#define HOST_KCS_PORT kcs3
+#define HOST_KCS_PORT kcs4
 #define BMC_USB_PORT "CDC_ACM_0"
 
 #endif

--- a/meta-facebook/yv3-dl/src/platform/plat_init.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_init.c
@@ -11,6 +11,7 @@ SCU_CFG scu_cfg[] = {
 	{ 0x7e6e2614, 0xffffffff }, //disable GPIO internal pull down #1
 	{ 0x7e6e2618, 0xF8000000 }, //disable GPIO internal pull down #2
 	{ 0x7e6e261c, 0xC0200F3A }, //disable GPIO internal pull down #3
+	{ 0x7e789110, 0x0ca60ca2 }, //set kcs data addr:ca2, cmd addr:ca6
 };
 
 void pal_pre_init()


### PR DESCRIPTION
Summary:
- The status/command port address of kcs is 0xca6 on Yv3 bios.
- Enable kcs4 to support customize status/command port address.

Test plan:
1.build pass on fby3 dl
2.boot into os send ipmitool raw command:(pass)
[root@Yv3_host ~]# ipmitool raw 0x6 0x1
 20 81 01 03 02 bf 15 a0 00 46 31 00 00 00 00
[root@Yv3_host ~]# ipmitool raw 0x6 0x4
 55 00