### PR TITLE
fby3.5: hd: Modify LCR of P3V3_STBY Vol

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_sdr_table.c
@@ -1903,7 +1903,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x8B, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x84, // LCT
+		0x7D, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold


### PR DESCRIPTION
Summary:
- Modify LCR of P3V3_STBY Vol from 3.30 to 3.12

Test Plan:
- Build code: Pass

Log:
root@bmc-oob:~# sensor-util slot1 -t | grep P3V3_STBY
P3V3_STBY Vol                (0x16) :    3.32 Volts | (ok) | UCR: 3.47 | UNC: NA | UNR: NA | LCR: 3.12 | LNC: NA | LNR: NA