### PR TITLE
fby3.5: cl: Update sensor threshold according to 20220930 sensor table

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
@@ -1785,8 +1785,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xC1, // UCT
 		0xBF, // UNCT
 		0x28, // LNRT
-		0xA4, // LCT
-		0xA6, // LNCT
+		0x92, // LCT
+		0x94, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved


### PR DESCRIPTION
Summary:
- Update sensor threshold according to 20220930 sensor table.

Test Plan:
- Build code: Pass
- Check sensor threshold is updated: Pass

Log:
root@bmc-oob:~# sensor-util slot2 --thre | grep "MB_VR_VCCIN_VOLT_V"
MB_VR_VCCIN_VOLT_V           (0x2A) :    1.78 Volts | (ok) | UCR: 1.93 | UNC: 1.91 | UNR: 2.20 | LCR: 1.46 | LNC: 1.48 | LNR: 0.40