### PR TITLE
fby35: common: Support i2c mux PCA9846

### DIFF
--- a/common/dev/i2c-mux-pca984x.c
+++ b/common/dev/i2c-mux-pca984x.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <logging/log.h>
+#include "sensor.h"
+#include "libutil.h"
+#include "hal_i2c.h"
+#include "i2c-mux-pca984x.h"
+
+LOG_MODULE_REGISTER(i2c_mux_pca9846);
+
+bool set_pca9846_channel_and_transfer(uint8_t bus, uint8_t mux_addr, uint8_t mux_channel,
+				      uint8_t tran_type, I2C_MSG *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+
+	bool ret = true;
+	int status = 0;
+	int retry = 5;
+
+	/* Set channel */
+	I2C_MSG mux_msg = { 0 };
+	mux_msg.bus = bus;
+	mux_msg.target_addr = mux_addr;
+	mux_msg.tx_len = 1;
+	mux_msg.data[0] = mux_channel;
+
+	/* Mutex lock */
+	status = k_mutex_lock(&msg->lock, K_MSEC(PCA9846_MUTEX_LOCK_MS));
+	if (status != 0) {
+		LOG_ERR("mutex lock fail, status: %d, bus: %d, mux addr: 0x%x\n", status, bus,
+			mux_addr);
+		return false;
+	}
+
+	status = i2c_master_write(&mux_msg, retry);
+	if (status != 0) {
+		LOG_ERR("set channel fail, status: %d\n", status);
+		ret = false;
+		goto mutex_unlock;
+	}
+
+	/* Transfer via i2c */
+	switch (tran_type) {
+	case I2C_READ:
+		status = i2c_master_read(msg, retry);
+		break;
+	case I2C_WRITE:
+		status = i2c_master_write(msg, retry);
+		break;
+	default:
+		LOG_ERR("transfer type is invalid, transfer type: %d\n", tran_type);
+		ret = false;
+		goto mutex_unlock;
+	}
+
+	if (status != 0) {
+		LOG_ERR("transfer msg fail, status: %d\n", status);
+		ret = false;
+		goto mutex_unlock;
+	}
+
+	/* Disable all channels */
+	mux_msg.bus = bus;
+	mux_msg.target_addr = mux_addr;
+	mux_msg.tx_len = 1;
+	mux_msg.data[0] = PCA9846_DEFAULT_CHANNEL;
+
+	status = i2c_master_write(&mux_msg, retry);
+	if (status != 0) {
+		LOG_ERR("disable all channels fail, status: %d\n", status);
+		ret = false;
+	}
+
+mutex_unlock:
+	status = k_mutex_unlock(&msg->lock);
+	if (status != 0) {
+		LOG_ERR("mutex unlock fail, status: %d\n", status);
+		ret = false;
+	}
+
+	return ret;
+}

--- a/common/dev/include/i2c-mux-pca984x.h
+++ b/common/dev/include/i2c-mux-pca984x.h
@@ -1,0 +1,17 @@
+#ifndef I2C_MUX_PCA984X_H
+#define I2C_MUX_PCA984X_H
+
+#define PCA9846_MUTEX_LOCK_MS 1000
+#define PCA9846_DEFAULT_CHANNEL 0
+
+enum PCA9846_CHANNEL {
+	PCA9846_CHANNEL_0 = BIT(0),
+	PCA9846_CHANNEL_1 = BIT(1),
+	PCA9846_CHANNEL_2 = BIT(2),
+	PCA9846_CHANNEL_3 = BIT(3),
+};
+
+bool set_pca9846_channel_and_transfer(uint8_t bus, uint8_t mux_addr, uint8_t mux_channel,
+				      uint8_t tran_type, I2C_MSG *msg);
+
+#endif

--- a/common/hal/hal_i2c.h
+++ b/common/hal/hal_i2c.h
@@ -72,6 +72,11 @@
 
 #define I2C_BUFF_SIZE 256
 
+enum I2C_TRANSFER_TYPE {
+	I2C_READ,
+	I2C_WRITE,
+};
+
 typedef struct _I2C_MSG_ {
 	uint8_t bus;
 	uint8_t target_addr;


### PR DESCRIPTION
Summary:
- Add device i2c-mux-PCA9846 common function to set channel and transfer i2c message.

Test Plan and Log:
1. Y35 CL/Y35 BB/Y35 RF/GT CC/YV3 DL BIC build code: Pass
2. Set mux to switch channel: Pass

  - Origin i2c bus 8, i2c mux PCA9846 slave address is 0x71 uart:~$ i2c scan I2C_8 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
  00:             -- -- -- -- -- -- -- -- -- -- -- --
  10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  70: -- 71 -- -- -- -- -- --
  1 devices found on I2C_8

  - Set mux to switch to channel 0 uart:~$ i2c scan I2C_8 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
  00:             -- -- -- -- -- -- -- -- -- -- -- --
  10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  40: -- -- -- -- -- 45 -- -- -- -- -- -- -- -- -- --
  50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  70: -- 71 -- -- -- -- -- --
  2 devices found on I2C_8

  - Set mux to switch to channel 1 uart:~$ i2c scan I2C_8 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
  00:             -- -- -- -- -- -- -- -- -- -- -- --
  10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  40: 40 41 -- 43 -- -- -- -- -- -- -- -- -- -- -- --
  50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  70: -- 71 -- -- -- -- -- --
  4 devices found on I2C_8

3. Mutex lock/unlock: Pass

  - Trigger GPIO thread enter queue for locking mutex, setting channel, transfering message and unlocking mutex.
  root@bmc-oob:~# bic-util slot1 --set_gpio 0 0     // Set mux to switch to channel 0
  slot 1: setting [0]FM_BMC_PCH_SCI_LPC_R_N to 0
  root@bmc-oob:~# bic-util slot1 --set_gpio 47 0    // Set mux to switch to channel 1
  slot 1: setting [47]FBRK_N_R to 0

  [ BIC console ]

  [ISR_SET_CHANNEL_0] set channel 0
  [set_pca9846_channel_and_transfer] lock start, count: 0x1
  [set_pca9846_channel_and_transfer] lock done
  [set_pca9846_channel_and_transfer] transfer data success
  [set_pca9846_channel_and_transfer] disable all channel and unlock, count: 0x0
  [set_pca9846_channel_and_transfer] device response data [0] [0]
  [ISR_SET_CHANNEL_0] success

  [ISR_SET_CHANNEL_1] set channel 1
  [set_pca9846_channel_and_transfer] lock start, count: 0x1
  [set_pca9846_channel_and_transfer] lock done
  [set_pca9846_channel_and_transfer] transfer data success
  [set_pca9846_channel_and_transfer] disable all channel and unlock, count: 0x0
  [set_pca9846_channel_and_transfer] device response data [0] [0]
  [ISR_SET_CHANNEL_1] success

4. Stress with 43090 times of mux sequential switch: Pass