### PR TITLE
fby3-dl: using custom work queue instead system work queue

### DIFF
--- a/common/lib/util_worker.c
+++ b/common/lib/util_worker.c
@@ -29,6 +29,8 @@
 #define WARN_WORK_PROC_TIME_MS 1000
 
 K_THREAD_STACK_DEFINE(worker_stack_area, WORKER_STACK_SIZE);
+K_THREAD_STACK_DEFINE(plat_worker_stack_area, WORKER_STACK_SIZE);
+struct k_work_q plat_work_q;
 static struct k_work_q worker_work_q;
 static struct k_mutex mutex_use_count;
 static uint8_t work_count;
@@ -158,4 +160,16 @@ void init_worker()
 			   K_THREAD_STACK_SIZEOF(worker_stack_area), WORKER_PRIORITY, NULL);
 	k_thread_name_set(&worker_work_q.thread, "util_worker");
 	k_mutex_init(&mutex_use_count);
+}
+
+/* Initialize platform work queue
+ *
+ * Should call this function to initialize worker before use other APIs.
+ * It export the work queue for queue operation
+ */
+void init_plat_worker(int priority)
+{
+	k_work_queue_start(&plat_work_q, plat_worker_stack_area,
+			   K_THREAD_STACK_SIZEOF(plat_worker_stack_area), priority, NULL);
+	k_thread_name_set(&plat_work_q.thread, "plat_worker");
 }

--- a/common/lib/util_worker.h
+++ b/common/lib/util_worker.h
@@ -44,6 +44,9 @@ typedef struct {
 	char name[MAX_WORK_NAME_LEN];
 } worker_job;
 
+extern struct k_work_q plat_work_q;
+
+void init_plat_worker(int);
 uint8_t get_work_count();
 int add_work(worker_job *);
 void init_worker();

--- a/meta-facebook/yv3-dl/src/lib/plat_sys.c
+++ b/meta-facebook/yv3-dl/src/lib/plat_sys.c
@@ -29,6 +29,7 @@
 #include "plat_gpio.h"
 #include "xdpe12284c.h"
 #include "plat_sensor_table.h"
+#include "util_worker.h"
 
 /* BMC reset */
 void BMC_reset_handler()
@@ -41,7 +42,7 @@ void BMC_reset_handler()
 K_WORK_DELAYABLE_DEFINE(BMC_reset_work, BMC_reset_handler);
 int pal_submit_bmc_cold_reset()
 {
-	k_work_schedule(&BMC_reset_work, K_MSEC(1000));
+	k_work_schedule_for_queue(&plat_work_q, &BMC_reset_work, K_MSEC(1000));
 	return 0;
 }
 /* BMC reset */
@@ -56,7 +57,7 @@ void clear_cmos_handler()
 K_WORK_DEFINE(clear_cmos_work, clear_cmos_handler);
 int pal_clear_cmos()
 {
-	k_work_submit(&clear_cmos_work);
+	k_work_submit_to_queue(&plat_work_q, &clear_cmos_work);
 	return 0;
 }
 

--- a/meta-facebook/yv3-dl/src/platform/plat_init.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_init.c
@@ -20,6 +20,7 @@
 #include "util_sys.h"
 #include "plat_class.h"
 #include "plat_gpio.h"
+#include "util_worker.h"
 
 SCU_CFG scu_cfg[] = {
 	//register    value
@@ -35,6 +36,7 @@ void pal_pre_init()
 	init_platform_config();
 	disable_PRDY_interrupt();
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
+	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
 }
 
 void pal_device_init()


### PR DESCRIPTION
Summary:
1. Work queue is designed for offloading non-urgent processing, its priority should lower than current running thread
2. Current priority setting in yv3-dl: Application thread: 0 (preemptive thread) system work queue: -1 (non-preemptive thread)
3. Using custom work queue with lower priority(1) to prevent non-urgent task blocking other thread

Test plan:
Build and test pass on yv3-dl

1. Check the work job could be executed normally.
2. Running yv3 BIC sanity test - PASS
3. Running host power cycle stress test - PASS
   - check all sensor reading are good and no error messages in BMC syslog