### PR TITLE
common: shell: Improve shell sensor read command

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -56,12 +56,48 @@ static bool sensor_poll_enable_flag = true;
 static bool is_sensor_initial_done = false;
 static bool is_sensor_ready_flag = false;
 
-const int negative_ten_power[16] = { 1,	    1,		1,	   1,	     1,	      1,
-				     1,	    1000000000, 100000000, 10000000, 1000000, 100000,
-				     10000, 1000,	100,	   10 };
+const int negative_ten_power[16] = { 1,     1,		1,	 1,	1,       1,
+				     1,     1000000000, 100000000, 10000000, 1000000, 100000,
+				     10000, 1000,       100,       10 };
 
 sensor_cfg *sensor_config;
 uint8_t sensor_config_count;
+
+// clang-format off
+const char *const sensor_type_name[] = {
+	sensor_name_to_num(tmp75)
+	sensor_name_to_num(adc)
+	sensor_name_to_num(peci)
+	sensor_name_to_num(isl69259)
+	sensor_name_to_num(hsc)
+	sensor_name_to_num(nvme)
+	sensor_name_to_num(pch)
+	sensor_name_to_num(mp5990)
+	sensor_name_to_num(isl28022)
+	sensor_name_to_num(pex89000)
+	sensor_name_to_num(tps53689)
+	sensor_name_to_num(xdpe15284)
+	sensor_name_to_num(ltc4282)
+	sensor_name_to_num(fan)
+	sensor_name_to_num(tmp431)
+	sensor_name_to_num(pmic)
+	sensor_name_to_num(ina233)
+	sensor_name_to_num(isl69254)
+	sensor_name_to_num(max16550a)
+	sensor_name_to_num(ina230)
+	sensor_name_to_num(xdpe12284c)
+	sensor_name_to_num(raa229621)
+	sensor_name_to_num(nct7718w)
+	sensor_name_to_num(ltc4286)
+#ifdef ENABLE_APML
+	sensor_name_to_num(amd_tsi)
+	sensor_name_to_num(apml_mailbox)
+#endif
+	sensor_name_to_num(xdpe19283b)
+	sensor_name_to_num(g788p81u)
+	sensor_name_to_num(mp2856gut)
+};
+// clang-format on
 
 SENSOR_DRIVE_INIT_DECLARE(tmp75);
 SENSOR_DRIVE_INIT_DECLARE(ast_adc);

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -25,6 +25,8 @@
 #include "sdr.h"
 #include "libutil.h"
 
+#define sensor_name_to_num(x) #x,
+
 #define SENSOR_POLL_STACK_SIZE 2048
 #define NONE 0
 
@@ -402,6 +404,7 @@ extern sensor_cfg *sensor_config;
 // Mapping sensor number to sensor config index
 extern uint8_t sensor_config_index_map[SENSOR_NUM_MAX];
 extern uint8_t sensor_config_count;
+extern const char *const sensor_type_name[];
 
 void clear_unaccessible_sensor_cache(uint8_t sensor_num);
 uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode);

--- a/common/shell/commands/sensor_shell.h
+++ b/common/shell/commands/sensor_shell.h
@@ -19,8 +19,6 @@
 
 #include <shell/shell.h>
 
-#define sensor_name_to_num(x) #x,
-
 /* According to IPMI specification Table 43, length of sensor name maximum is 16 bytes. */
 #define MAX_SENSOR_NAME_LENGTH 32 // 31 bytes sensor name and 1 byte null character
 


### PR DESCRIPTION
Summary:
- Move sensor type name list to sensor.h
- Fix sensor value error problem in shell sensor command
- Add optional filter keyword to shell sensor list_all command
  - platform sensor list_all **optional keyword**
    - **optional keyword**: from sensor name or sensor type name

Test Plan:
- Build Code: PASS
- Check sensor reading from BIC console: PASS

Log:
- BIC console:
  ```
  /* check from sensor name */
  uart:~$ platform sensor list_all IOM
  ---------------------------------------------------------------------------------
  [0x3 ] IOM Temp                 : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.000
  [0x6b] IOM INA Pwr              : ina230     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    17.250
  [0x47] IOM INA Cur              : ina230     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.437
  [0x2f] IOM INA vol              : ina230     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    11.998
  ---------------------------------------------------------------------------------

  /* check from sensor type name */
  uart:~$ platform sensor list_all isl
  ---------------------------------------------------------------------------------
  [0x2d] VCCD VR Vol              : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.143
  [0x2e] FAON VR Vol              : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.980
  [0x2c] EHV VR Vol               : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.800
  [0x2a] VCCIN VR Vol             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.784
  [0x2b] FIVRA VR Vol             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.796
  [0x44] VCCD VR Cur              : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.700
  [0x45] VCCD VR Cur in           : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.210
  [0x46] FAON VR Cur              : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     6.900
  [0x43] EHV VR Cur               : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.800
  [0x41] VCCIN VR Cur             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    17.700
  [0x42] FIVRA VR Cur             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.600
  [0x11] VCCD SPS Temp            : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
  [0x12] FAON SPS Temp            : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
  [0x10] EHV SPS Temp             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    37.000
  [0xe ] VCCIN SPS Temp           : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    43.000
  [0xf ] FIVRA SPS Temp           : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    42.000
  [0x69] VCCD VR Pout             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.000
  [0x6a] FAON VR Pout             : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     7.000
  [0x68] EHV VR Pout              : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.000
  [0x66] VCCIN VR Pout            : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    30.000
  [0x67] FIVRA VR Pout            : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     8.000
  ---------------------------------------------------------------------------------
  ```