### PR TITLE
fby3: dl:check nvme present before polling temperature

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_hook.h
+++ b/meta-facebook/yv3-dl/src/platform/plat_hook.h
@@ -17,6 +17,8 @@
 #ifndef PLAT_HOOK_H
 #define PLAT_HOOK_H
 
+#include "i2c-mux-tca9548.h"
+
 typedef struct _vr_pre_proc_arg {
 	/* vr page to set */
 	uint8_t vr_page;
@@ -25,6 +27,11 @@ typedef struct _vr_pre_proc_arg {
 typedef struct _dimm_pre_proc_arg {
 	bool is_present_checked;
 } dimm_pre_proc_arg;
+
+typedef struct _nvme_pre_proc_arg {
+	struct tca9548 mux_conf;
+	bool is_present_checked;
+} nvme_pre_proc_arg;
 /**************************************************************************************************
  * INIT ARGS
 **************************************************************************************************/
@@ -40,6 +47,7 @@ extern mp5990_init_arg mp5990_init_args[];
 extern struct tca9548 mux_conf_addr_0xe2[];
 extern vr_pre_proc_arg vr_page_select[];
 extern dimm_pre_proc_arg dimm_pre_proc_args[];
+extern nvme_pre_proc_arg nvme_pre_proc_args[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK FUNC

--- a/meta-facebook/yv3-dl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_sensor_table.c
@@ -53,7 +53,7 @@ sensor_cfg plat_sensor_config[] = {
 	// NVME
 	{ SENSOR_NUM_T_NVME1, sensor_dev_nvme, I2C_BUS5, SSD0_ADDR, SSD0_OFFSET, post_access, 0, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
-	  pre_nvme_read, &mux_conf_addr_0xe2[1], NULL, NULL, NULL },
+	  pre_nvme_read, &nvme_pre_proc_args[1], NULL, NULL, NULL },
 
 	// VR voltage
 	{ SENSOR_NUM_VOL_PVCCIO_VR, sensor_dev_xdpe12284c, I2C_BUS8, VCCIO_P3V3_STBY_ADDR,


### PR DESCRIPTION
Summary:
- BIC will show i2c retry log in console, because the ssd do not support nvme.

Solution:
- check the slave addr of nvme before bic get the temperature.

Test Plan:
- Build Code : pass
- Log uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x1 ] MB Inlet Temp            : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    27.000
[0x3 ] FRONT IO Temp            : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    23.000
[0xe ] SSD0 Temp                : nvme       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x29] VCCIO VR Vol             : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.019
[0x2a] P3V3_STBY VR Vol         : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.293
[0x2c] VDDQ_ABC VR Vol          : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.234
[0x2d] VDDQ_DEF VR Vol          : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.233
[0x27] VCCIN VR Vol             : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.696
[0x28] VCCSA VR Vol             : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.825
[0x33] VCCIO VR Cur             : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.400
[0x34] P3V3_STBY VR Cur         : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.600
[0x35] VDDQ_ABC VR Cur          : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.200
[0x36] VDDQ_DEF VR Cur          : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.400
[0x31] VCCIN VR Cur             : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.000
[0x32] VCCSA VR Cur             : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.000
[0x12] VCCIO VR Temp            : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0x13] 3V3_STBY VR Temp         : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    36.000
[0x14] VDDQ_ABC VR Temp         : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    37.000
[0x15] VDDQ_DEF VR Temp         : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0x10] VCCIN VR Temp            : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0x11] VCCSA VR Temp            : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0x3d] VCCIO VR Pout            : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.000
[0x3e] P3V3_STBY VRPout         : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.000
[0x3f] VDDQ_ABC VRPout          : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.000
[0x42] VDDQ_DEF VRPout          : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.000
[0x3a] VCCIN VR Pout            : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     6.000
[0x3c] VCCSA VR Pout            : isl69254   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.000
[0x5 ] SOC CPU Temp             : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    36.000
[0xd ] SOC Therm Margin         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.000
[0x25] SOC CPU TjMax            : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    76.000
[0x1e] CPU Package Pwr          : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    13.000
[0x6 ] SOC DIMMA Temp           : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    33.000
[0x7 ] SOC DIMMB Temp           : peci       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x9 ] SOC DIMMC Temp           : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    32.000
[0xa ] SOC DIMMD Temp           : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    33.000
[0xb ] SOC DIMME Temp           : peci       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0xc ] SOC DIMMF Temp           : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    33.000
[0x20] P12V_STBY Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.077
[0x22] P3V3_STBY Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.321
[0x23] P1V05_PCH Vol            : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.059
[0x21] P3V_BAT Vol              : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.105
[0x24] PVNN_PCH Vol             : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.013
[0x4 ] PCH Temp                 : pch        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    36.000
[0x2 ] MB Outlet Temp           : tmp431     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    36.562
[0xf ] HSC Temp                 : tmp431     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    34.312
[0x26] HSC Input Vol            : ltc4282    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    11.996
[0x2e] HSC Input Pwr            : ltc4282    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    22.953
[0x39] HSC Input AvgPwr         : ltc4282    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.015
[0x30] HSC Output Cur           : ltc4282    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.953