### PR TITLE
fby3.5: common: Refactor gpio initial flow

### DIFF
--- a/common/hal/hal_gpio.c
+++ b/common/hal/hal_gpio.c
@@ -17,8 +17,11 @@
 #include <zephyr.h>
 #include <stdio.h>
 #include <string.h>
+#include <logging/log.h>
 #include "hal_gpio.h"
 #include "util_sys.h"
+
+LOG_MODULE_REGISTER(hal_gpio);
 
 #define STACK_SIZE 2048
 
@@ -29,7 +32,7 @@ static K_THREAD_STACK_DEFINE(gpio_work_stack, GPIO_STACK_SIZE);
 
 struct k_work gpio_work[TOTAL_GPIO_NUM];
 
-uint8_t gpio_ind_to_num_table[200];
+uint8_t gpio_ind_to_num_table[TOTAL_GPIO_NUM];
 uint8_t gpio_ind_to_num_table_cnt;
 
 __weak const char *const gpio_name[] = {};
@@ -86,7 +89,7 @@ void irq_callback(const struct device *dev, struct gpio_callback *cb, uint32_t p
 	} else if (dev == dev_gpio[GPIO_U_V]) {
 		group = GPIO_U_V;
 	} else {
-		printf("invalid dev group for isr cb\n");
+		LOG_ERR("invalid dev group for isr cb\n");
 		return;
 	}
 
@@ -97,13 +100,13 @@ void irq_callback(const struct device *dev, struct gpio_callback *cb, uint32_t p
 		}
 	}
 	if (index == GPIO_GROUP_SIZE) {
-		printf("irq_callback: pin %x not found\n", pins);
+		LOG_ERR("irq_callback: pin %x not found\n", pins);
 		return;
 	}
 	gpio_num = (group * GPIO_GROUP_SIZE) + pins;
 
 	if (gpio_cfg[gpio_num].int_cb == NULL) {
-		printf("Callback function pointer NULL for gpio num %d\n", gpio_num);
+		LOG_ERR("Callback function pointer NULL for gpio num %d\n", gpio_num);
 		return;
 	}
 
@@ -120,15 +123,7 @@ static int gpio_add_cb(uint8_t gpio_num)
 {
 	return gpio_add_callback(dev_gpio[gpio_num / GPIO_GROUP_SIZE], &callbacks[gpio_num]);
 }
