### PR TITLE
Common: Support PLDM command GetPLDMTypes and GetPLDMCommands

### DIFF
--- a/common/service/pldm/pldm.c
+++ b/common/service/pldm/pldm.c
@@ -23,6 +23,7 @@
 #include <sys/printk.h>
 #include <sys/slist.h>
 #include <zephyr.h>
+#include "libutil.h"
 
 LOG_MODULE_REGISTER(pldm);
 
@@ -354,6 +355,72 @@ uint8_t mctp_pldm_send_msg(void *mctp_p, pldm_msg *msg)
 		k_mutex_lock(&wait_recv_resp_mutex, K_FOREVER);
 		sys_slist_append(&wait_recv_resp_list, &p->node);
 		k_mutex_unlock(&wait_recv_resp_mutex);
+	}
+
+	return PLDM_SUCCESS;
+}
+
+/**
+ * @brief Get the supported PLDM types.
+ *
+ * @param buf Pointer to the buffer, which should have 8 bytes
+ * @param buf_size Number of buf's bytes
+ *
+ * @retval 0 if successful
+ */
+uint8_t get_supported_pldm_type(uint8_t *buf, uint8_t buf_size)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, PLDM_ERROR);
+
+	if (buf_size != GET_PLDM_TYPE_BUF_SIZE)
+		return PLDM_ERROR_INVALID_LENGTH;
+
+	memset(buf, 0, buf_size);
+
+	for (uint8_t i = 0; i < ARRAY_SIZE(query_tbl); i++) {
+		const uint8_t buf_index = query_tbl[i].type / 8;
+		const uint8_t bit_index = query_tbl[i].type % 8;
+
+		if (buf_index >= buf_size) {
+			LOG_WRN("The PLDM type(0x%x) is out of range!", query_tbl[i].type);
+			continue;
+		}
+
+		buf[buf_index] |= BIT(bit_index);
+	}
+
+	return PLDM_SUCCESS;
+}
+
+uint8_t get_supported_pldm_commands(PLDM_TYPE type, uint8_t *buf, uint8_t buf_size)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, PLDM_ERROR);
+
+	if (buf_size != GET_PLDM_COMMNAD_BUF_SIZE)
+		return PLDM_ERROR_INVALID_LENGTH;
+
+	memset(buf, 0, buf_size);
+
+	uint8_t (*handler_query)(uint8_t, void **) = NULL;
+
+	for (uint8_t i = 0; i < ARRAY_SIZE(query_tbl); i++) {
+		if (type == query_tbl[i].type) {
+			handler_query = query_tbl[i].handler_query;
+			break;
+		}
+	}
+
+	if (!handler_query) {
+		LOG_WRN("Invalid PLDM type, (0x%x)", type);
+		return PLDM_ERROR_INVALID_PLDM_TYPE;
+	}
+
+	for (uint16_t cmd = 0; cmd < (GET_PLDM_COMMNAD_BUF_SIZE * 8); cmd++) {
+		pldm_cmd_proc_fn handler = NULL;
+
+		uint8_t rc = handler_query(cmd, (void **)&handler);
+		if ((rc == PLDM_SUCCESS) && handler)
+			buf[cmd / 8] |= BIT(cmd % 8);
 	}
 
 	return PLDM_SUCCESS;

--- a/common/service/pldm/pldm.h
+++ b/common/service/pldm/pldm.h
@@ -138,6 +138,10 @@ uint16_t mctp_pldm_read(void *mctp_p, pldm_msg *msg, uint8_t *rbuf, uint16_t rbu
 
 pldm_t *pldm_init(void *interface, uint8_t user_idx);
 
+uint8_t get_supported_pldm_type(uint8_t *buf, uint8_t buf_size);
+
+uint8_t get_supported_pldm_commands(PLDM_TYPE type, uint8_t *buf, uint8_t buf_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/common/service/pldm/pldm_base.h
+++ b/common/service/pldm/pldm_base.h
@@ -33,6 +33,12 @@ extern "C" {
 
 #define DEFAULT_TID 0x86
 
+#define GET_PLDM_TYPE_BUF_SIZE 8
+#define GET_PLDM_COMMNAD_BUF_SIZE 32
+
+#define INVALID_PLDM_TYPE_IN_REQUEST_DATA 0x83
+#define INVALID_PLDM_VERSION_IN_REQUEST_DATA 0x84
+
 enum pldm_completion_codes {
 	PLDM_SUCCESS = 0x00,
 	PLDM_ERROR = 0x01,
@@ -63,6 +69,21 @@ struct _set_tid_resp {
 struct _get_tid_resp {
 	uint8_t completion_code;
 	uint8_t tid;
+} __attribute__((packed));
+
+struct _get_pldm_types_resp {
+	uint8_t completion_code;
+	uint8_t pldm_types[GET_PLDM_TYPE_BUF_SIZE];
+} __attribute__((packed));
+
+struct _get_pldm_commands_req {
+	uint8_t type;
+	uint32_t version;
+} __attribute__((packed));
+
+struct _get_pldm_commands_resp {
+	uint8_t completion_code;
+	uint8_t pldm_commands[GET_PLDM_COMMNAD_BUF_SIZE];
 } __attribute__((packed));
 
 uint8_t pldm_base_handler_query(uint8_t code, void **ret_fn);


### PR DESCRIPTION
Summary:
- Add PLDM base command GetPLDMTypes (0x04), GetPLDMCommands (0x05).

Test Plan:
- Build Code: Pass
- Check command on GT: Pass

Log:
```
root@bmc-oob:~# pldmd-util -b 3 -e 0x0a raw 0x00 0x04 Request :
  Bus = 3
  Eid = 10
  Data = 0x00 0x04
Response:
  Return Code: 0
  PLDM Request Bit     : 0x00
  PLDM Instance ID     : 0x00
  PLDM Type            : 0x00
  PLDM Command         : 0x04
  PLDM Completion Code : 0x00
  PLDM Data : 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0x80
root@bmc-oob:~# pldmd-util -b 3 -e 0x0a raw 0x00 0x05 0x00 0x00 0x00 0x00 0x01
Request :
  Bus = 3
  Eid = 10
  Data = 0x00 0x05 0x00 0x00 0x00 0x00 0x01
Response:
  Return Code: 0
  PLDM Request Bit     : 0x00
  PLDM Instance ID     : 0x00
  PLDM Type            : 0x00
  PLDM Command         : 0x05
  PLDM Completion Code : 0x00
  PLDM Data : 0x36 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
```