### PR TITLE
fby3.5: cl: Fix throttle event when DC off

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.c
@@ -271,8 +271,7 @@ void ISR_HSC_THROTTLE()
 	common_addsel_msg_t sel_msg;
 	static bool is_hsc_throttle_assert = false; // Flag for filt out fake alert
 	if (gpio_get(RST_RSMRST_BMC_N) == GPIO_HIGH) {
-		if ((gpio_get(PWRGD_SYS_PWROK) == GPIO_LOW) &&
-		    (get_DC_off_delayed_status() == false)) {
+		if (gpio_get(PWRGD_SYS_PWROK) == GPIO_LOW) {
 			return;
 		} else {
 			if ((gpio_get(IRQ_SML1_PMBUS_ALERT_N) == GPIO_HIGH) &&


### PR DESCRIPTION
Summary:
- When DC off, it shouldn't log throttle event

Test plan:
- Build code: Pass
- Plug in slot with ME recovery jumpper, it shouldn't log throttle event

1    slot1    2022-09-29 23:21:22    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-09-29 23:21:22, Sensor: SPS_FW_HEALTH (0x17), Event Data: (A00000) Recovery GPIO forced
1    slot1    2022-09-29 23:21:22    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-09-29 23:21:22, Sensor: SPS_FW_HEALTH (0x17), Event Data: (A00801) Automatic Restore to Factory Presets
1    slot1    2022-09-29 23:21:22    power-util       SERVER_12V_ON successful for FRU: 1
1    slot1    2022-09-29 23:21:23    gpiointrd        FRU: 1, CPU presence
1    slot1    2022-09-29 23:21:28    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-09-29 23:21:28, Sensor: SPS_FW_HEALTH (0x17), Event Data: (A00004) Recovery GPIO forced