### PR TITLE
fby3.5: common: Correct logging service type in ipmi command

### DIFF
--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -169,7 +169,7 @@ bool common_add_sel_evt_record(common_addsel_msg_t *sel_msg)
 	uint8_t evt_msg_version = 0x04;
 	ipmi_msg *msg = (ipmi_msg *)malloc(sizeof(ipmi_msg));
 	if (msg == NULL) {
-		LOG_DBG("Malloc fail");
+		LOG_ERR("Add sel msg malloc fail");
 		return false;
 	}
 	memset(msg, 0, sizeof(ipmi_msg));
@@ -310,7 +310,7 @@ void IPMI_handler(void *arug0, void *arug1, void *arug2)
 				k_msleep(10);
 				kcs_buff = malloc(KCS_BUFF_SIZE * sizeof(uint8_t));
 				if (kcs_buff == NULL) {
-					LOG_DBG("IPMI_handler: Fail to malloc for kcs_buff");
+					LOG_ERR("IPMI_handler: Fail to malloc for kcs_buff");
 					continue;
 				}
 			}

--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -677,7 +677,7 @@ __weak void OEM_1S_PECI_ACCESS(ipmi_msg *msg)
 		}
 		writeBuf = (uint8_t *)malloc(sizeof(uint8_t) * writeLen);
 		if ((readBuf == NULL) || (writeBuf == NULL)) {
-			LOG_DBG("PECI access util buffer alloc fail");
+			LOG_ERR("PECI access util buffer alloc fail");
 			SAFE_FREE(writeBuf);
 			SAFE_FREE(readBuf);
 			msg->completion_code = CC_OUT_OF_SPACE;
@@ -1262,10 +1262,8 @@ __weak void OEM_1S_READ_BIC_REGISTER(ipmi_msg *msg)
 	* data 0~3: start of register address to read, LSB first
 	* data 4  : bytes to read
 	***********************************/
-	if (!msg) {
-		LOG_DBG("pal_OEM_1S_READ_BIC_REGISTER: parameter msg is NULL");
-		return;
-	}
+	CHECK_NULL_ARG(msg);
+
 	if (msg->data_len != 5) {
 		msg->completion_code = CC_INVALID_LENGTH;
 		return;
@@ -1289,10 +1287,8 @@ __weak void OEM_1S_WRITE_BIC_REGISTER(ipmi_msg *msg)
 	*
 	* NOTE: The register address must be a multiple of 4
 	***********************************/
-	if (!msg) {
-		LOG_DBG("pal_OEM_1S_WRITE_BIC_REGISTER: parameter msg is NULL");
-		return;
-	}
+	CHECK_NULL_ARG(msg);
+
 	if (msg->data[4] < 1 || msg->data[4] > 4 || (msg->data_len != 5 + msg->data[4])) {
 		msg->completion_code = CC_INVALID_LENGTH;
 		return;
@@ -1515,10 +1511,7 @@ __weak void OEM_1S_MULTI_ACCURACY_SENSOR_READING(ipmi_msg *msg)
 	Response -
 	data 0: Completion code
 	***********************************/
-	if (!msg) {
-		LOG_DBG("failed due to parameter *msg is NULL");
-		return;
-	}
+	CHECK_NULL_ARG(msg);
 
 	if (!msg->data_len) {
 		msg->completion_code = CC_INVALID_LENGTH;

--- a/common/service/ipmi/oem_handler.c
+++ b/common/service/ipmi/oem_handler.c
@@ -92,7 +92,7 @@ __weak void OEM_SET_SYSTEM_GUID(ipmi_msg *msg)
 
 	if (msg->data_len != 16) {
 		msg->completion_code = CC_INVALID_LENGTH;
-		LOG_DBG("Message Data invalid length");
+		LOG_ERR("Message Data invalid length");
 		return;
 	}
 

--- a/common/service/ipmi/storage_handler.c
+++ b/common/service/ipmi/storage_handler.c
@@ -255,7 +255,7 @@ __weak void STORAGE_ADD_SEL(ipmi_msg *msg)
 
 	add_sel_msg = (ipmi_msg *)malloc(sizeof(ipmi_msg));
 	if (add_sel_msg == NULL) {
-		LOG_DBG("Malloc fail");
+		LOG_ERR("Storge add sel msg malloc fail");
 		msg->completion_code = CC_UNSPECIFIED_ERROR;
 		return;
 	}


### PR DESCRIPTION
Summary:
- Correct logging service type in ipmi command.
- Swapped the ipmi command checks for NULL input parameters to the new NULL check macro.

Test Plan:
- Build code: Pass
- 12V-cycle/DC cycle 50 times: Pass
- IPMI storge/oem commands don't show abnormal log: Pass

Log:
[00:00:00.003,000] <inf> usb_dc_aspeed: select ep[0x82] as IN endpoint [00:00:00.003,000] <wrn> usb_dc_aspeed: pre-selected ep[0x1] as IN endpoint *** Booting Zephyr OS buater Lake 2022.37.2
BIC class type(class-1), 1ou present status(0), 2ou present status(0), board revision(0x5) [00:00:00.003,000] <inf> usb_dc_aspeed: select ep[0x3] as OUT endpoint [00:00:00.056,000] <inf> kcs_aspeed: KCS3: addr=0xca2, idr=0x2c, odr=0x38, str=0x44

[add_sensor_config] replace the sensor[0x02] configuration [add_sensor_config] replace the sensor[0x0e] configuration [spi1_cs0]SFDP magic 00000000 invalid
[00:00:00.197,000] <inf> ipmb: Initial IPMB TX/RX threads, bus(0x6), addr(0x10) [00:00:00.197,000] <inf> ipmb: Initial IPMB TX/RX threads, bus(0x2), addr(0x16) [00:00:00.200,000] <inf> usb_cdc_acm: Device suspended [00:00:00.207,000] <wrn> power_status: DC_STATUS: on [00:00:00.207,000] <wrn> power_status: POST_COMPLETE: yes [00:00:00.207,000] <wrn> power_status: CPU_PWR_GOOD: yes

uart:~$ [00:00:00.429,000] <inf> usb_cdc_acm: Device resumed [00:00:00.429,000] <inf> usb_cdc_acm: from suspend [00:00:00.734,000] <inf> usb_cdc_acm: Device configured BIC Ready