### PR TITLE
fby3.5: cl: Fix logging PMIC error when triggering Memory Uncorrectable Error

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_pmic.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_pmic.c
@@ -127,7 +127,7 @@ void monitor_pmic_error_handler()
 				}
 
 				// Compare error pattern, if status change add SEL to BMC and update record
-				ret = compare_pmic_error(dimm_id, pmic_msg.data,
+				ret = compare_pmic_error(dimm_id, pmic_msg.data, pmic_msg.data_len,
 							 READ_PMIC_ERROR_VIA_ME);
 				if (ret < 0) {
 					continue;
@@ -200,7 +200,8 @@ int pal_set_pmic_error_flag(uint8_t dimm_id, uint8_t error_type)
 	return SUCCESS;
 }
 
-int compare_pmic_error(uint8_t dimm_id, uint8_t *pmic_err_data, uint8_t read_path)
+int compare_pmic_error(uint8_t dimm_id, uint8_t *pmic_err_data, uint8_t pmic_err_data_len,
+		       uint8_t read_path)
 {
 	uint8_t err_index = 0, reg_index = 0, data_index = 0;
 	uint8_t pattern = 0;
@@ -221,6 +222,11 @@ int compare_pmic_error(uint8_t dimm_id, uint8_t *pmic_err_data, uint8_t read_pat
 			default:
 				LOG_ERR("Wrong path 0x%x to read PMIC error", read_path);
 				return -1;
+			}
+
+			// Not enough data
+			if (data_index >= pmic_err_data_len) {
+				break;
 			}
 
 			pattern = pmic_err_pattern[err_index][reg_index];
@@ -420,7 +426,8 @@ void read_pmic_error_via_i3c()
 		}
 
 		// Compare error pattern, add SEL to BMC and update record
-		ret = compare_pmic_error(dimm_id, i3c_msg.data, READ_PMIC_ERROR_VIA_I3C);
+		ret = compare_pmic_error(dimm_id, i3c_msg.data, i3c_msg.rx_len,
+					 READ_PMIC_ERROR_VIA_I3C);
 		if (ret < 0) {
 			continue;
 		}

--- a/meta-facebook/yv35-cl/src/platform/plat_pmic.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_pmic.h
@@ -53,7 +53,8 @@ enum READ_PMIC_ERROR_PATH {
 
 void start_monitor_pmic_error_thread();
 void monitor_pmic_error_handler();
-int compare_pmic_error(uint8_t dimm_id, uint8_t *pmic_err_data, uint8_t read_path);
+int compare_pmic_error(uint8_t dimm_id, uint8_t *pmic_err_data, uint8_t pmic_err_data_len,
+		       uint8_t read_path);
 int get_dimm_info(uint8_t dimm_id, uint8_t *bus, uint8_t *addr);
 void add_pmic_error_sel(uint8_t dimm_id, uint8_t error_type);
 int switch_i3c_dimm_mux(uint8_t i3c_mux_position, uint8_t dimm_mux_position);


### PR DESCRIPTION
Summary:
- When triggering Memory Uncorrectable Error, the resonse of PMIC data by ME will be only 3 bytes: 57 01 00

Test plan:
- Build code: Pass
- Triggering Memory Uncorrectable Error without logging PMIC error event