### PR TITLE
fby35: gl: Disable the GPIOs internal pull-down

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_init.c
@@ -20,10 +20,33 @@
 #include "plat_gpio.h"
 
 /*
- *   TODO :
- *   Set SCU table to disable parts of GPIO PD/PU
+ * The operating voltage of GPIO input pins are lower than actual voltage because the chip 
+ * internal pull-down is enabled.
+ * BIC disables the internal GPIO pull-down for all input pins.
  *
+ * Disabled GPIO list (Refer to chapter 18 of AST1030's datasheet) :
+ * GPIOA0 GPIOA1 GPIOA2 GPIOA4
+ * GPIOB5 GPIOB6
+ * GPIOC0 GPIOC1 GPIOC2 GPIOC4 GPIOC5 GPIOC6 GPIOC7
+ * GPIOD0 GPIOD2
+ * GPIOF1 GPIOF4
+ * GPIOG0 GPIOG2 GPIOG5 GPIOG6 GPIOG7
+ * GPIOH1 GPIOH2 GPIOH3
+ * GPIOL3 GPIOL4 GPIOL5 GPIOL6 GPIOL7
+ * GPIOM1 GPIOM4 GPIOM5
  */
+SCU_CFG scu_cfg[] = {
+	//register    value
+	{ 0x7e6e2610, 0x05F76017 },
+	{ 0x7e6e2614, 0x0EE51200 },
+	{ 0x7e6e2618, 0xF8000000 },
+	{ 0x7e6e261C, 0x00000032 },
+};
+
+void pal_pre_init()
+{
+	scu_init(scu_cfg, ARRAY_SIZE(scu_cfg));
+}
 
 void pal_set_sys_status()
 {


### PR DESCRIPTION
Summary:
The operating voltage of GPIO input pins are lower than actual voltage because the chip internal pull-down is enabled. BIC disables the internal GPIO pull-down for all input pins.

Test Plan:
- Check SCU registers’ value by referring to chapter 18 of AST1030's datasheet: Pass

Test Log:
- Check SCU registers' value: uart:~$ md 0x7e6e2610 1 [7e6e2610] 05f76017 uart:~$ md 0x7e6e2614 1 [7e6e2614] 0ee51200 uart:~$ md 0x7e6e2618 1 [7e6e2618] f8000000 uart:~$ md 0x7e6e261c 1 [7e6e261c] 00000032