### PR TITLE
fby3: dl: Support IPMI command of get card type

### DIFF
--- a/meta-facebook/yv3-dl/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/yv3-dl/src/ipmi/include/plat_ipmi.h
@@ -4,6 +4,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+enum REQ_GET_CARD_TYPE {
+	GET_1OU_CARD_TYPE = 0x0,
+	GET_2OU_CARD_TYPE,
+};
+
 enum DL_FIRMWARE_COMPONENT {
 	DL_COMPNT_BIOS = 0,
 	DL_COMPNT_CPLD,

--- a/meta-facebook/yv3-dl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv3-dl/src/ipmi/plat_ipmi.c
@@ -13,6 +13,50 @@
 #include "isl69254iraz_t.h"
 #include "xdpe12284c.h"
 
+void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
+{
+	if (msg == NULL) {
+		printf("[%s] Failed due to parameter *msg is NULL\n", __func__);
+		return;
+	}
+
+	if (msg->data_len != 1) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	CARD_STATUS _1ou_status = get_1ou_status();
+	CARD_STATUS _2ou_status = get_2ou_status();
+	switch (msg->data[0]) {
+	case GET_1OU_CARD_TYPE:
+		msg->data_len = 2;
+		msg->completion_code = CC_SUCCESS;
+		msg->data[0] = GET_1OU_CARD_TYPE;
+		if (_1ou_status.present) {
+			msg->data[1] = _1ou_status.card_type;
+		} else {
+			msg->data[1] = TYPE_1OU_ABSENT;
+		}
+		break;
+	case GET_2OU_CARD_TYPE:
+		msg->data_len = 2;
+		msg->completion_code = CC_SUCCESS;
+		msg->data[0] = GET_2OU_CARD_TYPE;
+		if (_2ou_status.present) {
+			msg->data[1] = _2ou_status.card_type;
+		} else {
+			msg->data[1] = TYPE_2OU_ABSENT;
+		}
+		break;
+	default:
+		msg->data_len = 0;
+		msg->completion_code = CC_INVALID_DATA_FIELD;
+		break;
+	}
+
+	return;
+}
+
 void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 {
 	if (msg == NULL) {


### PR DESCRIPTION
Summary:
- As title. Netfn: 38h; Cmd: A1h

  Request Data:
        Byte[3:1] - Manufacturer ID
        Byte4 - (00h/01h) 00h for 1OU; 01h for 2OU.
  Response Data:
        Byte1 - Completion code
                00h - Successfully
                C7h - Request data length invalid
                CCh - Invalid data field in Request
        Byte2 - 1OU/2OU(00h for 1OU and 01h for 2OU)
        Byte3 - card type
                1OU -
                    * FEh: 1OU card is absent
                    * FFh: Unknown 1OU card type
                2OU -
                    * 01h: 2OU Expansion
                    * 02h: 2OU Expansion E1S
                    * 06h: Hardware Security Module
                    * FEh: 2OU card is absent
                    * FFh: Unknown 2OU card type

Test Plan:
- Built and tested on yv3 dl. - passed

Log:
```
root@bmc-oob:~# bic-util slot4 0xE0 0xA1 0x9c 0x9c 0x0 0
9C 9C 00 00 FE
root@bmc-oob:~# bic-util slot4 0xE0 0xA1 0x9c 0x9c 0x0 1
9C 9C 00 01 FE
root@bmc-oob:~#
```