### PR TITLE
fby3.5: rf: Disable GPIO internal Pull-Down

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_init.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_init.c
@@ -5,9 +5,16 @@
 #include "plat_power_seq.h"
 #include "power_status.h"
 
+SCU_CFG scu_cfg[] = {
+	//register    value
+	{ 0x7e6e2610, 0x0000D7BF },
+	{ 0x7e6e2614, 0x00044300 },
+};
+
 void pal_pre_init()
 {
 	init_platform_config();
+	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
 }
 
 void pal_set_sys_status()


### PR DESCRIPTION
Summary:

- Disable GPIO internal Pull-Down.

Test Plan:

-  Build code: PASS.
