### PR TITLE
fby3: vf: modify the thermal sensor's threshold

### DIFF
--- a/meta-facebook/yv3-vf/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv3-vf/src/platform/plat_sdr_table.c
@@ -75,10 +75,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xFF, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x5A, // UCT
+		0x46, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x00, // LCT
+		0x0A, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1665,10 +1665,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xFF, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x4B, // UCT
+		0x44, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x00, // LCT
+		0x0A, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1727,10 +1727,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xFF, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x4B, // UCT
+		0x44, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x00, // LCT
+		0x0A, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1789,10 +1789,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xFF, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x4B, // UCT
+		0x44, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x00, // LCT
+		0x0A, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1851,10 +1851,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xFF, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x4B, // UCT
+		0x44, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x00, // LCT
+		0x0A, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold


### PR DESCRIPTION
Summary:

- Modify the thermal sensor's threshold

Test Plan:

Build code: PASS
Check SDR threshold: PASS

Log:

root@bmc-oob:~# sensor-util slot1 --threshold | grep -i e1s | grep -i temp
E1S Outlet Temp              (0x50) :   29.00 C     | (ok) | UCR: 70.00 | UNC: NA | UNR: NA | LCR: 10.00 | LNC: NA | LNR: NA
E1S DEV0 Temp                (0x62) :   31.00 C     | (ok) | UCR: 68.00 | UNC: NA | UNR: NA | LCR: 10.00 | LNC: NA | LNR: NA
E1S DEV1 Temp                (0x6A) :   31.00 C     | (ok) | UCR: 68.00 | UNC: NA | UNR: NA | LCR: 10.00 | LNC: NA | LNR: NA
E1S DEV2 Temp                (0x72) :   31.00 C     | (ok) | UCR: 68.00 | UNC: NA | UNR: NA | LCR: 10.00 | LNC: NA | LNR: NA
E1S DEV3 Temp                (0x7A) :   30.00 C     | (ok) | UCR: 68.00 | UNC: NA | UNR: NA | LCR: 10.00 | LNC: NA | LNR: NA
