### PR TITLE
fby3: dl: Add OEM GET GPIO CONFIG

### DIFF
--- a/common/hal/hal_gpio.c
+++ b/common/hal/hal_gpio.c
@@ -130,6 +130,18 @@ int gpio_interrupt_conf(uint8_t gpio_num, gpio_flags_t flags)
 					    (gpio_num % GPIO_GROUP_SIZE), flags);
 }
 
+uint8_t gpio_get_reg_value(uint8_t gpio_num, uint8_t reg_offset)
+{
+	uint8_t gpio_group = gpio_num / GPIO_GROUP_SIZE;
+	uint8_t gpio_group_index = gpio_num % GPIO_GROUP_SIZE;
+	uint8_t res = (sys_read32(GPIO_GROUP_REG_ACCESS[gpio_group] + reg_offset) &
+		       BIT(gpio_group_index)) ?
+			      1 :
+			      0;
+
+	return res;
+}
+
 void gpio_cb_irq_init(uint8_t gpio_num, gpio_flags_t flags)
 {
 	gpio_init_cb(gpio_num);

--- a/common/hal/hal_gpio.h
+++ b/common/hal/hal_gpio.h
@@ -61,6 +61,10 @@
 #define REG_GPIO_BASE 0x7e780000
 #define REG_SCU 0x7E6E2000
 #define REG_DIRECTION_OFFSET 4
+#define REG_INTERRUPT_ENABLE_OFFSET 8
+#define REG_INTERRUPT_TYPE0_OFFSET 0x0C
+#define REG_INTERRUPT_TYPE1_OFFSET 0x10
+#define REG_INTERRUPT_TYPE2_OFFSET 0x14
 
 extern uint32_t GPIO_GROUP_REG_ACCESS[];
 extern uint32_t GPIO_MULTI_FUNC_PIN_CTL_REG_ACCESS[];
@@ -129,6 +133,7 @@ int gpio_set(uint8_t, uint8_t);
 bool pal_load_gpio_config(void);
 int gpio_init(const struct device *args);
 int gpio_interrupt_conf(uint8_t, gpio_flags_t);
+uint8_t gpio_get_reg_value(uint8_t gpio_num, uint8_t reg_offset);
 uint8_t gpio_conf(uint8_t gpio_num, int dir);
 int gpio_get_direction(uint8_t gpio_num);
 void scu_init(SCU_CFG cfg[], size_t size);

--- a/common/service/ipmi/include/oem_1s_handler.h
+++ b/common/service/ipmi/include/oem_1s_handler.h
@@ -76,6 +76,8 @@ uint8_t gpio_idx_exchange(ipmi_msg *msg);
 
 void OEM_1S_MSG_OUT(ipmi_msg *msg);
 void OEM_1S_GET_GPIO(ipmi_msg *msg);
+void OEM_1S_GET_GPIO_CONFIG(ipmi_msg *msg);
+void OEM_1S_SET_GPIO_CONFIG(ipmi_msg *msg);
 void OEM_1S_FW_UPDATE(ipmi_msg *msg);
 void OEM_1S_GET_BIC_FW_INFO(ipmi_msg *msg);
 void OEM_1S_GET_FW_VERSION(ipmi_msg *msg);

--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -179,6 +179,24 @@ __weak void OEM_1S_GET_GPIO(ipmi_msg *msg)
 	return;
 }
 
