### PR TITLE
common: Support MCTP I3C Tx function

### DIFF
--- a/common/service/mctp/mctp.c
+++ b/common/service/mctp/mctp.c
@@ -51,7 +51,9 @@ static uint8_t set_thread_name(mctp *mctp_inst)
 	    mctp_inst->medium_type >= MCTP_MEDIUM_TYPE_MAX)
 		return MCTP_ERROR;
 
-	if (mctp_inst->medium_type == MCTP_MEDIUM_TYPE_SMBUS) {
+	switch (mctp_inst->medium_type) {
+	case MCTP_MEDIUM_TYPE_SMBUS:
+		LOG_INF("medium_type: smbus");
 		mctp_smbus_conf *smbus_conf = (mctp_smbus_conf *)&mctp_inst->medium_conf;
 		snprintf(mctp_inst->mctp_rx_task_name, sizeof(mctp_inst->mctp_rx_task_name),
 			 "mctprx_%02x_%02x_%02x", mctp_inst->medium_type, smbus_conf->bus,
@@ -59,6 +61,20 @@ static uint8_t set_thread_name(mctp *mctp_inst)
 		snprintf(mctp_inst->mctp_tx_task_name, sizeof(mctp_inst->mctp_tx_task_name),
 			 "mctptx_%02x_%02x_%02x", mctp_inst->medium_type, smbus_conf->bus,
 			 smbus_conf->addr);
+		break;
+	case MCTP_MEDIUM_TYPE_I3C:
+		LOG_INF("medium_type: i3c");
+		mctp_i3c_conf *i3c_conf = (mctp_i3c_conf *)&mctp_inst->medium_conf;
+		snprintf(mctp_inst->mctp_rx_task_name, sizeof(mctp_inst->mctp_rx_task_name),
+			 "mctprx_%02x_%02x_%02x", mctp_inst->medium_type, i3c_conf->bus,
+			 i3c_conf->addr);
+		snprintf(mctp_inst->mctp_tx_task_name, sizeof(mctp_inst->mctp_tx_task_name),
+			 "mctptx_%02x_%02x_%02x", mctp_inst->medium_type, i3c_conf->bus,
+			 i3c_conf->addr);
+		break;
+	default:
+		return MCTP_ERROR;
+		break;
 	}
 
 	return MCTP_SUCCESS;
@@ -75,6 +91,9 @@ static uint8_t mctp_medium_init(mctp *mctp_inst, mctp_medium_conf medium_conf)
 	case MCTP_MEDIUM_TYPE_SMBUS:
 		ret = mctp_smbus_init(mctp_inst, medium_conf);
 		break;
+	case MCTP_MEDIUM_TYPE_I3C:
+		ret = mctp_i3c_init(mctp_inst, medium_conf);
+		break;
 	default:
 		break;
 	}
@@ -90,6 +109,9 @@ static uint8_t mctp_medium_deinit(mctp *mctp_inst)
 	switch (mctp_inst->medium_type) {
 	case MCTP_MEDIUM_TYPE_SMBUS:
 		mctp_smbus_deinit(mctp_inst);
+		break;
+	case MCTP_MEDIUM_TYPE_I3C:
+		mctp_i3c_deinit(mctp_inst);
 		break;
 	default:
 		break;

--- a/common/service/mctp/mctp.h
+++ b/common/service/mctp/mctp.h
@@ -204,6 +204,8 @@ uint8_t mctp_bridge_msg(mctp *mctp_inst, uint8_t *buf, uint16_t len, mctp_ext_pa
 /* medium init/deinit */
 uint8_t mctp_smbus_init(mctp *mctp_inst, mctp_medium_conf medium_conf);
 uint8_t mctp_smbus_deinit(mctp *mctp_inst);
+uint8_t mctp_i3c_init(mctp *mctp_instance, mctp_medium_conf medium_conf);
+uint8_t mctp_i3c_deinit(mctp *mctp_instance);
 
 /* register endpoint resolve function */
 uint8_t mctp_reg_endpoint_resolve_func(mctp *mctp_inst, endpoint_resolve resolve_fn);

--- a/common/service/mctp/mctp_i3c.c
+++ b/common/service/mctp/mctp_i3c.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mctp.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <zephyr.h>
+#include <sys/crc.h>
+#include <logging/log.h>
+#include "libutil.h"
+#include "hal_i3c.h"
+
+LOG_MODULE_REGISTER(mctp_i3c);
+
+#ifndef MCTP_I3C_PEC_ENABLE
+#define MCTP_I3C_PEC_ENABLE 0
+#endif
+
+static uint16_t mctp_i3c_read_smq(void *mctp_p, uint8_t *buf, uint32_t len,
+				  mctp_ext_params *extra_data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_p, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(buf, MCTP_ERROR);
+
+	/** blind return length 0 for now, the function will implement in rx commit **/
+	LOG_INF("mctp_i3c_read_smq is not ready, return 0(length) blindly");
+	return 0;
+}
+
+static uint16_t mctp_i3c_write_smq(void *mctp_p, uint8_t *buf, uint32_t len,
+				   mctp_ext_params extra_data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_p, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(buf, MCTP_ERROR);
+
+	if (extra_data.type != MCTP_MEDIUM_TYPE_I3C) {
+		LOG_ERR("mctp medium type incorrect");
+		return MCTP_ERROR;
+	}
+
+	int ret;
+	I3C_MSG *i3c_msg = (I3C_MSG *)malloc(sizeof(I3C_MSG));
+	mctp *mctp_instance = (mctp *)mctp_p;
+	i3c_msg->bus = mctp_instance->medium_conf.i3c_conf.bus;
+	/** mctp package **/
+	memcpy(&i3c_msg->data[0], buf, len);
+	/** +1 pec; default no pec **/
+	if (MCTP_I3C_PEC_ENABLE) {
+		i3c_msg->tx_len = len + 1;
+		/** pec byte use 7-degree polynomial with 0 init value and false reverse **/
+		i3c_msg->data[len + 1] = crc8(&i3c_msg->data[0], len, 0x07, 0x00, false);
+	} else {
+		i3c_msg->tx_len = len;
+	}
+
+	LOG_HEXDUMP_DBG(&i3c_msg->data[0], i3c_msg->tx_len, "mctp_i3c_write_smq msg dump");
+
+	ret = i3c_smq_write(i3c_msg);
+	SAFE_FREE(i3c_msg);
+
+	if (ret < 0) {
+		LOG_ERR("mctp_i3c_write_smq write failed");
+		return MCTP_ERROR;
+	}
+	return MCTP_SUCCESS;
+}
+
+uint8_t mctp_i3c_init(mctp *mctp_instance, mctp_medium_conf medium_conf)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_instance, MCTP_ERROR);
+
+	mctp_instance->medium_conf = medium_conf;
+	mctp_instance->read_data = mctp_i3c_read_smq;
+	mctp_instance->write_data = mctp_i3c_write_smq;
+
+	return MCTP_SUCCESS;
+}
+
+uint8_t mctp_i3c_deinit(mctp *mctp_instance)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_instance, MCTP_ERROR);
+
+	mctp_instance->read_data = NULL;
+	mctp_instance->write_data = NULL;
+	memset(&mctp_instance->medium_conf, 0, sizeof(mctp_instance->medium_conf));
+	return MCTP_SUCCESS;
+}


