### PR TITLE
fby3.5: rf: Fix the access setting of the sensor

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
@@ -46,7 +46,7 @@ sensor_cfg plat_sensor_config[] = {
 	{ SENSOR_NUM_VOL_STBY1V2, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, stby_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
-	{ SENSOR_NUM_VOL_ASIC_1V8, sensor_dev_ast_adc, ADC_PORT7, NONE, NONE, stby_access, 1, 1,
+	{ SENSOR_NUM_VOL_ASIC_1V8, sensor_dev_ast_adc, ADC_PORT7, NONE, NONE, dc_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 	{ SENSOR_NUM_VOL_PVPP_AB, sensor_dev_ast_adc, ADC_PORT10, NONE, NONE, dc_access, 2, 1,


### PR DESCRIPTION
Summary:
- Solve RF P1V8_ASIC Vol (0x61) sensor happened LNC/LCR/LNR event in the case of DC power off.
- Modify the access setting of the RF P1V8_ASIC Vol (0x61) sensor 

Test Plan:
- Build Code: PASS

Test Result:
```
root@bmc-oob:~# sensor-util slot1
slot1:
RF MB Inlet Temp             (0x50) :   31.00 C     | (ok)
RF CXL_cntr_Temp             (0x52) :   32.00 C     | (ok)
RF P0V9_A Temp               (0x58) : NA | (na)
RF P0V8_A Temp               (0x59) : NA | (na)
RF P0V8_D Temp               (0x5A) : NA | (na)
RF PVDDQ_AB Temp             (0x5B) : NA | (na)
RF PVDDQ_CD Temp             (0x5C) : NA | (na)
RF P12V_STBY Vol             (0x5D) :   12.13 Volts | (ok)
RF P3V3_STBY Vol             (0x5E) :    3.31 Volts | (ok)
RF P5V_STBY Vol              (0x5F) :    5.08 Volts | (ok)
RF P1V2_STBY Vol             (0x60) :    1.19 Volts | (ok)
RF P1V8_ASIC Vol             (0x61) : NA | (na)
RF P0V9_A Vol                (0x62) : NA | (na)
RF P0V8_A Vol                (0x64) : NA | (na)
RF P0V8_D Vol                (0x65) : NA | (na)
RF PVDDQ_AB Vol              (0x66) : NA | (na)
RF PVDDQ_CD Vol              (0x67) : NA | (na)
RF PVPP_AB Vol               (0x68) : NA | (na)
RF PVPP_CD Vol               (0x69) : NA | (na)
RF PVTT_AB Vol               (0x6A) : NA | (na)
RF PVTT_CD Vol               (0x6B) : NA | (na)
RF P12V_STBY Cur             (0x6C) :    0.04 Amps  | (ok)
RF P3V3_STBY Cur             (0x6D) :    0.07 Amps  | (ok)
RF P0V9_A Cur                (0x6E) : NA | (na)
RF P0V8_A Cur                (0x6F) : NA | (na)
RF P0V8_D Cur                (0x70) : NA | (na)
RF PVDDQ_AB Cur              (0x71) : NA | (na)
RF PVDDQ_CD Cur              (0x72) : NA | (na)
RF P12V_STBY_PWR             (0x73) :    0.50 Watts | (ok)
RF P3V3_STBY_PWR             (0x74) :    0.20 Watts | (ok)
RF P0V9_A_PWR                (0x75) : NA | (na)
RF P0V8_A_PWR                (0x76) : NA | (na)
RF P0V8_D_PWR                (0x77) : NA | (na)
RF PVDDQ_AB_PWR              (0x78) : NA | (na)
RF PVDDQ_CD_PWR              (0x79) : NA | (na)
```

Signed-off-by: Irene <Irene.Lin@quantatw.com>