### PR TITLE
fby3.5: CL: Modify I3C frequency

### DIFF
--- a/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
@@ -62,10 +62,10 @@
 &i3c3 {
 	status = "okay";
 	assigned-address = <0x11>;
-	i3c-scl-hz = <8000000>;
+	i3c-scl-hz = <5000000>;
 	pinctrl-0 = <&pinctrl_i3c3_default>;
-	i3c-pp-scl-hi-period-ns = <63>;
-	i3c-pp-scl-lo-period-ns = <63>;
+	i3c-pp-scl-hi-period-ns = <100>;
+	i3c-pp-scl-lo-period-ns = <100>;
 };
 
 &i2c4 {


### PR DESCRIPTION
Summary:
- Using 8M Hz frequency, some DIMMs can't I3C transfer successfully after switch DIMM MUX. Modify to 5M Hz, mostly DIMMs can transfer successfully.

Test plan:
- Build code: Pass
- I3C transfer: MTC20F2085S1RC48BA1 (DIMM: Micron, PMIC TI): Pass M321R4GA3BB6-CQKDG (DIMM: Samsung, PMIC TI): Pass M321R4GA3BB6-CQKMG (DIMM: Samsung, PMIC Samsung): Pass MTC20F2085S1RC48BA1 (DIMM: Micron, PMIC Richtek): Pass M321R4GA3BB6-CQKVG (DIMM: Samsung, PMIC MPS): Pass MTC20F2085S1RC48BA1 (DIMM: Micron, PMIC MPS): Pass

Log:
1. Check BIC no error message.
- Before modify
* BMC console root@bmc-oob:~# sensor-util slot1 | grep DIMM
MB_DIMMA0_TEMP_C             (0x6) : NA | (na)
MB_DIMMA2_TEMP_C             (0x7) :   23.00 C     | (ok)
MB_DIMMA3_TEMP_C             (0x9) :   23.00 C     | (ok)
MB_DIMMA4_TEMP_C             (0xA) : NA | (na)
MB_DIMMA6_TEMP_C             (0xB) : NA | (na)
MB_DIMMA7_TEMP_C             (0xC) : NA | (na)
MB_ADC_P12V_DIMM_VOLT_V      (0x26) :   12.70 Volts  | (ok)
MB_VR_DIMMA0_PMIC_PWR_W      (0x1E) : NA | (na)
MB_VR_DIMMA2_PMIC_PWR_W      (0x1F) :    0.00 Watts  | (ok)
MB_VR_DIMMA3_PMIC_PWR_W      (0x36) :    0.00 Watts  | (ok)
MB_VR_DIMMA4_PMIC_PWR_W      (0x37) : NA | (na)
MB_VR_DIMMA6_PMIC_PWR_W      (0x42) : NA | (na)
MB_VR_DIMMA7_PMIC_PWR_W      (0x47) : NA | (na)

* BIC console: Keep printing error message [get_sensor_reading]sensor number 0x6 reading and post_read fail [get_sensor_reading]sensor number 0xa reading and post_read fail [get_sensor_reading]sensor number 0xb reading and post_read fail [get_sensor_reading]sensor number 0xc reading and post_read fail [00:01:16.828,000] <err> hal_i3c: Failed to transfer messages to addr 0x48, ret: 5 [00:01:16.828,000] <err> plat_dimm: Failed to read DIMM 0 PMIC error via I3C, ret-5 [00:01:16.830,000] <err> hal_i3c: Failed to transfer messages to addr 0x48, ret: 5 [00:01:16.830,000] <err> plat_dimm: Failed to read DIMM 3 PMIC error via I3C, ret-5 [00:01:16.831,000] <err> hal_i3c: Failed to transfer messages to addr 0x4c, ret: 5 [00:01:16.831,000] <err> plat_dimm: Failed to read DIMM 4 PMIC error via I3C, ret-5 [00:01:16.831,000] <err> hal_i3c: Failed to transfer messages to addr 0x4e, ret: 5 [00:01:16.831,000] <err> plat_dimm: Failed to read DIMM 5 PMIC error via I3C, ret-5 [00:01:17.832,000] <err> hal_i3c: Failed to transfer messages to addr 0x48, ret: 5 [00:01:17.832,000] <err> plat_dimm: Failed to read DIMM 0 PMIC error via I3C, ret-5 [00:01:17.835,000] <err> hal_i3c: Failed to transfer messages to addr 0x48, ret: 5 01:17.835,0080] <eDrr> plat_dim: Failed t[o read DIMMJ 3 PMIC err[or via I3C,0 ret-5 0:01:16.828,000] <err> hal_i3c: Failed to transfer messages to addr 0x48, ret: 5

- After modify
* BMC console root@bmc-oob:~# sensor-util slot1 | grep DIMM
MB_DIMMA0_TEMP_C             (0x6) :   26.25 C     | (ok)
MB_DIMMA2_TEMP_C             (0x7) :   25.75 C     | (ok)
MB_DIMMA3_TEMP_C             (0x9) :   25.50 C     | (ok)
MB_DIMMA4_TEMP_C             (0xA) :   26.00 C     | (ok)
MB_DIMMA6_TEMP_C             (0xB) :   25.25 C     | (ok)
MB_DIMMA7_TEMP_C             (0xC) :   25.00 C     | (ok)
MB_ADC_P12V_DIMM_VOLT_V      (0x26) :   12.67 Volts  | (ok)
MB_VR_DIMMA0_PMIC_PWR_W      (0x1E) :    0.38 Watts  | (ok)
MB_VR_DIMMA2_PMIC_PWR_W      (0x1F) :    0.62 Watts  | (ok)
MB_VR_DIMMA3_PMIC_PWR_W      (0x36) :    0.50 Watts  | (ok)
MB_VR_DIMMA4_PMIC_PWR_W      (0x37) :    0.38 Watts  | (ok)
MB_VR_DIMMA6_PMIC_PWR_W      (0x42) :    0.25 Watts  | (ok)
MB_VR_DIMMA7_PMIC_PWR_W      (0x47) :    0.62 Watts  | (ok)

* BIC console: No error message uart:~$
uart:~$

2. Check that BMC can get DIMM information through I3C.
- DIMM A0 root@bmc-oob:~# bic-util slot1 0xE0 0xB1 0x15 0xA0 0x00 0x00 0x01 0x2 0x3C 15 A0 00 0B 2A

- DIMM A2 root@bmc-oob:~# bic-util slot1 0xE0 0xB1 0x15 0xA0 0x00 0x01 0x01 0x2 0x3C 15 A0 00 80 B3

- DIMM A3 root@bmc-oob:~# bic-util slot1 0xE0 0xB1 0x15 0xA0 0x00 0x02 0x01 0x2 0x3C 15 A0 00 80 B3

- DIMM A4 root@bmc-oob:~# bic-util slot1 0xE0 0xB1 0x15 0xA0 0x00 0x03 0x01 0x2 0x3C 15 A0 00 0B 2A

- DIMM A6 root@bmc-oob:~# bic-util slot1 0xE0 0xB1 0x15 0xA0 0x00 0x04 0x01 0x2 0x3C 15 A0 00 0B 2A

- DIMM A7 root@bmc-oob:~# bic-util slot1 0xE0 0xB1 0x15 0xA0 0x00 0x05 0x01 0x2 0x3C 15 A0 00 0B 2A