### PR TITLE
rf: Set DC on delayed flag if the power already on

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_isr.c
@@ -25,6 +25,7 @@ void control_power_sequence()
 		} else {
 			// If the last stage of power on sequence already power on , no need to recheck power on sequence
 			// Update the flag of power on sequence number
+			set_DC_on_delayed_status();
 			set_power_on_seq(NUMBER_OF_POWER_ON_SEQ);
 		}
 	} else { // CraterLake DC off


### PR DESCRIPTION
This patch fixes the VR sensors keeping not accessible after the RF FW updating.

It is because the vr_access function always checks the is_DC_on_delayed flag, but this flag is only set in `ISR_DC_STATE`, which can't be triggered if the power stage is already the last.

Tested:
After the BIC fw updating, the BIC shell command
`platform sensor list_all` shows the vr sensors are good.

Signed-off-by: Scron Chang <Scron.Chang@quantatw.com>