### PR DESCRIPTION
[Summary]
- Add MCTP I3C write smq function
- The function determine whether the PEC byte has to add, default disable by marco
- Add MCTP I3C init and deinit
- Produce MCTP I3C read smq frame (no function)

[Test Plan & Log]
1. Build code:	Y35 CL BIC			[ Pass ] GT  SW BIC			[ Pass ]

2. Test code for calling MCTP I3C Tx function:	[ Pass ] a. Maunal package MCTP over PLDM data with IPMI self test command during initial: mctp *mctp_inst = find_mctp_by_i3c(0); mctp_inst->medium_conf.i3c_conf.addr = I3C_STATIC_ADDR_BMC; I3C_MSG *i3c_msg = (I3C_MSG *)malloc(sizeof(I3C_MSG)); i3c_msg->tx_len = 10; i3c_msg->data[0] = 0x01;	// MCTP header version i3c_msg->data[1] = 0x00;	// Destination EID i3c_msg->data[2] = 0x00;	// Source EID i3c_msg->data[3] = 0xC0;	// Flags i3c_msg->data[4] = 0x01;	// bit7: Integrity Check bit, bit[6:0]: Message Type, 0x01: PLDM i3c_msg->data[5] = 0x80;	// PLDM data[1], 10000000b, bit-7: Rq, bit-6: d, bit-5: reserved, bit[4:0]: Instance ID i3c_msg->data[6] = 0x3F;	// PLDM data[2], Header+PLDM type (OEM 0x3F) i3c_msg->data[7] = 0x01;	// PLDM data[3], PLDM command code 0x01 = IPMI i3c_msg->data[8] = 0x18;	// IPMI NetFn i3c_msg->data[9] = 0x04;	// IPMI CMD ———————————————————— BIC console ———————————————————— [00:01:01.830,000] <dbg> mctp.mctp_tx_task: tx endpoint 1 [00:01:01.830,000] <dbg> mctp: mctp tx task receive data
					       01 00 00 c0 01 80 3f 01  18 04                   |......?. ..
		[00:01:01.838,000] <dbg> mctp_i3c: buf dump
						   01 00 00 c0 01 80 3f 01  18 04                   |......?. ..
		[00:01:01.838,000] <dbg> mctp_i3c: i3c msg dump
						   01 00 00 c0 01 80 3f 01  18 04                   |......?. ..

	b. Start BMC daemon and wait for BIC IBI:
		———————————————————— BMC console ————————————————————
		root@bmc-oob:~# mctpd asti3c 0-7ec80010000 > /dev/null &
		[1] 941
		root@bmc-oob:~# pldmd --bus 0-7ec80010000
		asti3c: Incorrect packet size: 0
		client[0] registered for type 1
		rc=0 tags_num=0 tags_flag = 0x1
		MCTP message received: len 6, tag 0 dest eid=0
		rx_message msg[0] =1
		rx_message msg[1] =80
		rx_message msg[2] =3f
		rx_message msg[3] =1
		rx_message msg[4] =18
		rx_message msg[5] =4
		forwarding to client 0
		netfn = 0x18
		cmd = 0x4
		PLDM data[0] = 0x1
		PLDM data[1] = 0x0
		PLDM data[2] = 0x3f
		PLDM data[3] = 0x1
		IPMI data[4] = 0x0
		IPMI data[5] = 0x1c
		IPMI data[6] = 0x4
		IPMI data[7] = 0x0
		IPMI data[8] = 0x55
		IPMI data[9] = 0x0
		client[0] sent message: dest 0x01 len 9
		core: Generating packets for transmission of 10 byte message from 0 to 1
		core: Enqueued 1 packets

	c. Check BMC response from BIC:
		———————————————————— BIC console ————————————————————
		uart:~$ i3c smq I3C_SMQ_0 -r 14
		00000000: 01 01 00 c0 01 00 3f 01  00 1c 04 00 55 00       |......?. ....U.  |

