### PR TITLE
fby3.5: rf: Version commit for oby35-rf-2022.38.01

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_version.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_version.h
@@ -33,7 +33,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x01
+#define FIRMWARE_REVISION_2 0x02
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -42,7 +42,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x34
+#define BIC_FW_WEEK 0x38
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x72 // char: r
 #define BIC_FW_platform_1 0x66 // char: f


### PR DESCRIPTION
- Summary:
  Version commit for Yv3.5 RainbowFalls BIC oby35-rf-2022.38.01.

- Test Plan:
  Build code: Pass
  Get BIC version: Pass

Tested:
```
root@bmc-oob:~# fw-util slot1 --version 1ou_bic
1OU Bridge-IC Version: oby35-rf-v2022.38.01
root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x15 0xA0 0x00 0x5 0x18 0x1
15 A0 00 05 07 01 00 00 80 13 01 02 BF 15 A0 00
00 00 00 00 00 00
root@bmc-oob:~#
```

Signed-off-by: Scron Chang <Scron.Chang@quantatw.com>