### PR TITLE
fby3.5: Enable I2C bus config setting

### DIFF
--- a/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
@@ -50,7 +50,7 @@
 
 &i2c3 {
 	pinctrl-0 = <&pinctrl_i2c3_default>;
-	status = "disabled";
+	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 


### PR DESCRIPTION
Summary:
- Enable I2C bus 3.

Test plan:
- Build code: Pass
- Scan I2C bus: Pass

Log:
1. Check all bus can scan. root@bmc-oob:~# bic-util slot1 0xe0 0x60 0x15 0xa0 0x00 0x00 15 A0 00 42
root@bmc-oob:~# bic-util slot1 0xe0 0x60 0x15 0xa0 0x00 0x01 15 A0 00 16 90 92 94 A8 B8 D4 E2
root@bmc-oob:~# bic-util slot1 0xe0 0x60 0x15 0xa0 0x00 0x02 15 A0 00 2C
root@bmc-oob:~# bic-util slot1 0xe0 0x60 0x15 0xa0 0x00 0x03 15 A0 00 10 88 D2
root@bmc-oob:~# bic-util slot1 0xe0 0x60 0x15 0xa0 0x00 0x04 15 A0 00 C0 C4 EC
root@bmc-oob:~# bic-util slot1 0xe0 0x60 0x15 0xa0 0x00 0x05 15 A0 00 A0 B0
root@bmc-oob:~# bic-util slot1 0xe0 0x60 0x15 0xa0 0x00 0x06 15 A0 00 20
root@bmc-oob:~# bic-util slot1 0xe0 0x60 0x15 0xa0 0x00 0x07 15 A0 00 40
root@bmc-oob:~# bic-util slot1 0xe0 0x60 0x15 0xa0 0x00 0x08 15 A0 00