### PR TITLE
fby3.5: cl: Workaround to fix GPIO bounce

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -519,6 +519,8 @@ void pal_extend_sensor_config()
 	CARD_STATUS _2ou_status = get_2ou_status();
 
 	int arg_index = (_2ou_status.present) ? 1 : 0;
+	int gpio_state = (_2ou_status.present) ? GPIO_HIGH : GPIO_LOW;
+	gpio_set(HSC_SET_EN_R, gpio_state);
 
 	switch (hsc_module) {
 	case HSC_MODULE_ADM1278:


### PR DESCRIPTION
Summary:
- Set HSC_SET_EN_N to high when 2OU card is present.
- Add debounce time to solve the ISR handler hanging problem. The root cause is that FAST_PROCHOT_N and FM_CPU_BIC_PROCHOT_LVT3_N have plus when setting HSC_SET_EN_N to high, and this cause SB BIC send SEL before ipmb handler initial complete.

Solution:
- SB BIC adds debounce time when FAST_PROCHOT_N has an interrupt.
- SB CPLD add debounce time when FAST_PROCHOT_N has an interrupt, and then decide whether to send interrupt of FM_CPU_BIC_PROCHOT_LVT3_N to SB BIC.

Test plan:
- Build time: Pass
- Check no ISR hanging: Pass
- Check no SEL when set HSC_SET_EN_N to high: Pass

Log:
1. Check GPIO ISR handler isn't hanging. root@bmc-oob:~# bic-util slot1 --get_gpio | grep HSC_SET 7 HSC_SET_EN_R: 1
root@bmc-oob:~# bic-util slot1 --get_gpio | grep POST 1 FM_BIOS_POST_CMPLT_BMC_N: 0
root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   29.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   46.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   25.00 C     | (ok)
MB_PCH_TEMP_C                (0x4) :   43.00 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x5) :   59.00 C     | (ok)
MB_SOC_THERMAL_MARGIN_C      (0x14) :  -41.00 C     | (ok)
MB_SOC_TJMAX_C               (0x15) :  100.00 C     | (ok)
MB_DIMMA0_TEMP_C             (0x6) :   44.00 C     | (ok)
MB_DIMMA2_TEMP_C             (0x7) :   41.00 C     | (ok)
MB_DIMMA3_TEMP_C             (0x9) :   40.00 C     | (ok)
MB_DIMMA4_TEMP_C             (0xA) :   43.00 C     | (ok)
MB_DIMMA6_TEMP_C             (0xB) :   40.00 C     | (ok)
MB_DIMMA7_TEMP_C             (0xC) :   40.00 C     | (ok)
MB_SSD0_M2A_TEMP_C           (0xD) :   33.00 C     | (ok)
MB_HSC_TEMP_C                (0xE) :   42.86 C     | (ok)
MB_VR_VCCIN_TEMP_C           (0xF) :   56.00 C     | (ok)
MB_VR_FIVRA_TEMP_C           (0x10) :   52.00 C     | (ok)
MB_VR_EHV_TEMP_C             (0x11) :   41.00 C     | (ok)
MB_VR_VCCD_TEMP_C            (0x12) :   44.00 C     | (ok)
MB_VR_FAON_TEMP_C            (0x13) :   47.00 C     | (ok)
MB_ADC_P12V_STBY_VOLT_V      (0x20) :   12.59 Volts | (ok)
MB_ADC_P3V_BAT_VOLT_V        (0x21) :    3.08 Volts | (ok)
MB_ADC_P3V3_STBY_VOLT_V      (0x22) :    3.33 Volts | (ok)
MB_ADC_P1V8_STBY_VOLT_V      (0x23) :    1.80 Volts | (ok)
MB_ADC_P1V05_PCH_VOLT_V      (0x24) :    1.05 Volts | (ok)
MB_ADC_P5V_STBY_VOLT_V       (0x25) :    4.96 Volts | (ok)
MB_ADC_P12V_DIMM_VOLT_V      (0x26) :   12.51 Volts | (ok)
MB_ADC_P1V2_STBY_VOLT_V      (0x27) :    1.19 Volts | (ok)
MB_ADC_P3V3_M2_VOLT_V        (0x28) :    3.31 Volts | (ok)
MB_HSC_INPUT_VOLT_V          (0x29) :   12.43 Volts | (ok)
MB_VR_VCCIN_VOLT_V           (0x2A) :    1.78 Volts | (ok)
MB_VR_FIVRA_VOLT_V           (0x2C) :    1.82 Volts | (ok)
MB_VR_EHV_VOLT_V             (0x2D) :    1.80 Volts | (ok)
MB_VR_VCCD_VOLT_V            (0x2E) :    1.14 Volts | (ok)
MB_VR_FAON_VOLT_V            (0x2F) :    1.05 Volts | (ok)
HSC_OUTPUT_CURR_A            (0x30) :    7.08 Amps  | (ok)
MB_VR_VCCIN_CURR_A           (0x31) :   22.20 Amps  | (ok)
MB_VR_FIVRA_CURR_A           (0x32) :    3.60 Amps  | (ok)
MB_VR_EHV_CURR_A             (0x33) :    0.50 Amps  | (ok)
MB_VR_VCCD_CURR_A            (0x34) :    2.80 Amps  | (ok)
MB_VR_FAON_CURR_A            (0x35) :    9.40 Amps  | (ok)
MB_SOC_PACKAGE_PWR_W         (0x38) :   59.00 Watts | (ok)
MB_HSC_INPUT_PWR_W           (0x39) :   86.49 Watts | (ok)
MB_VR_VCCIN_PWR_W            (0x3A) :   38.00 Watts | (ok)
MB_VR_FIVRA_PWR_W            (0x3C) :    6.00 Watts | (ok)
MB_VR_EHV_PWR_W              (0x3D) :    1.00 Watts | (ok)
MB_VR_VCCD_PWR_W             (0x3E) :    3.00 Watts | (ok)
MB_VR_FAON_PWR_W             (0x3F) :   10.00 Watts | (ok)
MB_VR_DIMMA0_PMIC_PWR_W      (0x1E) :    0.38 Watts | (ok)
MB_VR_DIMMA2_PMIC_PWR_W      (0x1F) :    0.50 Watts | (ok)
MB_VR_DIMMA3_PMIC_PWR_W      (0x36) :    0.50 Watts | (ok)
MB_VR_DIMMA4_PMIC_PWR_W      (0x37) :    1.00 Watts | (ok)
MB_VR_DIMMA6_PMIC_PWR_W      (0x42) :    0.38 Watts | (ok)
MB_VR_DIMMA7_PMIC_PWR_W      (0x47) :    0.38 Watts | (ok)
DPV2_2_12V_INPUT_VOLT_V      (0x91) :   12.44 Volts | (ok)
DPV2_2_12V_OUTPUT_VOLT_V     (0x92) :   12.46 Volts | (ok)
DPV2_2_12V_OUTPUT_CURR_A     (0x93) :    0.12 Amps  | (ok)
DPV2_2_EFUSE_TEMP_C          (0x94) :   21.38 C     | (ok)
DPV2_2_EFUSE_PWR_W           (0x95) :    1.19 Watts | (ok)

