### PR TITLE
fby35: cl: Update sensor threshold according to 20220831 sensor table.

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
@@ -2009,9 +2009,9 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xC8, // UNRT
-		0x9B, // UCT
-		0x99, // UNCT
+		0xD4, // UNRT
+		0x9F, // UCT
+		0x9D, // UNCT
 		0x39, // LNRT
 		0x81, // LCT
 		0x82, // LNCT


### PR DESCRIPTION
Summary:
- Update sensor threshold according to 20220831 sensor table.

Test Plan:
- Build code: Pass
- Sensor threshold is updated: Pass

Log:
Before update
root@bmc-oob:~# sensor-util slot1 --threshold | grep "FAON VR Vol"
FAON VR Vol                  (0x2F) :    1.05 Volts | (ok) | UCR: 1.09 | UNC: 1.07 | UNR: 1.40 | LCR: 0.90 | LNC: 0.91 | LNR: 0.40

After update
root@bmc-oob:~# sensor-util slot1 --threshold | grep "FAON VR Vol"
FAON VR Vol                  (0x2F) :    1.05 Volts | (ok) | UCR: 1.11 | UNC: 1.10 | UNR: 1.48 | LCR: 0.90 | LNC: 0.91 | LNR: 0.40