### PR TITLE
GT: Version commit fot gt-swb-2022.33.01

### DIFF
--- a/meta-facebook/gt-cc/src/platform/plat_version.h
+++ b/meta-facebook/gt-cc/src/platform/plat_version.h
@@ -21,7 +21,7 @@
  *    Count of release firmware at each stage.
  */
 #define FIRMWARE_REVISION_1 0x01
-#define FIRMWARE_REVISION_2 0x07
+#define FIRMWARE_REVISION_2 0x08
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
 #define PRODUCT_ID 0x0000
@@ -29,7 +29,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x28
+#define BIC_FW_WEEK 0x33
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x47 // char: G
 #define BIC_FW_platform_1 0x54 // char: T


### PR DESCRIPTION
Summary:
- Version commit for GT switch board gt-swb-2022.33.01

Test Plan:
- Build code: Pass
- Check BIC version is changed: Pass

Log:
1. Get version of SWB BIC from BMC
root@bmc-oob:~# fw-util swb --version bic
SWB BIC Version: 2022.33.01