+__weak void OEM_1S_GET_GPIO_CONFIG(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	msg->data_len = 0;
+	msg->completion_code = CC_INVALID_CMD;
+	return;
+}
+
+__weak void OEM_1S_SET_GPIO_CONFIG(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	msg->data_len = 0;
+	msg->completion_code = CC_INVALID_CMD;
+	return;
+}
+
 __weak void OEM_1S_FW_UPDATE(ipmi_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
@@ -1990,6 +2008,14 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 		break;
 	case CMD_OEM_1S_SET_GPIO:
 		LOG_DBG("Received 1S Set GPIO command");
+		break;
+	case CMD_OEM_1S_GET_GPIO_CONFIG:
+		LOG_DBG("Received 1S Get GPIO Config command");
+		OEM_1S_GET_GPIO_CONFIG(msg);
+		break;
+	case CMD_OEM_1S_SET_GPIO_CONFIG:
+		LOG_DBG("Received 1S Get GPIO Config command");
+		OEM_1S_SET_GPIO_CONFIG(msg);
 		break;
 	case CMD_OEM_1S_FW_UPDATE:
 		LOG_DBG("Received 1S Firmware Update command");

--- a/meta-facebook/yv3-dl/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/yv3-dl/src/ipmi/include/plat_ipmi.h
@@ -39,4 +39,12 @@ enum DL_FIRMWARE_COMPONENT {
 	DL_COMPNT_PVDDR_DEF
 };
 
+enum GPIO_CONFIG_SETTING_BIT {
+	GPIO_CONF_SET_DIR = 0, // 0: input, 1: output
+	GPIO_CONF_SET_INT, // 0: disable, 1 : enable
+	GPIO_CONF_SET_TRG_TYPE, // 0: edge, 1: level
+	GPIO_CONF_SET_TRG_EDGE, // 0: fall, 1: rise
+	GPIO_CONF_SET_TRG_BOTH // 1: both edge
+};
+
 #endif

--- a/meta-facebook/yv3-dl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv3-dl/src/ipmi/plat_ipmi.c
@@ -266,6 +266,135 @@ void OEM_1S_GET_GPIO(ipmi_msg *msg)
 	return;
 }
 
