### PR TITLE
fby3: dl: Fix set open drain gpio set high issue

### DIFF
--- a/meta-facebook/yv3-dl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv3-dl/src/ipmi/plat_ipmi.c
@@ -290,7 +290,6 @@ void OEM_1S_GET_SET_GPIO(ipmi_msg *msg)
 	case SET_GPIO_OUTPUT_STATUS:
 		if (msg->data_len == 3) {
 			msg->data[0] = gpio_num;
-			gpio_conf(gpio_num, GPIO_OUTPUT);
 			gpio_set(gpio_num, msg->data[2]);
 			msg->data[1] = gpio_get(gpio_num);
 			completion_code = CC_SUCCESS;


### PR DESCRIPTION
Summary:
- Fix setting open drain gpio to output before setting gpio value that will cause gpio drop to low.

Test plan:
- build pass on fby3 dl.
- Check the waveform of open drain gpio (pass)