### PR TITLE
wc: mb: Modify identification mechanism of vr sensor type

### DIFF
--- a/meta-facebook/wc-mb/src/platform/plat_sensor_table.c
+++ b/meta-facebook/wc-mb/src/platform/plat_sensor_table.c
@@ -316,21 +316,21 @@ void check_vr_type(uint8_t index)
 		vr_type = sensor_dev_isl69259;
 	}
 
-	for (uint8_t index = 0; index < ARRAY_SIZE(plat_sensor_config); index++) {
-		if (sensor_config[index].type == sensor_dev_isl69259) {
+	for (uint8_t idx = 0; idx < ARRAY_SIZE(plat_sensor_config); idx++) {
+		if (sensor_config[idx].type == sensor_dev_isl69259) {
 			/* if 2nd source, slave adress needed to be changed */
 			if (vr_type == sensor_dev_tps53689) {
-				if (sensor_config[index].target_addr == VR_PU14_SRC0_ADDR)
-					sensor_config[index].target_addr = VR_PU14_SRC1_ADDR;
-				else if (sensor_config[index].target_addr == VR_PU5_SRC0_ADDR)
-					sensor_config[index].target_addr = VR_PU5_SRC1_ADDR;
-				else if (sensor_config[index].target_addr == VR_PU35_SRC0_ADDR)
-					sensor_config[index].target_addr = VR_PU35_SRC1_ADDR;
+				if (sensor_config[idx].target_addr == VR_PU14_SRC0_ADDR)
+					sensor_config[idx].target_addr = VR_PU14_SRC1_ADDR;
+				else if (sensor_config[idx].target_addr == VR_PU5_SRC0_ADDR)
+					sensor_config[idx].target_addr = VR_PU5_SRC1_ADDR;
+				else if (sensor_config[idx].target_addr == VR_PU35_SRC0_ADDR)
+					sensor_config[idx].target_addr = VR_PU35_SRC1_ADDR;
 				else
 					LOG_ERR("sensor #%-2xh vr type: invalid address, using default VR address...",
-						sensor_config[index].num);
+						sensor_config[idx].num);
 			}
-			sensor_config[index].type = vr_type;
+			sensor_config[idx].type = vr_type;
 		}
 	}
 


### PR DESCRIPTION
Summary:
- For current stage, all vr type should follow one specific vr.
- Support vr type TPS53689 as 2nd source, and vr type XDPE15284 temporary use default address.

Test Plan:
- Build Code: PASS
- Check sensor value from bmc console: PASS

Log:
- BMC console:
  ```
  root@bmc-oob:~# sensor-util mb
  mb:
  MB_MB_INLET_TEMP_C           (0x1) :   30.00 C     | (ok)
  MB_MB_OUTLET_TEMP_C          (0x2) :   34.00 C     | (ok)
  MB_PCH_TEMP_C                (0x4) :   42.00 C     | (ok)
  MB_CPU_TEMP_C                (0x5) :   33.00 C     | (ok)
  MB_SOC_THERM_MARGIN_C        (0x6) :  -67.00 C     | (ok)
  MB_CPU_TJMAX_C               (0x7) :  100.00 C     | (ok)
  MB_SSD0_TEMP_C               (0x8) :   33.00 C     | (ok)
  MB_HSC_TEMP_C                (0x9) :   32.00 C     | (ok)
  MB_DIMMA_TEMP_C              (0xA) :   30.00 C     | (ok)
  MB_DIMMC_TEMP_C              (0xB) :   29.00 C     | (ok)
  MB_DIMME_TEMP_C              (0xC) :   31.00 C     | (ok)
  MB_DIMMG_TEMP_C              (0xD) :   30.00 C     | (ok)
  MB_VCCIN_SPS_TEMP_C          (0xE) :   41.56 C     | (ok)
  MB_FIVRA_SPS_TEMP_C          (0xF) :   38.75 C     | (ok)
  MB_EHV_SPS_TEMP_C            (0x10) :   36.81 C     | (ok)
  MB_VCCD_SPS_TEMP_C           (0x11) :   36.81 C     | (ok)
  MB_FAON_SPS_TEMP_C           (0x12) :   36.31 C     | (ok)
  MB_P12V_STBY_VOLT_V          (0x20) :   12.05 Volts | (ok)
  MB_P3V_BAT_VOLT_V            (0x21) :    3.10 Volts | (ok)
  MB_P3V3_STBY_VOLT_V          (0x22) :    3.34 Volts | (ok)
  MB_P1V8_STBY_VOLT_V          (0x23) :    1.82 Volts | (ok)
  MB_P1V05_PCH_VOLT_V          (0x24) :    1.04 Volts | (ok)
  MB_P5V_STBY_VOLT_V           (0x25) :    5.02 Volts | (ok)
  MB_P12V_DIMM_VOLT_V          (0x26) :   12.06 Volts | (ok)
  MB_P1V2_STBY_VOLT_V          (0x27) :    1.20 Volts | (ok)
  MB_P3V3_M2_VOLT_V            (0x28) :    3.33 Volts | (ok)
  MB_HSC_INPUT_VOLT_V          (0x29) :   11.94 Volts | (ok)
  MB_VCCIN_VR_VOLT_V           (0x2A) :    1.78 Volts | (ok)
  MB_FIVRA_VR_VOLT_V           (0x2B) :    1.80 Volts | (ok)
  MB_EHV_VR_VOLT_V             (0x2C) :    1.80 Volts | (ok)
  MB_VCCD_VR_VOLT_V            (0x2D) :    1.14 Volts | (ok)
  MB_FAON_VR_VOLT_V            (0x2E) :    1.06 Volts | (ok)
  MB_HSC_OUTPUT_CURR_A         (0x40) :    6.00 Amps  | (ok)
  MB_VCCIN_VR_CURR_A           (0x41) :   20.25 Amps  | (ok)
  MB_FIVRA_VR_CURR_A           (0x42) :    4.22 Amps  | (ok)
  MB_EHV_VR_CURR_A             (0x43) :    0.43 Amps  | (ok)
  MB_VCCD_VR_CURR_A            (0x44) :    1.59 Amps  | (ok)
  MB_VCCD_VR_CURR_IN_A         (0x45) :    1.53 Amps  | (ok)
  MB_FAON_VR_CURR_A            (0x46) :    8.25 Amps  | (ok)
  MB_CPU_PWR_W                 (0x60) :   55.00 Watts | (ok)
  MB_HSC_INPUT_PWR_W           (0x61) :   72.00 Watts | (ok)
  MB_DIMMA_PMIC_PWR_W          (0x62) :    0.88 Watts | (ok)
  MB_DIMMC_PMIC_PWR_W          (0x63) :    0.88 Watts | (ok)
  MB_DIMME_PMIC_PWR_W          (0x64) :    1.00 Watts | (ok)
  MB_DIMMG_PMIC_PWR_W          (0x65) :    0.75 Watts | (ok)
  MB_VCCIN_VR_PWR_W            (0x66) :   36.12 Watts | (ok)
  MB_FIVRA_VR_PWR_W            (0x67) :    7.32 Watts | (ok)
  MB_EHV_VR_PWR_W              (0x68) :    0.77 Watts | (ok)
  MB_VCCD_VR_PWR_W             (0x69) :    1.71 Watts | (ok)
  MB_FAON_VR_PWR_W             (0x6A) :    8.72 Watts | (ok)
  ```