### PR TITLE
fby3: dl: Add shifting NetFn for OEM command 0x38 0x02

### DIFF
--- a/common/service/ipmb/ipmb.c
+++ b/common/service/ipmb/ipmb.c
@@ -19,6 +19,7 @@
 #include "ipmi.h"
 #include "kcs.h"
 #include "libutil.h"
+#include "plat_def.h"
 #include "plat_ipmb.h"
 #include "plat_i2c.h"
 #include "timer.h"
@@ -715,9 +716,15 @@ void IPMB_RXTask(void *pvParameters, void *arvg0, void *arvg1)
 						bridge_msg->data[3] =
 							IPMB_config_table[ipmb_cfg.index]
 								.channel; // return response source as request target
+#ifdef ENABLE_OEM_BRIDGE_NETFN_SHIFT
+						bridge_msg->data[4] =
+							current_msg_rx->buffer
+								.netfn << 2; // Shift response NetFn to bridge response
+#else
 						bridge_msg->data[4] =
 							current_msg_rx->buffer
 								.netfn; // Move target response to bridge response data
+#endif
 						bridge_msg->data[5] = current_msg_rx->buffer.cmd;
 						bridge_msg->data[6] =
 							current_msg_rx->buffer.completion_code;

--- a/meta-facebook/yv3-dl/src/platform/plat_def.h
+++ b/meta-facebook/yv3-dl/src/platform/plat_def.h
@@ -17,6 +17,8 @@
 #ifndef PLAT_DEF_H
 #define PLAT_DEF_H
 
+#define ENABLE_OEM_BRIDGE_NETFN_SHIFT
+
 #define HOST_KCS_PORT kcs4
 #define BMC_USB_PORT "CDC_ACM_0"
 


### PR DESCRIPTION
Summary:
- The response of NetFn for OEM command 0x38 0x02 should align with YV3

Test plan:
- Build code: Pass

YV3.5
root@bmc-oob:~# bic-util slot1 0xE0 0x02 0x15 0xA0 0x00 0x05 0x18 0x01 
15 A0 00 05 07 01 00 00 80 47 04 02 BF 9C 9C 00
00 00 00 00 00 00
root@bmc-oob:~# bic-util slot1 0xE0 0x02 0x15 0xA0 0x00 0x01 0x18 0x01 
15 A0 00 01 07 01 00 50 01 06 03 02 21 57 01 00
18 0B 06 24 80 01

YV3
root@bmc-oob:~# bic-util slot1 0xE0 0x02 0x9C 0x9C 0x00 0x05 0x18 0x01 
9C 9C 00 05 1C 01 00 25 80 17 14 02 BF 4C 1C 00
50 57 00 00 00 00
root@bmc-oob:~# bic-util slot1 0xE0 0x02 0x9C 0x9C 0x00 0x01 0x18 0x01 
9C 9C 00 01 1C 01 00 50 01 04 44 02 21 57 01 00
0F 0B 04 11 60 01