### PR TITLE
common: Fix IPMI handler stop issue

### DIFF
--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -281,7 +281,7 @@ void IPMI_handler(void *arug0, void *arug1, void *arug2)
 		}
 
 		if (pal_is_not_return_cmd(msg_cfg.buffer.netfn, msg_cfg.buffer.cmd)) {
-			return;
+			continue;
 		}
 
 		if (msg_cfg.buffer.completion_code != CC_SUCCESS) {


### PR DESCRIPTION
Summary:
- IPMI handler shouldn't stop when receive OEM bypass command

Test Plan:
- Build code: Pass

When receive OEM bypass command, BIC should continue to handle

root@bmc-oob:~# me-util slot1 0x18 0x01
50 01 06 03 02 21 57 01 00 18 0B 06 17 20 01
root@bmc-oob:~# me-util slot1 0x18 0x01
50 01 06 03 02 21 57 01 00 18 0B 06 17 20 01
root@bmc-oob:~# me-util slot1 0x18 0x01
50 01 06 03 02 21 57 01 00 18 0B 06 17 20 01