### PR TITLE
fby3.5: Add patch to extend ipmb buffer

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0002-drivers-ipmb-Extend-the-ipmb-buffer.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0002-drivers-ipmb-Extend-the-ipmb-buffer.patch
@@ -1,0 +1,29 @@
+From 125da7f29475853823530a0906f48b833643ad2b Mon Sep 17 00:00:00 2001
+From: Tommy Haung <tommy_huang@aspeedtech.com>
+Date: Wed, 16 Mar 2022 14:12:59 +0800
+Subject: [PATCH] drivers: ipmb: Extend the ipmb buffer
+
+Extend the ipmb buffer count from 0x100 into 0x102
+
+Signed-off-by: Tommy Haung <tommy_huang@aspeedtech.com>
+Change-Id: I8c0c58ced8b695c13b62b8a9158aad0cf385ac6a
+---
+ include/drivers/i2c/slave/ipmb.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/drivers/i2c/slave/ipmb.h b/include/drivers/i2c/slave/ipmb.h
+index d71805bb2a..da2a6d6c53 100644
+--- a/include/drivers/i2c/slave/ipmb.h
++++ b/include/drivers/i2c/slave/ipmb.h
+@@ -8,7 +8,7 @@
+ 
+ /* ipmb define*/
+ #define IPMB_REQUEST_LEN	0x7
+-#define IPMB_TOTAL_LEN		0x100
++#define IPMB_TOTAL_LEN		0x102
+ 
+ #define GET_ADDR(addr)	((addr << 1) & 0xff)
+ #define LIST_SIZE sizeof(sys_snode_t)
+-- 
+2.17.1
+


### PR DESCRIPTION
Summary:
- Extend ipmb buffer from 250 bytes to 252 bytes, and fix host can't get post code via ipmitool command.

Test Plan:
- Build code: Pass
- Host can get post code via ipmitool command: Pass

Log:
Before fix
[root@Stream8_211112 ~]# ipmitool raw 0x30 0x49
No data available
Unable to send RAW command (channel=0x0 netfn=0x30 lun=0x0 cmd=0x49)

After fix
[root@Stream8_211112 ~]# ipmitool raw 0x30 0x49
 e3 e3 e3 aa 84 b1 b1 b0 af ad d9 ad d9 ad 92 a0
 92 92 92 92 99 92 9c 9a 9d 98 97 92 92 92 92 92
 92 91 99 92 92 92 92 92 ef 96 95 94 94 94 94 94
 94 94 94 94 94 94 94 94 92 91 90 79 70 68 9a 61
 60 33 4f 47 42 40 7f 7f 15 0d 0c 0b 06 04 00 22
 02 23 03 ee ed ec eb e9 e6 af af af bf 7e c6 ce
 bc bc bc bc cc 7e dc ca ca b7 7e 70 7e d1 7e d1
 7e d0 7e d0 7e d0 7e 7e bb bb bb bb bb bb bb bb
 bb bb cb 7e 7e 70 70 70 70 ba db d9 da c9 d7 b8
 b8 b8 b8 b8 b8 b8 b7 b7 b7 b7 b7 b7 b7 b7 b7 b7
 7e b9 70 d6 d2 7e d2 7e be be b7 b7 7e b7 7e 70
 70 70 70 7e b7 b7 b7 b7 7e 7e 7e 7e b6 b6 b7 b0
 b6 b6 b6 b3 b3 b3 b3 b3 c6 b2 c5 b8 7e b4 7e b6
 b1 b1 b1 7e 7e 70 7e c2 7e b1 b1 70 c1 7e b0 cd
 73 7e cf 7e bf b0 af af e5 e3 e4 e1 e0 e0 e0 ae
 aa a8 a9 a9