### PR TITLE
fby3: rf: Version commit for oby3-rf-2022.34.01

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_version.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_version.h
@@ -7,8 +7,8 @@
 #define DEVICE_REVISION 0x80
 // BIT 0:3  1: CraterLake 2: Baseboard 3: Rainbow falls
 // BIT 4:7  0: POC 1: EVT 2: DVT
-#define FIRMWARE_REVISION_1 0x03
-#define FIRMWARE_REVISION_2 0x03
+#define FIRMWARE_REVISION_1 0x13
+#define FIRMWARE_REVISION_2 0x01
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
 #define PRODUCT_ID 0x0000
@@ -16,7 +16,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x28
+#define BIC_FW_WEEK 0x34
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x72 // char: r
 #define BIC_FW_platform_1 0x66 // char: f


### PR DESCRIPTION
Version commit for Yv3.5 Rainbow Falls BIC oby35-rf-2022.34.01.
Move into the EVT stage.

Tested:
```
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xa0 0x00 0x05 0x18 0x01
15 A0 00 05 07 01 00 00 80 13 01 02 BF 15 A0 00
00 00 00 00 00 00
root@bmc-oob:~# fw-util slot1 --version 1ou_bic
1OU Bridge-IC Version: oby35-rf-v2022.34.01
root@bmc-oob:~#
```

Signed-off-by: Scron Chang <Scron.Chang@quantatw.com>