### PR TITLE
fby35: cl: Modify PMIC I3C frequency

### DIFF
--- a/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
@@ -22,18 +22,18 @@
 &i2c0 {
 	pinctrl-0 = <&pinctrl_i2c0_default>;
 	status = "okay";
-  clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c1 {
 	pinctrl-0 = <&pinctrl_i2c1_default>;
 	status = "okay";
-  clock-frequency = <I2C_BITRATE_STANDARD>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &i2c2 {
 	pinctrl-0 = <&pinctrl_i2c2_default>;
-  clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	status = "okay";
 
 	ipmb2: ipmb@10 {
@@ -64,23 +64,25 @@
 	assigned-address = <0x11>;
 	i3c-scl-hz = <8000000>;
 	pinctrl-0 = <&pinctrl_i3c3_default>;
+	i3c-pp-scl-hi-period-ns = <63>;
+	i3c-pp-scl-lo-period-ns = <63>;
 };
 
 &i2c4 {
 	pinctrl-0 = <&pinctrl_i2c4_default>;
 	status = "okay";
-  clock-frequency = <I2C_BITRATE_STANDARD>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &i2c5 {
 	pinctrl-0 = <&pinctrl_i2c5_default>;
 	status = "okay";
-  clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &i2c6 {
 	pinctrl-0 = <&pinctrl_i2c6_default>;
-  clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 
 	ipmb6: ipmb@20 {
@@ -94,7 +96,7 @@
 
 &i2c7 {
 	pinctrl-0 = <&pinctrl_i2c7_default>;
-  clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	status = "okay";
 
 	ipmb7: ipmb@20 {
@@ -111,7 +113,7 @@
 
 &i2c8 {
 	pinctrl-0 = <&pinctrl_i2c8_default>;
-  clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
 	status = "okay";
 
 	ipmb8: ipmb@20 {
@@ -150,21 +152,21 @@
 };
 
 &kcs3 {
-  status = "okay";
-  addr = <0xca2>;
+	status = "okay";
+	addr = <0xca2>;
 };
 
 &uart5 {
-  current-speed = <57600>;
+	current-speed = <57600>;
 };
 
 &gpio0_a_d {
-  aspeed,persist-maps = <0x08000000>;
+	aspeed,persist-maps = <0x08000000>;
 };
 
 &snoop {
-  status = "okay";
-  port = <0x80>, <0x81>;
+	status = "okay";
+	port = <0x80>, <0x81>;
 };
 
 &fmc {
@@ -185,9 +187,9 @@
 			reg = <0x0 0x100000>;
 		};
 		dfu_partition: partition@1 {
-		       label = "image-1";
-		       reg = <0x0 0x100000>;
-	       };
+			label = "image-1";
+			reg = <0x0 0x100000>;
+		};
 	};
 };
 


### PR DESCRIPTION
Summary:
- Unified format.
- Correct push pull SCL period time to meet 8Hz.
- Change i3c push pull SCL high period time from 36 ns (12.5Hz) to 63 ns.
- Change i3c push pull SCL low period time from 36 ns (12.5Hz) to 63 ns.

Test plan:
- Build code: Pass
- Read PMIC data: Pass

Log:
1. Read PMIC data via I3C.
- Attach PMIC adderss uart:~$ i3c attach I3C_3 -a 0x48 -m 0
Attach address 0x48 to I3C_3

uart:~$ i3c attach I3C_3 -a 0x4c -m 0
Attach address 0x4c to I3C_3

uart:~$ i3c attach I3C_3 -a 0x4e -m 0
Attach address 0x4e to I3C_3

- Read DIMM A0 A2 A3 PMIC vender ID uart:~$ i3c xfer I3C_3 -a 0x48 -w 0x3c -r 2
Private transfer to address 0x48

00000000: 80 97                                            |..               |
uart:~$ i3c xfer I3C_3 -a 0x4c -w 0x3c -r 2
Private transfer to address 0x4c

00000000: 80 97                                            |..               |
uart:~$ i3c xfer I3C_3 -a 0x4e -w 0x3c -r 2
Private transfer to address 0x4e

00000000: 80 97

- Switch DIMM mux and broadcast CCC uart:~$ i2c write_byte I2C_0 0x21 0x0B 0x03
uart:~$ i3c ccc I3C_3 -a 0x7E -i 0x6 -w 0
Send CCC ID 0x06 (w) to address 0x7e

uart:~$ i3c ccc I3C_3 -a 0x7E -i 0x29 -w 0
Send CCC ID 0x29 (w) to address 0x7e

- Read DIMM A4 A6 A7 PMIC vender ID uart:~$ i3c xfer I3C_3 -a 0x48 -w 0x3c -r 2
Private transfer to address 0x48

00000000: 80 97                                            |..               |
uart:~$ i3c xfer I3C_3 -a 0x4c -w 0x3c -r 2
Private transfer to address 0x4c

00000000: 80 97                                            |..               |
uart:~$ i3c xfer I3C_3 -a 0x4e -w 0x3c -r 2
Private transfer to address 0x4e

00000000: 80 97