### PR TITLE
fby3.5: rf:Modify the power-off sequence

### DIFF
--- a/meta-facebook/yv35-rf/src/lib/plat_spi.h
+++ b/meta-facebook/yv35-rf/src/lib/plat_spi.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_SPI_H
+#define PLAT_SPI_H
+
+#endif

--- a/meta-facebook/yv35-rf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_power_seq.c
@@ -25,7 +25,9 @@
 #include "plat_sensor_table.h"
 #include "plat_power_seq.h"
 #include <logging/log.h>
+#include "plat_spi.h"
 
+extern int cxl_update_stat;
 LOG_MODULE_REGISTER(power_sequence);
 
 static uint8_t power_on_seq = DEFAULT_POWER_ON_SEQ;
@@ -284,7 +286,7 @@ bool power_on_handler(uint8_t initial_stage)
 }
 
 bool power_off_handler(uint8_t initial_stage)
-{
+{	
 	bool enable_power_off_handler = true;
 	int check_power_ret = -1;
 	uint8_t control_stage = initial_stage;
@@ -303,12 +305,18 @@ bool power_off_handler(uint8_t initial_stage)
 			control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_06);
 			break;
 		case ASIC_POWER_OFF_STAGE1:
-			control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_04);
+			if(cxl_update_stat == POWER_OFF){
+				control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_04);
+				break;
+			}
 			break;
 		case ASIC_POWER_OFF_STAGE2:
-			control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_01);
-			control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_02);
-			control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_03);
+			if(cxl_update_stat == POWER_OFF){
+				control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_01);
+				control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_02);
+				control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_03);
+				break;
+			}
 			break;
 		case BOARD_POWER_OFF_STAGE:
 			control_power_stage(DISABLE_POWER_MODE, CLK_100M_OSC_EN);
@@ -358,7 +366,7 @@ bool power_off_handler(uint8_t initial_stage)
 			control_stage = ASIC_POWER_OFF_STAGE1;
 			break;
 		case ASIC_POWER_OFF_STAGE1:
-			if (check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_04) != 0) {
+			if (cxl_update_stat == POWER_OFF && check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_04) != 0) {
 				check_power_ret = -1;
 				break;
 			}
@@ -366,15 +374,15 @@ bool power_off_handler(uint8_t initial_stage)
 			control_stage = ASIC_POWER_OFF_STAGE2;
 			break;
 		case ASIC_POWER_OFF_STAGE2:
-			if (check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_03) != 0) {
+			if (cxl_update_stat == POWER_OFF && check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_03) != 0) {
 				check_power_ret = -1;
 				break;
 			}
-			if (check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_02) != 0) {
+			if (cxl_update_stat == POWER_OFF && check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_02) != 0) {
 				check_power_ret = -1;
 				break;
 			}
-			if (check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_01) != 0) {
+			if (cxl_update_stat == POWER_OFF && check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_01) != 0) {
 				check_power_ret = -1;
 				break;
 			}


### PR DESCRIPTION
Summary:
- Fix BMC log PWR_ERR assert event (1OU EXP Power OFF Failure) during OOB CXL FW update.

Root Cause:
- BMC will run off of DC power for the CPU before updating the CXL FW, and then BIC will control the power-off sequence and turn off the ASIC power, BUT ASIC power will be turned on again by BIC during the CXL FW update.
- Therefore, BIC would check the power status failed and log PWR_ERR assert event.

Solution:
- Check the CXL update status before BIC controls the power-off sequence.

Build Code: PASS

Test Plan:
1. Do the AC power cycle on the system.
2. Ensure the system connects to the CXL controller after the system boot is completed.
3. Update CXL FW (with graceful shutdown)
4. Check the BMC log file.

Test Result:
CXL test script passed the 91 cycling test

Signed-off-by: Irene <Irene.Lin@quantatw.com>