### PR TITLE
fby3: dl: Fix HSC Temp show abnormal reading

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_sensor_table.c
@@ -482,13 +482,6 @@ void pal_extend_sensor_config()
 		break;
 	}
 
-	/* Check outlet temperature sensor type */
-	for (uint8_t index = 0; index < sensor_config_count; index++) {
-		if (sensor_config[index].type == sensor_dev_tmp431) {
-			check_outlet_temp_type(index);
-		}
-	}
-
 	switch (hsc_module) {
 	case HSC_MODULE_MP5990:
 		sensor_count = ARRAY_SIZE(mp5990_sensor_config_table);
@@ -505,6 +498,13 @@ void pal_extend_sensor_config()
 	default:
 		LOG_ERR("unsupported HSC module, HSC module: 0x%x", hsc_module);
 		break;
+	}
+
+	/* Check outlet temperature sensor type */
+	for (uint8_t index = 0; index < sensor_config_count; index++) {
+		if (sensor_config[index].type == sensor_dev_tmp431) {
+			check_outlet_temp_type(index);
+		}
 	}
 
 	return;


### PR DESCRIPTION
Summary:
- HSC Temp will over threshold with the 2nd oulet temperature sensor.

Root cause:
- The function of identify the temperature sensor is wrong because the default sensor table removes the outlet temperature.

Solution:
- Check the type of temperature sensor after finishing extended sensor table.

Test Plan:
Build code:Pass

sensor-util: Pass
root@bmc-oob:~# sensor-util slot1 | grep HSC
HSC Temp                     (0xF) :   27.00 C     | (ok)