### PR TITLE
common: Support MCTP I3C Rx function

### DIFF
--- a/common/hal/hal_i3c.c
+++ b/common/hal/hal_i3c.c
@@ -54,25 +54,25 @@ static struct i3c_dev_desc *find_matching_desc(const struct device *dev, uint8_t
  * @brief api to read i3c message from target message queue
  * 
  * @param msg i3c message structure
- * @return 0: complete read data from target message
+ * @return ret: return the data size
  */
 int i3c_smq_read(I3C_MSG *msg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
 
-	int ret;
 	if (!dev_i3c[msg->bus]) {
 		LOG_ERR("[%s] bus%u did not define\n", __func__, msg->bus);
 		return -ENODEV;
 	}
 
-	ret = i3c_slave_mqueue_read(dev_i3c_smq[msg->bus], &msg->data[0], msg->rx_len);
-	if (ret < 0) {
+	msg->rx_len =
+		i3c_slave_mqueue_read(dev_i3c_smq[msg->bus], &msg->data[0], I3C_MAX_DATA_SIZE);
+	if (msg->rx_len < 0) {
 		LOG_ERR("[%s] bus%u message queue was empty\n", __func__, msg->bus);
 		return -ENODATA;
 	}
 
-	return I3C_SMQ_SUCCESS;
+	return msg->rx_len;
 }
 
 /**

--- a/common/service/mctp/mctp.c
+++ b/common/service/mctp/mctp.c
@@ -95,7 +95,7 @@ static uint8_t mctp_medium_init(mctp *mctp_inst, mctp_medium_conf medium_conf)
 		ret = mctp_i3c_init(mctp_inst, medium_conf);
 		break;
 	default:
-		break;
+		return MCTP_ERROR;
 	}
 
 	return ret;
@@ -114,7 +114,7 @@ static uint8_t mctp_medium_deinit(mctp *mctp_inst)
 		mctp_i3c_deinit(mctp_inst);
 		break;
 	default:
-		break;
+		return MCTP_ERROR;
 	}
 
 	return MCTP_SUCCESS;
@@ -196,6 +196,7 @@ static void mctp_rx_task(void *arg, void *dummy0, void *dummy1)
 	LOG_INF("mctp_rx_task start %p", mctp_inst);
 
 	while (1) {
+		k_msleep(MCTP_POLL_TIME_MS);
 		uint8_t read_buf[256] = { 0 };
 		mctp_ext_params ext_params;
 		uint8_t ret = MCTP_ERROR;

--- a/common/service/mctp/mctp.h
+++ b/common/service/mctp/mctp.h
@@ -53,6 +53,8 @@ extern "C" {
 #define MCTP_HDR_SEQ_MASK 0x03
 #define MCTP_HDR_TAG_MASK 0x07
 
+#define MCTP_POLL_TIME_MS 1
+
 typedef enum {
 	MCTP_MSG_TYPE_CTRL = 0x00,
 	MCTP_MSG_TYPE_PLDM,

--- a/common/service/mctp/mctp_i3c.c
+++ b/common/service/mctp/mctp_i3c.c
@@ -36,9 +36,33 @@ static uint16_t mctp_i3c_read_smq(void *mctp_p, uint8_t *buf, uint32_t len,
 	CHECK_NULL_ARG_WITH_RETURN(mctp_p, MCTP_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(buf, MCTP_ERROR);
 
-	/** blind return length 0 for now, the function will implement in rx commit **/
-	LOG_INF("mctp_i3c_read_smq is not ready, return 0(length) blindly");
-	return 0;
+	int ret = 0;
+	I3C_MSG i3c_msg;
+	mctp *mctp_inst = (mctp *)mctp_p;
+	i3c_msg.bus = mctp_inst->medium_conf.i3c_conf.bus;
+	ret = i3c_smq_read(&i3c_msg);
+
+	/** mctp rx keep polling, return length 0 directly if no data or invalid data **/
+	if (ret <= 0) {
+		return 0;
+	}
+
+	i3c_msg.rx_len = ret;
+	LOG_HEXDUMP_DBG(&i3c_msg.data[0], i3c_msg.rx_len, "mctp_i3c_read_smq msg dump");
+
+	if (MCTP_I3C_PEC_ENABLE) {
+		/** pec byte use 7-degree polynomial with 0 init value and false reverse **/
+		uint8_t pec = crc8(&i3c_msg.data[0], i3c_msg.rx_len - 1, 0x07, 0x00, false);
+		if (pec != i3c_msg.data[i3c_msg.rx_len - 1]) {
+			LOG_ERR("mctp i3c pec error: crc8 should be 0x%02x, but got 0x%02x", pec,
+				i3c_msg.data[i3c_msg.rx_len - 1]);
+			return 0;
+		}
+	}
+
+	extra_data->type = MCTP_MEDIUM_TYPE_I3C;
+	memcpy(buf, &i3c_msg.data[0], i3c_msg.rx_len);
+	return i3c_msg.rx_len;
 }
 
 static uint16_t mctp_i3c_write_smq(void *mctp_p, uint8_t *buf, uint32_t len,
@@ -53,30 +77,23 @@ static uint16_t mctp_i3c_write_smq(void *mctp_p, uint8_t *buf, uint32_t len,
 	}
 
 	int ret;
-	I3C_MSG *i3c_msg = (I3C_MSG *)malloc(sizeof(I3C_MSG));
-	if (i3c_msg == NULL) {
-		LOG_ERR("Memory allocation failed.");
-		return MCTP_ERROR;
-	}
-
+	I3C_MSG i3c_msg;
 	mctp *mctp_instance = (mctp *)mctp_p;
-	i3c_msg->bus = mctp_instance->medium_conf.i3c_conf.bus;
+	i3c_msg.bus = mctp_instance->medium_conf.i3c_conf.bus;
 	/** mctp package **/
-	memcpy(&i3c_msg->data[0], buf, len);
+	memcpy(&i3c_msg.data[0], buf, len);
 	/** +1 pec; default no pec **/
 	if (MCTP_I3C_PEC_ENABLE) {
-		i3c_msg->tx_len = len + 1;
+		i3c_msg.tx_len = len + 1;
 		/** pec byte use 7-degree polynomial with 0 init value and false reverse **/
-		i3c_msg->data[len + 1] = crc8(&i3c_msg->data[0], len, 0x07, 0x00, false);
+		i3c_msg.data[len + 1] = crc8(&i3c_msg.data[0], len, 0x07, 0x00, false);
 	} else {
-		i3c_msg->tx_len = len;
+		i3c_msg.tx_len = len;
 	}
 
-	LOG_HEXDUMP_DBG(&i3c_msg->data[0], i3c_msg->tx_len, "mctp_i3c_write_smq msg dump");
+	LOG_HEXDUMP_DBG(&i3c_msg.data[0], i3c_msg.tx_len, "mctp_i3c_write_smq msg dump");
 
-	ret = i3c_smq_write(i3c_msg);
-	SAFE_FREE(i3c_msg);
-
+	ret = i3c_smq_write(&i3c_msg);
 	if (ret < 0) {
 		LOG_ERR("mctp_i3c_write_smq write failed");
 		return MCTP_ERROR;


### PR DESCRIPTION
[Summary]
- Support MCTP I3C read smq function
- Modify mctp_i3c_write_smq function to non-dynamic memory allocation after evaluation
- Modify i3c_smq_read function in hal_i3c.c to return the actual length from driver
- Modify mctp_rx_task thread in mctp.c to add 1ms sleep for preventing busy waiting
- Modify mctp_medium_init/deinit functions in mctp.c to return error if receive unknown medium type(not smbus/i3c)

[Test Plan & Log]
1. Build code: a. Y35 CL BIC				[ Pass ] b. GT  SW BIC				[ Pass ]

2. Test code for sending IPMI command: a. IPMI standard command:		[ Pass ] root@bmc-oob:~# i3ctransfer -d /dev/bus/i3c/0-7ec80010000 -w 0x01,0x00,0x00,0xC0,0x01,0x80,0x3F,0x01,0x15,0xa0,0x00,0x18,0x04 Success on message 0

	uart:~$
	[00:05:34.956,000] <dbg> mctp: mctp receive data
				       01 00 00 c0 01 80 3f 01  15 a0 00 18 04          |......?. .....
	[00:05:34.956,000] <dbg> mctp.mctp_rx_task: dest_ep = 0, src_ep = 0, flags = c0

	[00:05:34.956,000] <dbg> pldm.mctp_pldm_cmd_handler: msg_type = 1
	[00:05:34.956,000] <dbg> pldm.mctp_pldm_cmd_handler: req_d_id = 0x80
	[00:05:34.956,000] <dbg> pldm.mctp_pldm_cmd_handler: pldm_type = 0x3f
	[00:05:34.956,000] <dbg> pldm.mctp_pldm_cmd_handler: cmd = 0x1
	[00:05:34.956,000] <dbg> pldm.ipmi_cmd: ipmi over pldm, len = 5

	[00:05:34.956,000] <dbg> pldm.ipmi_cmd: netfn 18, cmd 4
	[00:05:34.956,000] <dbg> pldm: ipmi cmd data
				       15 a0 00 18 04                                   |.....
	[00:05:34.956,000] <dbg> ipmi.IPMI_handler: IPMI_handler[0]: netfn: 6
	[00:05:34.956,000] <dbg> ipmi:
	[00:05:34.956,000] <dbg> ipmi.IPMI_APP_handler: entering IPMI_APP_handler
	[00:05:34.956,000] <dbg> ipmi.IPMI_APP_handler: msg->cmd: 0x04
	[00:05:34.956,000] <dbg> ipmi.APP_GET_SELFTEST_RESULTS: entering SELFTEST result
	[00:05:34.957,000] <dbg> ipmi.IPMI_handler: pal_is_not_return_cmd: false
	[00:05:34.957,000] <dbg> ipmi.IPMI_handler: return PLDM format
	[00:05:34.957,000] <dbg> ipmi.send_msg_by_pldm: mctp_inst = 0x3c640
	[00:05:34.957,000] <dbg> ipmi: mctp ext param
				       00 00 00 02 00 00 00 00  00 00 00 00             |........ ....
	[00:05:34.957,000] <dbg> ipmi: pldm header
				       01 00 3f 01                                      |..?.
	[00:05:34.957,000] <dbg> ipmi.send_msg_by_pldm: msg_cfg->buffer.data_len = 2
	[00:05:34.957,000] <dbg> ipmi.send_msg_by_pldm: msg_cfg->buffer.completion_code = 0
	[00:05:34.957,000] <dbg> ipmi: pldm resp data
				       01 00 3f 01 94 51 05 00  09 00 00 00 00          |..?..Q.. .....
	[00:05:34.957,000] <dbg> pldm: mctp_pldm_send_msg
				       01 00 3f 01 00 15 a0 00  1c 04 00 55 00          |..?..... ...U.
	[00:05:34.976,000] <dbg> mctp.mctp_tx_task: tx endpoint 0
	[00:05:34.976,000] <dbg> mctp: mctp tx task receive data
				       01 00 3f 01 00 15 a0 00  1c 04 00 55 00          |..?..... ...U.
	[00:05:34.985,000] <dbg> mctp.mctp_tx_task: mctp_msg.len = 13
	[00:05:34.985,000] <dbg> mctp.mctp_tx_task: split_pkt_num = 1
	[00:05:34.985,000] <dbg> mctp.mctp_tx_task: i = 0, cp_msg_size = 13
	[00:05:34.985,000] <dbg> mctp.mctp_tx_task: hdr->flags_seq_to_tag = c0
	[00:05:34.985,000] <dbg> mctp_i3c: mctp_i3c_write_smq msg dump
					   01 00 0a c0 01 00 3f 01  00 15 a0 00 1c 04 00 55 |......?. .......U
					   00                                               |.

	root@bmc-oob:~# hexdump -C /sys/bus/i3c/devices/0-7ec80010000/ibi-mqueue
	00000000  01 00 0a c0 01 00 3f 01  00 15 a0 00 1c 04 00 55  |......?........U|
	00000010  00                                                |.|

	b. IPMI OEM command:			[ Pass ]
	root@bmc-oob:~# i3ctransfer -d /dev/bus/i3c/0-7ec80010000 -w 0x01,0x00,0x00,0xC0,0x01,0x80,0x3F,0x01,0x15,0xa0,0x00,0xe0,0x60,0x15,0xa0,0x00,0
	Success on message 0

	uart:~$
	[00:05:42.179,000] <dbg> mctp: mctp receive data
				       01 00 00 c0 01 80 3f 01  15 a0 00 e0 60 15 a0 00 |......?. ....`...
				       00                                               |.
	[00:05:42.179,000] <dbg> mctp.mctp_rx_task: dest_ep = 0, src_ep = 0, flags = c0

	[00:05:42.179,000] <dbg> pldm.mctp_pldm_cmd_handler: msg_type = 1
	[00:05:42.179,000] <dbg> pldm.mctp_pldm_cmd_handler: req_d_id = 0x80
	[00:05:42.179,000] <dbg> pldm.mctp_pldm_cmd_handler: pldm_type = 0x3f
	[00:05:42.179,000] <dbg> pldm.mctp_pldm_cmd_handler: cmd = 0x1
	[00:05:42.179,000] <dbg> pldm.ipmi_cmd: ipmi over pldm, len = 9

	[00:05:42.179,000] <dbg> pldm.ipmi_cmd: netfn e0, cmd 60
	[00:05:42.179,000] <dbg> pldm: ipmi cmd data
				       15 a0 00 e0 60 15 a0 00  00                      |....`... .
	[00:05:42.179,000] <dbg> ipmi.IPMI_handler: IPMI_handler[4]: netfn: 38
	[00:05:42.179,000] <dbg> ipmi:
				       15 a0 00 00                                      |....
	[00:05:42.197,000] <dbg> ipmi.IPMI_handler: pal_is_not_return_cmd: false
	[00:05:42.197,000] <dbg> ipmi.IPMI_handler: return PLDM format
	[00:05:42.197,000] <dbg> ipmi.send_msg_by_pldm: mctp_inst = 0x3c640
	[00:05:42.197,000] <dbg> ipmi: mctp ext param
				       00 00 00 02 00 00 00 00  00 00 00 00             |........ ....
	[00:05:42.197,000] <dbg> ipmi: pldm header
				       01 00 3f 01                                      |..?.
	[00:05:42.197,000] <dbg> ipmi.send_msg_by_pldm: msg_cfg->buffer.data_len = 4
	[00:05:42.197,000] <dbg> ipmi.send_msg_by_pldm: msg_cfg->buffer.completion_code = 0
	[00:05:42.197,000] <dbg> ipmi: pldm resp data
				       01 00 3f 01 94 51 05 00  0b 00 00 00 00 00 00    |..?..Q.. .......
	[00:05:42.197,000] <dbg> pldm: mctp_pldm_send_msg
				       01 00 3f 01 00 15 a0 00  e4 60 00 15 a0 00 42    |..?..... .`....B
	[00:05:42.218,000] <dbg> mctp.mctp_tx_task: tx endpoint 0
	[00:05:42.218,000] <dbg> mctp: mctp tx task receive data
				       01 00 3f 01 00 15 a0 00  e4 60 00 15 a0 00 42    |..?..... .`....B
	[00:05:42.226,000] <dbg> mctp.mctp_tx_task: mctp_msg.len = 15
	[00:05:42.226,000] <dbg> mctp.mctp_tx_task: split_pkt_num = 1
	[00:05:42.226,000] <dbg> mctp.mctp_tx_task: i = 0, cp_msg_size = 15
	[00:05:42.226,000] <dbg> mctp.mctp_tx_task: hdr->flags_seq_to_tag = c0
	[00:05:42.226,000] <dbg> mctp_i3c: mctp_i3c_write_smq msg dump
					   01 00 0a c0 01 00 3f 01  00 15 a0 00 e4 60 00 15 |......?. .....`..
					   a0 00 42                                         |..B

	root@bmc-oob:~# hexdump -C /sys/bus/i3c/devices/0-7ec80010000/ibi-mqueue
	00000000  01 00 0a c0 01 00 3f 01  00 15 a0 00 e4 60 00 15  |......?......`..|
	00000010  a0 00 42                                          |..B|

	uart:~$ i2c scan I2C_0
	     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
	00:             -- -- -- -- -- -- -- -- -- -- -- --
	10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	20: -- 21 -- -- -- -- -- -- -- -- -- -- -- -- -- --
	30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
	70: -- -- -- -- -- -- -- --
	1 devices found on I2C_0

3. Ensure GT has no impact: a. MCTP threads:			[ Pass ] uart:~$ kernel stacks
	0x58e80 mctptx_01_0d_40 (real size 1024):       unused 172      usage 852 / 1024 (83 %)
	0x58db8 mctprx_01_0d_40 (real size 4096):       unused 2580     usage 1516 / 4096 (37 %)
	0x57680 mctptx_01_0c_40 (real size 1024):       unused 156      usage 868 / 1024 (84 %)
	0x575b8 mctprx_01_0c_40 (real size 4096):       unused 2580     usage 1516 / 4096 (37 %)
	0x55e80 mctptx_01_0b_40 (real size 1024):       unused 156      usage 868 / 1024 (84 %)
	0x55db8 mctprx_01_0b_40 (real size 4096):       unused 2580     usage 1516 / 4096 (37 %)
	0x54680 mctptx_01_0a_40 (real size 1024):       unused 164      usage 860 / 1024 (83 %)
	0x545b8 mctprx_01_0a_40 (real size 4096):       unused 2580     usage 1516 / 4096 (37 %)
	0x52e80 mctptx_01_03_40 (real size 1024):       unused 172      usage 852 / 1024 (83 %)
	0x52db8 mctprx_01_03_40 (real size 4096):       unused 2580     usage 1516 / 4096 (37 %)
	0x51680 mctptx_01_02_40 (real size 1024):       unused 156      usage 868 / 1024 (84 %)
	0x515b8 mctprx_01_02_40 (real size 4096):       unused 2580     usage 1516 / 4096 (37 %)
	0x4fe80 mctptx_01_01_40 (real size 1024):       unused 172      usage 852 / 1024 (83 %)
	0x4fdb8 mctprx_01_01_40 (real size 4096):       unused 2580     usage 1516 / 4096 (37 %)
	0x4e680 mctptx_01_00_40 (real size 1024):       unused 172      usage 852 / 1024 (83 %)
	0x4e5b8 mctprx_01_00_40 (real size 4096):       unused 2580     usage 1516 / 4096 (37 %)
	0x4ce80 mctptx_01_06_40 (real size 1024):       unused 164      usage 860 / 1024 (83 %)
	0x4cdb8 mctprx_01_06_40 (real size 4096):       unused 2548     usage 1548 / 4096 (37 %)
	0x70248 USB_handler (real size 2048):   unused 1748     usage 300 / 2048 (14 %)
	0x6df28 IPMI_thread (real size 4096):   unused 1684     usage 2412 / 4096 (58 %)
	0x6f180 sensor_poll (real size 2048):   unused 1052     usage 996 / 2048 (48 %)
	0x6dd60 WDT_thread (real size 256):     unused 36       usage 220 / 256 (85 %)
	0x6f0b8 pldm_wait_resp_to (real size 1024):     unused 812      usage 212 / 1024 (20 %)
	0x6eff0 monitor_tid (real size 1024):   unused 820      usage 204 / 1024 (19 %)
	0x70410 shell_uart (real size 2048):    unused 1012     usage 1036 / 2048 (50 %)
	0x6dc40 gpio_workq (real size 3072):    unused 2804     usage 268 / 3072 (8 %)
	0x35b68 ADC0       (real size 400):     unused 156      usage 244 / 400 (61 %)
	0x35ea0 ADC1       (real size 400):     unused 164      usage 236 / 400 (59 %)
	0x78858 sysworkq   (real size 2048):    unused 1588     usage 460 / 2048 (22 %)
	0x705c0 usbdworkq  (real size 1024):    unused 548      usage 476 / 1024 (46 %)
	0x704d8 usbworkq   (real size 1024):    unused 764      usage 260 / 1024 (25 %)
	0x70348 logging    (real size 768):     unused 212      usage 556 / 768 (72 %)
	0x706b8 idle 00    (real size 320):     unused 268      usage 52 / 320 (16 %)
	0x84bd8 IRQ 00     (real size 2048):    unused 1504     usage 544 / 2048 (26 %)

	b. SWB FRUID:				[ Pass ]
	root@bmc-oob:~# fruid-util swb

	FRU Information           : Switch Board
	---------------           : ------------------
	Chassis Type              : Rack Mount Chassis
	Chassis Serial Number     : QTWF0T22240008
	Board Mfg Date            : Tue Jun 21 13:54:00 2022
	Board Mfg                 : Quanta
	Board Product             : Grand Teton Expander BD
	Board Serial              : TWJ2021800098
	Board Part Number         : 3SF0TEA0000
	Board FRU ID              : Fru Version 0.02
	Board Custom Data 1       : 19-002196
	Board Custom Data 2       : TTM
	Board Custom Data 3       : EVT
	Product Manufacturer      : Quanta
	Product Name              : Grand Teton
	Product Part Number       : 1F0TUBZ0001
	Product Version           : 3QF0TEA0000
	Product Serial            : QTWF0T22240008
	Product Asset Tag         : AT99400
	Product FRU ID            : 17-000661
	Product Custom Data 1     : 01-006324
	Product Custom Data 2     : QTWF0TS22240013
	Product Custom Data 3     : AT99396

	c. CC-BIC FW update:			[ Pass ]
	root@bmc-oob:~# fw-util swb --update bic /tmp/GT-SWB-2022.37.01.bin
	updating fw on bus 3:
	updated: 100 %
	Elapsed time:  25   sec.
	Upgrade of swb : bic succeeded