### PR TITLE
at-cc: Support 2-channel i2c switch and multiplexer

### DIFF
--- a/common/dev/common_i2c_mux.c
+++ b/common/dev/common_i2c_mux.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <logging/log.h>
+#include "libutil.h"
+#include "hal_i2c.h"
+#include "common_i2c_mux.h"
+
+LOG_MODULE_REGISTER(common_i2c_mux);
+
+bool set_mux_channel(mux_config mux_cfg)
+{
+	int status = 0;
+	int retry = 5;
+
+	/* Set channel */
+	I2C_MSG mux_msg = { 0 };
+	mux_msg.bus = mux_cfg.bus;
+	mux_msg.target_addr = mux_cfg.target_addr;
+	mux_msg.tx_len = 1;
+	mux_msg.data[0] = mux_cfg.channel;
+
+	status = i2c_master_write(&mux_msg, retry);
+	if (status != 0) {
+		LOG_ERR("set channel fail, status: %d, bus: %d, addr: 0x%x", status, mux_cfg.bus,
+			mux_cfg.target_addr);
+		return false;
+	}
+
+	return true;
+}

--- a/common/dev/include/common_i2c_mux.h
+++ b/common/dev/include/common_i2c_mux.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef COMMON_I2C_MUX_H
+#define COMMON_I2C_MUX_H
+
+#define MUTEX_LOCK_INTERVAL_MS 1000
+#define DISABLE_MUX_ALL_CHANNEL_DEFAULT 0
+
+typedef struct _mux_config {
+	uint8_t bus;
+	uint8_t target_addr;
+	uint8_t channel;
+} mux_config;
+
+bool set_mux_channel(mux_config mux_cfg);
+
+#endif

--- a/common/dev/include/i2c-mux-pi4msd5v9542.h
+++ b/common/dev/include/i2c-mux-pi4msd5v9542.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef I2C_MUX_PI4MSD5V9542_H
+#define I2C_MUX_PI4MSD5V9542_H
+
+#define PI4MSD5V9542_ENABLE_BIT BIT(2)
+#define PI4MSD5V9542_SELECT_CHANNEL_0 0
+#define PI4MSD5V9542_SELECT_CHANNEL_1 1
+
+enum PI4MSD5V9542_CHANNEL {
+	PI4MSD5V9542_CHANNEL_0,
+	PI4MSD5V9542_CHANNEL_1,
+};
+
+#endif

--- a/common/dev/include/i2c-mux-tca9543a.h
+++ b/common/dev/include/i2c-mux-tca9543a.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef I2C_MUX_TCA9543A_H
+#define I2C_MUX_TCA9543A_H
+
+enum TCA9543A_CHANNEL {
+	TCA9543A_CHANNEL_0 = BIT(0),
+	TCA9543A_CHANNEL_1 = BIT(1),
+};
+
+#endif


### PR DESCRIPTION
Summary:
- Support mux common function to set channel.
- Support 2-channel i2c-bus switch (TCA9543A) device.
- Support 2-channel i2c-bus multiplexer (PI4MSD5V9542A) device.

Test Plan:
- Build code: Pass