### PR TITLE
fby3.5: cl: Change 1OU E1S VPP power event SEL

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.c
@@ -36,9 +36,9 @@ LOG_MODULE_REGISTER(plat_isr);
 uint8_t _1ou_m2_mapping_table[4] = { 4, 3, 2, 1 };
 uint8_t _1ou_m2_name_mapping_table[4] = {
 	0x3A,
-	0x3B,
 	0x3C,
-	0x3D,
+	0x3E,
+	0x37,
 };
 
 void send_gpio_interrupt(uint8_t gpio_num)
@@ -578,10 +578,10 @@ void ISR_CPU_VPP_INT()
 				sel_msg.InF_target = BMC_IPMB;
 				sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 				sel_msg.event_type = IPMI_OEM_EVENT_TYPE_NOTIFY;
-				sel_msg.sensor_number = SENSOR_NUM_VPP_POWER_CONTROL;
+				sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 				sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_VPP_EVENT;
-				sel_msg.event_data2 = _1ou_m2_name_mapping_table[device_id];
-				sel_msg.event_data3 = IPMI_OEM_EVENT_OFFSET_1OU;
+				sel_msg.event_data2 = IPMI_OEM_EVENT_OFFSET_1OU;
+				sel_msg.event_data3 = _1ou_m2_name_mapping_table[device_id];
 				if (!common_add_sel_evt_record(&sel_msg)) {
 					LOG_ERR("%s addsel fail\n", __func__);
 				}

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.h
@@ -125,7 +125,6 @@
 #define SENSOR_NUM_CPUDIMM_HOT 0xB3
 #define SENSOR_NUM_PMIC_ERROR 0xB4
 #define SENSOR_NUM_CATERR 0xEB
-#define SENSOR_NUM_VPP_POWER_CONTROL 0x46
 
 /*  threshold sensor number, DPV2  */
 #define SENSOR_NUM_VOL_DPV2_12VIN 0x91


### PR DESCRIPTION
Summary:
- Correct the data to add SEL when the 1OU E1S VPP power event happened.

Test plan:
- Build code: Pass
- Check SEL decode correctly: Pass

Log:
1. Check SEL of 1OU E1S VPP power decode successfully.
- Before fix root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON
root@bmc-oob:~# power-util slot3 1U-dev0 off
Powering fru 3 dev 1U-dev0 to OFF state...
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : OFF
root@bmc-oob:~# power-util slot3 1U-dev0 on
Powering fru 3 dev 1U-dev0 to ON state...
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON

root@bmc-oob:~# log-util --print slot3
2022 Sep 20 19:26:14 log-util: User cleared FRU: 3 logs
3    slot3    2022-09-20 19:26:26    power-util       SERVER_POWER_OFF successful for FRU: 3 DEV: 1U-dev0
3    slot3    2022-09-20 19:26:26    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 01/Fun 00, 1OU/Num 0,TotalErrID1Cnt: 0x0001, ErrID2: 0x50(Received ERR_COR Message), ErrID1: 0x00(Receiver Error)
3    slot3    2022-09-20 19:26:26    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 01/Fun 00, 1OU/Num 0,TotalErrID1Cnt: 0x0001, ErrID2: 0x21(Surprise Down Error), ErrID1: 0x50(Received ERR_COR Message)
3    slot3    2022-09-20 19:26:26    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 19:26:26, Sensor: PSB_STS (0x46), Event Data: (0B3A01) Unknown Assertion
3    slot3    2022-09-20 19:26:40    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 19:26:40, Sensor: PSB_STS (0x46), Event Data: (0B3A01) Unknown Assertion
3    slot3    2022-09-20 19:26:43    power-util       SERVER_POWER_ON successful for FRU: 3 DEV: 1U-dev0

- After fix root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON
root@bmc-oob:~# power-util slot3 1U-dev0 off
Powering fru 3 dev 1U-dev0 to OFF state...
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : OFF
root@bmc-oob:~# power-util slot3 1U-dev0 on
Powering fru 3 dev 1U-dev0 to ON state...
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON

root@bmc-oob:~# log-util --print slot3
2022 Sep 20 01:55:40 log-util: User cleared FRU: 3 logs
3    slot3    2022-09-20 01:55:48    power-util       SERVER_POWER_OFF successful for FRU: 3 DEV: 1U-dev0
3    slot3    2022-09-20 01:55:48    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 01/Fun 00, 1OU/Num 0,TotalErrID1Cnt: 0x0001, ErrID2: 0x50(Received ERR_COR Message), ErrID1: 0x00(Receiver Error)
3    slot3    2022-09-20 01:55:48    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 01/Fun 00, 1OU/Num 0,TotalErrID1Cnt: 0x0001, ErrID2: 0x21(Surprise Down Error), ErrID1: 0x50(Received ERR_COR Message)
3    slot3    2022-09-20 01:55:48    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 01:55:48, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B013A) 1OU/Num 0 VPP power control Triggered
3    slot3    2022-09-20 01:55:52    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 01:55:52, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B013A) 1OU/Num 0 VPP power control Triggered
3    slot3    2022-09-20 01:55:54    power-util       SERVER_POWER_ON successful for FRU: 3 DEV: 1U-dev0

