### PR TITLE
fby3.5: common: Fix sensor post read function parameter issue

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -37,7 +37,7 @@ uint8_t sdr_index_map[SENSOR_NUM_MAX];
 
 bool enable_sensor_poll_thread = true;
 static bool sensor_poll_enable_flag = true;
-
+static bool is_sensor_initial_done = false;
 static bool is_sensor_ready_flag = false;
 
 const int negative_ten_power[16] = { 1,	    1,		1,	   1,	     1,	      1,
@@ -238,6 +238,13 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 			cfg->cache_status = SENSOR_READ_4BYTE_ACUR_SUCCESS;
 			return cfg->cache_status;
 		} else {
+			/* Return current status if retry reach max retry count, otherwise return cache status instead of current status */
+			if (cfg->retry >= SENSOR_READ_RETRY_MAX) {
+				cfg->cache_status = current_status;
+			} else {
+				cfg->retry++;
+			}
+
 			/* If sensor read fails, let the reading argument in the
        * post_sensor_read_hook function to NULL.
        * All post_sensor_read_hook function define in each platform should check
@@ -251,13 +258,7 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 					       __func__, sensor_num);
 				}
 			}
-			/* common retry */
-			// Return current status if retry reach max retry count, otherwise return cache status instead of current status
-			if (cfg->retry >= SENSOR_READ_RETRY_MAX) {
-				cfg->cache_status = current_status;
-			} else {
-				cfg->retry++;
-			}
+
 			return cfg->cache_status;
 		}
 		break;
@@ -567,6 +568,7 @@ bool sensor_init(void)
 		sensor_poll_init();
 	}
 
+	is_sensor_initial_done = true;
 	return true;
 }
 
@@ -601,4 +603,17 @@ void control_sensor_polling(uint8_t sensor_num, uint8_t optional, uint8_t cache_
 	sensor_cfg *config = &sensor_config[sensor_config_index_map[sensor_num]];
 	config->is_enable_polling = optional;
 	config->cache_status = cache_status;
+}
+
+bool check_reading_pointer_null_is_allowed(uint8_t sensor_num)
+{
+	uint8_t sensor_retry_count = sensor_config[sensor_config_index_map[sensor_num]].retry;
+
+	/* Reading pointer NULL is allowed in sensor initial stage and sensor reading fail */
+	/* Sensor retry count will be set to zero when the sensor read success */
+	if (is_sensor_initial_done && (sensor_retry_count == 0)) {
+		return false;
+	} else {
+		return true;
+	}
 }

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -403,5 +403,6 @@ bool pal_is_time_to_poll(uint8_t sensor_num, int poll_time);
 uint8_t plat_get_config_size();
 void load_sensor_config(void);
 void control_sensor_polling(uint8_t sensor_num, uint8_t optional, uint8_t cache_status);
+bool check_reading_pointer_null_is_allowed(uint8_t sensor_num);
 
 #endif

--- a/meta-facebook/yv3-dl/src/platform/plat_hook.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_hook.c
@@ -77,7 +77,7 @@ bool pre_nvme_read(uint8_t sensor_num, void *args)
 bool post_cpu_margin_read(uint8_t sensor_num, void *args, int *reading)
 {
 	if (reading == NULL) {
-		return false;
+		return check_reading_pointer_null_is_allowed(sensor_num);
 	}
 	ARG_UNUSED(args);
 
@@ -183,7 +183,7 @@ bool post_xdpe12284c_read(uint8_t sensor_num, void *args, int *reading)
 	bool ret = true;
 
 	if (reading == NULL) {
-		ret = false;
+		ret = check_reading_pointer_null_is_allowed(sensor_num);
 		goto error_exit;
 	}
 	ARG_UNUSED(args);
@@ -265,7 +265,7 @@ bool post_isl69254_read(uint8_t sensor_num, void *args, int *reading)
 	}
 
 	if (reading == NULL) {
-		return false;
+		return check_reading_pointer_null_is_allowed(sensor_num);
 	}
 	ARG_UNUSED(args);
 

