### PR TITLE
GT: Add SEL API use in the project by MCTP

### DIFF
--- a/common/service/ipmi/include/storage_handler.h
+++ b/common/service/ipmi/include/storage_handler.h
@@ -3,6 +3,33 @@
 
 #include "ipmi.h"
 
+struct sel_event_record {
+	uint16_t record_id;
+	uint8_t record_type;
+	uint32_t timestamp;
+	uint8_t gen_id[2];
+	uint8_t evm_rev;
+	uint8_t sensor_type;
+	uint8_t sensor_num;
+
+	union {
+		struct {
+			uint8_t event_type : 7;
+			uint8_t event_dir : 1;
+		};
+		uint8_t event_dir_type;
+	};
+	uint8_t event_data[3];
+} __attribute__((__packed__));
+
+struct ipmi_storage_add_sel_req {
+	struct sel_event_record event;
+} __attribute__((__packed__));
+
+struct ipmi_storage_add_sel_resp {
+	uint8_t record_id[2];
+} __attribute__((__packed__));
+
 void STORAGE_GET_FRUID_INFO(ipmi_msg *msg);
 void STORAGE_READ_FRUID_DATA(ipmi_msg *msg);
 void STORAGE_WRITE_FRUID_DATA(ipmi_msg *msg);

--- a/meta-facebook/gt-cc/src/platform/plat_init.c
+++ b/meta-facebook/gt-cc/src/platform/plat_init.c
@@ -4,6 +4,7 @@
 #include "util_sys.h"
 #include "plat_gpio.h"
 #include "plat_i2c_target.h"
+#include "ipmi.h"
 #include "pldm.h"
 #include "plat_mctp.h"
 

--- a/meta-facebook/gt-cc/src/platform/plat_mctp.h
+++ b/meta-facebook/gt-cc/src/platform/plat_mctp.h
@@ -1,10 +1,39 @@
 #ifndef _PLAT_MCTP_h
 #define _PLAT_MCTP_h
 
+#include "storage_handler.h"
+
+struct mctp_to_ipmi_header_req {
+	uint8_t iana[IANA_LEN];
+	uint8_t netfn_lun;
+	uint8_t ipmi_cmd;
+} __attribute__((__packed__));
+;
+
+struct mctp_to_ipmi_header_resp {
+	uint8_t completion_code;
+	uint8_t iana[IANA_LEN];
+	uint8_t netfn_lun;
+	uint8_t ipmi_cmd;
+	uint8_t ipmi_comp_code;
+} __attribute__((__packed__));
+;
+
+struct mctp_to_ipmi_sel_req {
+	struct mctp_to_ipmi_header_req header;
+	struct ipmi_storage_add_sel_req req_data;
+} __attribute__((__packed__));
+
+struct mctp_to_ipmi_sel_resp {
+	struct mctp_to_ipmi_header_resp header;
+	struct ipmi_storage_add_sel_resp resp_data;
+} __attribute__((__packed__));
+
 /* init the mctp moduel for platform */
 void plat_mctp_init(void);
 void send_cmd_to_dev(struct k_timer *timer);
 void send_cmd_to_dev_handler(struct k_work *work);
+bool mctp_add_sel_to_ipmi(common_addsel_msg_t *sel_msg);
 
 extern struct pldm_variable_field nic_vesion[];
 


### PR DESCRIPTION
Summary:
- Send standard IPMI add system event log entry command through MCTP protocol to BMC

Test plan:
- Build code: Pass