### PR TITLE
fby3.5: common: Refactor gpio initial flow

### DIFF
--- a/common/hal/hal_gpio.h
+++ b/common/hal/hal_gpio.h
@@ -60,6 +60,8 @@
 
 #define REG_GPIO_BASE 0x7e780000
 #define REG_SCU 0x7E6E2000
+#define REG_DIRECTION_OFFSET 4
+
 extern uint32_t GPIO_GROUP_REG_ACCESS[];
 extern uint32_t GPIO_MULTI_FUNC_PIN_CTL_REG_ACCESS[];
 extern const int GPIO_MULTI_FUNC_CFG_SIZE;
@@ -84,7 +86,7 @@ typedef struct _SET_GPIO_VALUE_CFG_ {
 
 extern GPIO_CFG gpio_cfg[];
 
-enum {
+enum GPIO_GROUP {
 	GPIO_A_D,
 	GPIO_E_H,
 	GPIO_I_L,


### PR DESCRIPTION
Summary:
- Refactor gpio initial flow.

Test Plan:
- Build code: Pass
- Check gpio initial setting is match with gpio table: Pass
- Check BIC no abnormal event when BIC reset and 12V-cycle: 200 tims pass

Log:
- gpio configuration after gpio initialization uart:~$ platform gpio list_all
[0  ] FM_BMC_PCH_SCI_LPC_R_N             : OD  | output(I) | 1(1)
[1  ] FM_BIOS_POST_CMPLT_BMC_N           : OD  | input (I) | 0(0)
[2  ] FM_SLPS3_PLD_N                     : PP  | input (I) | 1(1)
[3  ] IRQ_BMC_PCH_SMI_LPC_R_N            : OD  | output(I) | 1(1)
[4  ] IRQ_UV_DETECT_N                    : OD  | input (I) | 1(1)
[5  ] FM_UV_ADR_TRIGGER_EN_R             : OD  | output(I) | 1(1)
[6  ] IRQ_SMI_ACTIVE_BMC_N               : OD  | input (I) | 1(1)
[7  ] HSC_SET_EN_R                       : PP  | output(O) | 0(0)
[8  ] FM_BIC_RST_RTCRST_R                : PP  | output(O) | 0(0)
[9  ] RST_USB_HUB_N_R                    : OD  | output(I) | 1(1)
[10 ] A_P3V_BAT_SCALED_EN_R              : PP  | output(O) | 0(0)
[11 ] FM_SPI_PCH_MASTER_SEL_R            : PP  | output(O) | 0(0)
[12 ] FM_PCHHOT_N                        : OD  | input (I) | 1(1)
[13 ] FM_SLPS4_PLD_N                     : PP  | input (I) | 1(1)
[14 ] FM_S3M_CPU0_CD_INIT_ERROR          : OD  | input (I) | 0(0)
[15 ] PWRGD_SYS_PWROK                    : PP  | input (I) | 1(1)
[16 ] FM_HSC_TIMER                       : OD  | input (I) | 0(0)
[17 ] IRQ_SMB_IO_LVC3_STBY_ALRT_N        : OD  | input (I) | 1(1)
[18 ] IRQ_CPU0_VRHOT_N                   : OD  | input (I) | 1(1)
[19 ] DBP_CPU_PREQ_BIC_N                 : OD  | output(I) | 1(1)
[20 ] FM_CPU_THERMTRIP_LATCH_LVT3_N      : OD  | input (I) | 1(1)
[21 ] FM_CPU_SKTOCC_LVT3_PLD_N           : OD  | input (I) | 0(0)
[22 ] H_CPU_MEMHOT_OUT_LVC3_N            : PP  | input (I) | 1(1)
[23 ] RST_PLTRST_PLD_N                   : PP  | input (I) | 1(1)
[24 ] PWRBTN_N                           : OD  | input (I) | 1(1)
[25 ] RST_BMC_R_N                        : OD  | output(I) | 1(1)
[26 ] H_BMC_PRDY_BUF_N                   : OD  | input (I) | 1(1)
[27 ] BMC_READY                          : PP  | output(O) | 1(1)
[28 ] BIC_READY                          : PP  | output(O) | 1(1)
[29 ] FM_RMCA_LVT3_N                     : PP  | input (I) | 1(1)
[30 ] HSC_MUX_SWITCH_R                   : PP  | output(O) | 0(0)
[31 ] FM_FORCE_ADR_N_R                   : OD  | output(I) | 1(1)
[32 ] PWRGD_CPU_LVC3                     : PP  | input (I) | 1(1)
[33 ] FM_PCH_BMC_THERMTRIP_N             : OD  | output(I) | 1(1)
[34 ] FM_THROTTLE_R_N                    : OD  | input (I) | 1(1)
[35 ] IRQ_HSC_ALERT2_N                   : OD  | input (I) | 1(1)
[36 ] SMB_SENSOR_LVC3_ALERT_N            : OD  | input (I) | 1(1)
[37 ] FM_CATERR_LVT3_N                   : PP  | input (I) | 1(1)
[38 ] SYS_PWRBTN_N                       : OD  | input (I) | 1(1)
[39 ] RST_PLTRST_BUF_N                   : PP  | input (I) | 1(1)
[40 ] IRQ_BMC_PCH_NMI_R                  : PP  | output(O) | 0(0)
[41 ] IRQ_SML1_PMBUS_ALERT_N             : OD  | input (I) | 1(1)
[42 ] IRQ_PCH_CPU_NMI_EVENT_N            : OD  | input (I) | 1(1)
[43 ] FM_BMC_DEBUG_ENABLE_N              : OD  | output(I) | 1(1)
[44 ] FM_DBP_PRESENT_N                   : OD  | input (I) | 1(1)
[45 ] FM_FAST_PROCHOT_EN_N_R             : PP  | output(O) | 0(0)
[46 ] FM_SPI_MUX_OE_CTL_PLD_N            : PP  | output(O) | 0(0)
[47 ] FBRK_N_R                           : OD  | output(I) | 1(1)
[48 ] FM_PEHPCPU_INT                     : PP  | input (I) | 0(0)
[49 ] FM_BIOS_MRC_DEBUG_MSG_DIS_R        : OD  | output(I) | 1(1)
[50 ] FAST_PROCHOT_N                     : OD  | input (I) | 1(1)
[51 ] FM_JTAG_TCK_MUX_SEL_R              : PP  | output(O) | 0(0)
[52 ] BMC_JTAG_SEL_R                     : PP  | output(O) | 0(0)
[53 ] H_CPU_ERR0_LVC3_N                  : PP  | input (I) | 1(1)
[54 ] H_CPU_ERR1_LVC3_N                  : PP  | input (I) | 1(1)
[55 ] H_CPU_ERR2_LVC3_N                  : PP  | input (I) | 1(1)
[56 ] RST_RSMRST_BMC_N                   : PP  | input (I) | 1(1)
[57 ] FM_MP_PS_FAIL_N                    : OD  | input (I) | 1(1)
[58 ] H_CPU_MEMTRIP_LVC3_N               : OD  | input (I) | 1(1)
[59 ] FM_CPU_BIC_PROCHOT_LVT3_N          : PP  | input (I) | 1(1)
[91 ] BOARD_ID2                          : PP  | input (I) | 0(0)
[92 ] IRQ_PVCCD_CPU0_VRHOT_LVC3_N        : OD  | input (I) | 1(1)
[93 ] FM_PVCCIN_CPU0_PWR_IN_ALERT_N      : OD  | input (I) | 1(1)
[94 ] BOARD_ID0                          : PP  | input (I) | 0(0)
[95 ] BOARD_ID1                          : PP  | input (I) | 0(0)
[97 ] BOARD_ID3                          : PP  | input (I) | 0(0)
[99 ] FM_THROTTLE_IN_N                   : OD  | output(I) | 1(1)
[100] AUTH_COMPLETE                      : PP  | input (I) | 0(0)
[101] AUTH_PRSNT_N                       : OD  | input (I) | 1(1)
[104] SGPIO_BMC_CLK_R                    : PP  | input (I) | 0(0)
[105] SGPIO_BMC_LD_R_N                   : PP  | input (I) | 0(0)
[106] SGPIO_BMC_DOUT_R                   : PP  | input (I) | 0(0)
[107] SGPIO_BMC_DIN                      : PP  | input (I) | 0(0)