--- a/meta-facebook/yv35-cl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.c
@@ -245,7 +245,7 @@ bool post_vol_bat3v_read(uint8_t sensor_num, void *args, int *reading)
 bool post_cpu_margin_read(uint8_t sensor_num, void *args, int *reading)
 {
 	if (!reading)
-		return false;
+		return check_reading_pointer_null_is_allowed(sensor_num);
 	ARG_UNUSED(args);
 
 	sensor_val *sval = (sensor_val *)reading;
@@ -266,7 +266,7 @@ bool post_cpu_margin_read(uint8_t sensor_num, void *args, int *reading)
 bool post_adm1278_power_read(uint8_t sensor_num, void *args, int *reading)
 {
 	if (!reading)
-		return false;
+		return check_reading_pointer_null_is_allowed(sensor_num);
 	ARG_UNUSED(args);
 
 	sensor_val *sval = (sensor_val *)reading;
@@ -291,7 +291,7 @@ bool post_adm1278_power_read(uint8_t sensor_num, void *args, int *reading)
 bool post_adm1278_current_read(uint8_t sensor_num, void *args, int *reading)
 {
 	if (!reading)
-		return false;
+		return check_reading_pointer_null_is_allowed(sensor_num);
 	ARG_UNUSED(args);
 
 	sensor_val *sval = (sensor_val *)reading;
@@ -316,7 +316,7 @@ bool post_adm1278_current_read(uint8_t sensor_num, void *args, int *reading)
 bool post_ltc4286_read(uint8_t sensor_num, void *args, int *reading)
 {
 	if (!reading) {
-		return false;
+		return check_reading_pointer_null_is_allowed(sensor_num);
 	}
 	ARG_UNUSED(args);
 
@@ -359,7 +359,7 @@ bool post_ltc4286_read(uint8_t sensor_num, void *args, int *reading)
 bool post_ltc4282_read(uint8_t sensor_num, void *args, int *reading)
 {
 	if (!reading) {
-		return false;
+		return check_reading_pointer_null_is_allowed(sensor_num);
 	}
 	ARG_UNUSED(args);
 


### PR DESCRIPTION
Summary:
- Fix sensor post read function parameter is NULL causing error message to be printed.

Test Plan:
- Build code: Pass
- BIC doesn't print post read error message at sensor initial stage and sensor read fail: Pass

Log:
- CL BIC console
  - Before fix

Hello, welcome to yv35 craterlake 2022.34.1
BIC class type(class-1), 1ou present status(0), 2ou present status(0), board revision(0x2) [00:00:00.003,000] <inf> usb_dc_aspeed: pre-selected ep[0x2] as IN endpoint [00:00:00.003,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint [00:00:00.056,000] <inf> kcs_aspeed: KCS3: addr=0xca2, idr=0x2c, odr=0x38, str=0x44

[init_drive_type] sensor 0x14 post sensor read failed! [init_drive_type] sensor 0x30 post sensor read failed! [init_drive_type] sensor 0x39 post sensor read failed!

[set_DC_status] gpio number(15) status(1)
[set_post_status] gpio number(1) status(0)

[00:00:00.203,000] <inf> usb_cdc_acm: Device suspended [00:00:00.402,000] <inf> usb_cdc_acm: Device resumed [00:00:00.402,000] <inf> usb_cdc_acm: from suspend [00:00:00.707,000] <inf> usb_cdc_acm: Device configured BIC Ready

[get_sensor_reading]sensor number 0x14 reading and post_read fail [get_sensor_reading]sensor number 0x14 reading and post_read fail Failed to read sensor value from cache, sensor number: 0x5, cache status: 0x4 Failed to read sensor value from cache, sensor number: 0x5, cache status: 0x4

  - After fix

Hello, welcome to yv35 craterlake 2022.34.1
BIC class type(class-1), 1ou present status(0), 2ou present status(0), board revision(0x2) [00:00:00.003,000] <inf> usb_dc_aspeed: pre-selected ep[0x2] as IN endpoint [00:00:00.003,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint [00:00:00.056,000] <inf> kcs_aspeed: KCS3: addr=0xca2, idr=0x2c, odr=0x38, str=0x44

[set_DC_status] gpio number(15) status(1)
[set_post_status] gpio number(1) status(0)

[00:00:00.203,000] <inf> usb_cdc_acm: Device suspended [00:00:00.402,000] <inf> usb_cdc_acm: Device resumed [00:00:00.402,000] <inf> usb_cdc_acm: from suspend [00:00:00.707,000] <inf> usb_cdc_acm: Device configured BIC Ready

Failed to read sensor value from cache, sensor number: 0x5, cache status: 0x4

- DL BIC console
  - Before fix

Hello, welcome to yv3 deltalake 2022.34.ee

[00:00:00.003VR type: RNS
[add_sensor_config] replace the sensor[0x29] configuration [add_sensor_config] replace the sensor[0x2a] configuration [add_sensor_config] replace the sensor[0x2c] configuration [add_sensor_config] replace the sensor[0x2d] configuration [add_sensor_config] replace the sensor[0x27] configuration [add_sensor_config] replace the sensor[0x28] configuration [add_sensor_config] replace the sensor[0x33] configuration [add_sensor_config] replace the sensor[0x34] configuration [add_sensor_config] replace the sensor[0x35] configuration [add_sensor_config] replace the sensor[0x36] configuration [add_sensor_config] replace the sensor[0x31] configuration [add_sensor_config] replace the sensor[0x32] configuration [add_sensor_config] replace the sensor[0x12] configuration [add_sensor_config] replace the sensor[0x13] configuration [add_sensor_config] replace the sensor[0x14] configuration [add_sensor_config] replace the sensor[0x15] configuration [add_sensor_config] replace the sensor[0x10] configuration [add_sensor_config] replace the sensor[0x11] configuration [add_sensor_config] replace the sensor[0x3d] configuration [add_sensor_config] replace the sensor[0x3e] configuration [add_sensor_config] replace the sensor[0x3f] configuration [add_sensor_config] replace the sensor[0x42] configuration [add_sensor_config] replace the sensor[0x3a] configuration [add_sensor_config] replace the sensor[0x3c] configuration [init_drive_type] sensor 0x29 post sensor read failed! [init_drive_type] sensor 0x2a post sensor read failed! [init_drive_type] sensor 0x2c post sensor read failed! [init_drive_type] sensor 0x2d post sensor read failed! [init_drive_type] sensor 0x27 post sensor read failed! [init_drive_type] sensor 0x28 post sensor read failed! [init_drive_type] sensor 0x33 post sensor read failed! [init_drive_type] sensor 0x34 post sensor read failed! [init_drive_type] sensor 0x35 post sensor read failed! [init_drive_type] sensor 0x36 post sensor read failed! [init_drive_type] sensor 0x31 post sensor read failed! [init_drive_type] sensor 0x32 post sensor read failed! [init_drive_type] sensor 0x12 post sensor read failed! [init_drive_type] sensor 0x13 post sensor read failed! [init_drive_type] sensor 0x14 post sensor read failed! [init_drive_type] sensor 0x15 post sensor read failed! [init_drive_type] sensor 0x10 post sensor read failed! [init_drive_type] sensor 0x11 post sensor read failed! [init_drive_type] sensor 0x3d post sensor read failed! [init_drive_type] sensor 0x3e post sensor read failed! [init_drive_type] sensor 0x3f post sensor read failed! [init_drive_type] sensor 0x42 post sensor read failed! [init_drive_type] sensor 0x3a post sensor read failed! [init_drive_type] sensor 0x3c post sensor read failed! [init_drive_type] sensor 0xd post sensor read failed!

[set_DC_status] gpio number(15) status(1)
[set_post_status] gpio number(1) status(1)
<inf> kcs_aspeed: KCS4: addr=0xca2, idr=0x114, odr=0x118, str=0x11c

[00:00:00.068,000] <err> spi_nor_multi_dev: [1347][spi1_cs0]SFDP magic ffffffff invalid [00:00:00.068,000] <err> spi_nor_multi_dev: [1609]SFDP read failed: -22 [00:00:00.659,000] <inf> usb_cdc_acm: Device suspended

uart:~$ [get_sensor_reading]sensor number 0xd reading and post_read fail BIC Ready
[get_sensor_reading]sensor number 0xd reading and post_read fail [get_sensor_reading]sensor number 0xd reading and post_read fail

Failed to read sensor value from cache, sensor number: 0x5, cache status: 0x4 Failed to read sensor value from cache, sensor number: 0x5, cache status: 0x4

  - After fix

Hello, welcome to yv3 deltalake 2022.34.ef

[00:00:00.003VR type: RNS
[add_sensor_config] replace the sensor[0x29] configuration [add_sensor_config] replace the sensor[0x2a] configuration [add_sensor_config] replace the sensor[0x2c] configuration [add_sensor_config] replace the sensor[0x2d] configuration [add_sensor_config] replace the sensor[0x27] configuration [add_sensor_config] replace the sensor[0x28] configuration [add_sensor_config] replace the sensor[0x33] configuration [add_sensor_config] replace the sensor[0x34] configuration [add_sensor_config] replace the sensor[0x35] configuration [add_sensor_config] replace the sensor[0x36] configuration [add_sensor_config] replace the sensor[0x31] configuration [add_sensor_config] replace the sensor[0x32] configuration [add_sensor_config] replace the sensor[0x12] configuration [add_sensor_config] replace the sensor[0x13] configuration [add_sensor_config] replace the sensor[0x14] configuration [add_sensor_config] replace the sensor[0x15] configuration [add_sensor_config] replace the sensor[0x10] configuration [add_sensor_config] replace the sensor[0x11] configuration [add_sensor_config] replace the sensor[0x3d] configuration [add_sensor_config] replace the sensor[0x3e] configuration [add_sensor_config] replace the sensor[0x3f] configuration [add_sensor_config] replace the sensor[0x42] configuration [add_sensor_config] replace the sensor[0x3a] configuration [add_sensor_config] replace the sensor[0x3c] configuration [set_DC_status] gpio number(15) status(1)
[set_post_status] gpio number(1) status(1)

[00:00:00.068,000] <err> spi_nor_multi_dev: [1347][spi1_cs0]SFDP magic ffffffff invalid [00:00:00.068,000] <err> spi_nor_multi_dev: [1609]SFDP read failed: -22 [00:00:00.395,000] <inf> usb_cdc_acm: Device suspended

uart:~$ BIC Ready
Failed to read sensor value from cache, sensor number: 0x5, cache status: 0x4
Failed to read sensor value from cache, sensor number: 0x5, cache status: 0x4