### PR TITLE
GT: Add switch board 2nd source FRU on HSC module

### DIFF
--- a/meta-facebook/gt-cc/src/platform/plat_fru.c
+++ b/meta-facebook/gt-cc/src/platform/plat_fru.c
@@ -11,7 +11,8 @@ const EEPROM_CFG plat_fru_config[] = {
 		FRU_DEV_ACCESS_BYTE,
 		FRU_START,
 		FRU_SIZE,
-		true, /*Because there has mux before eeprom, so mux_present is true to access mux first */
+		/* Because there has mux before eeprom, so mux_present is true to access mux first */
+		true,
 		SWB_FRU_MUX_ADDR,
 		SWB_FRU_MUX_CHAN,
 	},
@@ -23,6 +24,19 @@ const EEPROM_CFG plat_fru_config[] = {
 		FRU_DEV_ACCESS_BYTE,
 		FRU_START,
 		FRU_SIZE,
+	},
+	{
+		NV_ATMEL_24C64,
+		HSC_MODULE_FRU_ID,
+		HSC_MODULE_FRU_PORT,
+		HSC_MODULE_FRU_ADDR,
+		FRU_DEV_ACCESS_BYTE,
+		FRU_START,
+		FRU_SIZE,
+		/* Because there has mux before eeprom, so mux_present is true to access mux first */
+		true,
+		HSC_MODULE_FRU_MUX_ADDR,
+		HSC_MODULE_FRU_MUX_CHAN,
 	},
 };
 

--- a/meta-facebook/gt-cc/src/platform/plat_fru.h
+++ b/meta-facebook/gt-cc/src/platform/plat_fru.h
@@ -7,12 +7,16 @@
 #define SWB_FRU_MUX_CHAN 7
 #define FIO_FRU_PORT 0x04
 #define FIO_FRU_ADDR (0xA2 >> 1)
+#define HSC_MODULE_FRU_PORT 0x05
+#define HSC_MODULE_FRU_ADDR (0xA2 >> 1)
+#define HSC_MODULE_FRU_MUX_ADDR (0xE0 >> 1)
+#define HSC_MODULE_FRU_MUX_CHAN 6
 
-enum {
-	SWB_FRU_ID,
-	FIO_FRU_ID,
-	// OTHER_FRU_ID,
-	MAX_FRU_ID,
+enum { SWB_FRU_ID,
+       FIO_FRU_ID,
+       HSC_MODULE_FRU_ID,
+       // OTHER_FRU_ID,
+       MAX_FRU_ID,
 };
 
 #endif


### PR DESCRIPTION
Summary:
- Due to switch board second source HSC module has FRU, so add FRU config in the platform code

Test plan:
- Build code: Pass