### PR TITLE
common: Correct  LTC4286 initial function

### DIFF
--- a/common/dev/ltc4286.c
+++ b/common/dev/ltc4286.c
@@ -161,7 +161,6 @@ uint8_t ltc4286_read(uint8_t sensor_num, int *reading)
 
 uint8_t ltc4286_init(uint8_t sensor_num)
 {
-	static bool isParameterInitialized = false;
 	if (!sensor_config[sensor_config_index_map[sensor_num]].init_args) {
 		printf("<error> LTC4286 init args are not provided!\n");
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
@@ -195,14 +194,13 @@ init_param:
 	msg.tx_len = 1;
 	msg.rx_len = 3;
 	msg.data[0] = LTC4286_MFR_CONFIG1;
-	if (i2c_master_write(&msg, retry) != 0) {
+	if (i2c_master_read(&msg, retry) != 0) {
 		printf("Failed to read LTC4286 register(0x%x)\n", msg.data[0]);
 		init_args->is_init = false;
 		goto cleanup;
 	}
-	if ((msg.data[0] == LTC4286_MFR_CONFIG1) && (isParameterInitialized == false)) {
+	if (msg.data[0] == LTC4286_MFR_CONFIG1) {
 		init_args->mfr_config_1.value = (msg.data[1] | (msg.data[2] << 8));
-		isParameterInitialized = true;
 	}
 
 	init_args->is_init = true;


### PR DESCRIPTION
Summary:
- Remove redundant variable isParameterInitialized.
- Correct I2C function.

Test plan:
- Build code: Pass
- Read LTC4286 sensor: Pass

Log:
1. Reading LTC4286 sensor.
- BIC console uart:~$ platform sensor list_all
--------------------------------------------------------------------------------- ...
[0xe ] MB_HSC_TEMP_C            : tmp431     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    36.812
[0x29] MB_HSC_INPUT_VOLT_V      : ltc4286    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.555
[0x30] HSC_OUTPUT_CURR_A        : ltc4286    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.798
[0x39] MB_HSC_INPUT_PWR_W       : ltc4286    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    69.793
---------------------------------------------------------------------------------

- BMC console root@bmc-oob:~# sensor-util slot1 | grep HSC
MB_HSC_TEMP_C                (0xE) :   38.50 C     | (ok)
MB_HSC_INPUT_VOLT_V         (0x29) :   12.56 Volts | (ok)
HSC_OUTPUT_CURR_A           (0x30) :    5.84 Amps  | (ok)
MB_HSC_INPUT_PWR_W          (0x39) :   70.28 Watts | (ok)