### PR TITLE
Common: modify the behavior of setting GPIO value

### DIFF
--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -888,7 +888,6 @@ __weak void OEM_1S_GET_SET_GPIO(ipmi_msg *msg)
 	case SET_GPIO_OUTPUT_STATUS:
 		if (msg->data_len == 3) {
 			msg->data[0] = gpio_num;
-			gpio_conf(gpio_num, GPIO_OUTPUT);
 			gpio_set(gpio_num, msg->data[2]);
 			msg->data[1] = gpio_get(gpio_num);
 			completion_code = CC_SUCCESS;


### PR DESCRIPTION
Summery:
- If we want to set value of BIC GPIO via BMC, IPMI command handler will set GPIO direction to output firstly, and then set value.
This is dangerous because the default direction of some GPIOs may be input.
If user use the command of setting value, handler should only change value.

Test plan:
- Build code: Pass
- Set GPIO value: Pass

Log:
1. Set value of GPIO which default direction is output.
root@bmc-oob:~# bic-util slot1 --get_gpio | grep FM_JTAG_TCK_MUX_SEL_R
51 FM_JTAG_TCK_MUX_SEL_R: 0
root@bmc-oob:~# bic-util slot1 --set_gpio 51 1
slot 1: setting [51]FM_JTAG_TCK_MUX_SEL_R to 1
root@bmc-oob:~# bic-util slot1 --get_gpio | grep FM_JTAG_TCK_MUX_SEL_R
51 FM_JTAG_TCK_MUX_SEL_R: 1
root@bmc-oob:~# bic-util slot1 --set_gpio 51 0
slot 1: setting [51]FM_JTAG_TCK_MUX_SEL_R to 0
root@bmc-oob:~# bic-util slot1 --get_gpio | grep FM_JTAG_TCK_MUX_SEL_R
51 FM_JTAG_TCK_MUX_SEL_R: 0

2. Set value of GPIO which default direction is input.
- Before modify
root@bmc-oob:~# bic-util slot1 --get_gpio | grep PWRGD_SYS_PWROK
15 PWRGD_SYS_PWROK: 1
root@bmc-oob:~# bic-util slot1 --set_gpio 15 0
slot 1: setting [15]PWRGD_SYS_PWROK to 0
root@bmc-oob:~# bic-util slot1 --get_gpio | grep PWRGD_SYS_PWROK
15 PWRGD_SYS_PWROK: 0
root@bmc-oob:~# bic-util slot1 --set_gpio 15 1
slot 1: setting [15]PWRGD_SYS_PWROK to 1
root@bmc-oob:~# bic-util slot1 --get_gpio | grep PWRGD_SYS_PWROK
15 PWRGD_SYS_PWROK: 1

- After moddify
root@bmc-oob:~# bic-util slot1 --get_gpio | grep PWRGD_SYS_PWROK
15 PWRGD_SYS_PWROK: 1
root@bmc-oob:~# bic-util slot1 --set_gpio 15 0
slot 1: setting [15]PWRGD_SYS_PWROK to 0
root@bmc-oob:~# bic-util slot1 --get_gpio | grep PWRGD_SYS_PWROK
15 PWRGD_SYS_PWROK: 1