### PR TITLE
fby35: rf: Fix the target address of PVDDQ_CD's current sensor

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
@@ -194,7 +194,7 @@ sensor_cfg VR_RNS_sensor_config_table[] = {
 	  SMBUS_PWR_CMD, vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_isl69254iraz_t_read,
 	  &isl69254iraz_t_pre_read_args[1], NULL, NULL, NULL },
-	{ SENSOR_NUM_PWR_VRVDDQCD, sensor_dev_isl69254iraz_t, I2C_BUS10, VR_VDDQAB_ADDR,
+	{ SENSOR_NUM_PWR_VRVDDQCD, sensor_dev_isl69254iraz_t, I2C_BUS10, VR_VDDQCD_ADDR,
 	  SMBUS_PWR_CMD, vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_isl69254iraz_t_read,
 	  &isl69254iraz_t_pre_read_args[0], NULL, NULL, NULL },
@@ -267,7 +267,7 @@ sensor_cfg VR_INF_sensor_config_table[] = {
 	{ SENSOR_NUM_PWR_VRVDDQAB, sensor_dev_xdpe12284c, I2C_BUS10, VR_VDDQAB_ADDR, SMBUS_PWR_CMD,
 	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_vr_read, &vr_page_select[1], NULL, NULL, NULL },
-	{ SENSOR_NUM_PWR_VRVDDQCD, sensor_dev_xdpe12284c, I2C_BUS10, VR_VDDQAB_ADDR, SMBUS_PWR_CMD,
+	{ SENSOR_NUM_PWR_VRVDDQCD, sensor_dev_xdpe12284c, I2C_BUS10, VR_VDDQCD_ADDR, SMBUS_PWR_CMD,
 	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_vr_read, &vr_page_select[0], NULL, NULL, NULL },
 };


### PR DESCRIPTION
Summary:
- Fix the target address to make BMC read values correctly.

Test Plan:
- Build code: Pass
- Check PVDDQ_CD's value after modifying the load current: Pass

Test Log:
- Build code: #west build -p auto -b ast1030_evb meta-facebook/yv35-rf/ ``` [292/292] Linking C executable zephyr/Y35BRF.elf
    Memory region         Used Size  Region Size  %age Used
            SRAM_NC:         12 KB       320 KB      3.75%
            FLASH:          0 GB         0 GB
                SRAM:      420552 B       448 KB     91.67%
            IDT_LIST:          0 GB         2 KB      0.00%

- Check PVDDQ_CD's value after modifying the load current: root@bmc-oob:~# sensor-util slot1 | grep "RF PVDDQ_CD Cur"
    RF PVDDQ_CD Cur             (0x72) :    9.80 Amps  | (ok)
    root@bmc-oob:~# sensor-util slot1 | grep "RF PVDDQ_CD Cur"
    RF PVDDQ_CD Cur             (0x72) :    5.80 Amps  | (ok)
    root@bmc-oob:~# sensor-util slot1 | grep "RF PVDDQ_CD Cur"
    RF PVDDQ_CD Cur             (0x72) :    3.80 Amps  | (ok)