### PR TITLE
wc: mb: Recode BIOS firmware version in EEPROM (follow #657)

### DIFF
--- a/meta-facebook/wc-mb/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/wc-mb/src/ipmi/plat_ipmi.c
@@ -19,7 +19,73 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <logging/log.h>
 
 #include "libutil.h"
 #include "ipmi.h"
 #include "plat_ipmb.h"
+#include "fru.h"
+#include "eeprom.h"
+#include "plat_fru.h"
+
+LOG_MODULE_REGISTER(plat_ipmi);
+
+int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, -1);
+
+	int ret = -1;
+	EEPROM_ENTRY set_bios_ver = { 0 };
+	EEPROM_ENTRY get_bios_ver = { 0 };
+
+	ret = get_bios_version(&get_bios_ver);
+	if (ret == -1) {
+		LOG_ERR("Get version fail");
+		return -1;
+	}
+
+	set_bios_ver.data_len = size - 3; // skip netfn, cmd and command code
+	memcpy(&set_bios_ver.data[0], &buf[3], set_bios_ver.data_len);
+
+	// Check the written BIOS version is the same with the stored
+	ret = memcmp(&get_bios_ver.data[0], &set_bios_ver.data[0],
+		     BIOS_FW_VERSION_MAX_SIZE * sizeof(uint8_t));
+	if (ret == 0) {
+		LOG_DBG("The Written bios version is the same with the stored bios version in EEPROM");
+	} else {
+		LOG_DBG("Set bios version");
+
+		ret = set_bios_version(&set_bios_ver);
+		if (ret == -1) {
+			LOG_ERR("Set version fail");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+void OEM_1S_GET_BIOS_VERSION(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	int ret = -1;
+	EEPROM_ENTRY get_bios_ver = { 0 };
+
+	ret = get_bios_version(&get_bios_ver);
+	if (ret == -1) {
+		LOG_ERR("Get version fail");
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
+		return;
+	}
+
+	memcpy(&msg->data[0], &get_bios_ver.data[0], get_bios_ver.data_len);
+	msg->data_len = get_bios_ver.data_len;
+	msg->completion_code = CC_SUCCESS;
+	return;
+}

--- a/meta-facebook/wc-mb/src/platform/plat_fru.c
+++ b/meta-facebook/wc-mb/src/platform/plat_fru.c
@@ -17,6 +17,11 @@
 #include "fru.h"
 #include "plat_fru.h"
 #include <string.h>
+#include <logging/log.h>
+#include "libutil.h"
+#include "eeprom.h"
+
+LOG_MODULE_REGISTER(plat_fru);
 
 const EEPROM_CFG plat_fru_config[] = {
 	{
@@ -39,7 +44,52 @@ const EEPROM_CFG plat_fru_config[] = {
 	},
 };
 
+// BIOS version is stored in MB EEPROM, but the location of EEPROM is different from fru information
+const EEPROM_CFG plat_bios_version_area_config = {
+	NV_ATMEL_24C128,
+	MB_FRU_ID,
+	MB_FRU_PORT,
+	MB_FRU_ADDR,
+	FRU_DEV_ACCESS_BYTE,
+	BIOS_FW_VERSION_START,
+	BIOS_FW_VERSION_MAX_SIZE,
+};
+
 void pal_load_fru_config(void)
 {
 	memcpy(&fru_config, &plat_fru_config, sizeof(plat_fru_config));
+}
+
+int set_bios_version(EEPROM_ENTRY *entry)
+{
+	CHECK_NULL_ARG_WITH_RETURN(entry, -1);
+
+	bool ret = false;
+	entry->config = plat_bios_version_area_config;
+	entry->data_len = BIOS_FW_VERSION_MAX_SIZE;
+
+	ret = eeprom_write(entry);
+	if (ret == false) {
+		LOG_ERR("eeprom_write fail");
+		return -1;
+	}
+
+	return 0;
+}
+
+int get_bios_version(EEPROM_ENTRY *entry)
+{
+	CHECK_NULL_ARG_WITH_RETURN(entry, -1);
+
+	bool ret = false;
+	entry->config = plat_bios_version_area_config;
+	entry->data_len = BIOS_FW_VERSION_MAX_SIZE;
+
+	ret = eeprom_read(entry);
+	if (ret == false) {
+		LOG_ERR("eeprom_read fail");
+		return -1;
+	}
+
+	return 0;
 }

--- a/meta-facebook/wc-mb/src/platform/plat_fru.h
+++ b/meta-facebook/wc-mb/src/platform/plat_fru.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "eeprom.h"
+
 #ifndef PLAT_FRU_H
 #define PLAT_FRU_H
 
@@ -23,11 +25,18 @@
 #define IOM_FRU_PORT 0x07
 #define IOM_FRU_ADDR 0x50
 
+#define BIOS_FW_VERSION_START 0x0A00
+#define BIOS_FW_VERSION_MAX_SIZE 34
+
 enum {
 	MB_FRU_ID,
 	IOM_FRU_ID,
 	// OTHER_FRU_ID,
 	MAX_FRU_ID,
 };
+
+bool get_bios_version_area_config(EEPROM_CFG *config);
+int set_bios_version(EEPROM_ENTRY *entry);
+int get_bios_version(EEPROM_ENTRY *entry);
 
 #endif


### PR DESCRIPTION
Summary:
- Record BIOS firmware version in EEPROM.
- Add ipmi oem command (netfn = 0x38, cmd = 0xA2) to support BMC get BIOS firmware version.

Test Plan:
- Build Code: PASS
