### PR TITLE
fby3.5: cl: Modify HSC threshold when 2OU card present

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
@@ -3331,9 +3331,16 @@ uint8_t fix_class2_sdr_table[][10] = {
 	{ SENSOR_NUM_PWR_HSCIN, 0xE0, 0xBD, 0xAB, 0x00, 0x00, 0x00, 0x27, 0x00, 0xF0 },
 };
 
+uint8_t fix_2ou_sdr_table[][10] = {
+	// sensor_num , UNR , UCR , UNC , LNR , LCR , LNC , ( M_tolerance >> 6 ) || M , ( B_accuracy >> 6 ) || B , R
+	{ SENSOR_NUM_CUR_HSCOUT, 0xE2, 0xBF, 0xAC, 0x00, 0x00, 0x00, 0x1F, 0x00, 0xE0 },
+	{ SENSOR_NUM_PWR_HSCIN, 0xE0, 0xBD, 0xAB, 0x00, 0x00, 0x00, 0x27, 0x00, 0xF0 },
+};
+
 SDR_Full_sensor fix_1ou_sdr_table[] = {
 	// SDR_Full_sensor struct member
 };
+
 SDR_Full_sensor dpv2_sdr_table[] = {
 	{
 		// DPV2_2_12V Voltage in
@@ -3718,6 +3725,20 @@ void pal_extend_full_sdr_table()
 	// Fix sdr table if 2ou card is present
 	CARD_STATUS _2ou_status = get_2ou_status();
 	if (_2ou_status.present) {
+		// Change HSC threshold to meet the 2ou setting
+		extend_array_num = ARRAY_SIZE(fix_2ou_sdr_table);
+		for (int index = 0; index < extend_array_num; index++) {
+			for (int i = MBR_R; i >= THRESHOLD_UNR; --i) {
+				if (i < MBR_M) {
+					change_sensor_threshold(fix_2ou_sdr_table[index][0], i,
+								fix_2ou_sdr_table[index][i + 1]);
+				} else {
+					change_sensor_mbr(fix_2ou_sdr_table[index][0], i,
+							  fix_2ou_sdr_table[index][i + 1]);
+				}
+			}
+		}
+
 		// Add DPV2 sdr if DPV2_16 is present
 		if ((_2ou_status.card_type & TYPE_2OU_DPV2_16) == TYPE_2OU_DPV2_16) {
 			extend_array_num = ARRAY_SIZE(dpv2_sdr_table);


### PR DESCRIPTION
Summary:
- Using different thresholds of HSC power and HSC current at config B (2ou card is present).
- HSC input Power
          UNC     UCR     UNR
config A  360.22  399.28  499.1
config B  666.9   737.1   873.6
- HSC output current
          UNC     UCR     UNR
config A  28.73   31.69   39.95
config B  53.32   59.21   70.06

Test plan:
- Build code: Pass
- Check sensor at config A: Pass
- Check sensor at config B: Pass

Log:
1. Check sensor reading at config A. root@bmc-oob:~# show_sys_config | grep Slot3
Slot3 : Present, Config A
root@bmc-oob:~# sensor-util slot3 --thre
slot3:
MB_INLET_TEMP_C              (0x1) :   26.00 C     | (ok) | UCR: 48.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
MB_OUTLET_TEMP_C             (0x2) :   33.00 C     | (ok) | UCR: 93.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
FIO_FRONT_TEMP_C             (0x3) :   27.00 C     | (ok) | UCR: 40.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_PCH_TEMP_C                (0x4) :   39.00 C     | (ok) | UCR: 74.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_CPU_TEMP_C            (0x5) :   33.00 C     | (ok) | UCR: 84.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_THERMAL_MARGIN_C      (0x14) :  -67.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_TJMAX_C               (0x15) :  100.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA0_TEMP_C             (0x6) :   32.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA2_TEMP_C             (0x7) :   31.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA3_TEMP_C             (0x9) :   30.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA4_TEMP_C             (0xA) :   31.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA6_TEMP_C             (0xB) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA7_TEMP_C             (0xC) :   28.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SSD0_M2A_TEMP_C           (0xD) :   28.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_HSC_TEMP_C                (0xE) :   29.76 C     | (ok) | UCR: 86.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_TEMP_C           (0xF) :   41.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_TEMP_C           (0x10) :   39.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_TEMP_C             (0x11) :   34.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_TEMP_C            (0x12) :   35.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_TEMP_C            (0x13) :   37.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_ADC_P12V_STBY_VOLT_V      (0x20) :   12.79 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
MB_ADC_P3V_BAT_VOLT_V        (0x21) :    3.07 Volts | (ok) | UCR: 3.51 | UNC: 3.46 | UNR: NA | LCR: 2.76 | LNC: 2.79 | LNR: NA
MB_ADC_P3V3_STBY_VOLT_V      (0x22) :    3.34 Volts | (ok) | UCR: 3.56 | UNC: 3.53 | UNR: 4.00 | LCR: 3.04 | LNC: 3.08 | LNR: 2.30
MB_ADC_P1V8_STBY_VOLT_V      (0x23) :    1.79 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.09 | LCR: 1.67 | LNC: 1.69 | LNR: 1.44
MB_ADC_P1V05_PCH_VOLT_V      (0x24) :    1.06 Volts | (ok) | UCR: 1.12 | UNC: 1.10 | UNR: 1.22 | LCR: 0.97 | LNC: 0.98 | LNR: 0.84
MB_ADC_P5V_STBY_VOLT_V       (0x25) :    4.94 Volts | (ok) | UCR: 5.40 | UNC: 5.35 | UNR: 5.80 | LCR: 4.59 | LNC: 4.64 | LNR: 4.00
MB_ADC_P12V_DIMM_VOLT_V      (0x26) :   12.57 Volts | (ok) | UCR: 14.21 | UNC: 14.07 | UNR: NA | LCR: 9.87 | LNC: 10.01 | LNR: NA
MB_ADC_P1V2_STBY_VOLT_V      (0x27) :    1.19 Volts | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.39 | LCR: 1.10 | LNC: 1.12 | LNR: 0.96
MB_ADC_P3V3_M2_VOLT_V        (0x28) :    3.30 Volts | (ok) | UCR: 3.71 | UNC: 3.67 | UNR: NA | LCR: 2.91 | LNC: 2.94 | LNR: NA
MB_HSC_INPUT_VOLT_V          (0x29) :   12.54 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
MB_VR_VCCIN_VOLT_V           (0x2A) :    1.77 Volts | (ok) | UCR: 1.93 | UNC: 1.91 | UNR: 2.20 | LCR: 1.64 | LNC: 1.66 | LNR: 0.40
MB_VR_FIVRA_VOLT_V           (0x2C) :    1.82 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.20 | LCR: 1.69 | LNC: 1.71 | LNR: 0.40
MB_VR_EHV_VOLT_V             (0x2D) :    1.80 Volts | (ok) | UCR: 1.90 | UNC: 1.88 | UNR: 2.20 | LCR: 1.70 | LNC: 1.72 | LNR: 0.40
MB_VR_VCCD_VOLT_V            (0x2E) :    1.14 Volts | (ok) | UCR: 1.23 | UNC: 1.21 | UNR: 1.50 | LCR: 1.05 | LNC: 1.06 | LNR: 0.40
MB_VR_FAON_VOLT_V            (0x2F) :    1.05 Volts | (ok) | UCR: 1.11 | UNC: 1.10 | UNR: 1.48 | LCR: 0.90 | LNC: 0.91 | LNR: 0.40
HSC_OUTPUT_CURR_A            (0x30) :    7.03 Amps  | (ok) | UCR: 31.96 | UNC: 28.73 | UNR: 39.95 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_CURR_A           (0x31) :   28.60 Amps  | (ok) | UCR: 141.18 | UNC: 119.34 | UNR: 180.18 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_CURR_A           (0x32) :    2.80 Amps  | (ok) | UCR: 53.01 | UNC: 48.05 | UNR: 70.99 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_CURR_A             (0x33) :    0.80 Amps  | (ok) | UCR: 6.24 | UNC: 5.04 | UNR: 18.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_CURR_A            (0x34) :    2.70 Amps  | (ok) | UCR: 30.02 | UNC: 26.98 | UNR: 42.94 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_CURR_A            (0x35) :    8.80 Amps  | (ok) | UCR: 46.02 | UNC: 42.12 | UNR: 60.06 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_PACKAGE_PWR_W         (0x38) :   68.00 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_PWR_W           (0x39) :   86.81 Watts | (ok) | UCR: 399.28 | UNC: 360.22 | UNR: 499.10 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_PWR_W            (0x3A) :   50.00 Watts | (ok) | UCR: 253.80 | UNC: 214.32 | UNR: 324.30 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_PWR_W            (0x3C) :    4.00 Watts | (ok) | UCR: 95.19 | UNC: 86.64 | UNR: 127.68 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_PWR_W              (0x3D) :    1.00 Watts | (ok) | UCR: 11.25 | UNC: 8.97 | UNR: 32.38 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_PWR_W             (0x3E) :    3.00 Watts | (ok) | UCR: 34.32 | UNC: 31.02 | UNR: 49.28 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_PWR_W             (0x3F) :    9.00 Watts | (ok) | UCR: 49.28 | UNC: 45.08 | UNR: 64.12 | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA0_PMIC_PWR_W      (0x1E) :    1.00 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA2_PMIC_PWR_W      (0x1F) :    0.75 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA3_PMIC_PWR_W      (0x36) :    0.88 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA4_PMIC_PWR_W      (0x37) :    0.62 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA6_PMIC_PWR_W      (0x42) :    0.75 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA7_PMIC_PWR_W      (0x47) :    0.75 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA

root@bmc-oob:~# sensor-util slot3 --thre | grep HSC
MB_HSC_TEMP_C                (0xE) :   30.00 C     | (ok) | UCR: 86.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_VOLT_V          (0x29) :   12.54 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
HSC_OUTPUT_CURR_A            (0x30) :    7.28 Amps  | (ok) | UCR: 31.96 | UNC: 28.73 | UNR: 39.95 | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_PWR_W           (0x39) :   88.86 Watts | (ok) | UCR: 399.28 | UNC: 360.22 | UNR: 499.10 | LCR: NA | LNC: NA | LNR: NA
root@bmc-oob:~#

2. Check sensor reading at config C. root@bmc-oob:~# show_sys_config | grep Slot3
Slot3 : Present, Config B
root@bmc-oob:~# sensor-util slot3 --thre
slot3:
MB_INLET_TEMP_C              (0x1) :   26.00 C     | (ok) | UCR: 48.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
MB_OUTLET_TEMP_C             (0x2) :   33.00 C     | (ok) | UCR: 93.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
FIO_FRONT_TEMP_C             (0x3) :   28.00 C     | (ok) | UCR: 40.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_PCH_TEMP_C                (0x4) :   33.00 C     | (ok) | UCR: 74.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_CPU_TEMP_C            (0x5) :   33.00 C     | (ok) | UCR: 84.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_THERMAL_MARGIN_C      (0x14) :  -67.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_TJMAX_C               (0x15) :  100.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA0_TEMP_C             (0x6) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA2_TEMP_C             (0x7) :   28.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA3_TEMP_C             (0x9) :   28.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA4_TEMP_C             (0xA) :   28.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA6_TEMP_C             (0xB) :   28.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA7_TEMP_C             (0xC) :   27.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SSD0_M2A_TEMP_C           (0xD) :   29.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_HSC_TEMP_C                (0xE) :   29.05 C     | (ok) | UCR: 86.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_TEMP_C           (0xF) :   41.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_TEMP_C           (0x10) :   37.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_TEMP_C             (0x11) :   32.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_TEMP_C            (0x12) :   34.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_TEMP_C            (0x13) :   36.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_ADC_P12V_STBY_VOLT_V      (0x20) :   12.70 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
MB_ADC_P3V_BAT_VOLT_V        (0x21) :    3.07 Volts | (ok) | UCR: 3.51 | UNC: 3.46 | UNR: NA | LCR: 2.76 | LNC: 2.79 | LNR: NA
MB_ADC_P3V3_STBY_VOLT_V      (0x22) :    3.33 Volts | (ok) | UCR: 3.56 | UNC: 3.53 | UNR: 4.00 | LCR: 3.04 | LNC: 3.08 | LNR: 2.30
MB_ADC_P1V8_STBY_VOLT_V      (0x23) :    1.80 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.09 | LCR: 1.67 | LNC: 1.69 | LNR: 1.44
MB_ADC_P1V05_PCH_VOLT_V      (0x24) :    1.05 Volts | (ok) | UCR: 1.12 | UNC: 1.10 | UNR: 1.22 | LCR: 0.97 | LNC: 0.98 | LNR: 0.84
MB_ADC_P5V_STBY_VOLT_V       (0x25) :    4.96 Volts | (ok) | UCR: 5.40 | UNC: 5.35 | UNR: 5.80 | LCR: 4.59 | LNC: 4.64 | LNR: 4.00
MB_ADC_P12V_DIMM_VOLT_V      (0x26) :   12.60 Volts | (ok) | UCR: 14.21 | UNC: 14.07 | UNR: NA | LCR: 9.87 | LNC: 10.01 | LNR: NA
MB_ADC_P1V2_STBY_VOLT_V      (0x27) :    1.19 Volts | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.39 | LCR: 1.10 | LNC: 1.12 | LNR: 0.96
MB_ADC_P3V3_M2_VOLT_V        (0x28) :    3.31 Volts | (ok) | UCR: 3.71 | UNC: 3.67 | UNR: NA | LCR: 2.91 | LNC: 2.94 | LNR: NA
MB_HSC_INPUT_VOLT_V          (0x29) :   12.52 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
MB_VR_VCCIN_VOLT_V           (0x2A) :    1.77 Volts | (ok) | UCR: 1.93 | UNC: 1.91 | UNR: 2.20 | LCR: 1.64 | LNC: 1.66 | LNR: 0.40
MB_VR_FIVRA_VOLT_V           (0x2C) :    1.82 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.20 | LCR: 1.69 | LNC: 1.71 | LNR: 0.40
MB_VR_EHV_VOLT_V             (0x2D) :    1.80 Volts | (ok) | UCR: 1.90 | UNC: 1.88 | UNR: 2.20 | LCR: 1.70 | LNC: 1.72 | LNR: 0.40
MB_VR_VCCD_VOLT_V            (0x2E) :    1.14 Volts | (ok) | UCR: 1.23 | UNC: 1.21 | UNR: 1.50 | LCR: 1.05 | LNC: 1.06 | LNR: 0.40
MB_VR_FAON_VOLT_V            (0x2F) :    1.05 Volts | (ok) | UCR: 1.11 | UNC: 1.10 | UNR: 1.48 | LCR: 0.90 | LNC: 0.91 | LNR: 0.40
HSC_OUTPUT_CURR_A            (0x30) :    8.40 Amps  | (ok) | UCR: 59.21 | UNC: 53.32 | UNR: 70.06 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_CURR_A           (0x31) :   32.00 Amps  | (ok) | UCR: 141.18 | UNC: 119.34 | UNR: 180.18 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_CURR_A           (0x32) :    3.10 Amps  | (ok) | UCR: 53.01 | UNC: 48.05 | UNR: 70.99 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_CURR_A             (0x33) :    0.50 Amps  | (ok) | UCR: 6.24 | UNC: 5.04 | UNR: 18.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_CURR_A            (0x34) :    2.80 Amps  | (ok) | UCR: 30.02 | UNC: 26.98 | UNR: 42.94 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_CURR_A            (0x35) :    9.10 Amps  | (ok) | UCR: 46.02 | UNC: 42.12 | UNR: 60.06 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_PACKAGE_PWR_W         (0x38) :   76.00 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_PWR_W           (0x39) :  103.71 Watts | (ok) | UCR: 737.10 | UNC: 666.90 | UNR: 873.60 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_PWR_W            (0x3A) :   56.00 Watts | (ok) | UCR: 253.80 | UNC: 214.32 | UNR: 324.30 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_PWR_W            (0x3C) :    5.00 Watts | (ok) | UCR: 95.19 | UNC: 86.64 | UNR: 127.68 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_PWR_W              (0x3D) :    0.00 Watts | (ok) | UCR: 11.25 | UNC: 8.97 | UNR: 32.38 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_PWR_W             (0x3E) :    2.00 Watts | (ok) | UCR: 34.32 | UNC: 31.02 | UNR: 49.28 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_PWR_W             (0x3F) :   10.00 Watts | (ok) | UCR: 49.28 | UNC: 45.08 | UNR: 64.12 | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA0_PMIC_PWR_W      (0x1E) :    0.00 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA2_PMIC_PWR_W      (0x1F) :    0.00 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA3_PMIC_PWR_W      (0x36) :    0.00 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA4_PMIC_PWR_W      (0x37) :    0.00 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA6_PMIC_PWR_W      (0x42) :    0.00 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA7_PMIC_PWR_W      (0x47) :    0.00 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
BB_DPV2_1_12V_INPUT_VOLT_V   (0x8C) :   12.51 Volts | (ok) | UCR: 13.20 | UNC: 12.96 | UNR: 14.00 | LCR: 10.80 | LNC: 11.04 | LNR: 10.00
BB_DPV2_1_12V_OUTPUT_VOLT_V  (0x8D) :   12.51 Volts | (ok) | UCR: 13.20 | UNC: 12.96 | UNR: 14.00 | LCR: 10.80 | LNC: 11.04 | LNR: 10.00
BB_DPV2_1_12V_OUTPUT_CURR_A  (0x8E) :    0.14 Amps  | (ok) | UCR: 15.47 | UNC: 15.17 | UNR: 18.90 | LCR: NA | LNC: NA | LNR: NA
BB_DPV2_1_EFUSE_TEMP_C       (0x8F) :   25.40 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
BB_DPV2_1_EFUSE_PWR_W        (0x90) :    1.43 Watts | (ok) | UCR: 186.00 | UNC: NA | UNR: 226.80 | LCR: NA | LNC: NA | LNR: NA

root@bmc-oob:~#
root@bmc-oob:~# sensor-util slot3 --thre | grep HSC
MB_HSC_TEMP_C                (0xE) :   29.05 C     | (ok) | UCR: 86.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_VOLT_V          (0x29) :   12.53 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
HSC_OUTPUT_CURR_A            (0x30) :    7.33 Amps  | (ok) | UCR: 59.21 | UNC: 53.32 | UNR: 70.06 | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_PWR_W           (0x39) :   90.27 Watts | (ok) | UCR: 737.10 | UNC: 666.90 | UNR: 873.60 | LCR: NA | LNC: NA | LNR: NA