### PR TITLE
fby3:dl: Improve ssd access sensor reading

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_init.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_init.c
@@ -20,7 +20,7 @@ void pal_pre_init()
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
 }
 
-void pal_post_init()
+void pal_device_init()
 {
 	init_me_firmware();
 }

--- a/meta-facebook/yv3-dl/src/platform/plat_isr.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_isr.c
@@ -70,8 +70,6 @@ void ISR_SLP3()
 
 void ISR_POST_COMPLETE()
 {
-	set_post_status(FM_BIOS_POST_CMPLT_BMC_N);
-
 	if (gpio_get(FM_BIOS_POST_CMPLT_BMC_N) == GPIO_LOW) { // Post complete
 		if (get_me_mode() == ME_INIT_MODE) {
 			init_me_firmware();
@@ -83,6 +81,8 @@ void ISR_POST_COMPLETE()
 		enable_UV_detect_interrupt();
 		enable_SYS_Throttle_interrupt();
 	}
+
+	set_post_status(FM_BIOS_POST_CMPLT_BMC_N);
 }
 
 K_WORK_DELAYABLE_DEFINE(set_DC_on_15s_work, set_DC_on_delayed_status);

--- a/meta-facebook/yv3-dl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_sensor_table.c
@@ -35,7 +35,7 @@ sensor_cfg plat_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
 	// NVME
-	{ SENSOR_NUM_T_NVME1, sensor_dev_nvme, I2C_BUS5, SSD0_ADDR, SSD0_OFFSET, dc_access, 0, 0,
+	{ SENSOR_NUM_T_NVME1, sensor_dev_nvme, I2C_BUS5, SSD0_ADDR, SSD0_OFFSET, post_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  pre_nvme_read, &mux_conf_addr_0xe2[1], NULL, NULL, NULL },
 


### PR DESCRIPTION
Summary:
- Improve ssd access sensor reading.
  - Modify check ssd status timing to improve ssd access sensor reading fail after post complete.

Test Plan:
- Build code: Pass
- BIC would not print error message after BIC cold/warm reset: Pass
- BIC would not print error message after DC cycle/host reset: Pass