### PR TITLE
fby3: dl: support OEM get reading command for ME

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_sensor_table.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <logging/log.h>
 #include "plat_sensor_table.h"
 #include "sensor.h"
 #include "ast_adc.h"
@@ -15,6 +16,8 @@
 #include "tmp431.h"
 #include "libutil.h"
 #include "util_sys.h"
+
+LOG_MODULE_DECLARE(sensor);
 
 struct k_mutex vr_page_mutex;
 
@@ -365,4 +368,10 @@ void pal_extend_sensor_config()
 	}
 
 	return;
+}
+
+uint8_t get_hsc_pwr_reading(int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+	return get_sensor_reading(SENSOR_NUM_HSC_PIN, reading, GET_FROM_CACHE);
 }


### PR DESCRIPTION
Summary:
- Since the HSC has multiple sources, the ME will get power readings from the bic.

Test plan:
1. Build code : pass

2. IPMI oem command:
root@bmc-oob:~# bic-util slot2 0xc0 0xe2 0x0 0x0 0x0
00 17 00

3. Check the power reading from me:
root@bmc-oob:~# me-util slot2 0xb8 0xc8 0x57 0x01 0x00 0x1 0x0 0x0
57 01 00 18 00 17 00 21 00 18 00 FF FF FF FF EF 2E 00 00 50