### PR TITLE
Common: KCS respond immediately

### DIFF
--- a/common/service/host/kcs.c
+++ b/common/service/host/kcs.c
@@ -103,14 +103,10 @@ void kcs_read(void *arvg0, void *arvg1, void *arvg2)
 				do { // break if malloc fail.
 					uint8_t *kcs_buff;
 					kcs_buff = malloc(KCS_BUFF_SIZE * sizeof(uint8_t));
-					if (kcs_buff == NULL) { // allocate fail, retry allocate
-						k_msleep(10);
-						kcs_buff = malloc(KCS_BUFF_SIZE * sizeof(uint8_t));
-						if (kcs_buff == NULL) {
-							printf("[%s] Failed to malloc for kcs_buff\n",
-							       __func__);
-							break;
-						}
+					if (kcs_buff == NULL) {
+						printf("[%s] Failed to malloc for kcs_buff\n",
+						       __func__);
+						break;
 					}
 					kcs_buff[0] = (req->netfn | BIT(0)) << 2;
 					kcs_buff[1] = req->cmd;

--- a/common/service/host/kcs.c
+++ b/common/service/host/kcs.c
@@ -5,9 +5,11 @@
 #include <string.h>
 #include <stdio.h>
 #include <device.h>
+#include <stdlib.h>
 #include "ipmi.h"
 #include "kcs.h"
 #include "plat_def.h"
+#include "libutil.h"
 
 struct k_thread kcs_polling;
 K_KERNEL_STACK_MEMBER(KCS_POLL_stack, KCS_POLL_STACK_SIZE);
@@ -97,6 +99,34 @@ void kcs_read(void *arvg0, void *arvg1, void *arvg2)
 			}
 
 		} else { // default command for BMC, should add BIC firmware update, BMC reset, real time sensor read in future
+			if (pal_immediate_respond_from_KCS(req->netfn, req->cmd)) {
+				do { // break if malloc fail.
+					uint8_t *kcs_buff;
+					kcs_buff = malloc(KCS_BUFF_SIZE * sizeof(uint8_t));
+					if (kcs_buff == NULL) { // allocate fail, retry allocate
+						k_msleep(10);
+						kcs_buff = malloc(KCS_BUFF_SIZE * sizeof(uint8_t));
+						if (kcs_buff == NULL) {
+							printf("[%s] Failed to malloc for kcs_buff\n",
+							       __func__);
+							break;
+						}
+					}
+					kcs_buff[0] = (req->netfn | BIT(0)) << 2;
+					kcs_buff[1] = req->cmd;
+					kcs_buff[2] = CC_SUCCESS;
+
+					if (((req->netfn == NETFN_STORAGE_REQ) &&
+					     (req->cmd == CMD_STORAGE_ADD_SEL))) {
+						kcs_buff[3] = 0x00;
+						kcs_buff[4] = 0x00;
+						kcs_write(kcs_buff, 5);
+					} else {
+						kcs_write(kcs_buff, 3);
+					}
+					SAFE_FREE(kcs_buff);
+				} while (0);
+			}
 			bridge_msg.data_len = rc - 2; // exclude netfn, cmd
 			bridge_msg.seq_source = 0xff; // No seq for KCS
 			bridge_msg.InF_source = HOST_KCS;

--- a/common/service/ipmb/ipmb.c
+++ b/common/service/ipmb/ipmb.c
@@ -601,6 +601,11 @@ void IPMB_RXTask(void *pvParameters, void *arvg0, void *arvg1)
 							&current_msg, K_NO_WAIT);
 					} else if (current_msg_rx->buffer.InF_source == HOST_KCS) {
 #ifdef CONFIG_IPMI_KCS_ASPEED
+						if (pal_immediate_respond_from_KCS(
+							    current_msg_rx->buffer.netfn & ~BIT(0),
+							    current_msg_rx->buffer.cmd)) {
+							goto cleanup;
+						}
 						uint8_t *kcs_buff;
 						int retry = 0;
 						do {

--- a/common/service/ipmi/include/ipmi.h
+++ b/common/service/ipmi/include/ipmi.h
@@ -54,6 +54,8 @@ static inline void pack_ipmi_resp(struct ipmi_response *resp, ipmi_msg *ipmi_res
 
 // If command is from KCS, we need to check whether BIC support this command.
 bool pal_request_msg_to_BIC_from_KCS(uint8_t netfn, uint8_t cmd);
+// If command is from KCS, we need to check whether BIC BIC responds immediately.
+bool pal_immediate_respond_from_KCS(uint8_t netfn, uint8_t cmd);
 // If command is from ME, we need to check whether BIC support this command.
 bool pal_request_msg_to_BIC_from_ME(uint8_t netfn, uint8_t cmd);
 // For the command that BIC only bridges it, BIC doesn't return the command directly
@@ -143,6 +145,7 @@ enum {
 
 // Sensor Command Codes (0x04)
 enum {
+	CMD_SENSOR_PLATFORM_EVENT = 0x02,
 	CMD_SENSOR_GET_SENSOR_READING = 0x2D,
 };
 

--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -93,6 +93,16 @@ __weak bool pal_request_msg_to_BIC_from_KCS(uint8_t netfn, uint8_t cmd)
 	return false;
 }
 
+__weak bool pal_immediate_respond_from_KCS(uint8_t netfn, uint8_t cmd)
+{
+	if ((netfn == NETFN_STORAGE_REQ && cmd == CMD_STORAGE_ADD_SEL) ||
+	    ((netfn == NETFN_SENSOR_REQ) && (cmd == CMD_SENSOR_PLATFORM_EVENT))) {
+		return true;
+	}
+
+	return false;
+}
+
 __weak bool pal_request_msg_to_BIC_from_ME(uint8_t netfn, uint8_t cmd)
 {
 	if ((netfn == NETFN_OEM_REQ) && (cmd == CMD_OEM_NM_SENSOR_READ)) {


### PR DESCRIPTION
Summary:
- Check IPMI request from KCS, respond immediately if it's add sel command(Netfn:0x0A Cmd:0x44 or Netfn:0x04 Cmd:0x02).

Test Plan:
- Build code: PASS