### PR TITLE
fby3.5: cl: Avoid control 1OU E1S power twice

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.c
@@ -499,18 +499,41 @@ void ISR_RMCA()
 	}
 }
 
+int get_set_1ou_m2_power(ipmi_msg *msg, uint8_t device_id, uint8_t option)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -1);
+	uint32_t iana = IANA_ID;
+	ipmb_error status;
+
+	memset(msg, 0, sizeof(ipmi_msg));
+	msg->InF_source = SELF;
+	msg->InF_target = EXP1_IPMB;
+	msg->netfn = NETFN_OEM_1S_REQ;
+	msg->cmd = CMD_OEM_1S_GET_SET_M2;
+	msg->data_len = 5;
+	memcpy(&msg->data[0], (uint8_t *)&iana, 3);
+	msg->data[3] = _1ou_m2_mapping_table[device_id];
+	msg->data[4] = option;
+	status = ipmb_read(msg, IPMB_inf_index_map[msg->InF_target]);
+	if (status != IPMB_ERROR_SUCCESS) {
+		LOG_ERR("Failed to set get 1OU E1.S power: status 0x%x, id %d, option 0x%x", status,
+			device_id, option);
+		return -1;
+	}
+
+	return 0;
+}
+
 void ISR_CPU_VPP_INT()
 {
 	if (gpio_get(PWRGD_CPU_LVC3) == POWER_ON) {
-		int i = 0;
+		int i = 0, ret = 0;
 		uint8_t retry = 3;
 		uint8_t vpp_pwr_status_bit = 0;
 		uint8_t device_id = 0;
-		uint8_t set_power_status = POWER_OFF;
-		uint32_t iana = IANA_ID;
+		uint8_t set_power_status = DEVICE_SET_POWER_OFF;
 		static uint8_t last_vpp_pwr_status =
 			0xE1; // default all devices are on (bit1~4 = 0)
-		ipmb_error status = IPMB_ERROR_FAILURE;
 		I2C_MSG i2c_msg;
 		ipmi_msg msg;
 		common_addsel_msg_t sel_msg;
@@ -543,33 +566,29 @@ void ISR_CPU_VPP_INT()
 			}
 
 			if (vpp_pwr_status_bit == 0) {
-				set_power_status = POWER_ON;
+				set_power_status = DEVICE_SET_POWER_ON;
 			} else {
-				set_power_status = POWER_OFF;
+				set_power_status = DEVICE_SET_POWER_OFF;
 			}
 
-			// Notify 1OU BIC to turn on/off E1.S power
-			memset(&msg, 0, sizeof(msg));
-			msg.InF_source = SELF;
-			msg.InF_target = EXP1_IPMB;
-			msg.netfn = NETFN_OEM_1S_REQ;
-			msg.cmd = CMD_OEM_1S_GET_SET_M2;
-			msg.data_len = 5;
-			memcpy(&msg.data[0], (uint8_t *)&iana, 3);
-			msg.data[3] = _1ou_m2_mapping_table[device_id];
-			msg.data[4] = set_power_status;
-			for (i = 0; i < retry; i++) {
-				status = ipmb_read(&msg, IPMB_inf_index_map[msg.InF_target]);
-				if (status == IPMB_ERROR_SUCCESS) {
-					break;
+			// Check 1OU E1.S power status before control
+			// If power status isn't changed, control the power
+			ret = get_set_1ou_m2_power(&msg, device_id, DEVICE_GET_POWER_STATUS);
+			if ((msg.data[3] != set_power_status) || (ret < 0)) {
+				// Notify 1OU BIC to turn on/off E1.S power
+				for (i = 0; i < retry; i++) {
+					ret = get_set_1ou_m2_power(&msg, device_id, set_power_status);
+					if (ret == 0) {
+						break;
+					}
 				}
-			}
 
-			if (i == retry) {
-				LOG_ERR("Failed to send OEM_1S_GET_SET_M2 command 0x%x to 0x%x device%x\n",
-					CMD_OEM_1S_GET_SET_M2, EXP1_IPMB,
-					_1ou_m2_name_mapping_table[device_id]);
-				continue;
+				if (i == retry) {
+					LOG_ERR("Failed to send OEM_1S_GET_SET_M2 command 0x%x to 0x%x device%x\n",
+						CMD_OEM_1S_GET_SET_M2, EXP1_IPMB,
+						_1ou_m2_name_mapping_table[device_id]);
+					continue;
+				}
 			}
 
 			// Add SEL about VPP power event

--- a/meta-facebook/yv35-cl/src/platform/plat_isr.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.h
@@ -18,8 +18,16 @@
 #define PLAT_FUNC_H
 
 #include <stdint.h>
+#include "ipmi.h"
+
+enum GET_SET_M2_OPTION {
+	DEVICE_SET_POWER_OFF = 0x00,
+	DEVICE_SET_POWER_ON = 0x01,
+	DEVICE_GET_POWER_STATUS = 0x03,
+};
 
 void send_gpio_interrupt(uint8_t gpio_num);
+int get_set_1ou_m2_power(ipmi_msg *msg, uint8_t device_id, uint8_t option);
 void ISR_PLTRST();
 void ISR_SLP3();
 void ISR_DC_ON();


### PR DESCRIPTION
Summary:
- To avoid turning on or turning off 1OU E1S power twice, check 1OU E1.S power status before executing ipmi command of power control.
- Create a function for getting and setting 1OU E1S power to reduce repeated code.

Test plan:
- Build code: Pass
- Control 1OU E1.S power: Pass

Log:
1. Using debug print to check doesn't control 1OU E1.S power twice.
- Before fix [BMC console]
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON
root@bmc-oob:~# power-util slot3 1U-dev0 off
Powering fru 3 dev 1U-dev0 to OFF state...
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : OFF

[VF BIC console]
uart:~$ ###OEM_1S_GET_SET_M2
===device_all_power_set ind0
---is_on0
===device_all_power_set ind0
---is_on0

[BMC console]
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : OFF
root@bmc-oob:~# power-util slot3 1U-dev0 on
Powering fru 3 dev 1U-dev0 to ON state...
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON

[VF BIC console]
uart:~$ ###OEM_1S_GET_SET_M2
===device_all_power_set ind0
+++is_on1
===device_all_power_set ind0
+++is_on1

- After fix [BMC console]
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON
root@bmc-oob:~# power-util slot3 1U-dev0 off
Powering fru 3 dev 1U-dev0 to OFF state...
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : OFF

[VF BIC console]
uart:~$ ###OEM_1S_GET_SET_M2
===device_all_power_set ind0
---is_on0

[BMC console]
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : OFF
root@bmc-oob:~# power-util slot3 1U-dev0 on
Powering fru 3 dev 1U-dev0 to ON state...
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON

[VF BIC console]
uart:~$ ###OEM_1S_GET_SET_M2
===device_all_power_set ind0
+++is_on1

2. Check power control is successful. (1) Using power-util from BMC.
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON
root@bmc-oob:~# power-util slot3 1U-dev0 off
Powering fru 3 dev 1U-dev0 to OFF state...
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : OFF
root@bmc-oob:~# power-util slot3 1U-dev0 on
Powering fru 3 dev 1U-dev0 to ON state...
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON
root@bmc-oob:~# log-util --print slot3
2022 Sep 23 01:10:44 log-util: User cleared FRU: 3 logs
3    slot3    2022-09-23 01:11:37    power-util       SERVER_POWER_OFF successful for FRU: 3 DEV: 1U-dev0
3    slot3    2022-09-23 01:11:37    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 01/Fun 00, 1OU/Num 0,TotalErrID1Cnt: 0x0001, ErrID2: 0x50(Received ERR_COR Message), ErrID1: 0x00(Receiver Error)
3    slot3    2022-09-23 01:11:37    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-23 01:11:37, Sensor: PSB_STS (0x46), Event Data: (0B3A01) Unknown Assertion
3    slot3    2022-09-23 01:11:49    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-23 01:11:49, Sensor: PSB_STS (0x46), Event Data: (0B3A01) Unknown Assertion
3    slot3    2022-09-23 01:11:52    power-util       SERVER_POWER_ON successful for FRU: 3 DEV: 1U-dev0

(2) Using echo from host.
[host console]
[root@Stream8_211112 ~]# cat /sys/bus/pci/slots/17/power 1
[root@Stream8_211112 ~]# echo 0 > /sys/bus/pci/slots/17/power [ 1867.276363] {6}[Hardware Error]: Hardware error from APEI Generic Hardware Error Source: 0 [ 1867.294701] {6}[Hardware Error]: It has been corrected by h/w and requires no further action [ 1867.313423] {6}[Hardware Error]: event severity: corrected [ 1867.325591] {6}[Hardware Error]:  Error 0, type: corrected
[ 1867.337756] {6}[Hardware Error]:   section_type: PCIe error
[ 1867.350115] {6}[Hardware Error]:   port_type: 4, root port
[ 1867.362284] {6}[Hardware Error]:   version: 3.0
[ 1867.372328] {6}[Hardware Error]:   command: 0x0547, status: 0x0010
[ 1867.386036] {6}[Hardware Error]:   device_id: 0000:7f:01.0
[ 1867.398201] {6}[Hardware Error]:   slot: 17
[ 1867.407474] {6}[Hardware Error]:   secondary_bus: 0x80
[ 1867.418870] {6}[Hardware Error]:   vendor_id: 0x8086, device_id: 0x352a
[ 1867.433544] {6}[Hardware Error]:   class_code: 060400
[ 1867.444744] {6}[Hardware Error]:   bridge: secondary_status: 0x2000, control: 0x0013
[ 1867.461953] pcieport 0000:7f:01.0: AER: aer_status: 0x00000001, aer_mask: 0x00002000
[ 1867.479141] pcieport 0000:7f:01.0: AER:    [ 0] RxErr
[ 1867.493627] pcieport 0000:7f:01.0: AER: aer_layer=Physical Layer, aer_agent=Receiver ID
[root@Stream8_211112 ~]#
[root@Stream8_211112 ~]# cat /sys/bus/pci/slots/17/power
0
[root@Stream8_211112 ~]# echo 1 > /sys/bus/pci/slots/17/power
[ 1876.172952] pcieport 0000:7f:01.0: pciehp: Slot(17): Card present
[ 1876.603814] pci 0000:80:00.0: [1344:51c3] type 00 class 0x010802
[ 1876.617164] pci 0000:80:00.0: reg 0x10: [mem 0x00000000-0x0003ffff 64bit]
[ 1876.632248] pci 0000:80:00.0: reg 0x30: [mem 0x00000000-0x0003ffff pref]
[ 1876.647127] pci 0000:80:00.0: Max Payload Size set to 512 (was 128, max 512)
[ 1876.662826] pci 0000:80:00.0: PME# supported from D0 D1 D3hot
[ 1876.675670] pcieport 0000:7f:01.0: bridge window [io  0x1000-0x0fff] to [bus 80] add_size 1000
[ 1876.694787] pcieport 0000:7f:01.0: BAR 13: no space for [io  size 0x1000]
[ 1876.709856] pcieport 0000:7f:01.0: BAR 13: failed to assign [io  size 0x1000]
[ 1876.725689] pcieport 0000:7f:01.0: BAR 13: no space for [io  size 0x1000]
[ 1876.740754] pcieport 0000:7f:01.0: BAR 13: failed to assign [io  size 0x1000]
[ 1876.756593] pci 0000:80:00.0: BAR 0: assigned [mem 0xe0600000-0xe063ffff 64bit]
[ 1876.772822] pci 0000:80:00.0: BAR 6: assigned [mem 0xe0640000-0xe067ffff pref]
[ 1876.788849] pcieport 0000:7f:01.0: PCI bridge to [bus 80]
[ 1876.800829] pcieport 0000:7f:01.0:   bridge window [mem 0xe0600000-0xe06fffff]
[ 1876.816858] pcieport 0000:7f:01.0:   bridge window [mem 0x203000000000-0x2030001fffff 64bit pref]
[ 1876.836760] nvme nvme0: pci function 0000:80:00.0
[ 1876.847298] nvme 0000:80:00.0: enabling device (0100 -> 0102)
[root@Stream8_211112 ~]# [ 1879.150933] nvme nvme0: 32/0/0 default/read/poll queues

[root@Stream8_211112 ~]# cat /sys/bus/pci/slots/17/power 1

[BMC console]
root@bmc-oob:~# log-util --print slot3
2022 Sep 23 01:16:07 log-util: User cleared FRU: 3 logs
3    slot3    2022-09-23 01:17:23    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-23 01:17:23, Sensor: PSB_STS (0x46), Event Data: (0B3A01) Unknown Assertion
3    slot3    2022-09-23 01:17:23    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 01/Fun 00, 1OU/Num 0,TotalErrID1Cnt: 0x0001, ErrID2: 0x50(Received ERR_COR Message), ErrID1: 0x00(Receiver Error)
3    slot3    2022-09-23 01:17:32    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-23 01:17:32, Sensor: PSB_STS (0x46), Event Data: (0B3A01) Unknown Assertion

(3) Using CPLD's toggle button from BMC.
root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON
root@bmc-oob:~# bic-util slot3 0x18 0x52 0x1 0x42 0x00 0x0F 0xFD

root@bmc-oob:~# bic-util slot3 0x18 0x52 0x1 0x42 0x00 0x0F 0xFF

root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : OFF
root@bmc-oob:~# bic-util slot3 0x18 0x52 0x1 0x42 0x00 0x0F 0xFD

root@bmc-oob:~# bic-util slot3 0x18 0x52 0x1 0x42 0x00 0x0F 0xFF

root@bmc-oob:~# power-util slot3 1U-dev0 status
Power status for fru 3 dev 1U-dev0 : ON
root@bmc-oob:~# log-util --print slot3
2022 Sep 23 01:19:17 log-util: User cleared FRU: 3 logs
3    slot3    2022-09-23 01:20:19    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-23 01:20:19, Sensor: PSB_STS (0x46), Event Data: (0B3A01) Unknown Assertion
3    slot3    2022-09-23 01:20:19    ipmid            SEL Entry: FRU: 3, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 7F/Dev 01/Fun 00, 1OU/Num 0,TotalErrID1Cnt: 0x0001, ErrID2: 0x50(Received ERR_COR Message), ErrID1: 0x00(Receiver Error)
3    slot3    2022-09-23 01:20:37    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2022-09-23 01:20:37, Sensor: PSB_STS (0x46), Event Data: (0B3A01) Unknown Assertion