### PR TITLE
fby3: fix sending unaligned gpio number to BMC

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_gpio.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_gpio.c
@@ -5,6 +5,9 @@
 #include "hal_gpio.h"
 #include "plat_gpio.h"
 #include "plat_isr.h"
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(gpio);
 
 #define gpio_name_to_num(x) #x,
 const char *const gpio_name[] = {
@@ -359,4 +362,19 @@ void enable_SYS_Throttle_interrupt()
 void disable_SYS_Throttle_interrupt()
 {
 	gpio_interrupt_conf(FAST_PROCHOT_N, GPIO_INT_DISABLE);
+}
+
+uint8_t get_exported_gpio_num(uint8_t internal_gpio_num)
+{
+	uint8_t index = 0;
+	uint8_t ret = 0xff;
+
+	for (index = 0; index < gpio_align_table_length; index++) {
+		if (gpio_align_t[index] == internal_gpio_num) {
+			return index;
+		}
+	}
+
+	LOG_ERR("Fail to convert GPIO num: %u\n", internal_gpio_num);
+	return ret;
 }

--- a/meta-facebook/yv3-dl/src/platform/plat_gpio.h
+++ b/meta-facebook/yv3-dl/src/platform/plat_gpio.h
@@ -253,4 +253,5 @@ void enable_UV_detect_interrupt();
 void disable_UV_detect_interrupt();
 void enable_SYS_Throttle_interrupt();
 void disable_SYS_Throttle_interrupt();
+uint8_t get_exported_gpio_num(uint8_t internal_gpio_num);
 #endif

--- a/meta-facebook/yv3-dl/src/platform/plat_isr.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_isr.c
@@ -29,7 +29,7 @@ void send_gpio_interrupt(uint8_t gpio_num)
 	msg.data[0] = IANA_ID & 0xFF;
 	msg.data[1] = (IANA_ID >> 8) & 0xFF;
 	msg.data[2] = (IANA_ID >> 16) & 0xFF;
-	msg.data[3] = gpio_num;
+	msg.data[3] = get_exported_gpio_num(gpio_num);
 	msg.data[4] = gpio_val;
 
 	status = ipmb_read(&msg, IPMB_inf_index_map[msg.InF_target]);


### PR DESCRIPTION
Summary:
BIC should convert internal GPIO number first before sending it out.

Test plan:
Build and test pass on yv3-dl

1. Add debug print to check BIC is sending converted GPIO number to BMC.