### PR TITLE
fby3.5: hd: Record PSB error in CPU EEPROM

### DIFF
--- a/common/dev/fru.c
+++ b/common/dev/fru.c
@@ -133,3 +133,8 @@ void FRU_init(void)
 {
 	pal_load_fru_config();
 }
+
+__weak bool write_psb_inform(EEPROM_ENTRY *entry)
+{
+	return false;
+}

--- a/common/dev/include/fru.h
+++ b/common/dev/include/fru.h
@@ -47,5 +47,6 @@ uint8_t FRU_read(EEPROM_ENTRY *entry);
 uint8_t FRU_write(EEPROM_ENTRY *entry);
 void pal_load_fru_config(void);
 void FRU_init(void);
+bool write_psb_inform(EEPROM_ENTRY *entry);
 
 #endif

--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -54,7 +54,7 @@ int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
 
 	// Check the written BIOS version is the same with the stored
 	ret = memcmp(&get_bios_ver.data[0], &set_bios_ver.data[0],
-		     BIOS_FW_VERSION_MAX_SIZE * sizeof(uint8_t));
+		     BIOS_FW_VERSION_BLOCK_MAX_SIZE * sizeof(uint8_t));
 	if (ret == 0) {
 		LOG_DBG("The Written bios version is the same with the stored bios version in EEPROM");
 	} else {

--- a/meta-facebook/yv35-hd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-hd/src/ipmi/plat_ipmi.c
@@ -16,16 +16,18 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <logging/log.h>
 #include "ipmi.h"
 #include "plat_ipmi.h"
 #include "plat_class.h"
+#include "libutil.h"
+#include "plat_fru.h"
+
+LOG_MODULE_REGISTER(plat_ipmi);
 
 void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
 {
-	if (msg == NULL) {
-		printf("[%s] Failed due to parameter *msg is NULL\n", __func__);
-		return;
-	}
+	CHECK_NULL_ARG(msg)
 
 	if (msg->data_len != 1) {
 		msg->completion_code = CC_INVALID_LENGTH;
@@ -61,5 +63,74 @@ void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
 		break;
 	}
 
+	return;
+}
+
+int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, -1);
+
+	int ret = -1;
+	EEPROM_ENTRY set_bios_ver = { 0 };
+	EEPROM_ENTRY get_bios_ver = { 0 };
+
+	const uint8_t block_index = buf[3];
+	if (block_index >= BIOS_FW_VERSION_BLOCK_NUM) {
+		LOG_ERR("bios version block index is out of range");
+		return -1;
+	}
+
+	ret = get_bios_version(&get_bios_ver, block_index);
+	if (ret == -1) {
+		LOG_ERR("Get version fail");
+		return -1;
+	}
+
+	set_bios_ver.data_len = size - 3; // skip netfn, cmd and command code
+	memcpy(&set_bios_ver.data[0], &buf[3], set_bios_ver.data_len);
+
+	// Check the written BIOS version is the same with the stored
+	ret = memcmp(&get_bios_ver.data[0], &set_bios_ver.data[0],
+		     BIOS_FW_VERSION_BLOCK_MAX_SIZE * sizeof(uint8_t));
+	if (ret == 0) {
+		LOG_DBG("The Written bios version is the same with the stored bios version in EEPROM");
+	} else {
+		LOG_DBG("Set bios version");
+
+		ret = set_bios_version(&set_bios_ver, block_index);
+		if (ret == -1) {
+			LOG_ERR("Set version fail");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+void OEM_1S_GET_BIOS_VERSION(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	msg->data_len = 0;
+
+	for (uint8_t block_index = 0; block_index < BIOS_FW_VERSION_BLOCK_NUM; block_index++) {
+		EEPROM_ENTRY get_bios_ver = { 0 };
+		int ret = get_bios_version(&get_bios_ver, block_index);
+		if (ret == -1) {
+			LOG_ERR("Get version fail");
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+			return;
+		}
+
+		memcpy(msg->data + msg->data_len, get_bios_ver.data, get_bios_ver.data_len);
+		msg->data_len += get_bios_ver.data_len;
+	}
+
+	msg->completion_code = CC_SUCCESS;
 	return;
 }

--- a/meta-facebook/yv35-hd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-hd/src/ipmi/plat_ipmi.c
@@ -81,7 +81,7 @@ int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
 	}
 
 	ret = get_bios_version(&get_bios_ver, block_index);
-	if (ret == -1) {
+	if (ret < 0) {
 		LOG_ERR("Get version fail");
 		return -1;
 	}
@@ -116,12 +116,10 @@ void OEM_1S_GET_BIOS_VERSION(ipmi_msg *msg)
 		return;
 	}
 
-	msg->data_len = 0;
-
 	for (uint8_t block_index = 0; block_index < BIOS_FW_VERSION_BLOCK_NUM; block_index++) {
 		EEPROM_ENTRY get_bios_ver = { 0 };
 		int ret = get_bios_version(&get_bios_ver, block_index);
-		if (ret == -1) {
+		if (ret < 0) {
 			LOG_ERR("Get version fail");
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 			return;

--- a/meta-facebook/yv35-hd/src/platform/plat_fru.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_fru.c
@@ -54,9 +54,30 @@ const EEPROM_CFG plat_bios_version_area_config = {
 	BIOS_FW_VERSION_MAX_SIZE,
 };
 
+/* PSB error information */
+const EEPROM_CFG plat_psb_error_area_config = {
+	NV_ATMEL_24C128,     MB_FRU_ID,       MB_FRU_PORT,	MB_CPU_EEPROM_ADDR,
+	FRU_DEV_ACCESS_BYTE, PSB_ERROR_START, PSB_ERROR_MAX_SIZE,
+};
+
 void pal_load_fru_config(void)
 {
 	memcpy(fru_config, plat_fru_config, sizeof(plat_fru_config));
+}
+
+bool write_psb_inform(EEPROM_ENTRY *entry)
+{
+	CHECK_NULL_ARG_WITH_RETURN(entry, false);
+
+	bool ret = false;
+	entry->config = plat_psb_error_area_config;
+	ret = eeprom_write(entry);
+	if (ret == false) {
+		LOG_ERR("eeprom_write fail");
+		return ret;
+	}
+
+	return ret;
 }
 
 int set_bios_version(EEPROM_ENTRY *entry, uint8_t block_index)

--- a/meta-facebook/yv35-hd/src/platform/plat_fru.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_fru.h
@@ -17,11 +17,19 @@
 #ifndef PLAT_FRU_H
 #define PLAT_FRU_H
 
+#include "eeprom.h"
+
 #define MB_FRU_PORT 0x01
 #define MB_FRU_ADDR 0x54
 
 #define DPV2_FRU_PORT 0x08
 #define DPV2_FRU_ADDR 0x51
+
+#define BIOS_FW_VERSION_START 0x0A00
+#define BIOS_FW_VERSION_MAX_SIZE 34
+#define BIOS_FW_VERSION_BLOCK_NUM 2
+#define BIOS_FW_VERSION_SECOND_BLOCK_OFFSET 17
+#define BIOS_FW_VERSION_BLOCK_MAX_SIZE 17
 
 enum {
 	MB_FRU_ID,
@@ -29,5 +37,9 @@ enum {
 	// OTHER_FRU_ID,
 	MAX_FRU_ID,
 };
+
+bool get_bios_version_area_config(EEPROM_CFG *config);
+int set_bios_version(EEPROM_ENTRY *entry, uint8_t block_index);
+int get_bios_version(EEPROM_ENTRY *entry, uint8_t block_index);
 
 #endif

--- a/meta-facebook/yv35-hd/src/platform/plat_fru.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_fru.h
@@ -17,10 +17,11 @@
 #ifndef PLAT_FRU_H
 #define PLAT_FRU_H
 
-#include "eeprom.h"
+#include "fru.h"
 
 #define MB_FRU_PORT 0x01
 #define MB_FRU_ADDR 0x54
+#define MB_CPU_EEPROM_ADDR 0x50
 
 #define DPV2_FRU_PORT 0x08
 #define DPV2_FRU_ADDR 0x51
@@ -30,6 +31,9 @@
 #define BIOS_FW_VERSION_BLOCK_NUM 2
 #define BIOS_FW_VERSION_SECOND_BLOCK_OFFSET 17
 #define BIOS_FW_VERSION_BLOCK_MAX_SIZE 17
+
+#define PSB_ERROR_START 0x0002
+#define PSB_ERROR_MAX_SIZE 9
 
 enum {
 	MB_FRU_ID,


### PR DESCRIPTION
Summary:
- Record PSB error in CPU EEPROM if post code match PSB error.

Dependency: #698 

Test plan:
- Build code: PASS
- Check EEPROM data in error conditions: PASS
