### PR TITLE
Common: Fixed missed curly braces in INA230

### DIFF
--- a/common/dev/ina230.c
+++ b/common/dev/ina230.c
@@ -44,13 +44,13 @@ uint8_t ina230_reset_alt(uint8_t sensor_num)
 	ina230_init_arg *init_args;
 
 	if (sensor_num > SENSOR_NUM_MAX) {
-		LOG_ERR("invalid sensor_num\n");
+		LOG_ERR("Invalid sensor number");
 		return SENSOR_UNSPECIFIED_ERROR;
 	}
 
 	init_args = (ina230_init_arg *)sensor_config[sensor_config_index_map[sensor_num]].init_args;
 	if (init_args->is_init == false) {
-		LOG_ERR("[%s], device isn't initialized\n", __func__);
+		LOG_ERR("Device isn't initialized");
 		return SENSOR_UNSPECIFIED_ERROR;
 	}
 
@@ -63,7 +63,7 @@ uint8_t ina230_reset_alt(uint8_t sensor_num)
 	msg.data[0] = INA230_MSK_OFFSET;
 
 	if (i2c_master_read(&msg, I2C_RETRY)) {
-		LOG_ERR("fail to access sensor\n");
+		LOG_ERR("Failed to access sensor");
 		return SENSOR_FAIL_TO_ACCESS;
 	}
 
