### PR TITLE
fby3.5: hd: Version commit for oby35-hd-2022.38.01

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_sdr_table.c
@@ -1903,7 +1903,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x8B, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x84, // LCT
+		0x7D, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold

--- a/meta-facebook/yv35-hd/src/platform/plat_version.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_version.h
@@ -23,12 +23,18 @@
 #define PROJECT_NAME "Half Dome"
 #define PROJECT_STAGE EVT
 
-#define BOARD_ID 0x01
+/*
+ * 0x01 Crater Lake
+ * 0x02 Baseboard
+ * 0x03 Rainbow Falls
+ * 0x04 Half Dome
+ */
+#define BOARD_ID 0x04
 #define DEVICE_ID 0x00
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x05
+#define FIRMWARE_REVISION_2 0x06
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -37,7 +43,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x37
+#define BIC_FW_WEEK 0x38
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x68 // char: h
 #define BIC_FW_platform_1 0x64 // char: d


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 HalfDome BIC oby35-hd-2022.38.01.

Test Plan:
- Build code: Pass
- Get BIC version: Pass

Log:
root@bmc-oob:~# fw-util slot1 --version bic
SB Bridge-IC Version: oby35-hd-v2022.38.01

root@bmc-oob:~# bic-util slot1 0x18 0x1
00 80 14 06 02 BF 15 A0 00 00 00 00 00 00 00