+void OEM_1S_GET_GPIO_CONFIG(ipmi_msg *msg)
+{
+	if (msg == NULL) {
+		return;
+	}
+
+	if (msg->data_len == 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	uint8_t idx = 0;
+	uint8_t *gpio_mask = (uint8_t *)malloc(msg->data_len * sizeof(uint8_t));
+	memcpy(gpio_mask, &msg->data[0], msg->data_len);
+	for (uint8_t i = 0; i < gpio_align_table_length; i++) {
+		//check enough data
+		if (i / 8 == msg->data_len) {
+			break;
+		}
+
+		if (gpio_mask[i / 8] & (1 << (i % 8))) {
+			if ((gpio_align_t[i] == PVCCIO_CPU) ||
+			    (gpio_align_t[i] == BMC_HEARTBEAT_LED_R) ||
+			    (gpio_align_t[i] == FM_FORCE_ADR_N_R) ||
+			    (gpio_align_t[i] == JTAG_BMC_NTRST_R_N)) {
+				//pass dummy data to bmc, because AST bic do not have this gpio
+				msg->data[idx] = 0;
+			} else {
+				msg->data[idx] = gpio_get_direction(gpio_align_t[i]);
+				msg->data[idx] |= gpio_get_reg_value(gpio_align_t[i],
+								     REG_INTERRUPT_ENABLE_OFFSET)
+						  << GPIO_CONF_SET_INT;
+				msg->data[idx] |= gpio_get_reg_value(gpio_align_t[i],
+								     REG_INTERRUPT_TYPE1_OFFSET)
+						  << GPIO_CONF_SET_TRG_TYPE;
+				if (gpio_get_reg_value(gpio_align_t[i],
+						       REG_INTERRUPT_TYPE2_OFFSET)) {
+					msg->data[idx] |= 1 << GPIO_CONF_SET_TRG_BOTH;
+				} else {
+					msg->data[idx] |=
+						gpio_get_reg_value(gpio_align_t[i],
+								   REG_INTERRUPT_TYPE0_OFFSET)
+						<< GPIO_CONF_SET_TRG_EDGE;
+				}
+			}
+			idx++;
+		}
+	}
+	free(gpio_mask);
+	msg->data_len = idx;
+	msg->completion_code = CC_SUCCESS;
+
+	return;
+}
+
+#ifdef ENABLE_GPIO_SET_CONFG
+void OEM_1S_SET_GPIO_CONFIG(ipmi_msg *msg)
+{
+	if (msg == NULL) {
+		return;
+	}
+
+	uint8_t gpio_bytes_len = (gpio_align_table_length + 7) / 8;
+
+	if (msg->data_len < gpio_bytes_len + 1) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	uint8_t idx = gpio_bytes_len;
+	for (uint8_t i = 0; i < gpio_align_table_length; i++) {
+		//check mask
+		if (msg->data[i / 8] & (1 << (i % 8))) {
+			if ((gpio_align_t[i] == PVCCIO_CPU) ||
+			    (gpio_align_t[i] == BMC_HEARTBEAT_LED_R) ||
+			    (gpio_align_t[i] == FM_FORCE_ADR_N_R) ||
+			    (gpio_align_t[i] == JTAG_BMC_NTRST_R_N)) {
+				//AST bic do not have this gpio
+			} else {
+				//setting direction
+				if (msg->data[idx] & BIT(GPIO_CONF_SET_DIR)) {
+					gpio_conf(gpio_align_t[i], GPIO_OUTPUT);
+				} else {
+					gpio_conf(gpio_align_t[i], GPIO_INPUT);
+				}
+				//setting interrupt
+				if (msg->data[idx] & BIT(GPIO_CONF_SET_INT)) {
+					if (msg->data[idx] & BIT(GPIO_CONF_SET_TRG_BOTH)) {
+						gpio_interrupt_conf(gpio_align_t[i],
+								    GPIO_INT_EDGE_BOTH);
+					} else {
+						if (msg->data[idx] & BIT(GPIO_CONF_SET_TRG_TYPE)) {
+							if (msg->data[idx] &
+							    BIT(GPIO_CONF_SET_TRG_EDGE)) {
+								gpio_interrupt_conf(
+									gpio_align_t[i],
+									GPIO_INT_LEVEL_HIGH);
+							} else {
+								gpio_interrupt_conf(
+									gpio_align_t[i],
+									GPIO_INT_LEVEL_LOW);
+							}
+						} else {
+							if (msg->data[idx] &
+							    BIT(GPIO_CONF_SET_TRG_EDGE)) {
+								gpio_interrupt_conf(
+									gpio_align_t[i],
+									GPIO_INT_EDGE_RISING);
+							} else {
+								gpio_interrupt_conf(
+									gpio_align_t[i],
+									GPIO_INT_EDGE_FALLING);
+							}
+						}
+					}
+				} else {
+					gpio_interrupt_conf(gpio_align_t[i], GPIO_INT_DISABLE);
+				}
+			}
+			idx++;
+		}
+	}
+	msg->data_len = idx;
+	msg->completion_code = CC_SUCCESS;
+
+	return;
+}
+#endif
+
 uint8_t gpio_idx_exchange(ipmi_msg *msg)
 {
 	if (msg == NULL)


### PR DESCRIPTION
Summary:
- Add OEM command CMD_OEM_1S_GET_GPIO_CONFIG

Test plan:
- Build code: Pass

root@bmc-oob:~# bic-util slot1 0xE0 0x05 0x9C 0x9C 0x00 0xFF 9C 9C 00 12 12 00 01 00 01 12 02

root@bmc-oob:~# bic-util slot1 --get_gpio_config
gpio_config for pin#0 (PWRGD_BMC_PS_PWROK_R):
Direction: Input,  Interrupt: Enabled,  Trigger: Edge Trigger,  Edge: Both Edges gpio_config for pin#1 (FM_PCH_BMC_THERMTRIP_N):
Direction: Input,  Interrupt: Enabled,  Trigger: Edge Trigger,  Edge: Both Edges gpio_config for pin#2 (IRQ_HSC_ALERT2_N):
Direction: Input,  Interrupt: Disabled, Trigger: Edge Trigger,  Edge: Falling Edge gpio_config for pin#3 (FM_BMC_ONCTL_R_N):
Direction: Output, Interrupt: Disabled, Trigger: Edge Trigger,  Edge: Falling Edge gpio_config for pin#4 (RST_RSTBTN_OUT_N):
Direction: Input,  Interrupt: Disabled, Trigger: Edge Trigger,  Edge: Falling Edge gpio_config for pin#5 (FM_JTAG_TCK_MUX_SEL):
Direction: Output, Interrupt: Disabled, Trigger: Edge Trigger,  Edge: Falling Edge gpio_config for pin#6 (FM_HSC_TIMER):
Direction: Input,  Interrupt: Enabled,  Trigger: Edge Trigger,  Edge: Both Edges ..........