### PR TITLE
fby3: vf: support 2nd IANA for IPMI NetFn commands (#548)

### DIFF
--- a/meta-facebook/yv3-vf/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv3-vf/src/ipmi/plat_ipmi.c
@@ -24,6 +24,7 @@
 #include "plat_m2.h"
 #include "plat_led.h"
 #include "plat_power_seq.h"
+#include <logging/log.h>
 
 // for GET_SET_M2
 #define DRIVE_PWR_OFF 0 /* normal device power off/on */
@@ -35,6 +36,30 @@
 #define DRIVE_PWR_ON_ALL 7
 #define DRIVE_PWR_OFF_BY_12V_3V3 8 /* power off/on device by 12V/3V3 */
 #define DRIVE_PWR_ON_BY_12V_3V3 9
+
+LOG_MODULE_DECLARE(ipmi);
+
+static uint32_t iana_list[] = {
+	IANA_ID,
+	IANA_ID2,
+};
+
+// IANA 0 is reserved so it should never be a valid IANA
+uint32_t get_iana(uint8_t *iana_buf)
+{
+	CHECK_NULL_ARG_WITH_RETURN(iana_buf, 0);
+
+	uint32_t recieved_iana = iana_buf[2];
+	recieved_iana = (recieved_iana << 8) | (uint32_t)iana_buf[1];
+	recieved_iana = (recieved_iana << 8) | (uint32_t)iana_buf[0];
+
+	for (uint8_t iana_idx = 0; iana_idx < ARRAY_SIZE(iana_list); iana_idx++) {
+		if (recieved_iana == iana_list[iana_idx])
+			return iana_list[iana_idx];
+	}
+
+	return 0;
+}
 
 void OEM_1S_GET_BOARD_ID(ipmi_msg *msg)
 {

--- a/meta-facebook/yv3-vf/src/platform/plat_version.h
+++ b/meta-facebook/yv3-vf/src/platform/plat_version.h
@@ -38,6 +38,7 @@
 #define PRODUCT_ID 0x0000
 #define AUXILIARY_FW_REVISION 0x00000000
 #define IANA_ID 0x009C9C // same as TI BIC
+#define IANA_ID2 0x00A015 // for OEM 1S command supports YV3.5
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22


### PR DESCRIPTION
Summary:
- Support 2nd IANA for IPMI NetFn 0x38 commands
- VF 2.0 support Meta's IANA for IPMI NetFn 0x38 commands

Pull Request resolved: https://github.com/facebook/OpenBIC/pull/548

Test Plan:
- Build code : Pass

root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x9c 0x9c 0x00 0x05 0xe0 0x3A 0x9c 0x9c 0x00 0
9C 9C 00 05 E4 3A 00 9C 9C 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x9c 0x9c 0x00 0x05 0xe0 0x3A 0x15 0xa0 0x00 0
9C 9C 00 05 E4 3A 00 15 A0 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x9c 0x9c 0x00 0x05 0xe0 0x3A 0x15 0xa0 0x01 0
9C 9C 00 05 E4 3A 84

Differential Revision: D39494793

Pulled By: GoldenBug

