### PR TITLE
wc: mb: Version commit for obwc-mb-2022.37.01

### DIFF
--- a/meta-facebook/wc-mb/src/platform/plat_version.h
+++ b/meta-facebook/wc-mb/src/platform/plat_version.h
@@ -21,7 +21,7 @@
 
 #define PLATFORM_NAME "Waimea Canyon"
 #define PROJECT_NAME "Mainboard"
-#define PROJECT_STAGE POC
+#define PROJECT_STAGE EVT
 
 /*
  * 0x01 mainboard
@@ -31,7 +31,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x01 // Count of release firmware at each stage.
+#define FIRMWARE_REVISION_2 0x04 // Count of release firmware at each stage.
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -40,8 +40,8 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x25
-#define BIC_FW_VER 0x00
+#define BIC_FW_WEEK 0x37
+#define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x77 // char: w
 #define BIC_FW_platform_1 0x63 // char: c
 #define BIC_FW_platform_2 0x00 // char: '\0'


### PR DESCRIPTION
Summary:
- Version commit for Waimea Canyon BIC obwc-mb-2022.37.01.

Test Plan:
- Build code: Pass
- Get BIC version: Pass

Log:
- BMC console:
  ```
  root@bmc-oob:~# fw-util mb --version bic
  MB Bridge-IC Version: wc-v2022.37.01

  root@bmc-oob:~# bic-util mb 0x18 0x1
  00 80 11 04 02 BF 15 A0 00 00 00 00 00 00 00
  ```