### PR TITLE
fby3.5: rf:Modify the power-off sequence

### DIFF
--- a/meta-facebook/yv35-rf/src/lib/plat_spi.c
+++ b/meta-facebook/yv35-rf/src/lib/plat_spi.c
@@ -66,7 +66,6 @@ static bool control_flash_power(int power_state)
 		if (!retry) {
 			break;
 		}
-
 		control_power_stage(control_mode, P1V8_ASIC_EN_R);
 		k_msleep(CHKPWR_DELAY_MSEC);
 	}
@@ -79,6 +78,7 @@ static bool control_flash_power(int power_state)
 uint8_t fw_update_cxl(uint32_t offset, uint16_t msg_len, uint8_t *msg_buf, bool sector_end)
 {
 	uint8_t ret = FWUPDATE_UPDATE_FAIL;
+	set_CXL_update_status(POWER_ON);
 
 	if (offset > CXL_UPDATE_MAX_OFFSET) {
 		return FWUPDATE_OVER_LENGTH;
@@ -100,6 +100,7 @@ uint8_t fw_update_cxl(uint32_t offset, uint16_t msg_len, uint8_t *msg_buf, bool 
 	if (sector_end || ret != FWUPDATE_SUCCESS) {
 		control_flash_power(POWER_OFF);
 		switch_cxl_spi_mux(CXL_FLASH_TO_CXL);
+		set_CXL_update_status(POWER_OFF);
 	}
 
 	return ret;

--- a/meta-facebook/yv35-rf/src/platform/plat_power_seq.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_power_seq.h
@@ -84,5 +84,7 @@ void control_power_stage(uint8_t control_mode, uint8_t control_seq);
 int check_power_stage(uint8_t check_mode, uint8_t check_seq);
 bool power_on_handler(uint8_t initial_stage);
 bool power_off_handler(uint8_t initial_stage);
+void set_CXL_update_status(uint8_t set_status);
+bool get_CXL_update_status();
 
 #endif


### PR DESCRIPTION
Summary:
- Fix BMC log PWR_ERR assert event (1OU EXP Power OFF Failure) during OOB CXL FW update.

Root Cause:
- BMC will run off of DC power for the CPU before updating the CXL FW, and then BIC will control the power-off sequence and turn off the ASIC power, BUT ASIC power will be turned on again by BIC during the CXL FW update.
- Therefore, BIC would check the power status failed and log PWR_ERR assert event.

Solution:
- Check the CXL update status before BIC controls the power-off sequence.

Build Code: PASS

Test Plan:
1. Do the AC power cycle on the system.
2. Ensure the system connects to the CXL controller after the system boot is completed.
3. Update CXL FW (with graceful shutdown)
4. Check the BMC log file.

Test Result:
CXL test script passed the 91 cycling test

Signed-off-by: Irene <Irene.Lin@quantatw.com>