### PR TITLE
wc: mb: Modify BMC reset pin interrupt trigger time interval

### DIFF
--- a/meta-facebook/wc-mb/src/lib/plat_sys.c
+++ b/meta-facebook/wc-mb/src/lib/plat_sys.c
@@ -8,7 +8,7 @@
 void BMC_reset_handler()
 {
 	gpio_set(RST_BMC_R_N, GPIO_LOW);
-	k_msleep(10);
+	k_msleep(1000);
 	gpio_set(RST_BMC_R_N, GPIO_HIGH);
 }
 


### PR DESCRIPTION
Summary:
- Modify time interval of BMC reset pin from low to high while BIC receiving bmc reset command NetFn:0x38 Cmd:0x16.

Test Plan:
- Build Code: PASS