@@ -72,6 +72,8 @@ uint8_t ina230_reset_alt(uint8_t sensor_num)
 
 uint8_t ina230_read(uint8_t sensor_num, int *reading)
 {
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+
 	double val = 0.0;
 	int16_t signed_reg_val = 0;
 	uint16_t reg_val = 0;
@@ -80,19 +82,14 @@ uint8_t ina230_read(uint8_t sensor_num, int *reading)
 	sensor_cfg *cfg;
 	ina230_init_arg *init_args;
 
-	if (!reading || (sensor_num > SENSOR_NUM_MAX)) {
-		if (sensor_num > SENSOR_NUM_MAX){
-			LOG_ERR("invalid sensor_num\n");
-		}
-		else {
-			LOG_ERR("reading pointer is NULL\n");
-		}
+	if (sensor_num > SENSOR_NUM_MAX) {
+		LOG_ERR("Invalid sensor number");
 		return SENSOR_UNSPECIFIED_ERROR;
 	}
 
 	init_args = (ina230_init_arg *)sensor_config[sensor_config_index_map[sensor_num]].init_args;
 	if (init_args->is_init == false) {
-		LOG_ERR("[%s], device isn't initialized\n", __func__);
+		LOG_ERR("Device isn't initialized");
 		return SENSOR_UNSPECIFIED_ERROR;
 	}
 
@@ -104,9 +101,10 @@ uint8_t ina230_read(uint8_t sensor_num, int *reading)
 	msg.rx_len = 2;
 	msg.data[0] = cfg->offset;
 
-	if (i2c_master_read(&msg, I2C_RETRY))
-		LOG_ERR("fail to access sensor\n");
+	if (i2c_master_read(&msg, I2C_RETRY)) {
+		LOG_ERR("Failed to access sensor");
 		return SENSOR_FAIL_TO_ACCESS;
+	}
 
 	reg_val = (msg.data[0] << 8) | msg.data[1];
 
@@ -140,14 +138,14 @@ uint8_t ina230_init(uint8_t sensor_num)
 	ina230_init_arg *init_args;
 
 	if (sensor_num > SENSOR_NUM_MAX) {
-		LOG_ERR("invalid sensor_num\n");
+		LOG_ERR("Invalid sensor number");
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
 
 	init_args = (ina230_init_arg *)sensor_config[sensor_config_index_map[sensor_num]].init_args;
 
 	if (init_args->r_shunt <= 0.0 || init_args->i_max <= 0.0) {
-		LOG_ERR("<error> INA230 has invalid initail arguments\n");
+		LOG_ERR("INA230 has invalid initail arguments");
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
 
@@ -175,16 +173,15 @@ uint8_t ina230_init(uint8_t sensor_num)
 	msg.data[2] = init_args->config.value & 0xFF;
 
 	if (i2c_master_write(&msg, I2C_RETRY)) {
-		LOG_ERR("Failed to set INA230(%.2d-%.2x) configuration.\n", msg.bus,
-		       msg.target_addr);
+		LOG_ERR("Failed to set INA230(%.2d-%.2x) configuration.", msg.bus, msg.target_addr);
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
 
 	// The size of calibration is 15 bits, and the MSB is unused.
 	if (calibration & 0x8000) {
 		LOG_ERR("Failed to set INA230(%.2d-%.2x) calibration due to"
-		       " the data overflowed (CAL: 0x%.2X)\n",
-		       msg.bus, msg.target_addr, calibration);
+			" the data overflowed (CAL: 0x%.2X)",
+			msg.bus, msg.target_addr, calibration);
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
 
@@ -194,7 +191,7 @@ uint8_t ina230_init(uint8_t sensor_num)
 	msg.data[2] = calibration & 0xFF;
 
 	if (i2c_master_write(&msg, I2C_RETRY)) {
-		LOG_ERR("Failed to set INA230(%.2d-%.2x) calibration.\n", msg.bus, msg.target_addr);
+		LOG_ERR("Failed to set INA230(%.2d-%.2x) calibration.", msg.bus, msg.target_addr);
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
 
@@ -202,8 +199,8 @@ uint8_t ina230_init(uint8_t sensor_num)
 		if (init_args->alert_value == 0.0 ||
 		    ((init_args->alt_cfg.BOL || init_args->alt_cfg.BUL || init_args->alt_cfg.POL) &&
 		     init_args->alert_value < 0.0)) {
-			LOG_ERR("INA230(%.2d-%.2x) has invalid alert function config.\n", msg.bus,
-			       msg.target_addr);
+			LOG_ERR("INA230(%.2d-%.2x) has invalid alert function config.", msg.bus,
+				msg.target_addr);
 			return SENSOR_INIT_UNSPECIFIED_ERROR;
 		}
 
@@ -220,8 +217,8 @@ uint8_t ina230_init(uint8_t sensor_num)
 			alt_reg = (uint16_t)(init_args->alert_value / init_args->pwr_lsb);
 			break;
 		default:
-			LOG_ERR("INA230(%.2d-%.2x) has invalid alert function config.\n", msg.bus,
-			       msg.target_addr);
+			LOG_ERR("INA230(%.2d-%.2x) has invalid alert function config.", msg.bus,
+				msg.target_addr);
 			return SENSOR_INIT_UNSPECIFIED_ERROR;
 		}
 
@@ -231,8 +228,8 @@ uint8_t ina230_init(uint8_t sensor_num)
 		msg.data[2] = alt_reg & 0xFF;
 
 		if (i2c_master_write(&msg, I2C_RETRY)) {
-			LOG_ERR("Failed to set INA230(%.2d-%.2x) alert value.\n", msg.bus,
-			       msg.target_addr);
+			LOG_ERR("Failed to set INA230(%.2d-%.2x) alert value.", msg.bus,
+				msg.target_addr);
 			return SENSOR_INIT_UNSPECIFIED_ERROR;
 		}
 
@@ -242,8 +239,8 @@ uint8_t ina230_init(uint8_t sensor_num)
 		msg.data[2] = init_args->alt_cfg.value & 0xFF;
 
 		if (i2c_master_write(&msg, I2C_RETRY)) {
-			LOG_ERR("Failed to set INA230(%.2d-%.2x) mask/enable.\n", msg.bus,
-			       msg.target_addr);
+			LOG_ERR("Failed to set INA230(%.2d-%.2x) mask/enable.", msg.bus,
+				msg.target_addr);
 			return SENSOR_INIT_UNSPECIFIED_ERROR;
 		}
 	}


### PR DESCRIPTION
Summary:
- Add missed curly braces cause sensor reading failed.
- Remove newline and function print use in shell log.

Test Plan:
- Build Code: Pass
- Reading sensor on GT: Pass

Log:
```
root@bmc-oob:~# sensor-util swb
swb:
SWB_NIC0_TEMP_C              (0x1) :   70.00 C     | (ok)
SWB_NIC0_VOLT_V              (0x2) :   12.08 Volts | (ok)
SWB_NIC0_CURR_A              (0x3) :    1.13 Amps  | (ok)
SWB_NIC0_PWR_W               (0x4) :   13.70 Watts | (ok)
SWB_NIC1_TEMP_C              (0x5) :   63.00 C     | (ok)
SWB_NIC1_VOLT_V              (0x6) :   12.08 Volts | (ok)
SWB_NIC1_CURR_A              (0x7) :    1.17 Amps  | (ok)
SWB_NIC1_PWR_W               (0x8) :   14.15 Watts | (ok)
SWB_NIC2_TEMP_C              (0xA) :   60.00 C     | (ok)
SWB_NIC2_VOLT_V              (0xB) :   12.08 Volts | (ok)
SWB_NIC2_CURR_A              (0xC) :    1.14 Amps  | (ok)
SWB_NIC2_PWR_W               (0xD) :   13.74 Watts | (ok)
SWB_NIC3_TEMP_C              (0x11) :   61.00 C     | (ok)
SWB_NIC3_VOLT_V              (0x12) :   12.08 Volts | (ok)
SWB_NIC3_CURR_A              (0x13) :    1.18 Amps  | (ok)
SWB_NIC3_PWR_W               (0x14) :   14.30 Watts | (ok)
SWB_NIC4_TEMP_C              (0x15) :   55.00 C     | (ok)
SWB_NIC4_VOLT_V              (0x16) :   12.09 Volts | (ok)
SWB_NIC4_CURR_A              (0x17) :    1.13 Amps  | (ok)
SWB_NIC4_PWR_W               (0x18) :   13.62 Watts | (ok)
SWB_NIC5_TEMP_C              (0x1A) :   54.00 C     | (ok)
SWB_NIC5_VOLT_V              (0x1B) :   12.09 Volts | (ok)
SWB_NIC5_CURR_A              (0x1C) :    1.16 Amps  | (ok)
SWB_NIC5_PWR_W               (0x1D) :   14.05 Watts | (ok)
SWB_NIC6_TEMP_C              (0x21) :   61.00 C     | (ok)
SWB_NIC6_VOLT_V              (0x22) :   12.09 Volts | (ok)
SWB_NIC6_CURR_A              (0x23) :    1.14 Amps  | (ok)
SWB_NIC6_PWR_W               (0x24) :   13.85 Watts | (ok)
SWB_NIC7_TEMP_C              (0x25) :   54.00 C     | (ok)
SWB_NIC7_VOLT_V              (0x26) :   12.08 Volts | (ok)
SWB_NIC7_CURR_A              (0x27) :    1.14 Amps  | (ok)
SWB_NIC7_PWR_W               (0x28) :   13.82 Watts | (ok)
SWB_P12V_AUX_V               (0x30) :   12.10 Volts | (ok)
SWB_P5V_AUX_V                (0x31) :    4.98 Volts | (ok)
SWB_P3V3_AUX_V               (0x32) :    3.30 Volts | (ok)
SWB_P1V2_AUX_V               (0x33) :    1.20 Volts | (ok)
SWB_P3V3_V                   (0x34) :    3.29 Volts | (ok)
SWB_P1V8_PEX0_V              (0x35) :    1.81 Volts | (ok)
SWB_P1V8_PEX1_V              (0x36) :    1.80 Volts | (ok)
SWB_P1V8_PEX2_V              (0x37) :    1.80 Volts | (ok)
SWB_P1V8_PEX3_V              (0x38) :    1.80 Volts | (ok)
SWB_PEX0_VR_TEMP_C           (0x40) :   45.00 C     | (ok)
SWB_PEX0_P0V8_VOLT_V         (0x41) :    0.81 Volts | (ok)
SWB_PEX0_P0V8_CURR_A         (0x42) :   24.00 Amps  | (ok)
SWB_PEX0_P0V8_PWR_W          (0x43) :   19.00 Watts | (ok)
SWB_PEX0_P1V25_VOLT_V        (0x44) :    1.27 Volts | (ok)
SWB_PEX0_P1V25_CURR_A        (0x45) :    0.00 Amps  | (ok)
SWB_PEX0_P1V25_PWR_W         (0x46) :    0.00 Watts | (ok)
SWB_PEX1_VR_TEMP_C           (0x47) :   43.00 C     | (ok)
SWB_PEX1_P0V8_VOLT_V         (0x48) :    0.81 Volts | (ok)
SWB_PEX1_P0V8_CURR_A         (0x49) :   24.00 Amps  | (ok)
SWB_PEX1_P0V8_PWR_W          (0x4A) :   19.00 Watts | (ok)
SWB_PEX1_P1V25_VOLT_V        (0x4B) :    1.27 Volts | (ok)
SWB_PEX1_P1V25_CURR_A        (0x4C) :    9.00 Amps  | (ok)
SWB_PEX1_P1V25_PWR_W         (0x4D) :   11.43 Watts | (ok)
SWB_PEX2_VR_TEMP_C           (0x50) :   39.00 C     | (ok)
SWB_PEX2_P0V8_VOLT_V         (0x51) :    0.81 Volts | (ok)
SWB_PEX2_P0V8_CURR_A         (0x52) :   24.00 Amps  | (ok)
SWB_PEX2_P0V8_PWR_W          (0x53) :   19.00 Watts | (ok)
SWB_PEX2_P1V25_VOLT_V        (0x54) :    1.27 Volts | (ok)
SWB_PEX2_P1V25_CURR_A        (0x55) :    9.63 Amps  | (ok)
SWB_PEX2_P1V25_PWR_W         (0x56) :   12.26 Watts | (ok)
SWB_PEX3_VR_TEMP_C           (0x57) :   40.00 C     | (ok)
SWB_PEX3_P0V8_VOLT_V         (0x58) :    0.81 Volts | (ok)
SWB_PEX3_P0V8_CURR_A         (0x59) :   24.00 Amps  | (ok)
SWB_PEX3_P0V8_PWR_W          (0x5A) :   20.00 Watts | (ok)
SWB_PEX3_P1V25_VOLT_V        (0x5B) :    1.27 Volts | (ok)
SWB_PEX3_P1V25_CURR_A        (0x5C) :    9.02 Amps  | (ok)
SWB_PEX3_P1V25_PWR_W         (0x5D) :   11.49 Watts | (ok)
SWB_PEX_P1V8_VOLT_V          (0x60) :    1.80 Volts | (ok)
SWB_PEX_P1V8_CURR_A          (0x61) :    0.03 Amps  | (ok)
SWB_PEX_P1V8_PWR_W           (0x62) :    0.04 Watts | (ok)
SWB_PEX0_TEMP_C              (0x6A) :   60.66 C     | (ok)
SWB_PEX1_TEMP_C              (0x6B) :   61.61 C     | (ok)
SWB_PEX2_TEMP_C              (0x6C) :   59.95 C     | (ok)
SWB_PEX3_TEMP_C              (0x6D) :   56.39 C     | (ok)
SWB_SYSTEM_INLET_TEMP_C      (0x70) :   32.00 C     | (ok)
SWB_OUTLET_TEMP_L1_C         (0x71) :   38.00 C     | (ok)
SWB_OUTLET_TEMP_L2_C         (0x72) :   37.00 C     | (ok)
SWB_OUTLET_TEMP_R1_C         (0x73) :   31.00 C     | (ok)
SWB_OUTLET_TEMP_R2_C         (0x74) :   34.00 C     | (ok)
SWB_E1S_0_TEMP_C             (0x80) :   35.00 C     | (ok)
SWB_E1S_0_VOLT_V             (0x81) :   12.09 Volts | (ok)
SWB_E1S_0_CURR_A             (0x82) :    0.26 Amps  | (ok)
SWB_E1S_0_PWR_W              (0x83) :    3.11 Watts | (ok)
SWB_E1S_1_TEMP_C             (0x84) :   39.00 C     | (ok)
SWB_E1S_1_VOLT_V             (0x85) :   12.09 Volts | (ok)
SWB_E1S_1_CURR_A             (0x86) :    0.27 Amps  | (ok)
SWB_E1S_1_PWR_W              (0x87) :    3.24 Watts | (ok)
SWB_E1S_2_TEMP_C             (0x88) :   39.00 C     | (ok)
SWB_E1S_2_VOLT_V             (0x89) :   12.09 Volts | (ok)
SWB_E1S_2_CURR_A             (0x8A) :    0.27 Amps  | (ok)
SWB_E1S_2_PWR_W              (0x8B) :    3.21 Watts | (ok)
SWB_E1S_3_TEMP_C             (0x8C) :   38.00 C     | (ok)
SWB_E1S_3_VOLT_V             (0x8D) :   12.09 Volts | (ok)
SWB_E1S_3_CURR_A             (0x8E) :    0.26 Amps  | (ok)
SWB_E1S_3_PWR_W              (0x8F) :    3.14 Watts | (ok)
SWB_E1S_4_TEMP_C             (0x90) :   39.00 C     | (ok)
SWB_E1S_4_VOLT_V             (0x91) :   12.09 Volts | (ok)
SWB_E1S_4_CURR_A             (0x92) :    0.35 Amps  | (ok)
SWB_E1S_4_PWR_W              (0x93) :    4.20 Watts | (ok)
SWB_E1S_5_TEMP_C             (0x94) :   39.00 C     | (ok)
SWB_E1S_5_VOLT_V             (0x95) :   12.09 Volts | (ok)
SWB_E1S_5_CURR_A             (0x96) :    0.27 Amps  | (ok)
SWB_E1S_5_PWR_W              (0x97) :    3.20 Watts | (ok)
SWB_E1S_6_TEMP_C             (0x98) :   38.00 C     | (ok)
SWB_E1S_6_VOLT_V             (0x99) :   12.09 Volts | (ok)
SWB_E1S_6_CURR_A             (0x9A) :    0.32 Amps  | (ok)
SWB_E1S_6_PWR_W              (0x9B) :    3.89 Watts | (ok)
SWB_E1S_7_TEMP_C             (0x9C) :   35.00 C     | (ok)
SWB_E1S_7_VOLT_V             (0x9D) :   12.09 Volts | (ok)
SWB_E1S_7_CURR_A             (0x9E) :    0.26 Amps  | (ok)
SWB_E1S_7_PWR_W              (0x9F) :    3.14 Watts | (ok)
SWB_E1S_8_TEMP_C             (0xA0) :   32.00 C     | (ok)
SWB_E1S_8_VOLT_V             (0xA1) :   12.09 Volts | (ok)
SWB_E1S_8_CURR_A             (0xA2) :    0.26 Amps  | (ok)
SWB_E1S_8_PWR_W              (0xA3) :    3.14 Watts | (ok)
SWB_E1S_9_TEMP_C             (0xA4) :   31.00 C     | (ok)
SWB_E1S_9_VOLT_V             (0xA5) :   12.09 Volts | (ok)
SWB_E1S_9_CURR_A             (0xA6) :    0.26 Amps  | (ok)
SWB_E1S_9_PWR_W              (0xA7) :    3.15 Watts | (ok)
SWB_E1S_10_TEMP_C            (0xA8) :   31.00 C     | (ok)
SWB_E1S_10_VOLT_V            (0xA9) :   12.09 Volts | (ok)
SWB_E1S_10_CURR_A            (0xAA) :    0.26 Amps  | (ok)
SWB_E1S_10_PWR_W             (0xAB) :    3.11 Watts | (ok)
SWB_E1S_11_TEMP_C            (0xAC) :   30.00 C     | (ok)
SWB_E1S_11_VOLT_V            (0xAD) :   12.09 Volts | (ok)
SWB_E1S_11_CURR_A            (0xAE) :    0.26 Amps  | (ok)
SWB_E1S_11_PWR_W             (0xAF) :    3.09 Watts | (ok)
SWB_E1S_12_TEMP_C            (0xB0) :   34.00 C     | (ok)
SWB_E1S_12_VOLT_V            (0xB1) :   12.09 Volts | (ok)
SWB_E1S_12_CURR_A            (0xB2) :    0.26 Amps  | (ok)
SWB_E1S_12_PWR_W             (0xB3) :    3.14 Watts | (ok)
SWB_E1S_13_TEMP_C            (0xB4) :   35.00 C     | (ok)
SWB_E1S_13_VOLT_V            (0xB5) :   12.09 Volts | (ok)
SWB_E1S_13_CURR_A            (0xB6) :    0.26 Amps  | (ok)
SWB_E1S_13_PWR_W             (0xB7) :    3.11 Watts | (ok)
SWB_E1S_14_TEMP_C            (0xB8) :   35.00 C     | (ok)
SWB_E1S_14_VOLT_V            (0xB9) :   12.09 Volts | (ok)
SWB_E1S_14_CURR_A            (0xBA) :    0.26 Amps  | (ok)
SWB_E1S_14_PWR_W             (0xBB) :    3.09 Watts | (ok)
SWB_E1S_15_TEMP_C            (0xBC) :   33.00 C     | (ok)
SWB_E1S_15_VOLT_V            (0xBD) :   12.09 Volts | (ok)
SWB_E1S_15_CURR_A            (0xBE) :    0.26 Amps  | (ok)
SWB_E1S_15_PWR_W             (0xBF) :    3.17 Watts | (ok)
```