### PR TITLE
common: Fix ipmb mapping problem

### DIFF
--- a/common/service/ipmb/ipmb.c
+++ b/common/service/ipmb/ipmb.c
@@ -285,6 +285,33 @@ bool find_req_ipmi_msg(ipmi_msg_cfg *pnode, ipmi_msg *msg, uint8_t index)
 	return true;
 }
 
+void clean_req_ipmi_msg(ipmi_msg_cfg *pnode, ipmi_msg *msg, uint8_t index)
+{
+	CHECK_NULL_ARG(pnode);
+	CHECK_NULL_ARG(msg);
+
+	int ret = 0;
+
+	// Mutex for request sequence linked list change
+	ret = k_mutex_lock(&mutex_id[index], K_MSEC(1000));
+	if (ret) {
+		LOG_ERR("Failed to lock the mutex id%d, ret%d", index, ret);
+		return;
+	}
+
+	ipmi_msg_cfg *temp;
+
+	temp = pnode->next;
+	pnode->next = temp->next;
+	unregister_seq(index, temp->buffer.seq_target);
+	SAFE_FREE(temp);
+	seq_current_count[index]--;
+	pnode = pnode->next;
+
+	k_mutex_unlock(&mutex_id[index]);
+	return;
+}
+
 void IPMB_TXTask(void *pvParameters, void *arvg0, void *arvg1)
 {
 	CHECK_NULL_ARG(pvParameters);
@@ -929,7 +956,7 @@ ipmb_error ipmb_read(ipmi_msg *msg, uint8_t index)
 	// Set mutex timeout 10ms more than messageQueue timeout, prevent mutex
 	// timeout before messageQueue
 	if (k_mutex_lock(&mutex_read, K_MSEC(IPMB_SEQ_TIMEOUT_MS + 10))) {
-		LOG_ERR("[%s] Failed to lock mutex in time", __func__);
+		LOG_ERR("Failed to lock mutex in time, netfn0x%02x cmd0x%02x", msg->netfn, msg->cmd);
 		return IPMB_ERROR_MUTEX_LOCK;
 	}
 
@@ -938,20 +965,21 @@ ipmb_error ipmb_read(ipmi_msg *msg, uint8_t index)
 
 	ipmb_error ret = IPMB_ERROR_SUCCESS;
 	if (ipmb_send_request(msg, index) != IPMB_ERROR_SUCCESS) {
-		LOG_ERR("[%s] Failed to send IPMB request message", __func__);
+		LOG_ERR("Failed to send IPMB request message, netfn0x%02x cmd0x%02x", msg->netfn, msg->cmd);
 		ret = IPMB_ERROR_FAILURE;
 		goto exit;
 	}
 
 	if (k_msgq_get(&ipmb_rxqueue[index], (ipmi_msg *)msg, K_MSEC(IPMB_SEQ_TIMEOUT_MS))) {
-		LOG_ERR("[%s] Failed to get IPMB message from RX queue", __func__);
+		LOG_ERR("Failed to get IPMB message from RX queue, netfn0x%02x cmd0x%02x seq%d", msg->netfn, msg->cmd, msg->seq);
+		clean_req_ipmi_msg(P_start[index], (ipmi_msg *)msg, index);
 		ret = IPMB_ERROR_GET_MESSAGE_QUEUE;
 		goto exit;
 	}
 
 exit:
 	k_mutex_unlock(&mutex_read);
-	return IPMB_ERROR_SUCCESS;
+	return ret;
 }
 
 // Send message to IPMI message queue


### PR DESCRIPTION
Root cause:
- IPMB request doesn't map correct response.
- SB BIC waiting the response of request_1 timeout, and causes this response mapping to request_2 when BMC reboot.
- SB BIC doesn't remove the request from the request node list if this request times out waiting for a response.

Solution:
- Correct the ipmb_read function return code.
- Remove IPMB request node list data, if this request waiting for response timeout.

Test plan:
- Build code: Pass
- BMC reboot stress:  pass
- Sled cycle stress:  pass
- Host reboot stress: pass
- Host DC cycle stress: pass
- Host AC cycle stress: pass

Log:
1. Reboot BMC and check no PMIC error SEL. root@bmc-oob:~# log-util --print all
2022 Nov 02 03:11:53 log-util: User cleared all logs
0    all      2022-11-02 03:13:50    gpiointrd        ASSERT: GPIOH4 - PRSNT_MB_BMC_SLOT1_BB_N
0    all      2022-11-02 03:13:50    gpiointrd        slot1 present
1    slot1    2022-11-02 03:13:50    gpiointrd        FRU: 1, CPU presence
0    all      2022-11-02 03:13:50    gpiointrd        ASSERT: GPIOH6 - PRSNT_MB_BMC_SLOT3_BB_N
0    all      2022-11-02 03:13:50    gpiointrd        slot3 present
3    slot3    2022-11-02 03:13:50    gpiointrd        FRU: 3, CPU presence
6    nic      2022-11-02 03:13:50    ncsid            FRU: 6 NIC AEN Supported: 0x7, AEN Enable Mask=0x7
6    nic      2022-11-02 03:13:50    ncsid            FRU: 6 PLDM type supported = 0x35
6    nic      2022-11-02 03:13:50    ncsid            FRU: 6 PLDM type 0 version = 1.0.0.0
6    nic      2022-11-02 03:13:50    ncsid            FRU: 6 PLDM type 2 version = 1.1.0.0
6    nic      2022-11-02 03:13:50    ncsid            FRU: 6 PLDM type 4 version = 1.0.0.0
6    nic      2022-11-02 03:13:50    ncsid            FRU: 6 PLDM type 5 version = 1.0.0.0
6    nic      2022-11-02 03:13:50    ncsid            FRU: 6 PLDM sensor monitoring enabled
0    all      2022-11-02 03:13:50    healthd          BMC Reboot detected - caused by reboot command