### PR TITLE
fby3:dl:set i2c frequency to 100k

### DIFF
--- a/meta-facebook/yv3-dl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv3-dl/boards/ast1030_evb.overlay
@@ -22,12 +22,12 @@
 &i2c0 {
 	pinctrl-0 = <&pinctrl_i2c0_default>;
 	status = "okay";
-  clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &i2c1 {
 	pinctrl-0 = <&pinctrl_i2c1_default>;
-  clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	status = "okay";
 
 	ipmb1: ipmb@20 {
@@ -41,13 +41,13 @@
 
 &i2c2 {
 	pinctrl-0 = <&pinctrl_i2c2_default>;
-  clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 	status = "okay";
 };
 
 &i2c3 {
 	pinctrl-0 = <&pinctrl_i2c3_default>;
-  clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	status = "okay";
 
 	ipmb3: ipmb@20 {
@@ -81,12 +81,12 @@
 &i2c5 {
 	pinctrl-0 = <&pinctrl_i2c5_default>;
 	status = "okay";
-  clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &i2c6 {
 	pinctrl-0 = <&pinctrl_i2c6_default>;
-  clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	status = "okay";
 
 	ipmb6: ipmb@20 {
@@ -101,20 +101,19 @@
 &i2c7 {
 	pinctrl-0 = <&pinctrl_i2c7_default>;
 	status = "okay";
-  clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &i2c8 {
 	pinctrl-0 = <&pinctrl_i2c8_default>;
-  status = "okay";
-  clock-frequency = <I2C_BITRATE_FAST>;
-
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &i2c9 {
 	pinctrl-0 = <&pinctrl_i2c9_default>;
-  	status = "okay";
-  	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &espi {
@@ -135,21 +134,21 @@
 };
 
 &kcs4 {
-  status = "okay";
-  addr = <0xca2>;
+	status = "okay";
+	addr = <0xca2>;
 };
 
 &uart5 {
-  current-speed = <57600>;
+	current-speed = <57600>;
 };
 
 &gpio0_a_d {
-  aspeed,persist-maps = <0x08000000>;
+	aspeed,persist-maps = <0x08000000>;
 };
 
 &snoop {
-  status = "okay";
-  port = <0x80>, <0x81>;
+	status = "okay";
+	port = <0x80>, <0x81>;
 };
 
 &fmc {
@@ -219,9 +218,8 @@
 };
 
 &wdt0 {
-  status = "okay";
+	status = "okay";
 };
-
 
 &wdt1 {
 	status = "okay";
@@ -238,6 +236,7 @@
 &wdt4 {
 	status = "okay";
 };
+
 &sram0 {
 	reg = <0 DT_SIZE_K(512)>, <0x80000 DT_SIZE_K(256)>;
 };


### PR DESCRIPTION
Summary:
- Set the i2c frequency to 100k to align with TI BIC settings.
- Use tab to align code format.

Test plan:
1. build pass on fby3 dl.
2. EE check the i2c waveform : pass.
3. Sensor reading :
root@bmc-oob:~# sensor-util slot2
slot2:
MB Inlet Temp                (0x1) :   28.00 C     | (ok)
MB Outlet Temp               (0x2) :   38.00 C     | (ok)
FRONT IO Temp                (0x3) :   25.00 C     | (ok)
PCH Temp                     (0x4) :   36.00 C     | (ok)
SOC CPU Temp                 (0x5) :   33.00 C     | (ok)
SOC Therm Margin             (0xD) :  -43.00 C     | (ok)
SOC CPU TjMax                (0x25) :   76.00 C     | (ok)
CPU Package Pwr              (0x1E) :   13.00 Watts | (ok)
SOC DIMMA Temp               (0x6) :   33.00 C     | (ok)
SOC DIMMB Temp               (0x7) :    0.00 C     | (ok)
SOC DIMMC Temp               (0x9) :   32.00 C     | (ok)
SOC DIMMD Temp               (0xA) :   33.00 C     | (ok)
SOC DIMME Temp               (0xB) :    0.00 C     | (ok)
SOC DIMMF Temp               (0xC) :   33.00 C     | (ok)
SSD0 Temp                    (0xE) :   25.00 C     | (ok)
HSC Temp                     (0xF) :   35.00 C     | (ok)
VCCIN VR Temp                (0x10) :   40.00 C     | (ok)
VCCSA VR Temp                (0x11) :   39.00 C     | (ok)
VCCIO VR Temp                (0x12) :   39.00 C     | (ok)
3V3_STBY VR Temp             (0x13) :   35.00 C     | (ok)
VDDQ_ABC VR Temp             (0x14) :   39.00 C     | (ok)
VDDQ_DEF VR Temp             (0x15) :   40.00 C     | (ok)
P12V_STBY Vol                (0x20) :   11.97 Volts | (ok)
P3V_BAT Vol                  (0x21) :    3.12 Volts | (ok)
P3V3_STBY Vol                (0x22) :    3.32 Volts | (ok)
P1V05_PCH Vol                (0x23) :    1.06 Volts | (ok)
PVNN_PCH Vol                 (0x24) :    1.01 Volts | (ok)
HSC Input Vol                (0x26) :   11.88 Volts | (ok)
VCCIN VR Vol                 (0x27) :    1.69 Volts | (ok)
VCCSA VR Vol                 (0x28) :    0.83 Volts | (ok)
VCCIO VR Vol                 (0x29) :    1.01 Volts | (ok)
P3V3_STBY VR Vol             (0x2A) :    3.28 Volts | (ok)
VDDQ_ABC VR Vol              (0x2C) :    1.23 Volts | (ok)
VDDQ_DEF VR Vol              (0x2D) :    1.23 Volts | (ok)
HSC Output Cur               (0x30) :    1.80 Amps  | (ok)
VCCIN VR Cur                 (0x31) :    4.00 Amps  | (ok)
VCCSA VR Cur                 (0x32) :    2.10 Amps  | (ok)
VCCIO VR Cur                 (0x33) :    3.20 Amps  | (ok)
P3V3_STBY VR Cur             (0x34) :    0.60 Amps  | (ok)
VDDQ_ABC VR Cur              (0x35) :    1.25 Amps  | (ok)
VDDQ_DEF VR Cur              (0x36) :    1.00 Amps  | (ok)
HSC Input Pwr                (0x2E) :   22.00 Watts | (ok)
HSC Input AvgPwr             (0x39) :   22.00 Watts | (ok)
VCCIN VR Pout                (0x3A) :    6.00 Watts | (ok)
VCCSA VR Pout                (0x3C) :    2.00 Watts | (ok)
VCCIO VR Pout                (0x3D) :    2.00 Watts | (ok)
P3V3_STBY VRPout             (0x3E) :    1.00 Watts | (ok)
VDDQ_ABC VRPout              (0x3F) :    0.99 Watts | (ok)
VDDQ_DEF VRPout              (0x42) :    0.99 Watts | (ok)