2. Check no throttle SEL when set HSC_SET_EN_N to high.
- Before fix root@bmc-oob:~# log-util --print slot1
2022 Oct 10 19:48:39 log-util: User cleared FRU: 1 logs

root@bmc-oob:~# bic-util slot1 --set_gpio 7 1
slot 1: setting [7]HSC_SET_EN_R to 1

root@bmc-oob:~# log-util --print slot1
2022 Oct 10 19:48:39 log-util: User cleared FRU: 1 logs
1    slot1    2022-10-10 19:49:09    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-10-10 19:49:09, Sensor: SYSTEM_STATUS (0x10), Event Data: (07FFFF) MB_Throttle throttle Deassertion
1    slot1    2022-10-10 19:49:09    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-10-10 19:49:09, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Deassertion

- After fix root@bmc-oob:~# log-util --print slot1
2022 Oct 10 19:53:34 log-util: User cleared FRU: 1 logs

root@bmc-oob:~# bic-util slot1 --set_gpio 7 1
slot 1: setting [7]HSC_SET_EN_R to 1

root@bmc-oob:~# log-util --print slot1
2022 Oct 10 19:53:34 log-util: User cleared FRU: 1 logs

3. Check have SEL when throttle event trigger. root@bmc-oob:~# bic-util slot1 --set_gpio 50 0
slot 1: setting [50]FAST_PROCHOT_N to 0

root@bmc-oob:~# bic-util slot1 --set_gpio 50 1
slot 1: setting [50]FAST_PROCHOT_N to 1

root@bmc-oob:~# log-util --print slot1
2022 Oct 10 23:26:48 log-util: User cleared FRU: 1 logs
1    slot1    2022-10-10 23:26:52    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-10-10 23:26:52, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Assertion
1    slot1    2022-10-10 23:26:52    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-10-10 23:26:52, Sensor: SYSTEM_STATUS (0x10), Event Data: (07FFFF) MB_Throttle throttle Assertion
1    slot1    2022-10-10 23:26:52    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-10-10 23:26:52, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Assertion
1    slot1    2022-10-10 23:26:54    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-10-10 23:26:54, Sensor: SYSTEM_STATUS (0x10), Event Data: (07FFFF) MB_Throttle throttle Deassertion
1    slot1    2022-10-10 23:26:54    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-10-10 23:26:54, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Deassertion
1    slot1    2022-10-10 23:26:54    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2022-10-10 23:26:54, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Deassertion