3. Test no impact on GT				[ Pass ] a. BIC MCTP threads: uart:~$ kernel stacks
		0x55ec8 mctptx_01_0d_40 (real size 1024):       unused 180      usage 844 / 1024 (82 %)
		0x55e00 mctprx_01_0d_40 (real size 4096):       unused 2596     usage 1500 / 4096 (36 %)
		0x546c8 mctptx_01_0c_40 (real size 1024):       unused 180      usage 844 / 1024 (82 %)
		0x54600 mctprx_01_0c_40 (real size 4096):       unused 2596     usage 1500 / 4096 (36 %)
		0x52ec8 mctptx_01_0b_40 (real size 1024):       unused 180      usage 844 / 1024 (82 %)
		0x52e00 mctprx_01_0b_40 (real size 4096):       unused 2596     usage 1500 / 4096 (36 %)
		0x516c8 mctptx_01_0a_40 (real size 1024):       unused 164      usage 860 / 1024 (83 %)
		0x51600 mctprx_01_0a_40 (real size 4096):       unused 2596     usage 1500 / 4096 (36 %)
		0x4fec8 mctptx_01_03_40 (real size 1024):       unused 164      usage 860 / 1024 (83 %)
		0x4fe00 mctprx_01_03_40 (real size 4096):       unused 2596     usage 1500 / 4096 (36 %)
		0x4e6c8 mctptx_01_02_40 (real size 1024):       unused 164      usage 860 / 1024 (83 %)
		0x4e600 mctprx_01_02_40 (real size 4096):       unused 2596     usage 1500 / 4096 (36 %)
		0x4cec8 mctptx_01_01_40 (real size 1024):       unused 164      usage 860 / 1024 (83 %)
		0x4ce00 mctprx_01_01_40 (real size 4096):       unused 2596     usage 1500 / 4096 (36 %)
		0x4b6c8 mctptx_01_00_40 (real size 1024):       unused 164      usage 860 / 1024 (83 %)
		0x4b600 mctprx_01_00_40 (real size 4096):       unused 2596     usage 1500 / 4096 (36 %)
		0x49ec8 mctptx_01_06_40 (real size 1024):       unused 172      usage 852 / 1024 (83 %)
		0x49e00 mctprx_01_06_40 (real size 4096):       unused 2564     usage 1532 / 4096 (37 %)
		0x6d290 USB_handler (real size 2048):   unused 1748     usage 300 / 2048 (14 %)
		0x6af70 IPMI_thread (real size 4096):   unused 1724     usage 2372 / 4096 (57 %)
		0x6c1c8 sensor_poll (real size 2048):   unused 1060     usage 988 / 2048 (48 %)
		0x6ada8 WDT_thread (real size 256):     unused 36       usage 220 / 256 (85 %)
		0x6c100 pldm_wait_resp_to (real size 1024):     unused 812      usage 212 / 1024 (20 %)
		0x6c038 monitor_tid (real size 1024):   unused 820      usage 204 / 1024 (19 %)
		0x6d458 shell_uart (real size 2048):    unused 1004     usage 1044 / 2048 (50 %)
		0x6ac88 gpio_workq (real size 3072):    unused 2804     usage 268 / 3072 (8 %)
		0x32c70 ADC0       (real size 400):     unused 156      usage 244 / 400 (61 %)
		0x32fa8 ADC1       (real size 400):     unused 164      usage 236 / 400 (59 %)
		0x758a0 sysworkq   (real size 2048):    unused 1612     usage 436 / 2048 (21 %)
		0x6d608 usbdworkq  (real size 1024):    unused 556      usage 468 / 1024 (45 %)
		0x6d520 usbworkq   (real size 1024):    unused 764      usage 260 / 1024 (25 %)
		0x6d390 logging    (real size 768):     unused 220      usage 548 / 768 (71 %)
		0x6d700 idle 00    (real size 320):     unused 268      usage 52 / 320 (16 %)
		0x81c40 IRQ 00     (real size 2048):    unused 1504     usage 544 / 2048 (26 %)

	b. BIC FW update(flash back from this commit to official image):
		root@bmc-oob:~# fw-util swb --update bic /tmp/GT-SWB-2022.37.01.bin
		updating fw on bus 3:
		updated: 100 %
		Elapsed time:  23   sec.
		Upgrade of swb : bic succeeded

	c. SWB FRUID:
		root@bmc-oob:~# fruid-util swb

		FRU Information           : Switch Board
		---------------           : ------------------
		Chassis Type              : Rack Mount Chassis
		Chassis Serial Number     : QTWF0T22240008
		Board Mfg Date            : Tue Jun 21 13:54:00 2022
		Board Mfg                 : Quanta
		Board Product             : Grand Teton Expander BD
		Board Serial              : TWJ2021800098
		Board Part Number         : 3SF0TEA0000
		Board FRU ID              : Fru Version 0.02
		Board Custom Data 1       : 19-002196
		Board Custom Data 2       : TTM
		Board Custom Data 3       : EVT
		Product Manufacturer      : Quanta
		Product Name              : Grand Teton
		Product Part Number       : 1F0TUBZ0001
		Product Version           : 3QF0TEA0000
		Product Serial            : QTWF0T22240008
		Product Asset Tag         : AT99400
		Product FRU ID            : 17-000661
		Product Custom Data 1     : 01-006324
		Product Custom Data 2     : QTWF0TS22240013
		Product Custom Data 3     : AT99396