### PR TITLE
common: shell: Modify shell sensor polling control command

### DIFF
--- a/common/shell/commands/sensor_shell.c
+++ b/common/shell/commands/sensor_shell.c
@@ -127,39 +127,42 @@ static int sensor_access(const struct shell *shell, int sensor_num, enum SENSOR_
 
 		char *check_access =
 			(sensor_access_check(sensor_config[sen_idx].num) == true) ? "O" : "X";
+		char *check_poll = (sensor_config[sen_idx].is_enable_polling == true) ? "O" : "X";
+
 		if (!strcmp(check_access, "O")) {
 			if (sensor_config[sen_idx].cache_status == SENSOR_READ_4BYTE_ACUR_SUCCESS) {
 				int16_t fraction = sensor_config[sen_idx].cache >> 16;
 				int16_t integer = sensor_config[sen_idx].cache & 0xFFFF;
 				shell_print(
 					shell,
-					"[0x%-2x] %-25s: %-10s | access[%s] | %-25s | %-4d sec | %.2f",
+					"[0x%-2x] %-25s: %-10s | access[%s] | poll[%s] %-4d sec | %-25s | %d.%d",
 					sensor_config[sen_idx].num, sensor_name,
 					sensor_type_name[sensor_config[sen_idx].type], check_access,
+					check_poll, (int)sensor_config[sen_idx].poll_time,
 					sensor_status_name[sensor_config[sen_idx].cache_status],
-					sensor_config[sen_idx].poll_time,
-					integer + (0.001 * fraction));
+					integer, fraction);
 				break;
 			} else if (sensor_config[sen_idx].cache_status == SENSOR_READ_SUCCESS ||
 				   sensor_config[sen_idx].cache_status ==
 					   SENSOR_READ_ACUR_SUCCESS) {
 				shell_print(
 					shell,
-					"[0x%-2x] %-25s: %-10s | access[%s] | %-25s | %-4d sec | %-8d",
+					"[0x%-2x] %-25s: %-10s | access[%s] | poll[%s] %-4d sec | %-25s | %-8d",
 					sensor_config[sen_idx].num, sensor_name,
 					sensor_type_name[sensor_config[sen_idx].type], check_access,
+					check_poll, (int)sensor_config[sen_idx].poll_time,
 					sensor_status_name[sensor_config[sen_idx].cache_status],
-					sensor_config[sen_idx].poll_time,
 					sensor_config[sen_idx].cache);
 				break;
 			}
 		}
 
-		shell_print(shell, "[0x%-2x] %-25s: %-10s | access[%s] | %-25s | %-4d sec | na",
+		shell_print(shell,
+			    "[0x%-2x] %-25s: %-10s | access[%s] | poll[%s] %-4d sec | %-25s | na",
 			    sensor_config[sen_idx].num, sensor_name,
-			    sensor_type_name[sensor_config[sen_idx].type], check_access,
-			    sensor_status_name[sensor_config[sen_idx].cache_status],
-			    sensor_config[sen_idx].poll_time);
+			    sensor_type_name[sensor_config[sen_idx].type], check_access, check_poll,
+			    (int)sensor_config[sen_idx].poll_time,
+			    sensor_status_name[sensor_config[sen_idx].cache_status]);
 		break;
 
 	case SENSOR_WRITE:
