### PR TITLE
fby3: vf: support 2nd IANA for IPMI NetFn commands

### DIFF
--- a/meta-facebook/yv3-vf/src/platform/plat_version.h
+++ b/meta-facebook/yv3-vf/src/platform/plat_version.h
@@ -22,6 +22,7 @@
 #define PRODUCT_ID 0x0000
 #define AUXILIARY_FW_REVISION 0x00000000
 #define IANA_ID 0x009C9C // same as TI BIC
+#define IANA_ID2 0x00A015 // for OEM 1S command supports YV3.5
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22


### PR DESCRIPTION
Summary:
- Support 2nd IANA for IPMI NetFn 0x38 commands
- VF 2.0 support Meta's IANA for IPMI NetFn 0x38 commands

Test plan:
- Build code : Pass

root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x9c 0x9c 0x00 0x05 0xe0 0x3A 0x9c 0x9c 0x00 0
9C 9C 00 05 E4 3A 00 9C 9C 00 00 
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x9c 0x9c 0x00 0x05 0xe0 0x3A 0x15 0xa0 0x00 0
9C 9C 00 05 E4 3A 00 15 A0 00 00 
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x9c 0x9c 0x00 0x05 0xe0 0x3A 0x15 0xa0 0x01 0
9C 9C 00 05 E4 3A 84 