### PR TITLE
wc: mb: Version commit for obwc-mb-2022.38.01

### DIFF
--- a/common/dev/tmp75.c
+++ b/common/dev/tmp75.c
@@ -30,7 +30,7 @@ uint8_t tmp75_read(uint8_t sensor_num, int *reading)
 	msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
 	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
 	msg.tx_len = 1;
-	msg.rx_len = 1;
+	msg.rx_len = 2;
 	msg.data[0] = sensor_config[sensor_config_index_map[sensor_num]].offset;
 
 	if (i2c_master_read(&msg, retry))

--- a/meta-facebook/wc-mb/src/platform/plat_version.h
+++ b/meta-facebook/wc-mb/src/platform/plat_version.h
@@ -31,7 +31,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x04 // Count of release firmware at each stage.
+#define FIRMWARE_REVISION_2 0x05 // Count of release firmware at each stage.
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -40,7 +40,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x37
+#define BIC_FW_WEEK 0x38
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x77 // char: w
 #define BIC_FW_platform_1 0x63 // char: c


### PR DESCRIPTION
Summary:
- Version commit for Waimea Canyon BIC obwc-mb-2022.38.01.

Test Plan:
- Build code: Pass
- Get BIC version: Pass

Log:
- BMC console:
  ```
  root@bmc-oob:~# fw-util mb --version bic
  MB Bridge-IC Version: wc-v2022.38.01

  root@bmc-oob:~# bic-util mb 0x18 0x1
  00 80 11 05 02 BF 15 A0 00 00 00 00 00 00 00
  ```