### PR TITLE
fby3: dl: Fix HSC MP5990 IOUT_CAL_GAIN

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_hook.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_hook.c
@@ -39,7 +39,7 @@ adc_asd_init_arg adc_asd_init_args[] = { [0] = { .is_init = false } };
 ltc4282_init_arg ltc4282_init_args[] = { [0] = { .is_init = false, .r_sense_mohm = 0.25 } };
 
 mp5990_init_arg mp5990_init_args[] = {
-	[0] = { .is_init = false, .iout_cal_gain = 0x0104, .iout_oc_fault_limit = 0x0028 }
+	[0] = { .is_init = false, .iout_cal_gain = 0x0202, .iout_oc_fault_limit = 0x0028 }
 };
 
 /**************************************************************************************************


### PR DESCRIPTION
Summary:
- Fix HSC MP5990 IOUT_CAL_GAIN. The resistor of IMON is 2.49K. IOUT_CAL_GAIN should be 0x0202.

Test plan:
- Build code: Pass
- Get HSC sensors correctly

MP5990:
HSC Temp                     (0xF) :   34.00 C     | (ok)
HSC Input Vol                (0x26) :   11.76 Volts | (ok)
HSC Output Cur               (0x30) :    1.60 Amps  | (ok)
HSC Input Pwr                (0x2E) :   18.00 Watts | (ok)
HSC Input AvgPwr             (0x39) :   18.00 Watts | (ok)