### PR TITLE
Common: extend BIC warm reset delay time

### DIFF
--- a/common/lib/util_sys.c
+++ b/common/lib/util_sys.c
@@ -50,7 +50,7 @@ bool is_ac_lost()
 }
 
 /* bic warm reset work */
-#define bic_warm_reset_delay 200
+#define bic_warm_reset_delay 2000
 
 void bic_warm_reset()
 {


### PR DESCRIPTION
Summary:
- Sometimes BMC can't receive the last package response after update BIC image, because BIC didn't send out the response yet before BIC reset

Test Plan:
- Build code: PASS

Before extending reset delay time, fail rate:
Slot1 8/922,
Slot3 12/940,

After extending reset delay time,  11000 loops pass.