-/*
-interrupt type:
-  GPIO_INT_DISABLE
-  GPIO_INT_EDGE_RISING
-  GPIO_INT_EDGE_FALLING
-  GPIO_INT_EDGE_BOTH
-  GPIO_INT_LEVEL_LOW
-  GPIO_INT_LEVEL_HIGH
-*/
+
 int gpio_interrupt_conf(uint8_t gpio_num, gpio_flags_t flags)
 {
 	return gpio_pin_interrupt_configure(dev_gpio[gpio_num / GPIO_GROUP_SIZE],
@@ -155,12 +150,14 @@ int gpio_get_direction(uint8_t gpio_num)
 	uint8_t dir = 0xFF;
 
 	if (gpio_num >= TOTAL_GPIO_NUM) {
-		printf("getting invalid gpio num %d", gpio_num);
+		LOG_ERR("getting invalid gpio num %d", gpio_num);
 		return dir;
 	}
 
-	uint32_t g_dir = sys_read32(GPIO_GROUP_REG_ACCESS[gpio_num / 32] + 0x4);
-	if (g_dir & BIT(gpio_num % 32))
+	uint8_t gpio_group = gpio_num / GPIO_GROUP_SIZE;
+	uint8_t gpio_group_index = gpio_num % GPIO_GROUP_SIZE;
+	uint32_t g_dir = sys_read32(GPIO_GROUP_REG_ACCESS[gpio_group] + REG_DIRECTION_OFFSET);
+	if (g_dir & BIT(gpio_group_index))
 		dir = 0x01;
 	else
 		dir = 0x00;
@@ -171,33 +168,33 @@ int gpio_get_direction(uint8_t gpio_num)
 int gpio_get(uint8_t gpio_num)
 {
 	if (gpio_num >= TOTAL_GPIO_NUM) {
-		printf("getting invalid gpio num %d", gpio_num);
+		LOG_ERR("getting invalid gpio num %d", gpio_num);
 		return false;
 	}
 
 	return gpio_pin_get(dev_gpio[gpio_num / GPIO_GROUP_SIZE], (gpio_num % GPIO_GROUP_SIZE));
-	//  return gpio[0].get(&gpio[0], gpio_num);
 }
 
 int gpio_set(uint8_t gpio_num, uint8_t status)
 {
 	if (gpio_num >= TOTAL_GPIO_NUM) {
-		printf("setting invalid gpio num %d", gpio_num);
+		LOG_ERR("setting invalid gpio num %d", gpio_num);
 		return false;
 	}
 
+	uint8_t gpio_group = gpio_num / GPIO_GROUP_SIZE;
+	uint8_t gpio_group_index = gpio_num % GPIO_GROUP_SIZE;
+
 	if (gpio_cfg[gpio_num].property == OPEN_DRAIN) { // should release gpio ctrl for OD high
-		if (status) {
+		if (status == GPIO_HIGH) {
 			return gpio_conf(gpio_num, GPIO_INPUT);
 		} else {
 			gpio_conf(gpio_num, GPIO_OUTPUT);
-			return gpio_pin_set(dev_gpio[gpio_num / GPIO_GROUP_SIZE],
-					    (gpio_num % GPIO_GROUP_SIZE), status);
+			return gpio_pin_set(dev_gpio[gpio_group], gpio_group_index, GPIO_LOW);
 		}
-	} else {
-		return gpio_pin_set(dev_gpio[gpio_num / GPIO_GROUP_SIZE],
-				    (gpio_num % GPIO_GROUP_SIZE), status);
 	}
+
+	return gpio_pin_set(dev_gpio[gpio_group], gpio_group_index, status);
 }
 
 void gpio_index_to_num(void)
@@ -254,6 +251,8 @@ int gpio_init(const struct device *args)
 	gpio_index_to_num();
 
 	bool ac_lost = is_ac_lost();
+	uint8_t gpio_group = 0;
+	uint8_t gpio_group_index = 0;
 
 	k_work_queue_start(&gpio_work_queue, gpio_work_stack, GPIO_STACK_SIZE,
 			   K_PRIO_PREEMPT(CONFIG_MAIN_THREAD_PRIORITY), NULL);
@@ -261,25 +260,49 @@ int gpio_init(const struct device *args)
 
 	for (i = 0; i < TOTAL_GPIO_NUM; i++) {
 		if (gpio_cfg[i].is_init == ENABLE) {
-			if ((gpio_cfg[i].is_latch == ENABLE) && (!ac_lost)) {
+			if ((gpio_cfg[i].is_latch == ENABLE) && (ac_lost == false)) {
 				continue;
 			}
 			if (gpio_cfg[i].chip == CHIP_GPIO) {
-				gpio_set(gpio_cfg[i].number, gpio_cfg[i].status);
-				if (gpio_cfg[i].property ==
-				    PUSH_PULL) { // OD config is set during status set
+				gpio_group = gpio_cfg[i].number / GPIO_GROUP_SIZE;
+				gpio_group_index = gpio_cfg[i].number % GPIO_GROUP_SIZE;
+				switch (gpio_cfg[i].direction) {
+				case GPIO_INPUT:
 					gpio_conf(gpio_cfg[i].number, gpio_cfg[i].direction);
+					break;
+				case GPIO_OUTPUT:
+					switch (gpio_cfg[i].property) {
+					case OPEN_DRAIN:
+						if (gpio_cfg[i].status == GPIO_LOW) {
+							gpio_pin_set(dev_gpio[gpio_group],
+								     gpio_group_index,
+								     gpio_cfg[i].status);
+							gpio_conf(gpio_cfg[i].number,
+								  gpio_cfg[i].direction);
+						} else {
+							gpio_conf(gpio_cfg[i].number, GPIO_INPUT);
+						}
+						break;
+					case PUSH_PULL:
+						gpio_pin_set(dev_gpio[gpio_group], gpio_group_index,
+							     gpio_cfg[i].status);
+						gpio_conf(gpio_cfg[i].number,
+							  gpio_cfg[i].direction);
+						break;
+					}
 				}
-				gpio_set(gpio_cfg[i].number, gpio_cfg[i].status);
-				if ((gpio_cfg[i].int_type == GPIO_INT_EDGE_RISING) ||
-				    (gpio_cfg[i].int_type == GPIO_INT_EDGE_FALLING) ||
-				    (gpio_cfg[i].int_type == GPIO_INT_EDGE_BOTH) ||
-				    (gpio_cfg[i].int_type == GPIO_INT_LEVEL_LOW) ||
-				    (gpio_cfg[i].int_type == GPIO_INT_LEVEL_HIGH)) {
+
+				switch (gpio_cfg[i].int_type) {
+				case GPIO_INT_EDGE_RISING:
+				case GPIO_INT_EDGE_FALLING:
+				case GPIO_INT_EDGE_BOTH:
+				case GPIO_INT_LEVEL_LOW:
+				case GPIO_INT_LEVEL_HIGH:
 					gpio_cb_irq_init(gpio_cfg[i].number, gpio_cfg[i].int_type);
+					break;
 				}
 			} else {
-				printf("TODO: add sgpio handler\n");
+				LOG_DBG("TODO: add sgpio handler\n");
 			}
 		}
 	}

--- a/common/hal/hal_gpio.h
+++ b/common/hal/hal_gpio.h
@@ -60,6 +60,8 @@
 
 #define REG_GPIO_BASE 0x7e780000
 #define REG_SCU 0x7E6E2000
+#define REG_DIRECTION_OFFSET 4
+
 extern uint32_t GPIO_GROUP_REG_ACCESS[];
 extern uint32_t GPIO_MULTI_FUNC_PIN_CTL_REG_ACCESS[];
 extern const int GPIO_MULTI_FUNC_CFG_SIZE;
@@ -84,7 +86,7 @@ typedef struct _SET_GPIO_VALUE_CFG_ {
 
 extern GPIO_CFG gpio_cfg[];
 
-enum {
+enum GPIO_GROUP {
 	GPIO_A_D,
 	GPIO_E_H,
 	GPIO_I_L,


### PR DESCRIPTION
Summary:
- Refactor gpio initial flow.

Test Plan:
- Build code: Pass
- Check gpio initial setting is match with gpio table: Pass
- Check BIC no abnormal event when BIC reset and 12V-cycle with yv3.5 CL + RF: 235 tims pass
- Check BIC no abnormal event when BIC reset and 12V-cycle with yv3.5 HD + RF: 150 tims pass

Log:
- gpio configuration after gpio initialization
  - yv3.5 CraterLake BIC uart:~$ platform gpio list_all
[0  ] FM_BMC_PCH_SCI_LPC_R_N             : OD  | output(I) | 1(1)
[1  ] FM_BIOS_POST_CMPLT_BMC_N           : OD  | input (I) | 0(0)
[2  ] FM_SLPS3_PLD_N                     : PP  | input (I) | 1(1)
[3  ] IRQ_BMC_PCH_SMI_LPC_R_N            : OD  | output(I) | 1(1)
[4  ] IRQ_UV_DETECT_N                    : OD  | input (I) | 1(1)
[5  ] FM_UV_ADR_TRIGGER_EN_R             : OD  | output(I) | 1(1)
[6  ] IRQ_SMI_ACTIVE_BMC_N               : OD  | input (I) | 1(1)
[7  ] HSC_SET_EN_R                       : PP  | output(O) | 0(0)
[8  ] FM_BIC_RST_RTCRST_R                : PP  | output(O) | 0(0)
[9  ] RST_USB_HUB_N_R                    : OD  | output(I) | 1(1)
[10 ] A_P3V_BAT_SCALED_EN_R              : PP  | output(O) | 0(0)
[11 ] FM_SPI_PCH_MASTER_SEL_R            : PP  | output(O) | 0(0)
[12 ] FM_PCHHOT_N                        : OD  | input (I) | 1(1)
[13 ] FM_SLPS4_PLD_N                     : PP  | input (I) | 1(1)
[14 ] FM_S3M_CPU0_CD_INIT_ERROR          : OD  | input (O) | 0(0)
[15 ] PWRGD_SYS_PWROK                    : PP  | input (I) | 1(1)
[16 ] FM_HSC_TIMER                       : OD  | input (I) | 0(0)
[17 ] IRQ_SMB_IO_LVC3_STBY_ALRT_N        : OD  | input (I) | 1(1)
[18 ] IRQ_CPU0_VRHOT_N                   : OD  | input (I) | 1(1)
[19 ] DBP_CPU_PREQ_BIC_N                 : OD  | output(I) | 1(1)
[20 ] FM_CPU_THERMTRIP_LATCH_LVT3_N      : OD  | input (I) | 1(1)
[21 ] FM_CPU_SKTOCC_LVT3_PLD_N           : OD  | input (I) | 0(0)
[22 ] H_CPU_MEMHOT_OUT_LVC3_N            : PP  | input (I) | 1(1)
[23 ] RST_PLTRST_PLD_N                   : PP  | input (I) | 1(1)
[24 ] PWRBTN_N                           : OD  | input (I) | 1(1)
[25 ] RST_BMC_R_N                        : OD  | output(I) | 1(1)
[26 ] H_BMC_PRDY_BUF_N                   : OD  | input (I) | 1(1)
[27 ] BMC_READY                          : PP  | output(O) | 1(1)
[28 ] BIC_READY                          : PP  | output(O) | 1(1)
[29 ] FM_RMCA_LVT3_N                     : PP  | input (I) | 1(1)
[30 ] HSC_MUX_SWITCH_R                   : PP  | output(O) | 0(0)
[31 ] FM_FORCE_ADR_N_R                   : OD  | output(I) | 1(1)
[32 ] PWRGD_CPU_LVC3                     : PP  | input (I) | 1(1)
[33 ] FM_PCH_BMC_THERMTRIP_N             : OD  | output(I) | 1(1)
[34 ] FM_THROTTLE_R_N                    : OD  | input (I) | 1(1)
[35 ] IRQ_HSC_ALERT2_N                   : OD  | input (I) | 1(1)
[36 ] SMB_SENSOR_LVC3_ALERT_N            : OD  | input (I) | 1(1)
[37 ] FM_CATERR_LVT3_N                   : PP  | input (I) | 1(1)
[38 ] SYS_PWRBTN_N                       : OD  | input (I) | 1(1)
[39 ] RST_PLTRST_BUF_N                   : PP  | input (I) | 1(1)
[40 ] IRQ_BMC_PCH_NMI_R                  : PP  | output(O) | 0(0)
[41 ] IRQ_SML1_PMBUS_ALERT_N             : OD  | input (I) | 1(1)
[42 ] IRQ_PCH_CPU_NMI_EVENT_N            : OD  | input (I) | 1(1)
[43 ] FM_BMC_DEBUG_ENABLE_N              : OD  | output(I) | 1(1)
[44 ] FM_DBP_PRESENT_N                   : OD  | input (I) | 1(1)
[45 ] FM_FAST_PROCHOT_EN_N_R             : PP  | output(O) | 0(0)
[46 ] FM_SPI_MUX_OE_CTL_PLD_N            : PP  | output(O) | 0(0)
[47 ] FBRK_N_R                           : OD  | output(I) | 1(1)
[48 ] FM_PEHPCPU_INT                     : PP  | input (I) | 0(0)
[49 ] FM_BIOS_MRC_DEBUG_MSG_DIS_R        : OD  | output(I) | 1(1)
[50 ] FAST_PROCHOT_N                     : OD  | input (I) | 1(1)
[51 ] FM_JTAG_TCK_MUX_SEL_R              : PP  | output(O) | 0(0)
[52 ] BMC_JTAG_SEL_R                     : PP  | output(O) | 0(0)
[53 ] H_CPU_ERR0_LVC3_N                  : PP  | input (I) | 1(1)
[54 ] H_CPU_ERR1_LVC3_N                  : PP  | input (I) | 1(1)
[55 ] H_CPU_ERR2_LVC3_N                  : PP  | input (I) | 1(1)
[56 ] RST_RSMRST_BMC_N                   : PP  | input (I) | 1(1)
[57 ] FM_MP_PS_FAIL_N                    : OD  | input (I) | 1(1)
[58 ] H_CPU_MEMTRIP_LVC3_N               : OD  | input (I) | 1(1)
[59 ] FM_CPU_BIC_PROCHOT_LVT3_N          : PP  | input (I) | 1(1)
[91 ] BOARD_ID2                          : PP  | input (I) | 0(0)
[92 ] IRQ_PVCCD_CPU0_VRHOT_LVC3_N        : OD  | input (I) | 1(1)
[93 ] FM_PVCCIN_CPU0_PWR_IN_ALERT_N      : OD  | input (I) | 1(1)
[94 ] BOARD_ID0                          : PP  | input (I) | 0(0)
[95 ] BOARD_ID1                          : PP  | input (I) | 0(0)
[97 ] BOARD_ID3                          : PP  | input (I) | 0(0)
[99 ] FM_THROTTLE_IN_N                   : OD  | output(I) | 1(1)
[100] AUTH_COMPLETE                      : PP  | input (I) | 0(0)
[101] AUTH_PRSNT_N                       : OD  | input (I) | 1(1)
[104] SGPIO_BMC_CLK_R                    : PP  | input (I) | 0(0)
[105] SGPIO_BMC_LD_R_N                   : PP  | input (I) | 0(0)
[106] SGPIO_BMC_DOUT_R                   : PP  | input (I) | 0(0)
[107] SGPIO_BMC_DIN                      : PP  | input (I) | 0(0)

  - yv3.5 Rainbow falls uart:~$ platform gpio list_all
[0  ] ASIC_DEV_RST_N                     : OD  | output(O) | 0(0)
[1  ] ASIC_PERST0_N                      : OD  | output(O) | 0(0)
[2  ] ASIC_PERST1_N                      : OD  | output(O) | 0(0)
[3  ] ASIC_FAIL_N                        : OD  | output(I) | 1(1)
[4  ] ASIC_EVENT_N                       : OD  | output(I) | 1(1)
[5  ] ASIC_DUALPORTEN_N                  : OD  | output(I) | 1(1)
[6  ] JTAG2_BIC_ASIC_NTRST2              : PP  | output(O) | 1(1)
[7  ] ASIC_TAP_SEL                       : OD  | output(O) | 0(0)
[8  ] ASIC_CPU_BOOT_0                    : OD  | output(I) | 1(1)
[9  ] ASIC_CPU_BOOT_1                    : OD  | output(O) | 0(0)
[10 ] ASIC_M_SCAN_PCAP_SEL               : OD  | output(I) | 1(1)
[11 ] ASIC_GPIO_R_0                      : OD  | input (I) | 1(1)
[12 ] ASIC_GPIO_R_1                      : OD  | output(I) | 1(1)
[13 ] AUX_PWR_EN_4C                      : PP  | input (I) | 1(1)
[14 ] I2CS_SRSTB_GPIO                    : OD  | output(O) | 0(0)
[15 ] FM_ISOLATED_EN_N                   : OD  | output(I) | 0(0)
[16 ] FM_P0V8_ASICD_EN                   : PP  | output(O) | 0(0)
[17 ] P1V8_ASIC_EN_R                     : PP  | output(O) | 0(0)
[18 ] FM_P0V8_ASICA_EN                   : PP  | output(O) | 0(0)
[19 ] PVTT_AB_EN_R                       : PP  | output(O) | 0(0)
[20 ] PVTT_CD_EN_R                       : PP  | output(O) | 0(0)
[21 ] FM_P0V9_ASICA_EN                   : PP  | output(O) | 0(0)
[22 ] PVPP_CD_EN_R                       : PP  | output(O) | 0(0)
[23 ] FM_PVDDQ_AB_EN                     : PP  | output(O) | 0(0)
[24 ] PVPP_AB_EN_R                       : PP  | output(O) | 0(0)
[25 ] FM_PVDDQ_CD_EN                     : PP  | output(O) | 0(0)
[26 ] SLOT_ID0                           : PP  | input (I) | 0(0)
[27 ] PVPP_CD_PG_R                       : PP  | input (I) | 0(0)
[28 ] P0V8_ASICA_PWRGD                   : PP  | input (I) | 0(0)
[29 ] PVTT_AB_PG_R                       : PP  | input (I) | 0(0)
[30 ] SMB_SENSOR_LVC3_ALERT_N            : PP  | input (I) | 1(1)
[31 ] PVTT_CD_PG_R                       : PP  | input (I) | 0(0)
[32 ] FM_POWER_EN                        : PP  | input (I) | 0(0)
[33 ] PWRGD_CARD_PWROK                   : PP  | output(O) | 0(0)
[34 ] RST_MB_N                           : PP  | input (I) | 0(0)
[35 ] SPI_MASTER_SEL                     : PP  | output(O) | 0(0)
[36 ] FM_SPI_MUX_OE_CTL_N                : PP  | output(O) | 0(0)
[37 ] SMB_12V_INA_ALRT_N                 : PP  | input (I) | 1(1)
[38 ] SMB_3V3_INA_ALRT_N                 : PP  | input (I) | 1(1)
[39 ] FM_MEM_THERM_EVENT_LVT3_N          : PP  | input (I) | 0(0)
[40 ] SPI_RST_FLASH_N                    : OD  | output(I) | 0(0)
[41 ] SMBUS_ALERT_R_N                    : OD  | output(I) | 1(1)
[42 ] LSFT_SMB_DIMM_EN                   : PP  | output(O) | 0(0)
[43 ] P0V9_ASICA_PWRGD                   : PP  | input (I) | 0(0)
[44 ] P1V8_ASIC_PG_R                     : PP  | input (I) | 0(0)
[45 ] JTAG2_ASIC_PORT_SEL_EN_R           : PP  | output(O) | 0(0)
[46 ] SAVE_N_BIC                         : PP  | input (I) | 1(1)
[47 ] FM_ADR_COMPLETE_DLY                : PP  | output(O) | 0(0)
[48 ] P5V_STBY_PG                        : PP  | input (I) | 1(1)
[49 ] PVPP_AB_PG_R                       : PP  | input (I) | 0(0)
[50 ] P1V2_STBY_PG_R                     : PP  | input (I) | 1(1)
[51 ] SLOT_ID1                           : PP  | input (I) | 0(0)
[52 ] SMB_VR_PVDDQ_CD_ALERT_N            : PP  | input (I) | 1(1)
[53 ] P0V8_ASICD_PWRGD                   : PP  | input (I) | 0(0)
[54 ] PWRGD_PVDDQ_CD                     : PP  | input (I) | 0(0)
[55 ] SMB_VR_PASICA_ALERT_N              : PP  | input (I) | 1(1)
[56 ] JTAG2_BIC_SHIFT_EN                 : PP  | output(O) | 1(1)
[57 ] SMB_VR_PVDDQ_AB_ALERT_N            : PP  | input (I) | 1(1)
[58 ] SPI_BIC_SHIFT_EN                   : OD  | output(O) | 0(0)
[59 ] PWRGD_PVDDQ_AB                     : PP  | input (I) | 0(0)
[68 ] P0V9_ASICA_FT_R                    : PP  | input (I) | 0(0)
[69 ] PVDDQ_AB_FT_R                      : PP  | input (I) | 0(0)
[70 ] PVDDQ_CD_FT_R                      : PP  | input (I) | 0(0)
[71 ] FM_PWRBRK_PRIMARY_R_N              : PP  | input (I) | 1(1)
[74 ] P0V8_ASICD_FT_R                    : PP  | input (I) | 0(0)
[75 ] P0V8_ASICA_FT_R                    : PP  | input (I) | 0(0)
[90 ] LED_CXL_POWER                      : PP  | output(O) | 0(0)
[91 ] FM_BOARD_REV_ID2                   : PP  | input (I) | 0(0)
[92 ] FM_BOARD_REV_ID1                   : PP  | input (I) | 0(0)
[93 ] FM_BOARD_REV_ID0                   : PP  | input (I) | 0(0)
[94 ] BOARD_ID0                          : PP  | input (I) | 0(0)
[95 ] BOARD_ID1                          : PP  | input (I) | 1(1)
[96 ] BIC_SECUREBOOT                     : PP  | input (I) | 0(0)
[97 ] BOARD_ID2                          : PP  | input (I) | 0(0)
[98 ] BOARD_ID3                          : PP  | input (I) | 1(1)
[99 ] BIC_ESPI_SELECT                    : PP  | input (I) | 1(1)
[100] LED_CXL_FAULT                      : PP  | output(O) | 0(0)
[107] CLK_100M_OSC_EN                    : PP  | output(O) | 0(0)