### PR TITLE
Common: Fix erorr parsing TMP75 negative value

### DIFF
--- a/common/dev/tmp75.c
+++ b/common/dev/tmp75.c
@@ -21,7 +21,7 @@ uint8_t tmp75_read(uint8_t sensor_num, int *reading)
 		return SENSOR_FAIL_TO_ACCESS;
 
 	sensor_val *sval = (sensor_val *)reading;
-	sval->integer = msg.data[0];
+	sval->integer = (int8_t)msg.data[0];
 	sval->fraction = 0;
 	return SENSOR_READ_SUCCESS;
 }


### PR DESCRIPTION
Summary:
- Fix erorr parsing TMP75 negative value.

Test Plan:
- Build code: PASS