### PR TITLE
Common: Modify APML mailbox wait time

### DIFF
--- a/common/service/apml/apml.c
+++ b/common/service/apml/apml.c
@@ -4,6 +4,7 @@
 #include "apml.h"
 
 #define RETRY_MAX 3
+#define MAILBOX_COMPLETE_RETRY_MAX 200
 #define APML_RESP_BUFFER_SIZE 10
 #define APML_HANDLER_STACK_SIZE 1024
 #define APML_MSGQ_LEN 32
@@ -305,7 +306,7 @@ static uint8_t access_RMI_mailbox(apml_msg *msg)
 	}
 
 	/* wait for the requested command to complete */
-	if (!check_mailbox_command_complete(msg, RETRY_MAX)) {
+	if (!check_mailbox_command_complete(msg, MAILBOX_COMPLETE_RETRY_MAX)) {
 		printf("[%s] command not complete, retry %d times.\n", __func__, RETRY_MAX);
 		return APML_ERROR;
 	}


### PR DESCRIPTION
Summary:
- Based on AMD suggestion, modify the time to wait for mailbox to complete from 30ms to 2 seconds.

Test plan:
- Build code: PASS.