### PR TITLE
fby3.5: rf:Modify the power-off sequence

### DIFF
--- a/meta-facebook/yv35-rf/src/lib/plat_spi.c
+++ b/meta-facebook/yv35-rf/src/lib/plat_spi.c
@@ -21,11 +21,13 @@
 #include "util_spi.h"
 #include "util_sys.h"
 #include "plat_gpio.h"
+#include "plat_spi.h"
 
 #define CXL_FLASH_TO_BIC 1
 #define CXL_FLASH_TO_CXL 0
 
 #define CXL_UPDATE_MAX_OFFSET 0x2000000
+int cxl_update_stat = POWER_OFF;
 
 static bool switch_cxl_spi_mux(int gpio_status)
 {
@@ -66,7 +68,6 @@ static bool control_flash_power(int power_state)
 		if (!retry) {
 			break;
 		}
-
 		control_power_stage(control_mode, P1V8_ASIC_EN_R);
 		k_msleep(CHKPWR_DELAY_MSEC);
 	}
@@ -79,7 +80,7 @@ static bool control_flash_power(int power_state)
 uint8_t fw_update_cxl(uint32_t offset, uint16_t msg_len, uint8_t *msg_buf, bool sector_end)
 {
 	uint8_t ret = FWUPDATE_UPDATE_FAIL;
-
+	cxl_update_stat = POWER_ON;
 	if (offset > CXL_UPDATE_MAX_OFFSET) {
 		return FWUPDATE_OVER_LENGTH;
 	}
@@ -100,6 +101,7 @@ uint8_t fw_update_cxl(uint32_t offset, uint16_t msg_len, uint8_t *msg_buf, bool 
 	if (sector_end || ret != FWUPDATE_SUCCESS) {
 		control_flash_power(POWER_OFF);
 		switch_cxl_spi_mux(CXL_FLASH_TO_CXL);
+		cxl_update_stat = POWER_OFF;
 	}
 
 	return ret;

--- a/meta-facebook/yv35-rf/src/lib/plat_spi.h
+++ b/meta-facebook/yv35-rf/src/lib/plat_spi.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_SPI_H
+#define PLAT_SPI_H
+
+#endif


### PR DESCRIPTION
fby3.5: rf: Modify the power-off sequence
Summary:
- Fix BMC log PWR_ERR assert event (1OU EXP Power OFF Failure) during OOB CXL FW update.

Root Cause:
- BMC will run off of DC power for the CPU before updating the CXL FW, and then BIC will control the power-off sequence and 
  **turn off the ASIC power**, BUT ASIC power will be **turned on again** by BIC during the CXL FW update.
- Therefore, BIC would check the power status failed and log PWR_ERR assert event.

Solution:
- Check the CXL update status before BIC controls the power-off sequence.

Build Code: PASS

Test Plan:
1. Do the AC power cycle on the system.
2. Ensure the system connects to the CXL controller after the system boot is completed.
3. Update CXL FW (with **graceful shutdown**)
4. Check the BMC log file.

Test Result:
CXL test script passed the 91 cycling test

Signed-off-by: Irene <Irene.Lin@quantatw.com>