### PR TITLE
fby3.5: hd: Modify judgement method of VR Vender

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_class.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_class.h
@@ -32,6 +32,12 @@ enum BIC_BOARD_REVISION {
 	SYS_BOARD_PVT = 0x80,
 };
 
+enum VR_VENDER_TYPE {
+	VR_VENDER_RENESAS = 0x0,
+	VR_VENDER_INFINEON = 0x1,
+	VR_VENDER_MPS = 0x2,
+};
+
 typedef struct _CARD_STATUS_ {
 	bool present;
 	uint8_t card_type;

--- a/meta-facebook/yv35-hd/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_isr.c
@@ -378,10 +378,11 @@ void ISR_PVDDCR_CPU0_PMALERT()
 {
 	if (get_DC_status() == true) {
 		uint8_t board_rev = get_board_revision();
-		if (board_rev == SYS_BOARD_EVT_BOM2) {
+		uint8_t vr_vender = (board_rev & 0x30) >> 4;
+		if (vr_vender == VR_VENDER_INFINEON) {
 			add_vr_pmalert_sel(PVDDCR_CPU0_PMALERT_N, XDPE19283B_PVDDCR_CPU0_ADDR, 0,
 					   2);
-		} else if (board_rev == SYS_BOARD_EVT_BOM3) {
+		} else if (vr_vender == VR_VENDER_MPS) {
 			add_vr_pmalert_sel(PVDDCR_CPU0_PMALERT_N, MP2856GUT_PVDDCR_CPU0_ADDR, 0, 2);
 		} else {
 			add_vr_pmalert_sel(PVDDCR_CPU0_PMALERT_N, RAA229621_PVDDCR_CPU0_ADDR, 0, 2);
@@ -393,10 +394,11 @@ void ISR_PVDDCR_CPU1_PMALERT()
 {
 	if (get_DC_status() == true) {
 		uint8_t board_rev = get_board_revision();
-		if (board_rev == SYS_BOARD_EVT_BOM2) {
+		uint8_t vr_vender = (board_rev & 0x30) >> 4;
+		if (vr_vender == VR_VENDER_INFINEON) {
 			add_vr_pmalert_sel(PVDDCR_CPU1_PMALERT_N, XDPE19283B_PVDDCR_CPU1_ADDR, 1,
 					   2);
-		} else if (board_rev == SYS_BOARD_EVT_BOM3) {
+		} else if (vr_vender == VR_VENDER_MPS) {
 			add_vr_pmalert_sel(PVDDCR_CPU1_PMALERT_N, MP2856GUT_PVDDCR_CPU1_ADDR, 1, 2);
 		} else {
 			add_vr_pmalert_sel(PVDDCR_CPU1_PMALERT_N, RAA229621_PVDDCR_CPU1_ADDR, 1, 2);
@@ -408,9 +410,10 @@ void ISR_PVDD11_S3_PMALERT()
 {
 	if (get_DC_status() == true) {
 		uint8_t board_rev = get_board_revision();
-		if (board_rev == SYS_BOARD_EVT_BOM2) {
+		uint8_t vr_vender = (board_rev & 0x30) >> 4;
+		if (vr_vender == VR_VENDER_INFINEON) {
 			add_vr_pmalert_sel(PVDD11_S3_PMALERT_N, XDPE19283B_PVDD11_S3_ADDR, 2, 1);
-		} else if (board_rev == SYS_BOARD_EVT_BOM3) {
+		} else if (vr_vender == VR_VENDER_MPS) {
 			add_vr_pmalert_sel(PVDD11_S3_PMALERT_N, MP2856GUT_PVDD11_S3_ADDR, 2, 1);
 		} else {
 			add_vr_pmalert_sel(PVDD11_S3_PMALERT_N, RAA229621_PVDD11_S3_ADDR, 2, 1);

--- a/meta-facebook/yv35-hd/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_sensor_table.c
@@ -479,14 +479,15 @@ void pal_extend_sensor_config()
 	}
 
 	uint8_t board_revision = get_board_revision();
-	switch (board_revision) {
-	case SYS_BOARD_EVT_BOM2:
+	uint8_t vr_vender = (board_revision & 0x30) >> 4;
+	switch (vr_vender) {
+	case VR_VENDER_INFINEON:
 		sensor_count = ARRAY_SIZE(EVT_BOM2_sensor_config_table);
 		for (int index = 0; index < sensor_count; index++) {
 			add_sensor_config(EVT_BOM2_sensor_config_table[index]);
 		}
 		break;
-	case SYS_BOARD_EVT_BOM3:
+	case VR_VENDER_MPS:
 		sensor_count = ARRAY_SIZE(EVT_BOM3_sensor_config_table);
 		for (int index = 0; index < sensor_count; index++) {
 			add_sensor_config(EVT_BOM3_sensor_config_table[index]);


### PR DESCRIPTION
Summary:
- Fix DVT BOM2 and BOM3 VR sensor reading problem. 
The root cause is that the BIC judges the VR vender by entire board REV ID(including board stage and VR vender).
Fix it by ignoring the board stage part of board REV ID.

Test Plan:
- Build code: PASS