### PR TITLE
wc: mb: Change monitor PMIC polling time(Follow #612)

### DIFF
--- a/meta-facebook/wc-mb/src/platform/plat_pmic.h
+++ b/meta-facebook/wc-mb/src/platform/plat_pmic.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #define MONITOR_PMIC_ERROR_STACK_SIZE 4096
-#define MONITOR_PMIC_ERROR_TIME_MS (30 * 1000) // 30s
+#define MONITOR_PMIC_ERROR_TIME_MS (3 * 1000) // 3s
 
 #define MAX_LEN_GET_PMIC_ERROR_INFO 6 //include R05,  R06,  R08,  R09,  R0A,  R0B
 


### PR DESCRIPTION
Summary:
- To avoid PMIC error SEL show too delay, change monitor PMIC time from 30s to 3s.

Test Plan:
- Build Code: PASS
