### PR TITLE
GT: Version commit for obgt-cc-2022.40.02

### DIFF
--- a/meta-facebook/gt-cc/src/platform/plat_version.h
+++ b/meta-facebook/gt-cc/src/platform/plat_version.h
@@ -21,7 +21,7 @@
 
 #define PLATFORM_NAME "Grand Teton"
 #define PROJECT_NAME "Cascade Creek (SWB)"
-#define PROJECT_STAGE EVT
+#define PROJECT_STAGE DVT
 
 /* 
  * 0x01 cascade-creek 
@@ -31,7 +31,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x08
+#define FIRMWARE_REVISION_2 0x01
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -40,8 +40,8 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x37
-#define BIC_FW_VER 0x01
+#define BIC_FW_WEEK 0x40
+#define BIC_FW_VER 0x02
 #define BIC_FW_platform_0 0x47 // char: G
 #define BIC_FW_platform_1 0x54 // char: T
 #define BIC_FW_platform_2 0x00 // char: '\0'


### PR DESCRIPTION
Summary:
- Version commit for Grand Teton switch board BIC obgt-cc-2022.40.02

Test Plan:
- Build code: Pass
- Get BIC version: Pass

Log:
root@bmc-oob:~# fw-util swb --version bic
SWB BIC Version: 2022.40.02