### PR TITLE
Common: Modify APML handler

### DIFF
--- a/common/service/apml/apml.c
+++ b/common/service/apml/apml.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include "hal_i2c.h"
 #include "apml.h"
+#include "power_status.h"
 
 #define RETRY_MAX 3
 #define MAILBOX_COMPLETE_RETRY_MAX 200
@@ -404,6 +405,14 @@ static void apml_handler(void *arvg0, void *arvg1, void *arvg2)
 		ret = APML_ERROR;
 		memset(&msg_data, 0, sizeof(apml_msg));
 		k_msgq_get(&apml_msgq, &msg_data, K_FOREVER);
+
+		if (get_post_status() == false) {
+			if (msg_data.error_cb_fn) {
+				msg_data.error_cb_fn(&msg_data);
+			}
+			k_msleep(10);
+			continue;
+		}
 
 		switch (msg_data.msg_type) {
 		case APML_MSG_TYPE_MAILBOX:


### PR DESCRIPTION
Summary:
- Abandon APML msg if post code not complete .

Test plan:
- Build code: Pass

Log:
sensor read value of HalfDome
root@bmc-oob:~# sensor-util slot1
slot1:
MB Inlet Temp                (0x1) :   32.00 C     | (ok)
MB Outlet Temp               (0x2) :   44.00 C     | (ok)
FIO Temp                     (0x3) :   28.00 C     | (ok)
CPU Temp                     (0x4) :   58.75 C     | (ok)
DIMMA Temp                   (0x5) :   39.75 C     | (ok)
DIMMB Temp                   (0x6) :   38.25 C     | (ok)
DIMMC Temp                   (0x7) :   39.50 C     | (ok)
DIMME Temp                   (0x8) :   38.00 C     | (ok)
DIMMG Temp                   (0x9) :   34.00 C     | (ok)
DIMMH Temp                   (0xA) :   32.25 C     | (ok)
DIMMI Temp                   (0xB) :   32.00 C     | (ok)
DIMMK Temp                   (0xC) :   32.25 C     | (ok)
SSD Temp                     (0xD) :   37.00 C     | (ok)
HSC Temp                     (0xE) :   44.12 C     | (ok)
CPU0 VR Temp                 (0xF) :   51.00 C     | (ok)
SOC VR Temp                  (0x10) :   53.00 C     | (ok)
CPU1 VR Temp                 (0x11) :   39.00 C     | (ok)
PVDDIO VR Temp               (0x12) :   40.00 C     | (ok)
PVDD11 VR Temp               (0x13) :   39.00 C     | (ok)
P12V_STBY Vol                (0x14) :   12.06 Volts | (ok)
PVDD18_S5 Vol                (0x15) :    1.81 Volts | (ok)
P3V3_STBY Vol                (0x16) :    3.31 Volts | (ok)
PVDD11_S3 Vol                (0x17) :    1.11 Volts | (ok)
P3V_BAT Vol                  (0x18) :    2.87 Volts | (ok)
PVDD33_S5 Vol                (0x19) :    3.32 Volts | (ok)
P5V_STBY Vol                 (0x1A) :    5.00 Volts | (ok)
P12V_MEM_1 Vol               (0x1B) :   12.06 Volts | (ok)
P12V_MEM_0 Vol               (0x1C) :   12.08 Volts | (ok)
P1V2_STBY Vol                (0x1D) :    1.20 Volts | (ok)
P3V3_M2 Vol                  (0x1E) :    3.31 Volts | (ok)
P1V8_STBY Vol                (0x1F) :    1.81 Volts | (ok)
HSC Input Vol                (0x20) :   12.07 Volts | (ok)
CPU0 VR Vol                  (0x21) :    0.98 Volts | (ok)
SOC VR Vol                   (0x22) :    1.10 Volts | (ok)
CPU1 VR Vol                  (0x23) :    0.98 Volts | (ok)
PVDDIO VR Vol                (0x24) :    1.10 Volts | (ok)
PVDD11 VR Vol                (0x25) :    1.10 Volts | (ok)
HSC Output Cur               (0x26) :   11.45 Amps  | (ok)
CPU0 VR Cur                  (0x27) :    4.70 Amps  | (ok)
SOC VR Cur                   (0x28) :   46.70 Amps  | (ok)
CPU1 VR Cur                  (0x29) :    7.10 Amps  | (ok)
PVDDIO VR Cur                (0x2A) :   30.90 Amps  | (ok)
PVDD11 VR Cur                (0x2B) :    7.90 Amps  | (ok)
HSC Input Pwr                (0x2C) :  138.50 Watts | (ok)
CPU0 VR Pwr                  (0x2D) :    4.00 Watts | (ok)
SOC VR Pwr                   (0x2E) :   50.00 Watts | (ok)
CPU1 VR Pwr                  (0x2F) :    7.00 Watts | (ok)
PVDDIO VR Pwr                (0x30) :   34.00 Watts | (ok)
PVDD11 VR Pwr                (0x31) :    9.00 Watts | (ok)
CPU Pwr                      (0x32) :  121.63 Watts | (ok)
DIMMA Pwr                    (0x33) :    0.88 Watts | (ok)
DIMMB Pwr                    (0x34) :    0.50 Watts | (ok)
DIMMC Pwr                    (0x35) :    1.25 Watts | (ok)
DIMME Pwr                    (0x36) :    1.12 Watts | (ok)
DIMMG Pwr                    (0x37) :    1.38 Watts | (ok)
DIMMH Pwr                    (0x38) :    0.62 Watts | (ok)
DIMMI Pwr                    (0x39) :    0.62 Watts | (ok)
DIMMK Pwr                    (0x3A) :    2.00 Watts | (ok)