### PR TITLE
fby3.5: hd: Record BIOS firmware version in EEPROM

### DIFF
--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -54,7 +54,7 @@ int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
 
 	// Check the written BIOS version is the same with the stored
 	ret = memcmp(&get_bios_ver.data[0], &set_bios_ver.data[0],
-		     BIOS_FW_VERSION_MAX_SIZE * sizeof(uint8_t));
+		     BIOS_FW_VERSION_BLOCK_MAX_SIZE * sizeof(uint8_t));
 	if (ret == 0) {
 		LOG_DBG("The Written bios version is the same with the stored bios version in EEPROM");
 	} else {

--- a/meta-facebook/yv35-hd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-hd/src/ipmi/plat_ipmi.c
@@ -16,16 +16,18 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <logging/log.h>
 #include "ipmi.h"
 #include "plat_ipmi.h"
 #include "plat_class.h"
+#include "libutil.h"
+#include "plat_fru.h"
+
+LOG_MODULE_REGISTER(plat_ipmi);
 
 void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
 {
-	if (msg == NULL) {
-		printf("[%s] Failed due to parameter *msg is NULL\n", __func__);
-		return;
-	}
+	CHECK_NULL_ARG(msg)
 
 	if (msg->data_len != 1) {
 		msg->completion_code = CC_INVALID_LENGTH;
@@ -61,5 +63,74 @@ void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
 		break;
 	}
 
+	return;
+}
+
+int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, -1);
+
+	int ret = -1;
+	EEPROM_ENTRY set_bios_ver = { 0 };
+	EEPROM_ENTRY get_bios_ver = { 0 };
+
+	const uint8_t block_index = buf[3];
+	if (block_index >= BIOS_FW_VERSION_BLOCK_NUM) {
+		LOG_ERR("bios version block index is out of range");
+		return -1;
+	}
+
+	ret = get_bios_version(&get_bios_ver, block_index);
+	if (ret == -1) {
+		LOG_ERR("Get version fail");
+		return -1;
+	}
+
+	set_bios_ver.data_len = size - 3; // skip netfn, cmd and command code
+	memcpy(&set_bios_ver.data[0], &buf[3], set_bios_ver.data_len);
+
+	// Check the written BIOS version is the same with the stored
+	ret = memcmp(&get_bios_ver.data[0], &set_bios_ver.data[0],
+		     BIOS_FW_VERSION_BLOCK_MAX_SIZE * sizeof(uint8_t));
+	if (ret == 0) {
+		LOG_DBG("The Written bios version is the same with the stored bios version in EEPROM");
+	} else {
+		LOG_DBG("Set bios version");
+
+		ret = set_bios_version(&set_bios_ver, block_index);
+		if (ret == -1) {
+			LOG_ERR("Set version fail");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+void OEM_1S_GET_BIOS_VERSION(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	msg->data_len = 0;
+
+	for (uint8_t block_index = 0; block_index < BIOS_FW_VERSION_BLOCK_NUM; block_index++) {
+		EEPROM_ENTRY get_bios_ver = { 0 };
+		int ret = get_bios_version(&get_bios_ver, block_index);
+		if (ret == -1) {
+			LOG_ERR("Get version fail");
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+			return;
+		}
+
+		memcpy(msg->data + msg->data_len, get_bios_ver.data, get_bios_ver.data_len);
+		msg->data_len += get_bios_ver.data_len;
+	}
+
+	msg->completion_code = CC_SUCCESS;
 	return;
 }

--- a/meta-facebook/yv35-hd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-hd/src/ipmi/plat_ipmi.c
@@ -81,7 +81,7 @@ int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
 	}
 
 	ret = get_bios_version(&get_bios_ver, block_index);
-	if (ret == -1) {
+	if (ret < 0) {
 		LOG_ERR("Get version fail");
 		return -1;
 	}
@@ -116,12 +116,10 @@ void OEM_1S_GET_BIOS_VERSION(ipmi_msg *msg)
 		return;
 	}
 
-	msg->data_len = 0;
-
 	for (uint8_t block_index = 0; block_index < BIOS_FW_VERSION_BLOCK_NUM; block_index++) {
 		EEPROM_ENTRY get_bios_ver = { 0 };
 		int ret = get_bios_version(&get_bios_ver, block_index);
-		if (ret == -1) {
+		if (ret < 0) {
 			LOG_ERR("Get version fail");
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 			return;

--- a/meta-facebook/yv35-hd/src/platform/plat_fru.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_fru.h
@@ -17,11 +17,19 @@
 #ifndef PLAT_FRU_H
 #define PLAT_FRU_H
 
+#include "eeprom.h"
+
 #define MB_FRU_PORT 0x01
 #define MB_FRU_ADDR 0x54
 
 #define DPV2_FRU_PORT 0x08
 #define DPV2_FRU_ADDR 0x51
+
+#define BIOS_FW_VERSION_START 0x0A00
+#define BIOS_FW_VERSION_MAX_SIZE 34
+#define BIOS_FW_VERSION_BLOCK_NUM 2
+#define BIOS_FW_VERSION_SECOND_BLOCK_OFFSET 17
+#define BIOS_FW_VERSION_BLOCK_MAX_SIZE 17
 
 enum {
 	MB_FRU_ID,
@@ -29,5 +37,9 @@ enum {
 	// OTHER_FRU_ID,
 	MAX_FRU_ID,
 };
+
+bool get_bios_version_area_config(EEPROM_CFG *config);
+int set_bios_version(EEPROM_ENTRY *entry, uint8_t block_index);
+int get_bios_version(EEPROM_ENTRY *entry, uint8_t block_index);
 
 #endif


### PR DESCRIPTION
Summary:
- Record BIOS firmware version in EEPROM.
- Support ipmi oem command (netfn = 0x38, cmd = 0xA2) to support BMC get BIOS firmware version.

Test Plan:
- Build code: Pass