2. Check SB BIC sends SELs when all 1OU E1S devices happened VPP power event.
- Device 0 root@bmc-oob:~# log-util --print slot3
2022 Sep 20 01:55:40 log-util: User cleared FRU: 3 logs
3    slot3    2022-09-20 01:55:48    power-util       SERVER_POWER_OFF successful for FRU: 3 DEV: 1U-dev0
3    slot3    2022-09-20 01:55:48    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 01/Fun 00, 1OU/Num 0,TotalErrID1Cnt: 0x0001, ErrID2: 0x50(Received ERR_COR Message), ErrID1: 0x00(Receiver Error)
3    slot3    2022-09-20 01:55:48    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 01/Fun 00, 1OU/Num 0,TotalErrID1Cnt: 0x0001, ErrID2: 0x21(Surprise Down Error), ErrID1: 0x50(Received ERR_COR Message)
3    slot3    2022-09-20 01:55:48    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 01:55:48, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B013A) 1OU/Num 0 VPP power control Triggered
3    slot3    2022-09-20 01:55:52    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 01:55:52, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B013A) 1OU/Num 0 VPP power control Triggered
3    slot3    2022-09-20 01:55:54    power-util       SERVER_POWER_ON successful for FRU: 3 DEV: 1U-dev0

- Device 1 root@bmc-oob:~# log-util --print slot3
2022 Sep 20 01:52:29 log-util: User cleared FRU: 3 logs
3    slot3    2022-09-20 01:52:58    power-util       SERVER_POWER_OFF successful for FRU: 3 DEV: 1U-dev1
3    slot3    2022-09-20 01:52:58    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 03/Fun 00, 1OU/Num 1,TotalErrID1Cnt: 0x0001, ErrID2: 0x50(Received ERR_COR Message), ErrID1: 0x00(Receiver Error)
3    slot3    2022-09-20 01:52:58    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 03/Fun 00, 1OU/Num 1,TotalErrID1Cnt: 0x0001, ErrID2: 0x21(Surprise Down Error), ErrID1: 0x50(Received ERR_COR Message)
3    slot3    2022-09-20 01:52:58    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 01:52:58, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B013C) 1OU/Num 1 VPP power control Triggered
3    slot3    2022-09-20 01:53:03    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 01:53:03, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B013C) 1OU/Num 1 VPP power control Triggered
3    slot3    2022-09-20 01:53:05    power-util       SERVER_POWER_ON successful for FRU: 3 DEV: 1U-dev1

- Decive 2 root@bmc-oob:~# log-util --print slot3
2022 Sep 20 01:57:46 log-util: User cleared FRU: 3 logs
3    slot3    2022-09-20 01:57:53    power-util       SERVER_POWER_OFF successful for FRU: 3 DEV: 1U-dev2
3    slot3    2022-09-20 01:57:53    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 05/Fun 00, 1OU/Num 2,TotalErrID1Cnt: 0x0001, ErrID2: 0x50(Received ERR_COR Message), ErrID1: 0x00(Receiver Error)
3    slot3    2022-09-20 01:57:53    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 05/Fun 00, 1OU/Num 2,TotalErrID1Cnt: 0x0001, ErrID2: 0x21(Surprise Down Error), ErrID1: 0x50(Received ERR_COR Message)
3    slot3    2022-09-20 01:57:53    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 01:57:53, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B013E) 1OU/Num 2 VPP power control Triggered
3    slot3    2022-09-20 01:57:58    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 01:57:58, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B013E) 1OU/Num 2 VPP power control Triggered
3    slot3    2022-09-20 01:58:00    power-util       SERVER_POWER_ON successful for FRU: 3 DEV: 1U-dev2

- Device 3 root@bmc-oob:~# log-util --print slot3
2022 Sep 20 01:58:45 log-util: User cleared FRU: 3 logs
3    slot3    2022-09-20 01:58:53    power-util       SERVER_POWER_OFF successful for FRU: 3 DEV: 1U-dev3
3    slot3    2022-09-20 01:58:53    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 07/Fun 00, 1OU/Num 3,TotalErrID1Cnt: 0x0001, ErrID2: 0x50(Received ERR_COR Message), ErrID1: 0x00(Receiver Error)
3    slot3    2022-09-20 01:58:53    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 07/Fun 00, 1OU/Num 3,TotalErrID1Cnt: 0x0001, ErrID2: 0x21(Surprise Down Error), ErrID1: 0x50(Received ERR_COR Message)
3    slot3    2022-09-20 01:58:54    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 01:58:54, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B0137) 1OU/Num 3 VPP power control Triggered
3    slot3    2022-09-20 01:58:57    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-20 01:58:57, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B0137) 1OU/Num 3 VPP power control Triggered
3    slot3    2022-09-20 01:58:59    power-util       SERVER_POWER_ON successful for FRU: 3 DEV: 1U-dev3