### PR TITLE
Common: Support PLDM firmware update for BIC

### DIFF
--- a/common/lib/util_spi.h
+++ b/common/lib/util_spi.h
@@ -30,6 +30,9 @@
 
 #define SHA256_DIGEST_SIZE 32
 
+#define SECTOR_END_FLAG BIT(7)
+#define NO_RESET_FLAG BIT(0)
+
 enum DEVICE_POSITIONS {
 	DEVSPI_FMC_CS0,
 	DEVSPI_FMC_CS1,
@@ -39,7 +42,7 @@ enum DEVICE_POSITIONS {
 	DEVSPI_SPI2_CS1,
 };
 
-uint8_t fw_update(uint32_t offset, uint16_t msg_len, uint8_t *msg_buf, bool sector_end,
+uint8_t fw_update(uint32_t offset, uint16_t msg_len, uint8_t *msg_buf, uint8_t flag,
 		  uint8_t flash_position);
 int read_fw_image(uint32_t offset, uint8_t msg_len, uint8_t *msg_buf, uint8_t flash_position);
 uint8_t fw_update_cxl(uint32_t offset, uint16_t msg_len, uint8_t *msg_buf, bool sector_end);

--- a/common/service/pldm/pldm.c
+++ b/common/service/pldm/pldm.c
@@ -59,6 +59,7 @@ typedef struct _pldm_recv_resp_arg {
 static struct _pldm_handler_query_entry query_tbl[] = {
 	{ PLDM_TYPE_BASE, pldm_base_handler_query },
 	{ PLDM_TYPE_PLAT_MON_CTRL, pldm_monitor_handler_query },
+	{ PLDM_TYPE_FW_UPDATE, pldm_fw_update_handler_query },
 	{ PLDM_TYPE_OEM, pldm_oem_handler_query },
 };
 

--- a/common/service/pldm/pldm.h
+++ b/common/service/pldm/pldm.h
@@ -25,6 +25,7 @@ extern "C" {
 #include "pldm_base.h"
 #include "pldm_oem.h"
 #include "pldm_monitor.h"
+#include "pldm_firmware_update.h"
 
 #define MONITOR_THREAD_STACK_SIZE 1024
 

--- a/common/service/pldm/pldm_base.h
+++ b/common/service/pldm/pldm_base.h
@@ -58,6 +58,13 @@ enum pldm_transport_protocol_type {
 	PLDM_TRANSPORT_PROTOCOL_TYPE_OEM = 0xFF,
 };
 
+enum pldm_transfer_flag {
+	PLDM_START = 0x01,
+	PLDM_MIDDLE = 0x02,
+	PLDM_END = 0x04,
+	PLDM_START_AND_END = 0x05,
+};
+
 struct _set_tid_req {
 	uint8_t tid;
 } __attribute__((packed));

--- a/common/service/pldm/pldm_firmware_update.c
+++ b/common/service/pldm/pldm_firmware_update.c
@@ -1,0 +1,529 @@
+#include <logging/log.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "util_spi.h"
+#include "util_sys.h"
+#include "libutil.h"
+#include "pldm_firmware_update.h"
+
+LOG_MODULE_DECLARE(pldm);
+
+#define FW_UPDATE_BUF_SIZE 256
+#define FW_UPDATE_SIZE 224
+#define PLDM_FW_UPDATE_STACK_SIZE 2048
+#define UPDATE_THREAD_DELAY_SECOND 1
+
+k_tid_t fw_update_tid;
+struct k_thread pldm_fw_update_thread;
+K_KERNEL_STACK_MEMBER(pldm_fw_update_stack, PLDM_FW_UPDATE_STACK_SIZE);
+
+static enum pldm_firmware_update_state current_state = STATE_IDLE;
+static uint32_t comp_image_size;
+
+uint16_t pldm_fw_update_read(void *mctp_p, enum pldm_firmware_update_commands cmd, uint8_t *req,
+			     uint16_t req_len, uint8_t *rbuf, uint16_t rbuf_len, void *ext_params)
+{
+	/* Return read length zero means read fail */
+	CHECK_NULL_ARG_WITH_RETURN(mctp_p, 0);
+	CHECK_NULL_ARG_WITH_RETURN(req, 0);
+	CHECK_NULL_ARG_WITH_RETURN(rbuf, 0);
+	CHECK_NULL_ARG_WITH_RETURN(ext_params, 0);
+
+	pldm_msg msg = { 0 };
+	mctp_ext_params *extra_data = (mctp_ext_params *)ext_params;
+
+	msg.ext_params = *extra_data;
+
+	msg.hdr.pldm_type = PLDM_TYPE_FW_UPDATE;
+	msg.hdr.cmd = cmd;
+	msg.hdr.rq = 1;
+
+	msg.buf = req;
+	msg.len = req_len;
+
+	return mctp_pldm_read(mctp_p, &msg, rbuf, rbuf_len);
+}
+
+static void update_fail_handler(void *mctp_p, void *ext_params)
+{
+	if (!mctp_p || !ext_params) {
+		LOG_ERR("Pass argument is NULL");
+		current_state = STATE_IDLE;
+		return;
+	}
+
+	uint16_t read_len;
+	uint16_t rbuf_len = 10;
+
+	uint8_t rbuf[10] = { 0 };
+
+	/* Handle the error case to send the error status to the UA */
+	switch (current_state) {
+	case STATE_DOWNLOAD: {
+		struct pldm_transfer_complete_req tran_comp_req = { 0 };
+		tran_comp_req.transferResult = PLDM_FW_UPDATE_GENERIC_ERROR;
+
+		read_len = pldm_fw_update_read(mctp_p, PLDM_FW_UPDATE_CMD_CODE_TRANSFER_COMPLETE,
+					       (uint8_t *)&tran_comp_req,
+					       sizeof(struct pldm_transfer_complete_req), rbuf,
+					       rbuf_len, ext_params);
+
+		if ((read_len != 1) || (rbuf[0] != PLDM_SUCCESS)) {
+			LOG_ERR("Send transfer complete error failed");
+		}
+		break;
+	}
+	case STATE_VERIFY: {
+		struct pldm_verify_complete_req verify_comp_req = { 0 };
+		verify_comp_req.verifyResult = PLDM_FW_UPDATE_GENERIC_ERROR;
+
+		read_len = pldm_fw_update_read(mctp_p, PLDM_FW_UPDATE_CMD_CODE_TRANSFER_COMPLETE,
+					       (uint8_t *)&verify_comp_req,
+					       sizeof(struct pldm_verify_complete_req), rbuf,
+					       rbuf_len, ext_params);
+
+		if ((read_len != 1) || (rbuf[0] != PLDM_SUCCESS)) {
+			LOG_ERR("Send verify complete error failed");
+		}
+		break;
+	}
+	case STATE_APPLY: {
+		struct pldm_apply_complete_req apply_comp_req = { 0 };
+		apply_comp_req.applyResult = PLDM_FW_UPDATE_GENERIC_ERROR;
+		apply_comp_req.compActivationMethodsModification = 0x0000;
+
+		read_len = pldm_fw_update_read(mctp_p, PLDM_FW_UPDATE_CMD_CODE_TRANSFER_COMPLETE,
+					       (uint8_t *)&apply_comp_req,
+					       sizeof(struct pldm_apply_complete_req), rbuf,
+					       rbuf_len, ext_params);
+
+		if ((read_len != 1) || (rbuf[0] != PLDM_SUCCESS)) {
+			LOG_ERR("Send apply complete error failed");
+		}
+		break;
+	}
+	default:
+		break;
+	}
+
+	if (fw_update_tid) {
+		fw_update_tid = NULL;
+	}
+	SAFE_FREE(ext_params);
+	return;
+}
+
+void req_fw_update_handler(void *mctp_p, void *ext_params, void *arg2)
+{
+	ARG_UNUSED(arg2);
+
+	if (!mctp_p || !ext_params) {
+		LOG_ERR("Pass argument is NULL");
+		current_state = STATE_IDLE;
+		SAFE_FREE(ext_params);
+		return;
+	}
+
+	uint16_t read_len;
+	uint8_t update_flag = 0;
+	uint8_t resp_buf[FW_UPDATE_BUF_SIZE] = { 0 };
+
+	struct pldm_request_firmware_data_req req = { 0 };
+
+	while (req.offset < comp_image_size) {
+		uint8_t ret;
+
+		if (req.offset + FW_UPDATE_SIZE < comp_image_size) {
+			/**
+       * Check block size write flash shouldn't exceed over 64 KB to align the 
+       * allocates space use in fw_update function.
+       */
+			if ((req.offset % SECTOR_SZ_64K) + FW_UPDATE_SIZE > SECTOR_SZ_64K) {
+				req.length = SECTOR_SZ_64K - (req.offset % SECTOR_SZ_64K);
+			} else {
+				req.length = FW_UPDATE_SIZE;
+			}
+		} else {
+			/* The remaining packets of the image */
+			req.length = comp_image_size - req.offset;
+			/**
+       * Check block size write flash shouldn't exceed over 64 KB to align the 
+       * allocates space use in fw_update function.
+       */
+			if ((req.offset % SECTOR_SZ_64K) + req.length > SECTOR_SZ_64K) {
+				req.length = SECTOR_SZ_64K - (req.offset % SECTOR_SZ_64K);
+			} else {
+				/* The last packet, set the flag. */
+				update_flag = (SECTOR_END_FLAG | NO_RESET_FLAG);
+			}
+		}
+
+		read_len =
+			pldm_fw_update_read(mctp_p, PLDM_FW_UPDATE_CMD_CODE_REQUEST_FIRMWARE_DATA,
+					    (uint8_t *)&req,
+					    sizeof(struct pldm_request_firmware_data_req), resp_buf,
+					    FW_UPDATE_BUF_SIZE, ext_params);
+
+		/* read_len = request length + completion code */
+		if (read_len != req.length + 1) {
+			LOG_ERR("Request firmware update failed, offset(0x%x), length(0x%x), read length(%d)",
+				req.offset, req.length, read_len);
+			goto error;
+		}
+
+		ret = fw_update(req.offset, req.length, &resp_buf[1], update_flag, DEVSPI_FMC_CS0);
+
+		if (ret) {
+			LOG_ERR("Firmware update failed, offset(0x%x), length(0x%x), status(%d)",
+				req.offset, req.length, ret);
+			goto error;
+		}
+
+		req.offset += req.length;
+	}
+
+	LOG_INF("Transfer completed");
+
+	struct pldm_transfer_complete_req tran_comp_req = { 0 };
+	/* Transfer has completed without error */
+	tran_comp_req.transferResult = PLDM_FW_UPDATE_TRANSFER_SUCCESS;
+
+	read_len = pldm_fw_update_read(mctp_p, PLDM_FW_UPDATE_CMD_CODE_TRANSFER_COMPLETE,
+				       (uint8_t *)&tran_comp_req,
+				       sizeof(struct pldm_transfer_complete_req), resp_buf,
+				       FW_UPDATE_BUF_SIZE, ext_params);
+
+	if ((read_len != 1) || (resp_buf[0] != PLDM_SUCCESS)) {
+		LOG_ERR("Transfer complete failed, (%d)", resp_buf[0]);
+		goto error;
+	}
+
+	current_state = STATE_VERIFY;
+
+	LOG_INF("Verify completed");
+
+	struct pldm_verify_complete_req verify_comp_req = { 0 };
+	/* Verify has completed without error */
+	verify_comp_req.verifyResult = PLDM_FW_UPDATE_VERIFY_SUCCESS;
+
+	read_len = pldm_fw_update_read(mctp_p, PLDM_FW_UPDATE_CMD_CODE_VERIFY_COMPLETE,
+				       (uint8_t *)&verify_comp_req,
+				       sizeof(struct pldm_verify_complete_req), resp_buf,
+				       FW_UPDATE_BUF_SIZE, ext_params);
+
+	if ((read_len != 1) || (resp_buf[0] != PLDM_SUCCESS)) {
+		LOG_ERR("Verify complete failed, (%d)", resp_buf[0]);
+		goto error;
+	}
+
+	current_state = STATE_APPLY;
+
+	LOG_INF("Apply completed");
+
+	struct pldm_apply_complete_req apply_comp_req = { 0 };
+
+	/* Apply has completed without error */
+	apply_comp_req.applyResult = PLDM_FW_UPDATE_APPLY_SUCCESS;
+	apply_comp_req.compActivationMethodsModification = 0x0000;
+	read_len = pldm_fw_update_read(mctp_p, PLDM_FW_UPDATE_CMD_CODE_APPLY_COMPLETE,
+				       (uint8_t *)&apply_comp_req,
+				       sizeof(struct pldm_apply_complete_req), resp_buf,
+				       FW_UPDATE_BUF_SIZE, ext_params);
+
+	if ((read_len != 1) || (resp_buf[0] != PLDM_SUCCESS)) {
+		LOG_ERR("Apply complete failed, (%d)", resp_buf[0]);
+		goto error;
+	}
+
+	current_state = STATE_RDY_XFER;
+	comp_image_size = 0;
+
+	if (fw_update_tid) {
+		fw_update_tid = NULL;
+	}
+
+	SAFE_FREE(ext_params);
+	return;
+
+error:
+	update_fail_handler(mctp_p, ext_params);
+	comp_image_size = 0;
+	SAFE_FREE(ext_params);
+	return;
+}
+
+static uint8_t request_update(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t *resp,
+			      uint16_t *resp_len, void *ext_params)
+{
+	if (!mctp_inst || !buf || !resp || !resp_len) {
+		LOG_ERR("Pass argument is NULL");
+		current_state = STATE_IDLE;
+		return PLDM_ERROR;
+	}
+
+	struct pldm_request_update_req *req_p = (struct pldm_request_update_req *)buf;
+	struct pldm_request_update_resp *resp_p = (struct pldm_request_update_resp *)resp;
+
+	*resp_len = 1;
+
+	if (len != (sizeof(struct pldm_request_update_req) + req_p->comp_image_set_ver_str_len)) {
+		resp_p->completion_code = PLDM_ERROR_INVALID_LENGTH;
+		return PLDM_SUCCESS;
+	}
+
+	if (current_state != STATE_IDLE) {
+		resp_p->completion_code = PLDM_FW_UPDATE_CC_ALREADY_IN_UPDATE_MODE;
+		return PLDM_SUCCESS;
+	}
+
+	resp_p->fd_meta_data_len = 0x0000;
+
+	if (req_p->pkg_data_len) {
+		resp_p->fd_will_send_pkg_data = 0x01;
+	} else {
+		resp_p->fd_will_send_pkg_data = 0x00;
+	}
+
+	LOG_INF("max transfer size(%u), number of component(%d), max_outstanding_transfer_req(%d)",
+		req_p->max_transfer_size, req_p->num_of_comp, req_p->max_outstanding_transfer_req);
+	LOG_INF("packet data length(%d), component sting type(%d) length(%d)", req_p->pkg_data_len,
+		req_p->comp_image_set_ver_str_type, req_p->comp_image_set_ver_str_len);
+	LOG_HEXDUMP_INF(buf + sizeof(struct pldm_request_update_req),
+			req_p->comp_image_set_ver_str_len, "Component image version: ");
+
+	*resp_len = sizeof(struct pldm_request_update_resp);
+	resp_p->completion_code = PLDM_SUCCESS;
+
+	current_state = STATE_LEARN_COMP;
+
+	return PLDM_SUCCESS;
+}
+
+static uint8_t pass_component_table(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t *resp,
+				    uint16_t *resp_len, void *ext_params)
+{
+	if (!mctp_inst || !buf || !resp || !resp_len) {
+		LOG_ERR("Pass argument is NULL");
+		current_state = STATE_IDLE;
+		return PLDM_ERROR;
+	}
+
+	struct pldm_pass_component_table_req *req_p = (struct pldm_pass_component_table_req *)buf;
+	struct pldm_pass_component_table_resp *resp_p =
+		(struct pldm_pass_component_table_resp *)resp;
+
+	*resp_len = 1;
+
+	if (len != (sizeof(struct pldm_pass_component_table_req) + req_p->comp_ver_str_len)) {
+		resp_p->completion_code = PLDM_ERROR_INVALID_LENGTH;
+		return PLDM_SUCCESS;
+	}
+
+	if (current_state == STATE_IDLE) {
+		resp_p->completion_code = PLDM_FW_UPDATE_CC_NOT_IN_UPDATE_MODE;
+		return PLDM_SUCCESS;
+	}
+
+	/* only support one currently */
+	if (req_p->transfer_flag != PLDM_START_AND_END) {
+		resp_p->completion_code = PLDM_ERROR_INVALID_DATA;
+		return PLDM_SUCCESS;
+	}
+
+	/* The classification should be downstream device */
+	if (req_p->comp_classification == PLDM_COMP_DOWNSTREAM_DEVICE) {
+		/**
+     * The identifier should be range 0x0000-0x0FFF when classification is the
+     * downstream device.
+     * TBD: Can use this field to identify update other components
+     */
+		if (req_p->comp_identifier > 0x0FFF) {
+			LOG_ERR("Invalid component identifier id");
+			resp_p->completion_code = PLDM_ERROR_INVALID_DATA;
+			return PLDM_SUCCESS;
+		}
+	} else {
+		LOG_ERR("Invalid component classification");
+		resp_p->completion_code = PLDM_ERROR_INVALID_DATA;
+		return PLDM_SUCCESS;
+	}
+
+	if (req_p->comp_classification_index != 0x00) {
+		LOG_ERR("Only support update one device currently");
+		resp_p->completion_code = PLDM_ERROR_INVALID_DATA;
+		return PLDM_SUCCESS;
+	}
+
+	LOG_HEXDUMP_INF(buf + sizeof(struct pldm_pass_component_table_req), req_p->comp_ver_str_len,
+			"Component version: ");
+
+	/* Currently not support error condition, so only response zero */
+	resp_p->completion_code = PLDM_SUCCESS;
+	resp_p->comp_resp = 0;
+	resp_p->comp_resp_code = 0;
+	*resp_len = sizeof(struct pldm_pass_component_table_resp);
+
+	current_state = STATE_RDY_XFER;
+
+	return PLDM_SUCCESS;
+}
+
+static uint8_t update_component(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t *resp,
+				uint16_t *resp_len, void *ext_params)
+{
+	if (!mctp_inst || !buf || !resp || !resp_len) {
+		LOG_ERR("Pass argument is NULL");
+		current_state = STATE_IDLE;
+		return PLDM_ERROR;
+	}
+
+	struct pldm_update_component_req *req_p = (struct pldm_update_component_req *)buf;
+	struct pldm_update_component_resp *resp_p = (struct pldm_update_component_resp *)resp;
+
+	*resp_len = 1;
+
+	if (len != (sizeof(struct pldm_update_component_req) + req_p->comp_ver_str_len)) {
+		resp_p->completion_code = PLDM_ERROR_INVALID_LENGTH;
+		return PLDM_SUCCESS;
+	}
+
+	if (current_state == STATE_IDLE) {
+		resp_p->completion_code = PLDM_FW_UPDATE_CC_NOT_IN_UPDATE_MODE;
+		return PLDM_SUCCESS;
+	}
+
+	/* The classification should be downstream device */
+	if (req_p->comp_classification == PLDM_COMP_DOWNSTREAM_DEVICE) {
+		/**
+     * The identifier should be range 0x0000-0x0FFF when classification is the
+     * downstream device.
+     * TBD: Can use this field to identify update other components
+     */
+		if (req_p->comp_identifier > 0x0FFF) {
+			LOG_ERR("Invalid component identifier id");
+			resp_p->completion_code = PLDM_ERROR_INVALID_DATA;
+			return PLDM_SUCCESS;
+		}
+	} else {
+		LOG_ERR("Invalid component classification");
+		resp_p->completion_code = PLDM_ERROR_INVALID_DATA;
+		return PLDM_SUCCESS;
+	}
+
+	if (req_p->comp_classification_index != 0x00) {
+		LOG_ERR("Only support update one device currently");
+		resp_p->completion_code = PLDM_ERROR_INVALID_DATA;
+		return PLDM_SUCCESS;
+	}
+
+	comp_image_size = req_p->comp_image_size;
+
+	LOG_INF("Update image size(0x%x)", comp_image_size);
+	LOG_HEXDUMP_INF(buf + sizeof(struct pldm_update_component_req), req_p->comp_ver_str_len,
+			"Component version: ");
+
+	resp_p->completion_code = PLDM_SUCCESS;
+	/* Currently not support error condition, so only response zero */
+	resp_p->comp_compatability_resp = 0x00;
+	resp_p->comp_compatability_resp_code = 0x00;
+	/* Return update option flags by request message */
+	resp_p->update_option_flags_enabled = req_p->update_option_flags;
+	/* Delay 1 second to start update thread */
+	resp_p->time_before_req_fw_data = UPDATE_THREAD_DELAY_SECOND;
+	*resp_len = sizeof(struct pldm_update_component_resp);
+
+	mctp_ext_params *extra_data = (mctp_ext_params *)malloc(sizeof(mctp_ext_params));
+
+	if (!extra_data) {
+		LOG_ERR("Allocate memory failed");
+		resp_p->completion_code = PLDM_ERROR;
+		return PLDM_SUCCESS;
+	}
+
+	memcpy(extra_data, ext_params, sizeof(mctp_ext_params));
+
+	fw_update_tid =
+		k_thread_create(&pldm_fw_update_thread, pldm_fw_update_stack,
+				K_THREAD_STACK_SIZEOF(pldm_fw_update_stack), req_fw_update_handler,
+				mctp_inst, extra_data, NULL, CONFIG_MAIN_THREAD_PRIORITY, 0,
+				K_SECONDS(UPDATE_THREAD_DELAY_SECOND));
+	k_thread_name_set(&pldm_fw_update_thread, "pldm_fw_update_thread");
+
+	current_state = STATE_DOWNLOAD;
+	return PLDM_SUCCESS;
+}
+
+K_WORK_DELAYABLE_DEFINE(submit_warm_reset_work, submit_bic_warm_reset);
+
+static uint8_t activate_firmware(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t *resp,
+				 uint16_t *resp_len, void *ext_params)
+{
+	if (!mctp_inst || !buf || !resp || !resp_len) {
+		LOG_ERR("Pass argument is NULL");
+		current_state = STATE_IDLE;
+		return PLDM_ERROR;
+	}
+
+	struct pldm_activate_firmware_req *req_p = (struct pldm_activate_firmware_req *)buf;
+	struct pldm_activate_firmware_resp *resp_p = (struct pldm_activate_firmware_resp *)resp;
+
+	*resp_len = 1;
+
+	if (len != sizeof(struct pldm_activate_firmware_req)) {
+		resp_p->completion_code = PLDM_ERROR_INVALID_LENGTH;
+		return PLDM_SUCCESS;
+	}
+
+	/* Not in the update mode */
+	if (current_state == STATE_IDLE) {
+		resp_p->completion_code = PLDM_FW_UPDATE_CC_NOT_IN_UPDATE_MODE;
+		return PLDM_SUCCESS;
+	}
+
+	/* Only expect this command in READY XFER state */
+	if (current_state != STATE_RDY_XFER) {
+		resp_p->completion_code = PLDM_FW_UPDATE_CC_INVALID_STATE_FOR_COMMAND;
+		return PLDM_SUCCESS;
+	}
+
+	if (req_p->selfContainedActivationRequest != PLDM_NOT_ACTIVATE_SELF_CONTAINED_COMPONENTS) {
+		resp_p->completion_code = PLDM_ERROR_INVALID_DATA;
+		return PLDM_SUCCESS;
+	}
+	LOG_INF("Activate firmware");
+	resp_p->completion_code = PLDM_SUCCESS;
+	resp_p->estimated = 0;
+	*resp_len = sizeof(struct pldm_activate_firmware_resp);
+
+	k_work_schedule(&submit_warm_reset_work, K_SECONDS(1));
+
+	current_state = STATE_ACTIVATE;
+	return PLDM_SUCCESS;
+}
+
+static pldm_cmd_handler pldm_fw_update_cmd_tbl[] = {
+	{ PLDM_FW_UPDATE_CMD_CODE_REQUEST_UPDATE, request_update },
+	{ PLDM_FW_UPDATE_CMD_CODE_PASS_COMPONENT_TABLE, pass_component_table },
+	{ PLDM_FW_UPDATE_CMD_CODE_UPDATE_COMPONENT, update_component },
+	{ PLDM_FW_UPDATE_CMD_CODE_ACTIVE_FIRMWARE, activate_firmware },
+};
+
+uint8_t pldm_fw_update_handler_query(uint8_t code, void **ret_fn)
+{
+	if (!ret_fn) {
+		return PLDM_ERROR;
+	}
+
+	pldm_cmd_proc_fn fn = NULL;
+
+	for (int i = 0; i < ARRAY_SIZE(pldm_fw_update_cmd_tbl); i++) {
+		if (pldm_fw_update_cmd_tbl[i].cmd_code == code) {
+			fn = pldm_fw_update_cmd_tbl[i].fn;
+			break;
+		}
+	}
+
+	*ret_fn = (void *)fn;
+	return fn ? PLDM_SUCCESS : PLDM_ERROR;
+}

--- a/common/service/pldm/pldm_firmware_update.h
+++ b/common/service/pldm/pldm_firmware_update.h
@@ -1,0 +1,251 @@
+#ifndef PLDM_FIRMWARE_UPDATE_H
+#define PLDM_FIRMWARE_UPDATE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "pldm.h"
+
+/** 
+ * PLDM Firmware update commands
+ */
+enum pldm_firmware_update_commands {
+	/* inventory commands */
+	PLDM_FW_UPDATE_CMD_CODE_QUERY_DEVICE_IDENTIFIERS = 0x01,
+	PLDM_FW_UPDATE_CMD_CODE_GET_FIRMWARE_PARAMETERS = 0x02,
+
+	/* update commands */
+	PLDM_FW_UPDATE_CMD_CODE_REQUEST_UPDATE = 0x10,
+	PLDM_FW_UPDATE_CMD_CODE_PASS_COMPONENT_TABLE = 0x13,
+	PLDM_FW_UPDATE_CMD_CODE_UPDATE_COMPONENT = 0x14,
+	PLDM_FW_UPDATE_CMD_CODE_REQUEST_FIRMWARE_DATA = 0x15,
+	PLDM_FW_UPDATE_CMD_CODE_TRANSFER_COMPLETE = 0x16,
+	PLDM_FW_UPDATE_CMD_CODE_VERIFY_COMPLETE = 0x17,
+	PLDM_FW_UPDATE_CMD_CODE_APPLY_COMPLETE = 0x18,
+	PLDM_FW_UPDATE_CMD_CODE_ACTIVE_FIRMWARE = 0x1A,
+	PLDM_FW_UPDATE_CMD_CODE_GET_STATUS = 0x1B,
+	PLDM_FW_UPDATE_CMD_CODE_CANCEL_UPDATE_COMPONENT = 0x1C,
+	PLDM_FW_UPDATE_CMD_CODE_CANCEL_UPDATE = 0x1D,
+};
+
+/**
+ * PLDM Firmware update completion codes
+ */
+enum pldm_firmware_update_completion_codes {
+	PLDM_FW_UPDATE_CC_NOT_IN_UPDATE_MODE = 0x80,
+	PLDM_FW_UPDATE_CC_ALREADY_IN_UPDATE_MODE = 0x81,
+	PLDM_FW_UPDATE_CC_DATA_OUT_OF_RANGE = 0x82,
+	PLDM_FW_UPDATE_CC_INVALID_TRANSFER_LENGTH = 0x83,
+	PLDM_FW_UPDATE_CC_INVALID_STATE_FOR_COMMAND = 0x84,
+	PLDM_FW_UPDATE_CC_INCOMPLETE_UPDATE = 0x85,
+	PLDM_FW_UPDATE_CC_BUSY_IN_BACKGROUND = 0x86,
+	PLDM_FW_UPDATE_CC_CANCEL_PENDING = 0x87,
+	PLDM_FW_UPDATE_CC_COMMAND_NOT_EXPECTED = 0x88,
+	PLDM_FW_UPDATE_CC_RETRY_REQUEST_FW_DATA = 0x89,
+	PLDM_FW_UPDATE_CC_UNABLE_TO_INITIATE_UPDATE = 0x8A,
+	PLDM_FW_UPDATE_CC_ACTIVATION_NOT_REQUIRED = 0x8B,
+	PLDM_FW_UPDATE_CC_SELF_CONTAINED_ACTIVATION_NOT_PERMITTED = 0x8C,
+	PLDM_FW_UPDATE_CC_NO_DEVICE_METADATA = 0x8D,
+	PLDM_FW_UPDATE_CC_RETRY_REQUEST_UPDATE = 0x8E,
+	PLDM_FW_UPDATE_CC_NO_PACKAGE_DATA = 0x8F,
+	PLDM_FW_UPDATE_CC_INVALID_TRANSFER_HANDLE = 0x90,
+	PLDM_FW_UPDATE_CC_INVALID_TRANSFER_OPERATION_FLAG = 0x91,
+	PLDM_FW_UPDATE_CC_ACTIVATE_PENDING_IMAGE_NOT_PERMITTED = 0x92,
+	PLDM_FW_UPDATE_CC_PACKAGE_DATA_ERROR = 0x93
+};
+
+/**
+ * PLDM Frimware update state 
+ */
+enum pldm_firmware_update_state {
+	STATE_IDLE,
+	STATE_LEARN_COMP,
+	STATE_RDY_XFER,
+	STATE_DOWNLOAD,
+	STATE_VERIFY,
+	STATE_APPLY,
+	STATE_ACTIVATE,
+};
+
+/** 
+ * Common error codes in TransferComplete, VerifyComplete and ApplyComplete request
+ */
+enum pldm_firmware_update_common_error_codes {
+	PLDM_FW_UPDATE_TIME_OUT = 0x09,
+	PLDM_FW_UPDATE_GENERIC_ERROR = 0x0A
+};
+
+/** 
+ * TransferResult values in the request of TransferComplete
+ */
+enum pldm_firmware_update_transfer_result_values {
+	PLDM_FW_UPDATE_TRANSFER_SUCCESS = 0x00,
+	/* Other values that are not currently used, and will be defined if they are 
+  used in the future. */
+};
+
+/**
+ * VerifyResult values in the request of VerifyComplete
+ */
+enum pldm_firmware_update_verify_result_values {
+	PLDM_FW_UPDATE_VERIFY_SUCCESS = 0x00,
+	/* Other values that are not currently used, and will be defined if they are 
+  used in the future. */
+};
+
+/**
+ * ApplyResult values in the request of ApplyComplete
+ */
+enum pldm_firmware_update_apply_result_values {
+	PLDM_FW_UPDATE_APPLY_SUCCESS = 0x00,
+	/* Other values that are not currently used, and will be defined if they are 
+  used in the future. */
+};
+
+/**
+ * component classification values define in PLDM firmware update specification 
+ * Table 27
+ */
+enum pldm_component_classification_values {
+	PLDM_COMP_UNKNOWN = 0x0000,
+	PLDM_COMP_OTHER = 0x0001,
+	PLDM_COMP_DRIVER = 0x0002,
+	PLDM_COMP_CONFIGURATION_SOFTWARE = 0x0003,
+	PLDM_COMP_APPLICATION_SOFTWARE = 0x0004,
+	PLDM_COMP_INSTRUMENTATION = 0x0005,
+	PLDM_COMP_FIRMWARE_OR_BIOS = 0x0006,
+	PLDM_COMP_DIAGNOSTIC_SOFTWARE = 0x0007,
+	PLDM_COMP_OPERATING_SYSTEM = 0x0008,
+	PLDM_COMP_MIDDLEWARE = 0x0009,
+	PLDM_COMP_FIRMWARE = 0x000A,
+	PLDM_COMP_BIOS_OR_FCODE = 0x000B,
+	PLDM_COMP_SUPPORT_OR_SERVICEPACK = 0x000C,
+	PLDM_COMP_SOFTWARE_BUNDLE = 0x000D,
+	PLDM_COMP_DOWNSTREAM_DEVICE = 0xFFFF
+};
+
+/** 
+ * Structure representing fixed part of Request Update request
+ */
+struct pldm_request_update_req {
+	uint32_t max_transfer_size;
+	uint16_t num_of_comp;
+	uint8_t max_outstanding_transfer_req;
+	uint16_t pkg_data_len;
+	uint8_t comp_image_set_ver_str_type;
+	uint8_t comp_image_set_ver_str_len;
+} __attribute__((packed));
+
+/**
+ * Structure representing Request Update response
+ */
+struct pldm_request_update_resp {
+	uint8_t completion_code;
+	uint16_t fd_meta_data_len;
+	uint8_t fd_will_send_pkg_data;
+} __attribute__((packed));
+
+/**
+ * Structure representing PassComponentTable request
+ */
+struct pldm_pass_component_table_req {
+	uint8_t transfer_flag;
+	uint16_t comp_classification;
+	uint16_t comp_identifier;
+	uint8_t comp_classification_index;
+	uint32_t comp_comparison_stamp;
+	uint8_t comp_ver_str_type;
+	uint8_t comp_ver_str_len;
+} __attribute__((packed));
+
+/**
+ * Structure representing PassComponentTable response
+ */
+struct pldm_pass_component_table_resp {
+	uint8_t completion_code;
+	uint8_t comp_resp;
+	uint8_t comp_resp_code;
+} __attribute__((packed));
+
+/** 
+ * Structure representing UpdateComponent request
+ */
+struct pldm_update_component_req {
+	uint16_t comp_classification;
+	uint16_t comp_identifier;
+	uint8_t comp_classification_index;
+	uint32_t comp_comparison_stamp;
+	uint32_t comp_image_size;
+	uint32_t update_option_flags;
+	uint8_t comp_ver_str_type;
+	uint8_t comp_ver_str_len;
+} __attribute__((packed));
+
+/** 
+ * Structure representing UpdateComponent response
+ */
+struct pldm_update_component_resp {
+	uint8_t completion_code;
+	uint8_t comp_compatability_resp;
+	uint8_t comp_compatability_resp_code;
+	uint32_t update_option_flags_enabled;
+	uint16_t time_before_req_fw_data;
+} __attribute__((packed));
+
+/**
+ * Structure representing RequestFirmwareData request
+ */
+struct pldm_request_firmware_data_req {
+	uint32_t offset;
+	uint32_t length;
+} __attribute__((packed));
+
+/**
+ * Structure representing ActivateFirmware request
+ */
+struct pldm_activate_firmware_req {
+	uint8_t selfContainedActivationRequest;
+} __attribute__((packed));
+
+/**
+ * Structure representing ActivateFirmware response
+ */
+struct pldm_activate_firmware_resp {
+	uint8_t completion_code;
+	uint16_t estimated;
+} __attribute__((packed));
+
+/**
+ * SelfContainedActivationRequest in the request of ActivateFirmware
+ */
+enum pldm_self_contained_activation_req {
+	PLDM_NOT_ACTIVATE_SELF_CONTAINED_COMPONENTS = false,
+	PLDM_ACTIVATE_SELF_CONTAINED_COMPONENTS = true
+};
+
+/**
+ * Structure representing TransferComplete request
+ */
+struct pldm_transfer_complete_req {
+	uint8_t transferResult;
+} __attribute__((packed));
+
+struct pldm_verify_complete_req {
+	uint8_t verifyResult;
+} __attribute__((packed));
+
+struct pldm_apply_complete_req {
+	uint8_t applyResult;
+	uint16_t compActivationMethodsModification;
+} __attribute__((packed));
+
+uint8_t pldm_fw_update_handler_query(uint8_t code, void **ret_fn);
+uint16_t pldm_fw_update_read(void *mctp_p, enum pldm_firmware_update_commands cmd, uint8_t *req,
+			     uint16_t req_len, uint8_t *rbuf, uint16_t rbuf_len, void *ext_params);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // End of PLDM_FIRMWARE_UPDATE_H


### PR DESCRIPTION
Summary:
- Support PLDM firmware update follow by Platform Level Data Model (PLDM) for Firmware Update Specification (DSP0627).
- Support update BIC currently and will add the update function to other components later.

Test Plan:
- Build code: Pass
- Use pldm firmware update on GT: Pass

Log:
```
root@bmc-oob:~# fw-util swb --update bic_pldm GT-pldm_update.bin 
size of file is 266199 bytes

PLDM Firmware Package Header Info
  UUID: f018878ccb7d4943980a02f59aca2    PLDM UUID Y/N? (Y)
  headerRevision: 0x1
  headerSize: 0xc3
  componentBitmapBitLength: 0x8
  versionStringType: 0x1 (ASCII)
  versionStringLength: 0x10
  version string: GT-SWB-2022.47.1  (0x47 0x54 0x2d 0x53 0x57 0x42 0x2d 0x32 0x30 0x32 0x32 0x2e 0x34 0x37 0x2e 0x31 )

 Number of Device ID Record in package (devIdRecordCnt) =1
DevRec[0].length=98, processed=98

Device ID[0] Record Info
  devRec[0].RecordLength: 98
  devRec[0].descriptorCnt: 0x4
  devRec[0].deviceUpdateOptionFlags: 0x1
  devRec[0].compImgSetVersionStringType: 0x1 (ASCII)
  devRec[0].compImgSetVersionStringLength: 0x10
  devRec[0].fwDevPkgDataLength: 0x0
  devRec[0].applicableComponents: 0
  devRec[0].versionString: GT-SWB-2022.47.1  (0x47 0x54 0x2d 0x53 0x57 0x42 0x2d 0x32 0x30 0x32 0x32 0x2e 0x34 0x37 0x2e 0x31 )
  Record Descriptors
    Record Descriptor[0]
      Type=0x1      length=0x4      data=[00a015]
    Record Descriptor[1]
      Type=0xffff      length=0x14      data=[18506c6174666f726d4772616e645465746f6e]
    Record Descriptor[2]
      Type=0xffff      length=0x14      data=[17426f6172644944537769746368426f617264]
    Record Descriptor[3]
      Type=0xffff      length=0xa      data=[155374616765445654]

 Number of Component in package (componentImageCnt) =1

Component[0] Info
  Component[0].classification: 65535 (unknown_classification)
  Component[0].identifier: 0x0
  Component[0].comparison stamp: 0xffffffff
  Component[0].component options: 0x2
  Component[0].request update activation method: 0x1
  Component[0].location offset: 0xc3
  Component[0].component size: 0x40f14
  Component[0].versionStringType: 0x1 (ASCII)
  Component[0].versionStringLength: 0x10
  Component[0].versionString: GT-SWB-2022.47.1  (0x47 0x54 0x2d 0x53 0x57 0x42 0x2d 0x32 0x30 0x32 0x32 0x2e 0x34 0x37 0x2e 0x31 )

PDLM Firmware Package Checksum=0x6eb8ca13

CMD_REQUEST_UPDATE
      Request_update buffer size=1024
dbgPrintCdb
   common:  810510
   payload: 00040000 01000100 00011047 542d5357
            422d3230 32322e34 372e3100 0000

   iid=1, cmd=0x10 (CMD_REQUEST_UPDATE)

01 PldmRequestUpdateOp: payload_size=30

CMD_PASS_COMPONENT_TABLE
dbgPrintCdb
   common:  820513
   payload: 05ffff00 0000ffff ffff0110 47542d53
            57422d32 3032322e 34372e31 000000

   iid=2, cmd=0x13 (CMD_PASS_COMPONENT_TABLE)

02 PldmPassComponentTableOp[0]: payload_size=31

CMD_UPDATE_COMPONENT
dbgPrintCdb
   common:  830514
   payload: ffff0000 00ffffff ff140f04 00020000
            00011047 542d5357 422d3230 32322e34
            372e3100 0000

   iid=3, cmd=0x14 (CMD_UPDATE_COMPONENT)

03 PldmUpdateComponentOp[0]: payload_size=38
handlePldmReqFwData offset = 0x40ee0, length = 0x34, compBytesLeft=52, numPadding=0handle CMD_TRANSFER_COMPLETE dbgPrintCdb
   common:  860516
   payload: 000e0400

   iid=6, cmd=0x16 (CMD_TRANSFER_COMPLETE)

handle CMD_VERIFY_COMPLETE
dbgPrintCdb
   common:  870517
   payload: 000e0400

   iid=7, cmd=0x17 (CMD_VERIFY_COMPLETE)

handle CMD_APPLY_COMPLETE
dbgPrintCdb
   common:  880518
   payload: 00000000 3400

   iid=8, cmd=0x18 (CMD_APPLY_COMPLETE)

Apply result = 0x0, compActivationMethodsModification=0x0

CMD_ACTIVATE_FIRMWARE

05 PldmActivateFirmwareOp
Upgrade of swb : bic_pldm succeeded
```