### PR TITLE
fby3.5: cl: Change monitor PMIC polling time

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_pmic.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_pmic.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #define MONITOR_PMIC_ERROR_STACK_SIZE 4096
-#define MONITOR_PMIC_ERROR_TIME_MS (30 * 1000) // 30s
+#define MONITOR_PMIC_ERROR_TIME_MS (3 * 1000) // 3s
 
 #define MAX_LEN_GET_PMIC_ERROR_INFO 6
 


### PR DESCRIPTION
Summary:
- To avoid PMIC error SEL show too delay, change monitor PMIC time from 30s to 3s.

Test plan:
- Build code: Pass
- Check SEL shows in 3s: Pass
- Inject error stress test: 14120 Pass

Log:
1. Check BIC sends SEL when PMIC error happened in 3 seconds. root@bmc-oob:~# log-util --print slot3
2022 Sep 21 22:33:23 log-util: User cleared FRU: 3 logs root@bmc-oob:~# dimm-util slot3 --pmic --dimm A0 --err_inj VinM_OV Error inject successfully on DIMM A0
root@bmc-oob:~# log-util --print slot3
2022 Sep 21 22:33:23 log-util: User cleared FRU: 3 logs
3    slot3    2022-09-21 22:33:36    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-21 22:33:36, Sensor: PMIC_ERR (0xB4), Event Data: (000500) DIMM A0 Vin Mgmt OV Assertion

root@bmc-oob:~# date; dimm-util slot3 --pmic --dimm A0 --err_inj Vin_switchover Wed Sep 21 22:34:34 PDT 2022
Error inject successfully on DIMM A0
root@bmc-oob:~# log-util --print slot3
2022 Sep 21 22:33:23 log-util: User cleared FRU: 3 logs
3    slot3    2022-09-21 22:34:35    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-21 22:34:35, Sensor: PMIC_ERR (0xB4), Event Data: (000B00) DIMM A0 Vin Mgmt to Vin buck switchover Assertion