@@ -221,13 +224,21 @@ void cmd_control_sensor_polling(const struct shell *shell, size_t argc, char **a
 
 	uint8_t sensor_num = strtol(argv[1], NULL, 16);
 	uint8_t operation = strtol(argv[2], NULL, 16);
+
+	uint8_t is_set_all = 0;
+
 	int sensor_index = sensor_get_idx_by_sensor_num(sensor_num);
 	if (sensor_index == -1) {
-		shell_warn(
-			shell,
-			"[%s]: can't find sensor number in sensor config table, sensor number: 0x%x",
-			__func__, sensor_num);
-		return;
+		/* Set all sensor polling mode only suppot 1-base sensor number */
+		if (sensor_num == 0) {
+			is_set_all = 1;
+		} else {
+			shell_warn(
+				shell,
+				"[%s]: can't find sensor number in sensor config table, sensor number: 0x%x",
+				__func__, sensor_num);
+			return;
+		}
 	}
 
 	if ((operation != DISABLE_SENSOR_POLLING) && (operation != ENABLE_SENSOR_POLLING)) {
@@ -235,9 +246,18 @@ void cmd_control_sensor_polling(const struct shell *shell, size_t argc, char **a
 		return;
 	}
 
+	if (is_set_all) {
+		for (int sen_idx = 0; sen_idx < sensor_config_count; sen_idx++) {
+			sensor_config[sen_idx].is_enable_polling = operation;
+		}
+		shell_print(shell, "All Sensors' polling %s success",
+			    ((operation == DISABLE_SENSOR_POLLING) ? "disable" : "enable"));
+		return;
+	}
+
 	sensor_config[sensor_index].is_enable_polling =
 		((operation == DISABLE_SENSOR_POLLING) ? DISABLE_SENSOR_POLLING :
-							       ENABLE_SENSOR_POLLING);
+							 ENABLE_SENSOR_POLLING);
 	shell_print(shell, "Sensor number 0x%x %s sensor polling success", sensor_num,
 		    ((operation == DISABLE_SENSOR_POLLING) ? "disable" : "enable"));
 	return;

--- a/common/shell/commands/sensor_shell.c
+++ b/common/shell/commands/sensor_shell.c
@@ -125,17 +125,17 @@ static int sensor_access(const struct shell *shell, int sensor_num, enum SENSOR_
 		char sensor_name[MAX_SENSOR_NAME_LENGTH] = { 0 };
 		snprintf(sensor_name, sizeof(sensor_name), "%s", full_sdr_table[sdr_index].ID_str);
 
-		char *check_access =
-			(sensor_access_check(sensor_config[sen_idx].num) == true) ? "O" : "X";
-		char *check_poll = (sensor_config[sen_idx].is_enable_polling == true) ? "O" : "X";
+		char check_access =
+			(sensor_access_check(sensor_config[sen_idx].num) == true) ? 'O' : 'X';
+		char check_poll = (sensor_config[sen_idx].is_enable_polling == true) ? 'O' : 'X';
 
-		if (!strcmp(check_access, "O")) {
+		if (check_access == 'O') {
 			if (sensor_config[sen_idx].cache_status == SENSOR_READ_4BYTE_ACUR_SUCCESS) {
 				int16_t fraction = sensor_config[sen_idx].cache >> 16;
 				int16_t integer = sensor_config[sen_idx].cache & 0xFFFF;
 				shell_print(
 					shell,
-					"[0x%-2x] %-25s: %-10s | access[%s] | poll[%s] %-4d sec | %-25s | %d.%d",
+					"[0x%-2x] %-25s: %-10s | access[%c] | poll[%c] %-4d sec | %-25s | %d.%d",
 					sensor_config[sen_idx].num, sensor_name,
 					sensor_type_name[sensor_config[sen_idx].type], check_access,
 					check_poll, (int)sensor_config[sen_idx].poll_time,
@@ -147,7 +147,7 @@ static int sensor_access(const struct shell *shell, int sensor_num, enum SENSOR_
 					   SENSOR_READ_ACUR_SUCCESS) {
 				shell_print(
 					shell,
-					"[0x%-2x] %-25s: %-10s | access[%s] | poll[%s] %-4d sec | %-25s | %-8d",
+					"[0x%-2x] %-25s: %-10s | access[%c] | poll[%c] %-4d sec | %-25s | %-8d",
 					sensor_config[sen_idx].num, sensor_name,
 					sensor_type_name[sensor_config[sen_idx].type], check_access,
 					check_poll, (int)sensor_config[sen_idx].poll_time,
@@ -158,7 +158,7 @@ static int sensor_access(const struct shell *shell, int sensor_num, enum SENSOR_
 		}
 
 		shell_print(shell,
-			    "[0x%-2x] %-25s: %-10s | access[%s] | poll[%s] %-4d sec | %-25s | na",
+			    "[0x%-2x] %-25s: %-10s | access[%c] | poll[%c] %-4d sec | %-25s | na",
 			    sensor_config[sen_idx].num, sensor_name,
 			    sensor_type_name[sensor_config[sen_idx].type], check_access, check_poll,
 			    (int)sensor_config[sen_idx].poll_time,
@@ -250,8 +250,8 @@ void cmd_control_sensor_polling(const struct shell *shell, size_t argc, char **a
 		for (int sen_idx = 0; sen_idx < sensor_config_count; sen_idx++) {
 			sensor_config[sen_idx].is_enable_polling = operation;
 		}
-		shell_print(shell, "All Sensors' polling %s success",
-			    ((operation == DISABLE_SENSOR_POLLING) ? "disable" : "enable"));
+		shell_print(shell, "All Sensors' polling successfully %s.",
+			    ((operation == DISABLE_SENSOR_POLLING) ? "disabled" : "enabled"));
 		return;
 	}
 


### PR DESCRIPTION
Summary:
- Support sensor polling control for all sensors by given sensor number 0(only support 1-base sensor number).
- Add sensor polling variable to sensor info format.

Test Plan:
- Build Code: PASS
- Test commands in BIC console: PASS

Log:
- BIC console:
  ```
  uart:~$ platform sensor control_sensor_polling 0 0
  All Sensors' polling disable success
  uart:~$ platform sensor list_all
  ---------------------------------------------------------------------------------
  [0x1 ] MB Inlet Temp            : tmp75      | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x2 ] MB Outlet Temp           : tmp75      | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x3 ] IOM Temp                 : tmp75      | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x8 ] SSD0 Temp                : nvme       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x5 ] SOC CPU Temp             : peci       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x6 ] SOC Therm Margi          : peci       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x7 ] CPU TjMax                : peci       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0xa ] DIMMA Temp               : peci       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0xb ] DIMMC Temp               : peci       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0xc ] DIMME Temp               : peci       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0xd ] DIMMG Temp               : peci       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x60] CPU Pwr                  : peci       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x20] P12V_STBY Vol            : adc        | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x26] P12V_DIMM Vol            : adc        | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x22] P3V3_STBY Vol            : adc        | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x24] P1V05_PCH Vol            : adc        | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x21] P3V_BAT Vol              : adc        | access[O] | poll[X] 3600 sec | polling_disable           | na
  [0x28] P3V3_M2 Vol              : adc        | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x25] P5V_STBY Vol             : adc        | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x23] P1V8_STBY Vol            : adc        | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x27] P1V2_STBY Vol            : adc        | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x2d] VCCD VR Vol              : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x2e] FAON VR Vol              : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x2c] EHV VR Vol               : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x2a] VCCIN VR Vol             : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x2b] FIVRA VR Vol             : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x44] VCCD VR Cur              : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x45] VCCD VR Cur in           : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x46] FAON VR Cur              : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x43] EHV VR Cur               : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x41] VCCIN VR Cur             : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x42] FIVRA VR Cur             : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x11] VCCD SPS Temp            : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x12] FAON SPS Temp            : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x10] EHV SPS Temp             : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0xe ] VCCIN SPS Temp           : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0xf ] FIVRA SPS Temp           : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x69] VCCD VR Pout             : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x6a] FAON VR Pout             : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x68] EHV VR Pout              : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x66] VCCIN VR Pout            : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x67] FIVRA VR Pout            : isl69259   | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x4 ] PCH Temp                 : pch        | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x62] DIMMA PMIC_Pout          : pmic       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x63] DIMMC PMIC_Pout          : pmic       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x64] DIMME PMIC_Pout          : pmic       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x65] DIMMG PMIC_Pout          : pmic       | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x6b] IOM INA Pwr              : ina230     | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x47] IOM INA Cur              : ina230     | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x2f] IOM INA vol              : ina230     | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x9 ] HSC Temp                 : mp5990     | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x29] HSC Input Vol            : mp5990     | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x40] HSC Output Cur           : mp5990     | access[O] | poll[X] 1    sec | polling_disable           | na
  [0x61] HSC Input Pwr            : mp5990     | access[O] | poll[X] 1    sec | polling_disable           | na
  ---------------------------------------------------------------------------------
  uart:~$ platform sensor control_sensor_polling 0 1
  All Sensors' polling enable success
  uart:~$ platform sensor list_all
  ---------------------------------------------------------------------------------
  [0x1 ] MB Inlet Temp            : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 37.0
  [0x2 ] MB Outlet Temp           : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 32.0
  [0x3 ] IOM Temp                 : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 30.0
  [0x8 ] SSD0 Temp                : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 33.0
  [0x5 ] SOC CPU Temp             : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 43.0
  [0x6 ] SOC Therm Margi          : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | -57.0
  [0x7 ] CPU TjMax                : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 100.0
  [0xa ] DIMMA Temp               : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 37.0
  [0xb ] DIMMC Temp               : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 34.0
  [0xc ] DIMME Temp               : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 38.0
  [0xd ] DIMMG Temp               : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 37.0
  [0x60] CPU Pwr                  : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 50.0
  [0x20] P12V_STBY Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 11.741
  [0x26] P12V_DIMM Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 11.761
  [0x22] P3V3_STBY Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 3.280
  [0x24] P1V05_PCH Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 1.5
  [0x21] P3V_BAT Vol              : adc        | access[O] | poll[O] 3600 sec | polling_disable           | na
  [0x28] P3V3_M2 Vol              : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 3.270
  [0x25] P5V_STBY Vol             : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 4.770
  [0x23] P1V8_STBY Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 1.699
  [0x27] P1V2_STBY Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 1.193
  [0x2d] VCCD VR Vol              : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 1.143
  [0x2e] FAON VR Vol              : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 0.978
  [0x2c] EHV VR Vol               : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 1.800
  [0x2a] VCCIN VR Vol             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 1.785
  [0x2b] FIVRA VR Vol             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 1.796
  [0x44] VCCD VR Cur              : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 1.600
  [0x45] VCCD VR Cur in           : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 0.200
  [0x46] FAON VR Cur              : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 7.800
  [0x43] EHV VR Cur               : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 0.800
  [0x41] VCCIN VR Cur             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 17.100
  [0x42] FIVRA VR Cur             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 5.100
  [0x11] VCCD SPS Temp            : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 44.0
  [0x12] FAON SPS Temp            : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 46.0
  [0x10] EHV SPS Temp             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 42.0
  [0xe ] VCCIN SPS Temp           : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 46.0
  [0xf ] FIVRA SPS Temp           : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 45.0
  [0x69] VCCD VR Pout             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 1.0
  [0x6a] FAON VR Pout             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 7.0
  [0x68] EHV VR Pout              : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 1.0
  [0x66] VCCIN VR Pout            : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 30.0
  [0x67] FIVRA VR Pout            : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 9.0
  [0x4 ] PCH Temp                 : pch        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 53.0
  [0x62] DIMMA PMIC_Pout          : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 0.750
  [0x63] DIMMC PMIC_Pout          : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 0.750
  [0x64] DIMME PMIC_Pout          : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 0.875
  [0x65] DIMMG PMIC_Pout          : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 0.875
  [0x6b] IOM INA Pwr              : ina230     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 1.737
  [0x47] IOM INA Cur              : ina230     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 0.144
  [0x2f] IOM INA vol              : ina230     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 11.991
  [0x9 ] HSC Temp                 : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 39.0
  [0x29] HSC Input Vol            : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 11.968
  [0x40] HSC Output Cur           : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 2.500
  [0x61] HSC Input Pwr            : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   | 30.0
  ---------------------------------------------------------------------------------
  ```