### PR TITLE
Common: Support PLDM set event receiver command

### DIFF
--- a/common/service/pldm/pldm_base.h
+++ b/common/service/pldm/pldm_base.h
@@ -46,6 +46,12 @@ enum pldm_completion_codes {
 	PLDM_LATER_RESP = 0x30,
 };
 
+enum pldm_transport_protocol_type {
+	PLDM_TRANSPORT_PROTOCOL_TYPE_MCTP = 0x00,
+	PLDM_TRANSPORT_PROTOCOL_TYPE_NCSI = 0x01,
+	PLDM_TRANSPORT_PROTOCOL_TYPE_OEM = 0xFF,
+};
+
 struct _set_tid_req {
 	uint8_t tid;
 } __attribute__((packed));


### PR DESCRIPTION
Summary:
- Add PLDM set event receiver command.
- Add a FIFO queue to buffer event messages until the set receiver command is received.
- Use a unified function pldm_send_platform_event to send event messages by different event classes or send them to the FIFO queue to wait for the event receiver setting.

Test Plan:
- Build code: Pass

Dependency: #653 
