### PR TITLE
fby3.5: hd: Update SDR table

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_sdr_table.c
@@ -54,7 +54,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x3C, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -115,7 +115,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x50, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -176,7 +176,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x28, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -236,8 +236,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x00, // UCT
+		0x69, // UNRT
+		0x5F, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -298,7 +298,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x55, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -359,7 +359,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x55, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -420,7 +420,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x55, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -481,7 +481,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x55, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -542,7 +542,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x55, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -603,7 +603,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x55, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -664,7 +664,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x55, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -725,7 +725,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x55, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -834,12 +834,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
+		0x27, // [7:0] M bits
+		0x40, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -847,8 +847,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
+		0x6A, // UCT
+		0x69, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -895,12 +895,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
+		0x27, // [7:0] M bits
+		0x40, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -908,8 +908,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
+		0x6A, // UCT
+		0x69, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -956,12 +956,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
+		0x27, // [7:0] M bits
+		0x40, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -969,8 +969,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
+		0x6A, // UCT
+		0x69, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1017,12 +1017,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
+		0x27, // [7:0] M bits
+		0x40, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -1030,8 +1030,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
+		0x6A, // UCT
+		0x69, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1078,12 +1078,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
+		0x27, // [7:0] M bits
+		0x40, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -1091,8 +1091,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
+		0x6A, // UCT
+		0x69, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1139,12 +1139,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
+		0x27, // [7:0] M bits
+		0x40, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -1152,8 +1152,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
+		0x6A, // UCT
+		0x69, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1200,12 +1200,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
+		0x27, // [7:0] M bits
+		0x40, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -1213,8 +1213,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
+		0x6A, // UCT
+		0x69, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1261,12 +1261,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
+		0x27, // [7:0] M bits
+		0x40, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -1274,8 +1274,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
+		0x6A, // UCT
+		0x69, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1335,7 +1335,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x46, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -1396,7 +1396,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x64, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -1456,7 +1456,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
+		0x7D, // UNRT
 		0x69, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
@@ -1517,7 +1517,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
+		0x7D, // UNRT
 		0x69, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
@@ -1578,7 +1578,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
+		0x7D, // UNRT
 		0x69, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
@@ -1639,7 +1639,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
+		0x7D, // UNRT
 		0x69, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
@@ -1700,7 +1700,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
+		0x7D, // UNRT
 		0x69, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
@@ -1749,24 +1749,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x02, // [7:0] M bits
+		0x06, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x42, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x39, // LCT
-		0x00, // LNCT
+		0xEF, // UNRT
+		0xDF, // UCT
+		0xDC, // UNCT
+		0xA8, // LNRT
+		0xB2, // LCT
+		0xB4, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -1815,7 +1815,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -1823,10 +1823,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0xBC, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x00, // LCT
+		0xAC, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1871,7 +1871,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x3B, // [7:0] M bits
+		0x19, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -1884,10 +1884,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x3B, // UCT
+		0x8B, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x35, // LCT
+		0x84, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1937,7 +1937,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -1945,10 +1945,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x74, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x00, // LCT
+		0x67, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1993,7 +1993,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x9E, // [7:0] M bits
+		0x37, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -2006,10 +2006,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x17, // UCT
+		0x42, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x11, // LCT
+		0x31, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -2054,12 +2054,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x19, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -2067,10 +2067,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
+		0x8B, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x00, // LCT
+		0x7D, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -2115,7 +2115,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x49, // [7:0] M bits
+		0x41, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -2128,10 +2128,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x48, // UCT
+		0x51, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x41, // LCT
+		0x49, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -2176,24 +2176,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x06, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
+		0xEF, // UNRT
+		0xDF, // UCT
+		0xDC, // UNCT
+		0xA8, // LNRT
+		0xB2, // LCT
+		0xB4, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -2237,24 +2237,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x06, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
+		0xEF, // UNRT
+		0xDF, // UCT
+		0xDC, // UNCT
+		0xA8, // LNRT
+		0xB2, // LCT
+		0xB4, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -2359,12 +2359,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x03, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -2372,11 +2372,11 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
+		0x7B, // UCT
+		0x7A, // UNCT
 		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
