### PR TITLE
GT: Version commit fot gt-swb-2022.37.01

### DIFF
--- a/meta-facebook/gt-cc/src/platform/plat_version.h
+++ b/meta-facebook/gt-cc/src/platform/plat_version.h
@@ -5,7 +5,7 @@
 
 #define PLATFORM_NAME "Grand Teton"
 #define PROJECT_NAME "Cascade Creek"
-#define PROJECT_STAGE POC
+#define PROJECT_STAGE EVT
 
 /* 
  * 0x01 cascade-creek 
@@ -24,7 +24,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x33
+#define BIC_FW_WEEK 0x37
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x47 // char: G
 #define BIC_FW_platform_1 0x54 // char: T


### PR DESCRIPTION
Summary:
- Version commit for GT switch board gt-swb-2022.37.01

Test Plan:
- Build code: Pass
- Check BIC version is changed: Pass

Log:
1. Get version of SWB BIC from BMC 
```
root@bmc-oob:~# fw-util swb --version bic
SWB BIC Version: 2022.37.01
```