### PR TITLE
by3.5: rf: Version commit for oby35-rf-2022.43.01

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_version.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_version.h
@@ -42,7 +42,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x41
+#define BIC_FW_WEEK 0x43
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x72 // char: r
 #define BIC_FW_platform_1 0x66 // char: f


### PR DESCRIPTION
- Summary:
Version commit for Yv3.5 RainbowFalls BIC oby35-rf-2022.43.01.

- Test Plan:
 Build code: Pass
Get BIC version: Pass

```
root@bmc-oob:~# fw-util slot1 --version 1ou_bic
1OU Bridge-IC Version: oby35-rf-v2022.43.01
```


Signed-off-by: Irene <Irene.Lin@quantatw.com>