### PR TITLE
fby3.5: rf: Set the DC delayed flag when boot-up.

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_init.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_init.c
@@ -15,6 +15,8 @@ void pal_set_sys_status()
 	set_MB_DC_status(FM_POWER_EN);
 	set_DC_status(PWRGD_CARD_PWROK);
 	control_power_sequence();
+	set_DC_on_delayed_status();
+	set_DC_off_delayed_status();
 }
 
 void pal_post_init()


### PR DESCRIPTION
Set DC on/off delayed flag whenever BIC boots. This patch fixes the bug that VR sensors will not be able to access if BIC processes the warm reboot, e.g., after updating fw.

Tested:
VR sensors can display well on BMC sensor-util logs and BIC platform
sensor list-all.

Signed-off-by: Scron Chang <Scron.Chang@quantatw.com>