### PR TITLE
Common: fix missing sensor number

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -96,6 +96,8 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(xdpe19283b)
 	sensor_name_to_num(g788p81u)
 	sensor_name_to_num(mp2856gut)
+	sensor_name_to_num(ddr5_power)
+	sensor_name_to_num(ddr5_temp)
 };
 // clang-format on
 


### PR DESCRIPTION
Summary:
- Add the sensor_name_to_num of ddr5_temp and ddr5_power.

Test Plan:
- Build code: PASS.
- Check sensor name: PASS.

Log:
```
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x1 ] MB Inlet Temp            : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    34.000
[0x2 ] MB Outlet Temp           : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.000
[0x3 ] FIO Temp                 : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    29.000
[0xe ] HSC Temp                 : nct7718w   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.625
[0xd ] SSD Temp                 : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x4 ] CPU Temp                 : amd_tsi    | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5 ] DIMMA Temp               : ddr5_temp  | access[X] | poll[O] 1    sec | not_accesible             | na
[0x6 ] DIMMB Temp               : ddr5_temp  | access[X] | poll[O] 1    sec | not_accesible             | na
[0x7 ] DIMMC Temp               : ddr5_temp  | access[X] | poll[O] 1    sec | not_accesible             | na
[0x8 ] DIMME Temp               : ddr5_temp  | access[X] | poll[O] 1    sec | not_accesible             | na
[0x9 ] DIMMG Temp               : ddr5_temp  | access[X] | poll[O] 1    sec | not_accesible             | na
[0xa ] DIMMH Temp               : ddr5_temp  | access[X] | poll[O] 1    sec | not_accesible             | na
[0xb ] DIMMI Temp               : ddr5_temp  | access[X] | poll[O] 1    sec | not_accesible             | na
[0xc ] DIMMK Temp               : ddr5_temp  | access[X] | poll[O] 1    sec | not_accesible             | na
[0x32] CPU Pwr                  : apml_mailbox | access[X] | poll[O] 1    sec | not_accesible             | na
[0x33] DIMMA Pwr                : ddr5_power | access[X] | poll[O] 1    sec | not_accesible             | na
[0x34] DIMMB Pwr                : ddr5_power | access[X] | poll[O] 1    sec | not_accesible             | na
[0x35] DIMMC Pwr                : ddr5_power | access[X] | poll[O] 1    sec | not_accesible             | na
[0x36] DIMME Pwr                : ddr5_power | access[X] | poll[O] 1    sec | not_accesible             | na
[0x37] DIMMG Pwr                : ddr5_power | access[X] | poll[O] 1    sec | not_accesible             | na
[0x38] DIMMH Pwr                : ddr5_power | access[X] | poll[O] 1    sec | not_accesible             | na
[0x39] DIMMI Pwr                : ddr5_power | access[X] | poll[O] 1    sec | not_accesible             | na
[0x3a] DIMMK Pwr                : ddr5_power | access[X] | poll[O] 1    sec | not_accesible             | na
[0x14] P12V_STBY Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.084
[0x15] PVDD18_S5 Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.806
[0x16] P3V3_STBY Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.320
[0x17] PVDD11_S3 Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.118
[0x18] P3V_BAT Vol              : adc        | access[O] | poll[O] 3600 sec | 4byte_acur_read_success   |     3.171
[0x19] PVDD33_S5 Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.320
[0x1a] P5V_STBY Vol             : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.998
[0x1b] P12V_MEM_1 Vol           : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.084
[0x1c] P12V_MEM_0 Vol           : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.111
[0x1d] P1V2_STBY Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.203
[0x1e] P3V3_M2 Vol              : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.314
[0x1f] P1V8_STBY Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.811
[0x21] CPU0 VR Vol              : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.895
[0x22] SOC VR Vol               : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.095
[0x23] CPU1 VR Vol              : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.894
[0x24] PVDDIO VR Vol            : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.100
[0x25] PVDD11 VR Vol            : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.100
[0x27] CPU0 VR Cur              : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.200
[0x28] SOC VR Cur               : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    35.500
[0x29] CPU1 VR Cur              : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    14.400
[0x2a] PVDDIO VR Cur            : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.900
[0x2b] PVDD11 VR Cur            : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    14.000
[0xf ] CPU0 VR Temp             : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    48.000
[0x10] SOC VR Temp              : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    50.000
[0x11] CPU1 VR Temp             : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    43.000
[0x12] PVDDIO VR Temp           : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    44.000
[0x13] PVDD11 VR Temp           : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    42.000
[0x2d] CPU0 VR Pwr              : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    10.000
[0x2e] SOC VR Pwr               : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0x2f] CPU1 VR Pwr              : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.000
[0x30] PVDDIO VR Pwr            : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.000
[0x31] PVDD11 VR Pwr            : raa229621  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    15.000
[0x20] HSC Input Vol            : hsc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.092
[0x26] HSC Output Cur           : hsc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     9.066
[0x2c] HSC Input Pwr            : hsc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |   110.985
---------------------------------------------------------------------------------
```