### PR TITLE
fby3.5: rf: Version commit for oby35-rf-2022.39.01

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_version.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_version.h
@@ -42,7 +42,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x38
+#define BIC_FW_WEEK 0x39
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x72 // char: r
 #define BIC_FW_platform_1 0x66 // char: f


### PR DESCRIPTION
Summary:
-Version commit for Yv3.5 Rainbow Falls BIC oby35-rf-2022.39.01.

Test Plan:

-Build code: Pass
-Get BIC version: Pass

Log:
root@bmc-oob:~# fw-util slot1 --version 1ou_bic
1OU Bridge-IC Version: oby35-rf-v2022.39.01

root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xa0 0x00 0x05 0x18 0x01 15 A0 00 05 07 01 00 00 80 13 02 02 BF 15 A0 00
00 00 00 00 00 00