### PR TITLE
at-cc: Support HSC and DC-to-DC power module device

### DIFF
--- a/common/dev/adm1272.c
+++ b/common/dev/adm1272.c
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <logging/log.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "pmbus.h"
+#include "adm1272.h"
+
+LOG_MODULE_REGISTER(dev_adm1272);
+
+#define REG_PWR_MONITOR_CFG 0xD4
+
+int adm1272_convert_real_value(uint8_t vrange, uint8_t irange, uint8_t offset, float *val)
+{
+	CHECK_NULL_ARG_WITH_RETURN(val, -1);
+
+	int convert_coefficient_m = 0;
+	int convert_coefficient_b = 0;
+	int convert_coefficient_R = 0;
+
+	switch (offset) {
+	case PMBUS_READ_VOUT:
+		switch (vrange) {
+		case VRANGE_0V_TO_60V:
+			convert_coefficient_m = 6770;
+			break;
+		case VRANGE_0V_TO_100V:
+			convert_coefficient_m = 4062;
+			break;
+		default:
+			LOG_ERR("Vrange 0x%x is invlid", vrange);
+			return -1;
+		}
+		convert_coefficient_b = 0;
+		convert_coefficient_R = 100;
+		break;
+
+	case PMBUS_READ_IOUT:
+		switch (irange) {
+		case IRANGE_0MV_TO_15MV:
+			convert_coefficient_m = 1326;
+			break;
+		case IRANGE_0MV_TO_30MV:
+			convert_coefficient_m = 663;
+			break;
+		default:
+			LOG_ERR("Irange 0x%x is invlid", irange);
+			return -1;
+		}
+		convert_coefficient_b = 20480;
+		convert_coefficient_R = 10;
+		break;
+
+	case PMBUS_READ_TEMPERATURE_1:
+		convert_coefficient_m = 42;
+		convert_coefficient_b = 31871;
+		convert_coefficient_R = 10;
+		break;
+
+	case PMBUS_READ_PIN:
+		switch (vrange) {
+		case VRANGE_0V_TO_60V:
+			switch (irange) {
+			case IRANGE_0MV_TO_15MV:
+				convert_coefficient_m = 3512;
+				convert_coefficient_R = 100;
+				break;
+			case IRANGE_0MV_TO_30MV:
+				convert_coefficient_m = 17561;
+				convert_coefficient_R = 1000;
+				break;
+			default:
+				LOG_ERR("Irange 0x%x is invlid", irange);
+				return -1;
+			}
+			break;
+		case VRANGE_0V_TO_100V:
+			switch (irange) {
+			case IRANGE_0MV_TO_15MV:
+				convert_coefficient_m = 21071;
+				convert_coefficient_R = 1000;
+				break;
+			case IRANGE_0MV_TO_30MV:
+				convert_coefficient_m = 10535;
+				convert_coefficient_R = 1000;
+				break;
+			default:
+				LOG_ERR("Irange 0x%x is invlid", irange);
+				return -1;
+			}
+			break;
+		default:
+			LOG_ERR("Vrange 0x%x is invlid", vrange);
+			return -1;
+		}
+		convert_coefficient_b = 0;
+		break;
+
+	default:
+		LOG_ERR("Offset 0x%x is invalid", offset);
+		return -1;
+	}
+
+	if (convert_coefficient_m == 0) {
+		LOG_ERR("Convert coefficient m is invalid, vrange: 0x%x, irange: 0x%x", vrange,
+			irange);
+		return -1;
+	}
+
+	*val = ((*val) * convert_coefficient_R - convert_coefficient_b) / convert_coefficient_m;
+
+	// Only positive IOUT values are used to avoid returning a negative power
+	if ((offset == PMBUS_READ_IOUT) && (*val < 0)) {
+		*val = 0;
+	}
+
+	return 0;
+}
+
+int adm1272_read_pout(uint8_t sensor_num, float *val)
+{
+	CHECK_NULL_ARG_WITH_RETURN(val, -1);
+
+	sensor_cfg cfg = sensor_config[sensor_config_index_map[sensor_num]];
+	adm1272_init_arg *init_arg =
+		(adm1272_init_arg *)sensor_config[sensor_config_index_map[sensor_num]].init_args;
+
+	uint8_t retry = 5;
+	int ret = 0;
+	float vout = 0;
+	float iout = 0;
+	I2C_MSG msg = { 0 };
+	msg.bus = cfg.port;
+	msg.target_addr = cfg.target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = PMBUS_READ_VOUT;
+
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Read vout fail, ret: %d", ret);
+		return -1;
+	}
+	vout = (msg.data[1] << 8) | msg.data[0];
+	ret = adm1272_convert_real_value(init_arg->pwr_monitor_cfg.fields.VRANGE,
+					 init_arg->pwr_monitor_cfg.fields.IRANGE, PMBUS_READ_VOUT,
+					 &vout);
+	if (ret != 0) {
+		LOG_ERR("Convert vout value fail");
+		return -1;
+	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = cfg.port;
+	msg.target_addr = cfg.target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = PMBUS_READ_IOUT;
+
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Read iout fail, ret: %d", ret);
+		return -1;
+	}
+	iout = (msg.data[1] << 8) | msg.data[0];
+	ret = adm1272_convert_real_value(init_arg->pwr_monitor_cfg.fields.VRANGE,
+					 init_arg->pwr_monitor_cfg.fields.IRANGE, PMBUS_READ_IOUT,
+					 &iout);
+	if (ret != 0) {
+		LOG_ERR("Convert iout value fail");
+		return -1;
+	}
+
+	*val = vout * iout;
+	return 0;
+}
+
+uint8_t adm1272_read(uint8_t sensor_num, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+
+	if (sensor_num > SENSOR_NUM_MAX) {
+		LOG_ERR("Input sensor number is invalid, sensor number: 0x%x", sensor_num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	if (sensor_config[sensor_config_index_map[sensor_num]].init_args == NULL) {
+		LOG_ERR("Initial arg is NULL");
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	adm1272_init_arg *init_arg =
+		(adm1272_init_arg *)sensor_config[sensor_config_index_map[sensor_num]].init_args;
+	if (init_arg->is_init == false) {
+		LOG_WRN("Device isn't initialized");
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	float val = 0;
+	uint8_t retry = 5;
+	I2C_MSG msg = { 0 };
+	int ret = 0;
+	uint8_t offset = sensor_config[sensor_config_index_map[sensor_num]].offset;
+
+	if (offset != PMBUS_READ_POUT) {
+		msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
+		msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
+		msg.tx_len = 1;
+		msg.data[0] = offset;
+		msg.rx_len = 2;
+
+		ret = i2c_master_read(&msg, retry);
+		if (ret != 0) {
+			LOG_ERR("I2c read fail, ret: %d, offset: 0x%x", ret, offset);
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+	}
+
+	switch (offset) {
+	case PMBUS_READ_VOUT:
+	case PMBUS_READ_IOUT:
+	case PMBUS_READ_TEMPERATURE_1:
+	case PMBUS_READ_PIN:
+		val = (msg.data[1] << 8) | msg.data[0];
+		ret = adm1272_convert_real_value(init_arg->pwr_monitor_cfg.fields.VRANGE,
+						 init_arg->pwr_monitor_cfg.fields.IRANGE, offset,
+						 &val);
+		break;
+	case PMBUS_READ_POUT:
+		ret = adm1272_read_pout(sensor_num, &val);
+		break;
+	default:
+		LOG_ERR("Invalid sensor 0x%x offset 0x%x", sensor_num, offset);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	if (ret != 0) {
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+	sensor_val *sval = (sensor_val *)reading;
+	sval->integer = (int)val & 0xFFFF;
+	sval->fraction = (val - sval->integer) * 1000;
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t adm1272_init(uint8_t sensor_num)
+{
+	if (sensor_num > SENSOR_NUM_MAX) {
+		LOG_ERR("Sensor number is invalid, sensor number: 0x%x", sensor_num);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	adm1272_init_arg *init_args =
+		(adm1272_init_arg *)sensor_config[sensor_config_index_map[sensor_num]].init_args;
+	uint8_t retry = 5;
+	int ret = -1;
+	I2C_MSG msg = { 0 };
+
+	if (init_args->is_need_set_pwr_cfg == false) {
+		goto skip_set_pwr_cfg;
+	}
+
+	msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
+	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
+	msg.tx_len = 3;
+	msg.data[0] = REG_PWR_MONITOR_CFG;
+	msg.data[1] = init_args->pwr_monitor_cfg.value & 0xFF;
+	msg.data[2] = (init_args->pwr_monitor_cfg.value >> 8) & 0xFF;
+
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Set power monitor config fail, ret: %d", ret);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+	memset(&msg, 0, sizeof(msg));
+
+skip_set_pwr_cfg:
+	msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
+	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
+	msg.tx_len = 1;
+	msg.data[0] = REG_PWR_MONITOR_CFG;
+	msg.rx_len = 2;
+
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Read power monitor config fail, ret: %d", ret);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	init_args->pwr_monitor_cfg.value = ((msg.data[1] << 8) | msg.data[0]);
+	init_args->is_init = 1;
+
+	sensor_config[sensor_config_index_map[sensor_num]].read = adm1272_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/dev/include/adm1272.h
+++ b/common/dev/include/adm1272.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ADM1272_H
+#define ADM1272_H
+
+enum ADM1272_IRANGE {
+	IRANGE_0MV_TO_15MV = 0x0,
+	IRANGE_0MV_TO_30MV = 0x1,
+};
+
+enum ADM1272_VRANGE {
+	VRANGE_0V_TO_60V = 0x0,
+	VRANGE_0V_TO_100V = 0x1,
+};
+
+#endif

--- a/common/dev/q50sn120a1.c
+++ b/common/dev/q50sn120a1.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <logging/log.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "pmbus.h"
+
+LOG_MODULE_REGISTER(dev_q50sn120a1);
+
+/** Q50SN120A1 VOUT scale is exponent -12 base 2 **/
+#define Q50SN120A1_VOUT_SCALE 0.000244140625
+
+/** Q50SN120A1 IOUT/Temperature scale is exponent -2 base 2 **/
+#define Q50SN120A1_IOUT_SCALE 0.25
+#define Q50SN120A1_TEMPERATURE_SCALE 0.25
+
+int q50sn120a1_read_pout(uint8_t sensor_num, float *pout_value)
+{
+	CHECK_NULL_ARG_WITH_RETURN(pout_value, -1)
+
+	uint8_t retry = 5;
+	float vout = 0, iout = 0;
+	int ret = 0;
+	I2C_MSG msg = { 0 };
+
+	msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
+	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = PMBUS_READ_VOUT;
+
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("I2c read vout fail, ret: %d", ret);
+		return -1;
+	}
+	vout = ((msg.data[1] << 8) | msg.data[0]) * Q50SN120A1_VOUT_SCALE;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
+	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = PMBUS_READ_IOUT;
+
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("I2c read iout fail, ret: %d", ret);
+		return -1;
+	}
+	iout = ((msg.data[1] << 8) | msg.data[0]) * Q50SN120A1_IOUT_SCALE;
+
+	*pout_value = vout * iout;
+	return 0;
+}
+
+uint8_t q50sn120a1_read(uint8_t sensor_num, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+
+	if (sensor_num > SENSOR_NUM_MAX) {
+		LOG_ERR("Sensor 0x%x input parameter is invalid", sensor_num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	uint8_t retry = 5;
+	uint8_t offset = sensor_config[sensor_config_index_map[sensor_num]].offset;
+	float val = 0;
+	int ret = 0;
+	I2C_MSG msg = { 0 };
+
+	msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
+	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = offset;
+
+	if (offset != PMBUS_READ_POUT) {
+		ret = i2c_master_read(&msg, retry);
+		if (ret != 0) {
+			LOG_ERR("I2c read fail  ret: %d", ret);
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+		val = (msg.data[1] << 8) | msg.data[0];
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	switch (offset) {
+	case PMBUS_READ_VOUT:
+		val = val * Q50SN120A1_VOUT_SCALE;
+		break;
+	case PMBUS_READ_IOUT:
+		val = val * Q50SN120A1_IOUT_SCALE;
+		break;
+	case PMBUS_READ_TEMPERATURE_1:
+		val = val * Q50SN120A1_TEMPERATURE_SCALE;
+		break;
+	case PMBUS_READ_POUT:
+		ret = q50sn120a1_read_pout(sensor_num, &val);
+		if (ret != 0) {
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+		break;
+	default:
+		LOG_ERR("Offset not supported: 0x%x", offset);
+		return SENSOR_FAIL_TO_ACCESS;
+		break;
+	}
+
+	sval->integer = (int)val & 0xFFFF;
+	sval->fraction = (val - sval->integer) * 1000;
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t q50sn120a1_init(uint8_t sensor_num)
+{
+	if (sensor_num > SENSOR_NUM_MAX) {
+		LOG_ERR("Input sensor number is invalid");
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	sensor_config[sensor_config_index_map[sensor_num]].read = q50sn120a1_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -98,6 +98,8 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(mp2856gut)
 	sensor_name_to_num(ddr5_power)
 	sensor_name_to_num(ddr5_temp)
+	sensor_name_to_num(adm1272)
+	sensor_name_to_num(q50sn120a1)
 };
 // clang-format on
 
@@ -133,6 +135,8 @@ SENSOR_DRIVE_INIT_DECLARE(g788p81u);
 SENSOR_DRIVE_INIT_DECLARE(mp2856gut);
 SENSOR_DRIVE_INIT_DECLARE(ddr5_power);
 SENSOR_DRIVE_INIT_DECLARE(ddr5_temp);
+SENSOR_DRIVE_INIT_DECLARE(adm1272);
+SENSOR_DRIVE_INIT_DECLARE(q50sn120a1);
 
 struct sensor_drive_api {
 	enum SENSOR_DEV dev;
@@ -170,6 +174,8 @@ struct sensor_drive_api {
 	SENSOR_DRIVE_TYPE_INIT_MAP(mp2856gut),
 	SENSOR_DRIVE_TYPE_INIT_MAP(ddr5_power),
 	SENSOR_DRIVE_TYPE_INIT_MAP(ddr5_temp),
+	SENSOR_DRIVE_TYPE_INIT_MAP(adm1272),
+	SENSOR_DRIVE_TYPE_INIT_MAP(q50sn120a1),
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -118,6 +118,8 @@ enum SENSOR_DEV {
 	sensor_dev_mp2856gut = 0x1C,
 	sensor_dev_ddr5_power = 0x1D,
 	sensor_dev_ddr5_temp = 0x1E,
+	sensor_dev_adm1272 = 0x1F,
+	sensor_dev_q50sn120a1 = 0x20,
 	sensor_dev_max
 };
 
@@ -412,6 +414,30 @@ typedef struct _ddr5_init_temp_arg_ {
 	float ts0_temp;
 	float ts1_temp;
 } ddr5_init_temp_arg;
+
+typedef struct _adm1272_init_arg {
+	union {
+		uint16_t value;
+		struct {
+			uint16_t IRANGE : 1;
+			uint16_t VOUT_EN : 1;
+			uint16_t VIN_EN : 1;
+			uint16_t TEMP1_EN : 1;
+			uint16_t PMON_MODE : 1;
+			uint16_t VRANGE : 1;
+			uint16_t RSV2 : 2;
+			uint16_t VI_AVG : 3;
+			uint16_t PWR_AVG : 3;
+			uint16_t SIMULTANEOUS : 1;
+			uint16_t TSFILT : 1;
+		} fields;
+	} pwr_monitor_cfg;
+
+	/* Initialize function will set following arguments, no need to give value */
+	bool is_init;
+	bool is_need_set_pwr_cfg;
+
+} adm1272_init_arg;
 
 extern bool enable_sensor_poll_thread;
 extern sensor_cfg *sensor_config;


### PR DESCRIPTION
Summary:
- Support HSC (ADM1272) device.
- Support DC-to-DC power module (Q50SN120A1) device.

Test Plan:
- Build code: Pass