+		0x61, // LCT
+		0x62, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -2481,24 +2481,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x06, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
+		0xEF, // UNRT
+		0xDF, // UCT
+		0xDC, // UNCT
+		0xA8, // LNRT
+		0xB2, // LCT
+		0xB4, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -2603,12 +2603,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x0B, // [7:0] M bits
+		0x01, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xD0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -2616,10 +2616,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x7C, // UCT
+		0x88, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x36, // LCT
+		0x3B, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -2725,7 +2725,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x03, // [7:0] M bits
+		0x01, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -2738,10 +2738,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x2B, // UCT
+		0x81, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x1B, // LCT
+		0x51, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -2847,20 +2847,20 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x8B, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x00, // UCT
+		0x24, // UNRT
+		0x21, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -3213,7 +3213,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x32, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -3225,8 +3225,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x00, // UCT
+		0x0C, // UNRT
+		0x0B, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -3274,8 +3274,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x07, // [7:0] M bits
-		0x40, // [9:8] M bits, tolerance
+		0x02, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
@@ -3287,7 +3287,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x01, // UCT
+		0x84, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -3396,8 +3396,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x07, // [7:0] M bits
-		0x40, // [9:8] M bits, tolerance
+		0x02, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
@@ -3409,7 +3409,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x01, // UCT
+		0x84, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT


### PR DESCRIPTION
Summary:
- Modify the threshold of sensors in SDR table.

Test Plan:
- Build code: PASS

