### PR TITLE
GT: Modify MP5990 sensor table and adjust power reading

### DIFF
--- a/meta-facebook/gt-cc/src/platform/plat_hook.c
+++ b/meta-facebook/gt-cc/src/platform/plat_hook.c
@@ -197,8 +197,8 @@ ina230_init_arg ina230_nic_sensor_init_args[] = {
 };
 
 mp5990_init_arg mp5990_hsc_init_args[] = {
-	/* Use default value by specification */
-	[0] = { .is_init = false, .iout_cal_gain = 0x0140, .iout_oc_fault_limit = 0x0037 },
+	/* MP5990 register value is written by OTP, so set to 0xFFFF to skip setting */
+	[0] = { .is_init = false, .iout_cal_gain = 0xFFFF, .iout_oc_fault_limit = 0xFFFF },
 };
 
 ltc4282_init_arg ltc4282_hsc_init_args[] = {
@@ -890,6 +890,35 @@ bool post_i2c_bus_read(uint8_t sensor_num, void *args, int *reading)
 	return true;
 }
 
+bool post_mp5990_power_read(uint8_t sensor_num, void *args, int *reading)
+{
+	if (!reading) {
+		post_i2c_bus_read(sensor_num, args, reading);
+		return false;
+	}
+	ARG_UNUSED(args);
+
+	if (!post_i2c_bus_read(sensor_num, args, reading))
+		return false;
+
+	sensor_val *sval = (sensor_val *)reading;
+	float val = sval->integer + (sval->fraction * 0.001);
+	/* Adjust the power value for accuracy by power team requirement */
+	if (val <= 65) {
+		val *= 1.098;
+	} else if (val > 65 && val <= 200) {
+		val *= 1.057;
+	} else if (val > 200 && val <= 210) {
+		val *= 1.033;
+	} else {
+		val *= 1.015;
+	}
+
+	sval->integer = (int16_t)val;
+	sval->fraction = (val - sval->integer) * 1000;
+
+	return true;
+}
 struct k_mutex *find_bus_mutex(uint8_t sensor_num)
 {
 	sensor_cfg *cfg = &sensor_config[sensor_config_index_map[sensor_num]];

--- a/meta-facebook/gt-cc/src/platform/plat_hook.h
+++ b/meta-facebook/gt-cc/src/platform/plat_hook.h
@@ -42,6 +42,7 @@ bool pre_vr_read(uint8_t sensor_num, void *args);
 bool pre_pex89000_read(uint8_t sensor_num, void *args);
 bool pre_i2c_bus_read(uint8_t sensor_num, void *args);
 bool post_i2c_bus_read(uint8_t sensor_num, void *args, int *reading);
+bool post_mp5990_power_read(uint8_t sensor_num, void *args, int *reading);
 
 struct k_mutex *find_bus_mutex(uint8_t sensor_num);
 bool is_mb_dc_on();

--- a/meta-facebook/gt-cc/src/platform/plat_sensor_table.c
+++ b/meta-facebook/gt-cc/src/platform/plat_sensor_table.c
@@ -202,7 +202,7 @@ sensor_cfg mp5990_hsc_sensor_config_table[] = {
 	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_i2c_bus_read, &mux_conf_addr_0xe0[6],
 	  post_i2c_bus_read, NULL, &mp5990_hsc_init_args[0] },
-	{ SENSOR_NUM_VOUT_PDB_HSC, sensor_dev_mp5990, I2C_BUS6, HSC_MP5990_ADDR, PMBUS_READ_VOUT,
+	{ SENSOR_NUM_VOUT_PDB_HSC, sensor_dev_mp5990, I2C_BUS6, HSC_MP5990_ADDR, PMBUS_READ_VIN,
 	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &mux_conf_addr_0xe0[6], post_i2c_bus_read, NULL,
 	  &mp5990_hsc_init_args[0] },
@@ -210,10 +210,10 @@ sensor_cfg mp5990_hsc_sensor_config_table[] = {
 	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &mux_conf_addr_0xe0[6], post_i2c_bus_read, NULL,
 	  &mp5990_hsc_init_args[0] },
-	{ SENSOR_NUM_POUT_PDB_HSC, sensor_dev_mp5990, I2C_BUS6, HSC_MP5990_ADDR, PMBUS_READ_POUT,
+	{ SENSOR_NUM_POUT_PDB_HSC, sensor_dev_mp5990, I2C_BUS6, HSC_MP5990_ADDR, PMBUS_READ_PIN,
 	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &mux_conf_addr_0xe0[6], post_i2c_bus_read, NULL,
-	  &mp5990_hsc_init_args[0] },
+	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &mux_conf_addr_0xe0[6], post_mp5990_power_read,
+	  NULL, &mp5990_hsc_init_args[0] },
 };
 
 sensor_cfg ltc4282_hsc_sensor_config_table[] = {


### PR DESCRIPTION
Summary:
- Modify initial value iout_cal_gain and iout_oc_fault_limit.
- Change the reading register of voltage and power to input.
- Adjust power reading value for accuracy by power team requirement.

Test plan:
- Build code: Pass