### PR TITLE
fby3:dl:support 2nd source for outlet temperature

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_sensor_table.c
@@ -366,6 +366,63 @@ static int check_vr_type(void)
 	return -1;
 }
 
+void check_outlet_temp_type(uint8_t index)
+{
+	if (index >= sensor_config_count) {
+		printf("Out of sensor_config_count\n");
+		return;
+	}
+
+	uint8_t retry = 5;
+	I2C_MSG msg;
+	uint8_t CID = 0;
+	uint8_t VID = 0;
+
+	/* Get Chip ID and Manufacturer ID
+	 * - Command code: 0xFD, 0xFE
+	 * TMP431: 0x31 0x55
+	 * NCT7718W: 0x50 0x50
+	 * G788P81U: 0x50 0x47
+	 */
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = sensor_config[index].port;
+	msg.target_addr = sensor_config[index].target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 1;
+	msg.data[0] = NCT7718W_CHIP_ID_OFFSET;
+
+	if (i2c_master_read(&msg, retry)) {
+		printf("Failed to read Outlet_Temp chip ID: register(0x%x)\n",
+		       NCT7718W_CHIP_ID_OFFSET);
+		return;
+	}
+	CID = msg.data[0];
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = sensor_config[index].port;
+	msg.target_addr = sensor_config[index].target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 1;
+	msg.data[0] = NCT7718W_VENDOR_ID_OFFSET;
+
+	if (i2c_master_read(&msg, retry)) {
+		printf("Failed to read Outlet_Temp vendor ID: register(0x%x)\n",
+		       NCT7718W_VENDOR_ID_OFFSET);
+		return;
+	}
+	VID = msg.data[0];
+
+	if ((CID == 0x31) && (VID == 0x55)) {
+		sensor_config[index].type = sensor_dev_tmp431;
+	} else if ((CID == 0x50) && (VID == 0x50)) {
+		sensor_config[index].type = sensor_dev_nct7718w;
+	} else if ((CID == 0x50) && (VID == 0x47)) {
+		sensor_config[index].type = sensor_dev_g788p81u;
+	} else {
+		printf("Unknown Outlet_Temp type\n");
+	}
+}
+
 void pal_extend_sensor_config()
 {
 	uint8_t sensor_count = 0;
@@ -381,6 +438,13 @@ void pal_extend_sensor_config()
 	default:
 		printf("Using default VR(INF) sensor table\n");
 		break;
+	}
+
+	/* Check outlet temperature sensor type */
+	for (uint8_t index = 0; index < sensor_config_count; index++) {
+		if (sensor_config[index].type == sensor_dev_tmp431) {
+			check_outlet_temp_type(index);
+		}
 	}
 
 	return;


### PR DESCRIPTION
Summary:
- Support nct7718 and g788p81u on yv3 dl.
- Check the CID and MID of the temperature ic when bic init sensor list.

Test plan:
build code : pass

root@bmc-oob:~# sensor-util slot1
slot1:
MB Inlet Temp                (0x1) :   26.00 C     | (ok)
MB Outlet Temp               (0x2) :   26.00 C     | (ok)
FRONT IO Temp                (0x3) : NA | (na)
PCH Temp                     (0x4) : NA | (na)
SOC CPU Temp                 (0x5) : NA | (na)
SOC Therm Margin             (0xD) : NA | (na)
SOC CPU TjMax                (0x25) : NA | (na)
CPU Package Pwr              (0x1E) : NA | (na)
SOC DIMMA Temp               (0x6) : NA | (na)
SOC DIMMB Temp               (0x7) : NA | (na)
SOC DIMMC Temp               (0x9) : NA | (na)
SOC DIMMD Temp               (0xA) : NA | (na)
SOC DIMME Temp               (0xB) : NA | (na)
SOC DIMMF Temp               (0xC) : NA | (na)
SSD0 Temp                    (0xE) : 0/NA | (na)
HSC Temp                     (0xF) :   28.00 C     | (ok)
VCCIN VR Temp                (0x10) : NA | (na)
VCCSA VR Temp                (0x11) : NA | (na)
VCCIO VR Temp                (0x12) : NA | (na)
3V3_STBY VR Temp             (0x13) :   31.00 C     | (ok)
VDDQ_ABC VR Temp             (0x14) : NA | (na)
VDDQ_DEF VR Temp             (0x15) : NA | (na)
P12V_STBY Vol                (0x20) :   11.78 Volts | (ok)
P3V_BAT Vol                  (0x21) :    3.01 Volts | (ok)
P3V3_STBY Vol                (0x22) :    3.28 Volts | (ok)
P1V05_PCH Vol                (0x23) :    1.04 Volts | (ok)
PVNN_PCH Vol                 (0x24) :    1.00 Volts | (ok)
HSC Input Vol                (0x26) :   11.82 Volts | (ok)
VCCIN VR Vol                 (0x27) : NA | (na)
VCCSA VR Vol                 (0x28) : NA | (na)
VCCIO VR Vol                 (0x29) : NA | (na)
P3V3_STBY VR Vol             (0x2A) :    3.28 Volts | (ok)
VDDQ_ABC VR Vol              (0x2C) : NA | (na)
VDDQ_DEF VR Vol              (0x2D) : NA | (na)
HSC Output Cur               (0x30) :    0.00 Amps  | (ok)
VCCIN VR Cur                 (0x31) : NA | (na)
VCCSA VR Cur                 (0x32) : NA | (na)
VCCIO VR Cur                 (0x33) : NA | (na)
P3V3_STBY VR Cur             (0x34) :    0.40 Amps  | (ok)
VDDQ_ABC VR Cur              (0x35) : NA | (na)
VDDQ_DEF VR Cur              (0x36) : NA | (na)
HSC Input Pwr                (0x2E) :    0.00 Watts | (ok)
HSC Input AvgPwr             (0x39) :    0.00 Watts | (ok)
VCCIN VR Pout                (0x3A) : NA | (na)
VCCSA VR Pout                (0x3C) : NA | (na)
VCCIO VR Pout                (0x3D) : NA | (na)
P3V3_STBY VRPout             (0x3E) :    0.00 Watts | (ok)
VDDQ_ABC VRPout              (0x3F) : NA | (na)
VDDQ_DEF VRPout              (0x42) : NA | (na)