### PR TITLE
fby3.5: cl: Recode BIOS firmware version in EEPROM

### DIFF
--- a/common/service/host/kcs.h
+++ b/common/service/host/kcs.h
@@ -26,7 +26,7 @@
 #define KCS_POLLING_INTERVAL 100
 #define KCS_BUFF_SIZE 256
 
-#define DEBUG_KCS 0
+#define CMD_SYS_INFO_FW_VERSION 0x01
 
 struct kcs_request {
 	uint8_t netfn;

--- a/common/service/ipmi/include/ipmi.h
+++ b/common/service/ipmi/include/ipmi.h
@@ -71,8 +71,10 @@ static inline void pack_ipmi_resp(struct ipmi_response *resp, ipmi_msg *ipmi_res
 
 // If command is from KCS, we need to check whether BIC support this command.
 bool pal_request_msg_to_BIC_from_KCS(uint8_t netfn, uint8_t cmd);
-// If command is from KCS, we need to check whether BIC BIC responds immediately.
+// If command is from KCS, we need to check whether BIC responds immediately.
 bool pal_immediate_respond_from_KCS(uint8_t netfn, uint8_t cmd);
+// If command is from KCS, we need to check whether system information is set via BIC.
+int pal_record_bios_fw_version(uint8_t *buf, uint8_t size);
 // If command is from ME, we need to check whether BIC support this command.
 bool pal_request_msg_to_BIC_from_ME(uint8_t netfn, uint8_t cmd);
 // For the command that BIC only bridges it, BIC doesn't return the command directly
@@ -153,6 +155,7 @@ enum {
 	CMD_APP_GET_SELFTEST_RESULTS = 0x04,
 	CMD_APP_GET_SYSTEM_GUID = 0x37,
 	CMD_APP_MASTER_WRITE_READ = 0x52,
+	CMD_APP_SET_SYS_INFO_PARAMS = 0x58,
 };
 
 // Chassis Command Codes (0x00)
@@ -255,6 +258,7 @@ enum {
 	CMD_OEM_1S_MULTI_ACCURACY_SENSOR_READING = 0x88,
 	CMD_OEM_1S_GET_BOARD_ID = 0xA0,
 	CMD_OEM_1S_GET_CARD_TYPE = 0xA1,
+	CMD_OEM_1S_GET_BIOS_VERSION = 0xA2,
 	CMD_OEM_1S_NOTIFY_PMIC_ERROR = 0xB0,
 	CMD_OEM_1S_GET_SDR = 0xC0,
 };

--- a/common/service/ipmi/include/oem_1s_handler.h
+++ b/common/service/ipmi/include/oem_1s_handler.h
@@ -100,6 +100,7 @@ void OEM_1S_CLEAR_CMOS(ipmi_msg *msg);
 void OEM_1S_NOTIFY_PMIC_ERROR(ipmi_msg *msg);
 void OEM_1S_GET_SDR(ipmi_msg *msg);
 void OEM_1S_BMC_IPMB_ACCESS(ipmi_msg *msg);
+void OEM_1S_GET_BIOS_VERSION(ipmi_msg *msg);
 
 #ifdef CONFIG_SNOOP_ASPEED
 void OEM_1S_GET_POST_CODE(ipmi_msg *msg);

--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -137,6 +137,11 @@ __weak bool pal_immediate_respond_from_KCS(uint8_t netfn, uint8_t cmd)
 	return false;
 }
 
+__weak int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
+{
+	return -2;
+}
+
 __weak bool pal_request_msg_to_BIC_from_ME(uint8_t netfn, uint8_t cmd)
 {
 	if ((netfn == NETFN_OEM_REQ) && (cmd == CMD_OEM_NM_SENSOR_READ)) {

--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -1932,7 +1932,14 @@ __weak void OEM_1S_BMC_IPMB_ACCESS(ipmi_msg *msg)
 	msg->completion_code = CC_UNSPECIFIED_ERROR;
 
 #endif
+}
 
+__weak void OEM_1S_GET_BIOS_VERSION(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	msg->data_len = 0;
+	msg->completion_code = CC_INVALID_CMD;
 	return;
 }
 
@@ -2154,6 +2161,10 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 	case CMD_OEM_1S_BMC_IPMB_ACCESS:
 		LOG_DBG("Received 1S BMC IPMB Access command");
 		OEM_1S_BMC_IPMB_ACCESS(msg);
+		break;
+	case CMD_OEM_1S_GET_BIOS_VERSION:
+		LOG_DBG("Received 1S Get BIOS version command");
+		OEM_1S_GET_BIOS_VERSION(msg);
 		break;
 	default:
 		LOG_ERR("Invalid OEM message, netfn(0x%x) cmd(0x%x)", msg->netfn, msg->cmd);

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -18,18 +18,80 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-
+#include <logging/log.h>
 #include "libutil.h"
 #include "ipmi.h"
+#include "fru.h"
+#include "eeprom.h"
+#include "plat_fru.h"
 #include "plat_class.h"
 #include "plat_ipmb.h"
 
-void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
+LOG_MODULE_REGISTER(plat_ipmi);
+
+int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
 {
-	if (msg == NULL) {
-		printf("[%s] Failed due to parameter *msg is NULL\n", __func__);
+	CHECK_NULL_ARG_WITH_RETURN(buf, -1);
+
+	int ret = -1;
+	EEPROM_ENTRY set_bios_ver = { 0 };
+	EEPROM_ENTRY get_bios_ver = { 0 };
+
+	ret = get_bios_version(&get_bios_ver);
+	if (ret == -1) {
+		LOG_ERR("Get version fail");
+		return -1;
+	}
+
+	set_bios_ver.data_len = size - 3; // skip netfn, cmd and command code
+	memcpy(&set_bios_ver.data[0], &buf[3], set_bios_ver.data_len);
+
+	// Check the written BIOS version is the same with the stored
+	ret = memcmp(&get_bios_ver.data[0], &set_bios_ver.data[0],
+		     BIOS_FW_VERSION_MAX_SIZE * sizeof(uint8_t));
+	if (ret == 0) {
+		LOG_DBG("The Written bios version is the same with the stored bios version in EEPROM");
+	} else {
+		LOG_DBG("Set bios version");
+
+		ret = set_bios_version(&set_bios_ver);
+		if (ret == -1) {
+			LOG_ERR("Set version fail");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+void OEM_1S_GET_BIOS_VERSION(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
 		return;
 	}
+
+	int ret = -1;
+	EEPROM_ENTRY get_bios_ver = { 0 };
+
+	ret = get_bios_version(&get_bios_ver);
+	if (ret == -1) {
+		LOG_ERR("Get version fail");
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
+		return;
+	}
+
+	memcpy(&msg->data[0], &get_bios_ver.data[0], get_bios_ver.data_len);
+	msg->data_len = get_bios_ver.data_len;
+	msg->completion_code = CC_SUCCESS;
+	return;
+}
+
+void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
 
 	if (msg->data_len != 1) {
 		msg->completion_code = CC_INVALID_LENGTH;

--- a/meta-facebook/yv35-cl/src/platform/plat_fru.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_fru.c
@@ -17,6 +17,11 @@
 #include "fru.h"
 #include "plat_fru.h"
 #include <string.h>
+#include <logging/log.h>
+#include "libutil.h"
+#include "eeprom.h"
+
+LOG_MODULE_REGISTER(plat_fru);
 
 const EEPROM_CFG plat_fru_config[] = {
 	{
@@ -39,7 +44,52 @@ const EEPROM_CFG plat_fru_config[] = {
 	},
 };
 
+// BIOS version is stored in MB EEPROM, but the location of EEPROM is different from fru information
+const EEPROM_CFG plat_bios_version_area_config = {
+	NV_ATMEL_24C128,
+	MB_FRU_ID,
+	MB_FRU_PORT,
+	MB_FRU_ADDR,
+	FRU_DEV_ACCESS_BYTE,
+	BIOS_FW_VERSION_START,
+	BIOS_FW_VERSION_MAX_SIZE,
+};
+
 void pal_load_fru_config(void)
 {
 	memcpy(&fru_config, &plat_fru_config, sizeof(plat_fru_config));
+}
+
+int set_bios_version(EEPROM_ENTRY *entry)
+{
+	CHECK_NULL_ARG_WITH_RETURN(entry, -1);
+
+	bool ret = false;
+	entry->config = plat_bios_version_area_config;
+	entry->data_len = BIOS_FW_VERSION_MAX_SIZE;
+
+	ret = eeprom_write(entry);
+	if (ret == false) {
+		LOG_ERR("eeprom_write fail");
+		return -1;
+	}
+
+	return 0;
+}
+
+int get_bios_version(EEPROM_ENTRY *entry)
+{
+	CHECK_NULL_ARG_WITH_RETURN(entry, -1);
+
+	bool ret = false;
+	entry->config = plat_bios_version_area_config;
+	entry->data_len = BIOS_FW_VERSION_MAX_SIZE;
+
+	ret = eeprom_read(entry);
+	if (ret == false) {
+		LOG_ERR("eeprom_read fail");
+		return -1;
+	}
+
+	return 0;
 }

--- a/meta-facebook/yv35-cl/src/platform/plat_fru.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_fru.h
@@ -17,11 +17,16 @@
 #ifndef PLAT_FRU_H
 #define PLAT_FRU_H
 
+#include "eeprom.h"
+
 #define MB_FRU_PORT 0x01
 #define MB_FRU_ADDR 0x54
 
 #define DPV2_FRU_PORT 0x08
 #define DPV2_FRU_ADDR 0x51
+
+#define BIOS_FW_VERSION_START 0x0A00
+#define BIOS_FW_VERSION_MAX_SIZE 34
 
 enum {
 	MB_FRU_ID,
@@ -29,5 +34,9 @@ enum {
 	// OTHER_FRU_ID,
 	MAX_FRU_ID,
 };
+
+bool get_bios_version_area_config(EEPROM_CFG *config);
+int set_bios_version(EEPROM_ENTRY *entry);
+int get_bios_version(EEPROM_ENTRY *entry);
 
 #endif


### PR DESCRIPTION
Summary:
- Record BIOS firmware version in EEPROM.
- Add ipmi oem command (netfn = 0x38, cmd = 0xA2) to support BMC get BIOS firmware version.

Note:
- IPMI command format
  - Request Byte 1:3 – MFG ID – 00A015h, LS byte first
  - Response Byte 1 – Completion Code Byte 2:18 BIOS version

Test Plan:
- Build code: Pass
- Check there are no unexpected error logs: Pass
- Check BIOS firmware version was stored in EEPROM after updating BIOS firmware: Pass
- Check BIOS firmware version was stored in EEPROM after power cycle/reset: Pass
- Check BIOS firmware version wasn't written to EEPROM if the written version is the same with the stored version in EEPROM: Pass

Log:
- Check BIOS firmware version was stored in EEPROM after updating BIOS firmware
  - Before updating BIOS firmware root@bmc-oob:~# fw-util slot2 --version bios BIOS Version: Y35CLD07 root@bmc-oob:~# bic-util slot2 0xE0 0xA2 0x15 0xA0 0x0 15 A0 00 00 00 08 59 33 35 43 4C 44 30 37 00 00 00 00 00 00 root@bmc-oob:~# cfg-util dump-all ...... sysfw_ver_slot2:000008593335434c443037000000000000 ......

  - After updating BIOS firmware root@bmc-oob:~# fw-util slot2 --version bios BIOS Version: Y35CLD08 root@bmc-oob:~# bic-util slot2 0xE0 0xA2 0x15 0xA0 0x0 15 A0 00 00 00 08 59 33 35 43 4C 44 30 38 00 00 00 00 00 00 root@bmc-oob:~# cfg-util dump-all ...... sysfw_ver_slot2:000008593335434c443038000000000000 ......

- Check there are no unexpected error logs
  - log-util root@bmc-oob:~# log-util slot2 --print 2022 Oct 16 23:35:48 log-util: User cleared FRU: 2 logs
    2    slot2    2022-10-16 23:36:00    gpiod            FRU: 2, System powered OFF
    2    slot2    2022-10-16 23:36:08    power-util       SERVER_POWER_CYCLE successful for FRU: 2
    2    slot2    2022-10-16 23:36:08    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2022-10-16 23:36:08, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
    2    slot2    2022-10-16 23:36:10    gpiod            FRU: 2, System powered ON

- Check BIOS firmware version wasn't written to EEPROM if the written version is the same with the stored version in EEPROM
  - If the written version is the same with the stored version in EEPROM [BIC console] [00:07:06.337,000] <wrn> power_status: DC_STATUS: on [00:07:06.476,000] <wrn> power_status: CPU_PWR_GOOD: yes [00:07:06.337,000] <wrn> power_status: DC_STATUS: on [00:07:06.476,000] <wrn> power_status: CPU_PWR_GOOD: yes ...... [00:00:38.352,000] <dbg> plat_ipmi.pal_record_bios_fw_version: Write bios version is the same with stored bios version in EEPROM [00:00:56.078,000] <wrn> power_status: POST_COMPLETE: yes [00:00:56.078,000] <wrn> power_status: POST_COMPLETE: yes

  - If the written version is different with the stored version in EEPROM [BIC console] [00:13:46.228,000] <wrn> power_status: DC_STATUS: on [00:13:46.460,000] <wrn> power_status: CPU_PWR_GOOD: yes [00:13:46.228,000] <wrn> power_status: DC_STATUS: on [00:13:46.460,000] <wrn> power_status: CPU_PWR_GOOD: yes ......
    [00:16:06.534,000] <dbg> plat_ipmi.pal_record_bios_fw_version: Set bios version
    [00:16:36.576,000] <wrn> power_status: POST_COMPLETE: yes
    [00:16:36.576,000] <wrn> power_status: POST_COMPLETE: yes