### PR TITLE
common: shell: Add shell flash commands

### DIFF
--- a/common/lib/libutil.h
+++ b/common/lib/libutil.h
@@ -15,6 +15,18 @@
 #define GETBIT(x, y) ((x & (1ULL << y)) > y)
 #define CLEARBIT(x, y) (x & (~(1ULL << y)))
 
+#define SHELL_CHECK_NULL_ARG(arg_ptr)                                                              \
+	if (arg_ptr == NULL) {                                                                     \
+		shell_error(shell, "Parameter \"" #arg_ptr "\" passed in as NULL");                \
+		return;                                                                            \
+	}
+
+#define SHELL_CHECK_NULL_ARG_WITH_RETURN(arg_ptr, ret_val)                                         \
+	if (arg_ptr == NULL) {                                                                     \
+		shell_error(shell, "Parameter \"" #arg_ptr "\" passed in as NULL");                \
+		return ret_val;                                                                    \
+	}
+
 #define CHECK_NULL_ARG(arg_ptr)                                                                    \
 	if (arg_ptr == NULL) {                                                                     \
 		LOG_DBG("Parameter \"" #arg_ptr "\" passed in as NULL");                           \

--- a/common/lib/libutil.h
+++ b/common/lib/libutil.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef LIBUTIL_H
 #define LIBUTIL_H
 

--- a/common/shell/commands/flash_shell.c
+++ b/common/shell/commands/flash_shell.c
@@ -1,5 +1,20 @@
-#include "flash_shell.h"
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+#include "flash_shell.h"
 #include <devicetree.h>
 #include <device.h>
 #include <stdio.h>

--- a/common/shell/commands/flash_shell.c
+++ b/common/shell/commands/flash_shell.c
@@ -66,7 +66,7 @@ void cmd_flash_sfdp_read(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "Failed to malloc memory for raw");
 		return;
 	}
-	memset(raw, 0, sizeof(raw));
+	memset(raw, 0, read_bytes);
 
 	int ret = flash_sfdp_read(flash_dev, offset, raw, read_bytes);
 	if (ret) {

--- a/common/shell/commands/flash_shell.c
+++ b/common/shell/commands/flash_shell.c
@@ -1,0 +1,111 @@
+#include "flash_shell.h"
+
+#include <devicetree.h>
+#include <device.h>
+#include <stdio.h>
+#include "libutil.h"
+
+/* 
+    Command FLASH
+*/
+void cmd_flash_re_init(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc != 2) {
+		shell_warn(shell, "Help: platform flash re_init <spi_device>");
+		return;
+	}
+
+	const struct device *flash_dev;
+	flash_dev = device_get_binding(argv[1]);
+
+	if (!flash_dev) {
+		shell_error(shell, "Can't find any binding device with label %s", argv[1]);
+	}
+
+	if (spi_nor_re_init(flash_dev)) {
+		shell_error(shell, "%s re-init failed!", argv[1]);
+		return;
+	}
+
+	shell_print(shell, "%s re-init success!", argv[1]);
+	return;
+}
+
+void cmd_flash_sfdp_read(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc != 2 && argc != 3 && argc != 4) {
+		shell_warn(
+			shell,
+			"Help: platform flash sfdp_read <spi_device> <offset(optional, default 0)> <read_bytes(optional, default 256)>");
+		return;
+	}
+
+	int read_bytes = SFDP_BUFF_SIZE;
+	int offset = 0;
+	if (argc == 4) {
+		offset = strtol(argv[2], NULL, 16);
+		read_bytes = strtol(argv[3], NULL, 10);
+	} else if (argc == 3) {
+		offset = strtol(argv[2], NULL, 10);
+	}
+
+	const struct device *flash_dev;
+	flash_dev = device_get_binding(argv[1]);
+
+	if (!flash_dev) {
+		shell_error(shell, "Can't find any binding device with label %s", argv[1]);
+	}
+
+	if (!device_is_ready(flash_dev)) {
+		shell_error(shell, "%s: device not ready", flash_dev->name);
+		return;
+	}
+
+	uint8_t *raw = malloc(read_bytes * sizeof(uint8_t));
+	if (!raw) {
+		shell_error(shell, "Failed to malloc memory for raw");
+		return;
+	}
+	memset(raw, 0, sizeof(raw));
+
+	int ret = flash_sfdp_read(flash_dev, offset, raw, read_bytes);
+	if (ret) {
+		shell_error(shell, "Failed to read flash sfdp with ret: %d", ret);
+		goto exit;
+	}
+
+	printf("sfdp raw read from ofst %xh with %d bytes:", offset, read_bytes);
+	if ((offset % 4)) {
+		printf("\n[%-3x] ", 0);
+		for (int i = 0; i < (offset % 4); i++) {
+			printf("   ");
+		}
+	}
+	for (int i = 0; i < read_bytes; i++) {
+		if (!((offset + i) % 4)) {
+			printf("\n[%-3x] ", (offset + i));
+		}
+		printf("%.2x ", raw[i]);
+	}
+	printf("\n");
+
+exit:
+	SAFE_FREE(raw);
+	return;
+}
+
+/* Flash sub command */
+void device_spi_name_get(size_t idx, struct shell_static_entry *entry)
+{
+	const struct device *dev = shell_device_lookup(idx, SPI_DEVICE_PREFIX);
+
+	if (entry == NULL) {
+		printf("%s passed null entry\n", __func__);
+		return;
+	}
+
+	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}

--- a/common/shell/commands/flash_shell.h
+++ b/common/shell/commands/flash_shell.h
@@ -7,7 +7,7 @@
 #include <drivers/flash.h>
 
 #define SPI_DEVICE_PREFIX "spi"
-#define SFDP_BUFF_SIZE 256
+#define MAX_SFDP_BUFF_SIZE 256
 
 void cmd_flash_re_init(const struct shell *shell, size_t argc, char **argv);
 void cmd_flash_sfdp_read(const struct shell *shell, size_t argc, char **argv);

--- a/common/shell/commands/flash_shell.h
+++ b/common/shell/commands/flash_shell.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef FLASH_SHELL_H
 #define FLASH_SHELL_H
 

--- a/common/shell/commands/flash_shell.h
+++ b/common/shell/commands/flash_shell.h
@@ -1,0 +1,25 @@
+#ifndef FLASH_SHELL_H
+#define FLASH_SHELL_H
+
+#include <stdlib.h>
+#include <shell/shell.h>
+#include <drivers/spi_nor.h>
+#include <drivers/flash.h>
+
+#define SPI_DEVICE_PREFIX "spi"
+#define SFDP_BUFF_SIZE 256
+
+void cmd_flash_re_init(const struct shell *shell, size_t argc, char **argv);
+void cmd_flash_sfdp_read(const struct shell *shell, size_t argc, char **argv);
+void device_spi_name_get(size_t idx, struct shell_static_entry *entry);
+
+SHELL_DYNAMIC_CMD_CREATE(spi_device_name, device_spi_name_get);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_flash_cmds,
+			       SHELL_CMD(re_init, &spi_device_name, "Re-init spi config",
+					 cmd_flash_re_init),
+			       SHELL_CMD(sfpd_read, &spi_device_name, "SFPD read",
+					 cmd_flash_sfdp_read),
+			       SHELL_SUBCMD_SET_END);
+
+#endif

--- a/common/shell/shell_platform.c
+++ b/common/shell/shell_platform.c
@@ -1,6 +1,7 @@
 #include "commands/gpio_shell.h"
 #include "commands/info_shell.h"
 #include "commands/sensor_shell.h"
+#include "commands/flash_shell.h"
 #include "commands/ipmi_shell.h"
 
 /* MAIN command */
@@ -8,6 +9,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_platform_cmds, SHELL_CMD(info, NULL, "Platform info.", cmd_info_print),
 	SHELL_CMD(gpio, &sub_gpio_cmds, "GPIO relative command.", NULL),
 	SHELL_CMD(sensor, &sub_sensor_cmds, "SENSOR relative command.", NULL),
+	SHELL_CMD(flash, &sub_flash_cmds, "FLASH(spi) relative command.", NULL),
 	SHELL_CMD(ipmi, &sub_ipmi_cmds, "IPMI relative command.", NULL), SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(platform, &sub_platform_cmds, "Platform commands", NULL);

--- a/common/shell/shell_platform.c
+++ b/common/shell/shell_platform.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "commands/gpio_shell.h"
 #include "commands/info_shell.h"
 #include "commands/sensor_shell.h"


### PR DESCRIPTION
Summary:
- Add shell flash commands including **spi re-init** and **sfpd read**.
  - spi re-init
    platform flash re_init <spi_device>
  - sfpd read
    platform flash sfdp_read <spi_device> <offset(optional, default 0h)> <read_bytes(optional, default 256)>

Test Plan:
- Build Code: PASS
- Check shell command in BIC console: PASS

Log:
- BIC console:
  ```
  uart:~$ platform flash re_init spi1_cs0 
  spi1_cs0 re-init success!

  uart:~$ platform flash sfpd_read spi1_cs0 1 16
  sfdp raw read from ofst 1 with 16 bytes:
  [0  ]    46 44 50 
  [4  ] 06 01 02 ff 
  [8  ] 00 06 01 10 
  [c  ] 30 00 00 ff 
  [10 ] c2
  ```