### PR TITLE
fby3.5: cl: Sensor "HSC_OUTPUT_CURR_A" follows sensor naming rule

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
@@ -3260,7 +3260,7 @@ SDR_Full_sensor hotswap_sdr_table[] = {
 		0x00, // reserved
 		0x00, // OEM
 		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
-		"HSC_OUTPUT_CURR_A",
+		"MB_HSC_OUTPUT_CURR_A",
 	},
 	{
 		// HSCIN power


### PR DESCRIPTION
Summary:
- To follow naming rule, modify sensor "HSC_OUTPUT_CURR_A" to "MB_HSC_OUTPUT_CURR_A".

Test Plan:
- Build code: PASS
- Check sensor name: PASS

Test Log:
- Before root@bmc-oob:~# sensor-util slot2 | grep "HSC_OUTPUT_CURR_A"
    HSC_OUTPUT_CURR_A            (0x30) :    8.31 Amps  | (ok)

- After root@bmc-oob:~# sensor-util slot2 | grep "HSC_OUTPUT_CURR_A"
    MB_HSC_OUTPUT_CURR_A         (0x30) :    8.26 Amps  | (ok)