Log:
```
root@bmc-oob:~# sensor-util slot1 -t
slot1:
MB Inlet Temp                (0x1) :   29.00 C     | (ok) | UCR: 60.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB Outlet Temp               (0x2) :   34.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
FIO Temp                     (0x3) :   28.00 C     | (ok) | UCR: 40.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU Temp                     (0x4) :   37.62 C     | (ok) | UCR: 95.00 | UNC: NA | UNR: 105.00 | LCR: NA | LNC: NA | LNR: NA
DIMMA Temp                   (0x5) :   30.50 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMB Temp                   (0x6) :   29.75 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMC Temp                   (0x7) :   29.50 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME Temp                   (0x8) :   29.50 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMG Temp                   (0x9) :   28.50 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH Temp                   (0xA) :   28.75 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMI Temp                   (0xB) :   28.25 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMK Temp                   (0xC) :   28.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SSD Temp                     (0xD) :   34.00 C     | (ok) | UCR: 70.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Temp                     (0xE) :   34.88 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU0 VR Temp                 (0xF) :   40.00 C     | (ok) | UCR: 105.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
SOC VR Temp                  (0x10) :   40.00 C     | (ok) | UCR: 105.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
CPU1 VR Temp                 (0x11) :   35.00 C     | (ok) | UCR: 105.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
PVDDIO VR Temp               (0x12) :   36.00 C     | (ok) | UCR: 105.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
PVDD11 VR Temp               (0x13) :   36.00 C     | (ok) | UCR: 105.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
P12V_STBY Vol                (0x14) :   12.14 Volts | (ok) | UCR: 13.38 | UNC: 13.20 | UNR: 14.34 | LCR: 10.68 | LNC: 10.80 | LNR: 10.08
PVDD18_S5 Vol                (0x15) :    1.81 Volts | (ok) | UCR: 1.88 | UNC: NA | UNR: NA | LCR: 1.72 | LNC: NA | LNR: NA
P3V3_STBY Vol                (0x16) :    3.32 Volts | (ok) | UCR: 3.47 | UNC: NA | UNR: NA | LCR: 3.30 | LNC: NA | LNR: NA
PVDD11_S3 Vol                (0x17) :    1.10 Volts | (ok) | UCR: 1.16 | UNC: NA | UNR: NA | LCR: 1.03 | LNC: NA | LNR: NA
P3V_BAT Vol                  (0x18) :    3.16 Volts | (ok) | UCR: 3.63 | UNC: NA | UNR: NA | LCR: 2.69 | LNC: NA | LNR: NA
PVDD33_S5 Vol                (0x19) :    3.32 Volts | (ok) | UCR: 3.47 | UNC: NA | UNR: NA | LCR: 3.12 | LNC: NA | LNR: NA
P5V_STBY Vol                 (0x1A) :    5.00 Volts | (ok) | UCR: 5.26 | UNC: NA | UNR: NA | LCR: 4.74 | LNC: NA | LNR: NA
P12V_MEM_1 Vol               (0x1B) :   12.14 Volts | (ok) | UCR: 13.38 | UNC: 13.20 | UNR: 14.34 | LCR: 10.68 | LNC: 10.80 | LNR: 10.08
P12V_MEM_0 Vol               (0x1C) :   12.18 Volts | (ok) | UCR: 13.38 | UNC: 13.20 | UNR: 14.34 | LCR: 10.68 | LNC: 10.80 | LNR: 10.08
P1V2_STBY Vol                (0x1D) :    1.20 Volts | (ok) | UCR: 1.27 | UNC: NA | UNR: NA | LCR: 1.13 | LNC: NA | LNR: NA
P3V3_M2 Vol                  (0x1E) :    3.31 Volts | (ok) | UCR: 3.69 | UNC: 3.66 | UNR: NA | LCR: 2.91 | LNC: 2.94 | LNR: NA
P1V8_STBY Vol                (0x1F) :    1.81 Volts | (ok) | UCR: 1.90 | UNC: NA | UNR: NA | LCR: 1.70 | LNC: NA | LNR: NA
HSC Input Vol                (0x20) :   12.15 Volts | (ok) | UCR: 13.38 | UNC: 13.20 | UNR: 14.34 | LCR: 10.68 | LNC: 10.80 | LNR: 10.08
CPU0 VR Vol                  (0x21) :    0.76 Volts | (ok) | UCR: 1.71 | UNC: NA | UNR: NA | LCR: 0.37 | LNC: NA | LNR: NA
SOC VR Vol                   (0x22) :    0.88 Volts | (ok) | UCR: 1.36 | UNC: NA | UNR: NA | LCR: 0.59 | LNC: NA | LNR: NA
CPU1 VR Vol                  (0x23) :    0.76 Volts | (ok) | UCR: 1.71 | UNC: NA | UNR: NA | LCR: 0.37 | LNC: NA | LNR: NA
PVDDIO VR Vol                (0x24) :    1.05 Volts | (ok) | UCR: 1.29 | UNC: NA | UNR: NA | LCR: 0.81 | LNC: NA | LNR: NA
PVDD11 VR Vol                (0x25) :    1.10 Volts | (ok) | UCR: 1.17 | UNC: NA | UNR: NA | LCR: 1.04 | LNC: NA | LNR: NA
HSC Output Cur               (0x26) :    2.99 Amps  | (ok) | UCR: 45.87 | UNC: NA | UNR: 50.04 | LCR: NA | LNC: NA | LNR: NA
CPU0 VR Cur                  (0x27) :    1.20 Amps  | (ok) | UCR: 154.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC VR Cur                   (0x28) :   10.50 Amps  | (ok) | UCR: 143.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU1 VR Cur                  (0x29) :    3.70 Amps  | (ok) | UCR: 154.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVDDIO VR Cur                (0x2A) :    8.80 Amps  | (ok) | UCR: 121.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVDD11 VR Cur                (0x2B) :    1.40 Amps  | (ok) | UCR: 88.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Input Pwr                (0x2C) :   36.72 Watts | (ok) | UCR: 550.00 | UNC: NA | UNR: 600.00 | LCR: NA | LNC: NA | LNR: NA
CPU0 VR Pwr                  (0x2D) :    1.00 Watts | (ok) | UCR: 264.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC VR Pwr                   (0x2E) :    9.00 Watts | (ok) | UCR: 194.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU1 VR Pwr                  (0x2F) :    2.00 Watts | (ok) | UCR: 264.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVDDIO VR Pwr                (0x30) :    9.00 Watts | (ok) | UCR: 156.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PVDD11 VR Pwr                (0x31) :    2.00 Watts | (ok) | UCR: 102.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU Pwr                      (0x32) :   44.83 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMA Pwr                    (0x33) :    0.00 Watts | (ok) | UCR: 31.27 | UNC: 30.98 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMB Pwr                    (0x34) :    0.50 Watts | (ok) | UCR: 31.27 | UNC: 30.98 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMC Pwr                    (0x35) :    0.75 Watts | (ok) | UCR: 31.27 | UNC: 30.98 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMME Pwr                    (0x36) :    0.12 Watts | (ok) | UCR: 31.27 | UNC: 30.98 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMG Pwr                    (0x37) :    1.12 Watts | (ok) | UCR: 31.27 | UNC: 30.98 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMH Pwr                    (0x38) :    0.00 Watts | (ok) | UCR: 31.27 | UNC: 30.98 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMI Pwr                    (0x39) :    0.12 Watts | (ok) | UCR: 31.27 | UNC: 30.98 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
DIMMK Pwr                    (0x3A) :    1.00 Watts | (ok) | UCR: 31.27 | UNC: 30.98 | UNR: NA | LCR: NA | LNC: NA | LNR: NA

```