### PR TITLE
Common: Remove gpio_name const

### DIFF
--- a/common/hal/hal_gpio.c
+++ b/common/hal/hal_gpio.c
@@ -35,7 +35,7 @@ struct k_work gpio_work[TOTAL_GPIO_NUM];
 uint8_t gpio_ind_to_num_table[TOTAL_GPIO_NUM];
 uint8_t gpio_ind_to_num_table_cnt;
 
-__weak const char *const gpio_name[] = {};
+__weak char *gpio_name[] = {};
 GPIO_CFG gpio_cfg[GPIO_CFG_SIZE] = {
 	//  chip,      number,   is_init, direction,    status,     property,    int_type,           int_cb
 	//  Defalut              DISABLE  GPIO_INPUT    LOW         PUSH_PULL    GPIO_INT_DISABLE    NULL

--- a/common/hal/hal_gpio.h
+++ b/common/hal/hal_gpio.h
@@ -116,7 +116,7 @@ enum GPIO_STATUS {
 	HIGH_INACTIVE = GPIO_LOW,
 };
 
-extern const char *const gpio_name[];
+extern char * gpio_name[];
 
 extern uint8_t gpio_ind_to_num_table[];
 extern uint8_t gpio_ind_to_num_table_cnt;

--- a/meta-facebook/at-cb/src/platform/plat_gpio.c
+++ b/meta-facebook/at-cb/src/platform/plat_gpio.c
@@ -23,7 +23,7 @@
 #include "plat_isr.h"
 
 #define gpio_name_to_num(x) #x,
-const char *const gpio_name[] = {
+char *gpio_name[] = {
 	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
 		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
 			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU

--- a/meta-facebook/at-cb/src/platform/plat_gpio.h
+++ b/meta-facebook/at-cb/src/platform/plat_gpio.h
@@ -246,7 +246,7 @@ enum _GPIO_NUMS_ {
 extern enum _GPIO_NUMS_ GPIO_NUMS;
 #undef gpio_name_to_num
 
-extern const char *const gpio_name[];
+extern char *gpio_name[];
 
 void enable_PRDY_interrupt();
 void disable_PRDY_interrupt();

--- a/meta-facebook/at-mc/src/platform/plat_gpio.c
+++ b/meta-facebook/at-mc/src/platform/plat_gpio.c
@@ -23,7 +23,7 @@
 #include "plat_isr.h"
 
 #define gpio_name_to_num(x) #x,
-const char *const gpio_name[] = {
+char *gpio_name[] = {
 	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
 		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
 			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU

--- a/meta-facebook/at-mc/src/platform/plat_gpio.h
+++ b/meta-facebook/at-mc/src/platform/plat_gpio.h
@@ -246,7 +246,7 @@ enum _GPIO_NUMS_ {
 extern enum _GPIO_NUMS_ GPIO_NUMS;
 #undef gpio_name_to_num
 
-extern const char *const gpio_name[];
+extern char *gpio_name[];
 
 void enable_PRDY_interrupt();
 void disable_PRDY_interrupt();

--- a/meta-facebook/gt-cc/src/platform/plat_gpio.c
+++ b/meta-facebook/gt-cc/src/platform/plat_gpio.c
@@ -23,7 +23,7 @@
 #include "plat_isr.h"
 
 #define gpio_name_to_num(x) #x,
-const char *const gpio_name[] = {
+char *gpio_name[] = {
 	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
 		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
 			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU

--- a/meta-facebook/gt-cc/src/platform/plat_gpio.h
+++ b/meta-facebook/gt-cc/src/platform/plat_gpio.h
@@ -252,6 +252,6 @@ enum _GPIO_NUMS_ {
 extern enum _GPIO_NUMS_ GPIO_NUMS;
 #undef gpio_name_to_num
 
-extern const char *const gpio_name[];
+extern char *gpio_name[];
 
 #endif

--- a/meta-facebook/wc-mb/src/platform/plat_gpio.c
+++ b/meta-facebook/wc-mb/src/platform/plat_gpio.c
@@ -23,7 +23,7 @@
 #include "plat_isr.h"
 
 #define gpio_name_to_num(x) #x,
-const char *const gpio_name[] = {
+char *gpio_name[] = {
 	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
 		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
 			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU

--- a/meta-facebook/wc-mb/src/platform/plat_gpio.h
+++ b/meta-facebook/wc-mb/src/platform/plat_gpio.h
@@ -252,7 +252,7 @@ enum _GPIO_NUMS_ {
 extern enum _GPIO_NUMS_ GPIO_NUMS;
 #undef gpio_name_to_num
 
-extern const char *const gpio_name[];
+extern char *gpio_name[];
 
 void enable_PRDY_interrupt();
 void disable_PRDY_interrupt();

--- a/meta-facebook/yv3-dl/src/platform/plat_gpio.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_gpio.c
@@ -26,7 +26,7 @@
 LOG_MODULE_REGISTER(gpio);
 
 #define gpio_name_to_num(x) #x,
-const char *const gpio_name[] = {
+char *gpio_name[] = {
 	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
 		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
 			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU

--- a/meta-facebook/yv3-dl/src/platform/plat_gpio.h
+++ b/meta-facebook/yv3-dl/src/platform/plat_gpio.h
@@ -258,7 +258,7 @@ extern enum _GPIO_NUMS_ GPIO_NUMS;
 #define FM_FORCE_ADR_N_R 0xFF
 #define JTAG_BMC_NTRST_R_N 0xff
 
-extern const char *const gpio_name[];
+extern char *gpio_name[];
 //  GPIO Table SET/GET GPIO Configuration align to Ti BIC
 extern uint8_t gpio_align_t[];
 extern int gpio_align_table_length;

--- a/meta-facebook/yv3-vf/src/platform/plat_gpio.c
+++ b/meta-facebook/yv3-vf/src/platform/plat_gpio.c
@@ -24,7 +24,7 @@
 #include "plat_power_seq.h"
 
 #define gpio_name_to_num(x) #x,
-const char *const gpio_name[] = {
+char *gpio_name[] = {
 	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
 		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
 			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU

--- a/meta-facebook/yv3-vf/src/platform/plat_gpio.h
+++ b/meta-facebook/yv3-vf/src/platform/plat_gpio.h
@@ -233,6 +233,6 @@ enum _GPIO_NUMS_ {
 extern enum _GPIO_NUMS_ GPIO_NUMS;
 #undef gpio_name_to_num
 
-extern const char *const gpio_name[];
+extern char *gpio_name[];
 
 #endif

--- a/meta-facebook/yv35-bb/src/platform/plat_gpio.c
+++ b/meta-facebook/yv35-bb/src/platform/plat_gpio.c
@@ -23,7 +23,7 @@
 #include "plat_isr.h"
 
 #define gpio_name_to_num(x) #x,
-const char *const gpio_name[] = {
+char *gpio_name[] = {
 	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
 		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
 			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU

--- a/meta-facebook/yv35-bb/src/platform/plat_gpio.h
+++ b/meta-facebook/yv35-bb/src/platform/plat_gpio.h
@@ -248,6 +248,6 @@ enum _GPIO_NUMS_ {
 extern enum _GPIO_NUMS_ GPIO_NUMS;
 #undef gpio_name_to_num
 
-extern const char *const gpio_name[];
+extern char *gpio_name[];
 
 #endif

--- a/meta-facebook/yv35-cl/src/platform/plat_gpio.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_gpio.c
@@ -23,7 +23,7 @@
 #include "plat_isr.h"
 
 #define gpio_name_to_num(x) #x,
-const char *const gpio_name[] = {
+char *gpio_name[] = {
 	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
 		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
 			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU

--- a/meta-facebook/yv35-cl/src/platform/plat_gpio.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_gpio.h
@@ -252,7 +252,7 @@ enum _GPIO_NUMS_ {
 extern enum _GPIO_NUMS_ GPIO_NUMS;
 #undef gpio_name_to_num
 
-extern const char *const gpio_name[];
+extern char *gpio_name[];
 
 void enable_PRDY_interrupt();
 void disable_PRDY_interrupt();

--- a/meta-facebook/yv35-gl/src/platform/plat_gpio.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_gpio.c
@@ -22,7 +22,7 @@
 #include "plat_gpio.h"
 
 #define gpio_name_to_num(x) #x,
-const char *const gpio_name[] = {
+char *gpio_name[] = {
     name_gpioA
     name_gpioB
     name_gpioC

--- a/meta-facebook/yv35-gl/src/platform/plat_gpio.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_gpio.h
@@ -261,7 +261,7 @@ enum _GPIO_NUMS_ {
 extern enum _GPIO_NUMS_ GPIO_NUMS;
 #undef gpio_name_to_num
 
-extern const char *const gpio_name[];
+extern char *gpio_name[];
 
 #endif
 

--- a/meta-facebook/yv35-hd/src/platform/plat_gpio.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_gpio.c
@@ -21,7 +21,7 @@
 #include "plat_isr.h"
 
 #define gpio_name_to_num(x) #x,
-const char *const gpio_name[] = {
+char *gpio_name[] = {
 	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
 		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
 			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU

--- a/meta-facebook/yv35-hd/src/platform/plat_gpio.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_gpio.h
@@ -251,6 +251,6 @@ enum _GPIO_NUMS_ {
 extern enum _GPIO_NUMS_ GPIO_NUMS;
 #undef gpio_name_to_num
 
-extern const char *const gpio_name[];
+extern char *gpio_name[];
 
 #endif

--- a/meta-facebook/yv35-rf/src/platform/plat_gpio.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_gpio.c
@@ -22,7 +22,7 @@
 #include "plat_gpio.h"
 
 #define gpio_name_to_num(x) #x,
-const char *const gpio_name[] = {
+char *gpio_name[] = {
 	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
 		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
 			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU

--- a/meta-facebook/yv35-rf/src/platform/plat_gpio.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_gpio.h
@@ -252,6 +252,6 @@ enum _GPIO_NUMS_ {
 extern enum _GPIO_NUMS_ GPIO_NUMS;
 #undef gpio_name_to_num
 
-extern const char *const gpio_name[];
+extern char *gpio_name[];
 
 #endif


### PR DESCRIPTION
Summary:
- In order to support different expansion cards (on the same project) using the same BIC firmware, remove "const" about variable gpio_name. They have different definitions of GPIO, so need to dynamically change the GPIO name.

Test plan:
- Build code: Pass
- Check GPIO name: Pass

Log:
1. Build all projects.
- at-cb ...
[303/303] Linking C executable zephyr/ATCB.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:         12 KB       320 KB      3.75%
           FLASH:          0 GB         0 GB
            SRAM:      429872 B       448 KB     93.70%
        IDT_LIST:          0 GB         2 KB      0.00%

- at-mc ...
[291/291] Linking C executable zephyr/ATMC.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:         12 KB       320 KB      3.75%
           FLASH:          0 GB         0 GB
            SRAM:      406128 B       448 KB     88.53%
        IDT_LIST:          0 GB         2 KB      0.00%

- gt-cc ...
[301/301] Linking C executable zephyr/GRAND_TETON.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:         12 KB       160 KB      7.50%
           FLASH:          0 GB         0 GB
            SRAM:      572824 B       608 KB     92.01%
        IDT_LIST:          0 GB         2 KB      0.00%

- wc-mb ...
[312/312] Linking C executable zephyr/WCMB.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:        152 KB       256 KB     59.38%
           FLASH:          0 GB         0 GB
            SRAM:      473776 B       512 KB     90.37%
        IDT_LIST:          0 GB         2 KB      0.00%

- yv3-dl ...
[310/310] Linking C executable zephyr/Y3BDL.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:       12704 B       256 KB      4.85%
           FLASH:          0 GB         0 GB
            SRAM:      502808 B       512 KB     95.90%
        IDT_LIST:          0 GB         2 KB      0.00%

- yv3-vf ...
[296/296] Linking C executable zephyr/Y3BVF.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:         12 KB       160 KB      7.50%
           FLASH:          0 GB         0 GB
            SRAM:      530208 B       608 KB     85.16%
        IDT_LIST:          0 GB         2 KB      0.00%

- yv35-bb ...
[300/300] Linking C executable zephyr/Y35BBB.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:         12 KB       320 KB      3.75%
           FLASH:          0 GB         0 GB
            SRAM:      424576 B       448 KB     92.55%
        IDT_LIST:          0 GB         2 KB      0.00%

- yv35-cl ...
[315/315] Linking C executable zephyr/Y35BCL.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:        152 KB       256 KB     59.38%
           FLASH:          0 GB         0 GB
            SRAM:      499032 B       512 KB     95.18%
        IDT_LIST:          0 GB         2 KB      0.00%

- yv35-gl ...
[299/299] Linking C executable zephyr/Y35BGL.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:        152 KB       320 KB     47.50%
           FLASH:          0 GB         0 GB
            SRAM:      425968 B       448 KB     92.85%
        IDT_LIST:          0 GB         2 KB      0.00%

- yv35-hd ...
[266/266] Linking C executable zephyr/Y35BHD.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:        168 KB       256 KB     65.62%
           FLASH:          0 GB         0 GB
            SRAM:      486376 B       512 KB     92.77%
        IDT_LIST:          0 GB         2 KB      0.00%

- yv35-rf ...
[292/292] Linking C executable zephyr/Y35BRF.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:         12 KB       320 KB      3.75%
           FLASH:          0 GB         0 GB
            SRAM:      420624 B       448 KB     91.69%
        IDT_LIST:          0 GB         2 KB      0.00%

2. Check GPIO name show normally.
- VF BIC uart:~$ platform gpio list_all
[0  ] IRQ_P12V_E1S_3_FLT_N               : PP  | input (I) | 1(1)
[1  ] IRQ_P12V_E1S_2_FLT_N               : PP  | input (I) | 1(1)
[2  ] IRQ_P12V_E1S_1_FLT_N               : PP  | input (I) | 1(1)
[3  ] IRQ_P12V_E1S_0_FLT_N               : PP  | input (I) | 1(1)
[4  ] IRQ_P3V3_E1S_3_FLT_N               : PP  | input (I) | 1(1)
[5  ] IRQ_P3V3_E1S_2_FLT_N               : PP  | input (I) | 1(1)
[6  ] IRQ_P3V3_E1S_1_FLT_N               : PP  | input (I) | 1(1)
[7  ] IRQ_P3V3_E1S_0_FLT_N               : PP  | input (I) | 1(1)
[8  ] PWRGD_P12V_AUX                     : PP  | input (I) | 0(0)
[9  ] IRQ_P12V_HSC_ALERT1_N              : PP  | input (I) | 1(1)
[10 ] IRQ_P12V_HSC_ALERT2_N              : PP  | input (I) | 1(1)
[11 ] PU_DB800_HI_BW                     : OD  | output(I) | 0(0)
[12 ] LED_PWRGD_P12V_E1S_ALL             : PP  | output(O) | 0(0)
[13 ] FM_AUX_PWR_EN                      : PP  | input (I) | 1(1)
[14 ] RST_SMB_E1S_3_N                    : PP  | output(O) | 1(1)
[15 ] RST_SMB_E1S_2_N                    : PP  | output(O) | 1(1)
[16 ] BOARD_ID0                          : PP  | input (I) | 0(0)
[17 ] BOARD_ID1                          : PP  | input (I) | 1(1)
[18 ] BOARD_ID2                          : PP  | input (I) | 1(1)
[19 ] BOARD_ID3                          : PP  | input (I) | 1(1)
[20 ] RST_BIC_E1S_3_N                    : PP  | output(O) | 0(0)
[21 ] RST_BIC_E1S_2_N                    : PP  | output(O) | 0(0)
[22 ] RST_BIC_E1S_1_N                    : PP  | output(O) | 0(0)
[23 ] RST_BIC_E1S_0_N                    : PP  | output(O) | 0(0)
[24 ] FM_MB_SLOT_ID0                     : PP  | input (I) | 0(0)
[25 ] FM_PWRDIS_E1S_3                    : PP  | output(O) | 0(0)
[26 ] FM_PWRDIS_E1S_2                    : PP  | output(O) | 0(0)
[27 ] FM_PWRDIS_E1S_1                    : PP  | output(O) | 0(0)
[28 ] FM_PWRDIS_E1S_0                    : PP  | output(O) | 0(0)
[29 ] FM_P12V_E1S_0_EN                   : PP  | output(O) | 0(0)
[30 ] IRQ_TMP75_ALERT_N                  : PP  | input (I) | 1(1)
[31 ] FM_P3V3_E1S_0_SW_EN                : PP  | output(O) | 1(1)
[32 ] FM_POWER_EN                        : PP  | input (I) | 0(0)
[33 ] PWRGD_EXP_PWROK                    : PP  | output(O) | 0(0)
[34 ] RST_MB_N                           : PP  | input (I) | 0(0)
[36 ] FM_FRU_WC_N                        : PP  | output(O) | 0(0)
[37 ] P1V2_VDD_PG_R                      : PP  | input (I) | 1(1)
[38 ] RST_SMB_E1S_1_N                    : PP  | output(O) | 1(1)
[39 ] RST_SMB_E1S_0_N                    : PP  | output(O) | 1(1)
[41 ] IRQ_SMB_ALERT_N                    : PP  | output(O) | 1(1)
[42 ] FM_P3V3_E1S_EN                     : PP  | output(O) | 1(1)
[43 ] FM_P12V_EDGE_EN                    : PP  | output(O) | 0(0)
[45 ] IRQ_P3V3_EDGE_FLT_N                : PP  | input (I) | 1(1)
[46 ] IRQ_P12V_EDGE_FLT_N                : PP  | input (I) | 1(1)
[48 ] LED_BIC_E1S_3                      : PP  | output(O) | 0(0)
[49 ] LED_BIC_E1S_2                      : PP  | output(O) | 0(0)
[50 ] LED_BIC_E1S_1                      : PP  | output(O) | 0(0)
[51 ] LED_BIC_E1S_0                      : PP  | output(O) | 0(0)
[52 ] FM_MB_SLOT_ID1                     : PP  | input (I) | 0(0)
[53 ] FM_PRSNT_E1S_3_N                   : PP  | input (I) | 0(0)
[54 ] FM_PRSNT_E1S_2_N                   : PP  | input (I) | 1(1)
[55 ] FM_PRSNT_E1S_1_N                   : PP  | input (I) | 0(0)
[56 ] FM_PRSNT_E1S_0_N                   : PP  | input (I) | 0(0)
[90 ] FM_BOARD_REV_ID2                   : PP  | input (I) | 0(0)
[91 ] FM_BOARD_REV_ID1                   : PP  | input (I) | 0(0)
[92 ] FM_BOARD_REV_ID0                   : PP  | input (I) | 0(0)
[93 ] HSC_SEL_ID2                        : PP  | input (I) | 0(0)
[94 ] HSC_SEL_ID1                        : PP  | input (I) | 0(0)
[95 ] HSC_SEL_ID0                        : PP  | input (I) | 1(1)
[108] FM_P12V_E1S_2_EN                   : PP  | output(O) | 0(0)
[109] FM_P12V_E1S_1_EN                   : PP  | output(O) | 0(0)
[110] IRQ_INA230_E1S_0_ALERT_N           : PP  | input (I) | 1(1)
[111] FM_CLKBUF_EN                       : PP  | output(O) | 0(0)
[112] FM_P12V_E1S_3_EN                   : PP  | output(O) | 0(0)
[113] IRQ_INA230_E1S_3_ALERT_N           : PP  | input (I) | 1(1)
[114] IRQ_INA230_E1S_2_ALERT_N           : PP  | input (I) | 1(1)
[115] IRQ_INA230_E1S_1_ALERT_N           : PP  | input (I) | 1(1)
[126] CLKBUF_E1S_3_OE_N                  : OD  | output(I) | 1(1)
[127] CLKBUF_E1S_2_OE_N                  : OD  | output(I) | 1(1)
[128] CLKBUF_E1S_1_OE_N                  : OD  | output(I) | 1(1)
[129] CLKBUF_E1S_0_OE_N                  : OD  | output(I) | 1(1)
[130] FM_P3V3_E1S_3_SW_EN                : PP  | output(O) | 1(1)
[131] FM_P3V3_E1S_2_SW_EN                : PP  | output(O) | 0(0)
[132] FM_P3V3_E1S_1_SW_EN                : PP  | output(O) | 1(1)

- CL BIC uart:~$ platform gpio list_all
[0  ] FM_BMC_PCH_SCI_LPC_R_N             : OD  | output(I) | 1(1)
[1  ] FM_BIOS_POST_CMPLT_BMC_N           : OD  | input (I) | 1(1)
[2  ] FM_SLPS3_PLD_N                     : PP  | input (I) | 0(0)
[3  ] IRQ_BMC_PCH_SMI_LPC_R_N            : OD  | output(I) | 1(1)
[4  ] IRQ_UV_DETECT_N                    : OD  | input (I) | 1(1)
[5  ] FM_UV_ADR_TRIGGER_EN_R             : OD  | output(I) | 1(1)
[6  ] IRQ_SMI_ACTIVE_BMC_N               : OD  | input (I) | 1(1)
[7  ] HSC_SET_EN_R                       : PP  | output(O) | 0(0)
[8  ] FM_BIC_RST_RTCRST_R                : PP  | output(O) | 0(0)
[9  ] RST_USB_HUB_N_R                    : OD  | output(I) | 1(1)
[10 ] A_P3V_BAT_SCALED_EN_R              : PP  | output(O) | 0(0)
[11 ] FM_SPI_PCH_MASTER_SEL_R            : PP  | output(O) | 0(0)
[12 ] FM_PCHHOT_N                        : OD  | input (I) | 1(1)
[13 ] FM_SLPS4_PLD_N                     : PP  | input (I) | 0(0)
[14 ] FM_S3M_CPU0_CD_INIT_ERROR          : OD  | input (I) | 0(0)
[15 ] PWRGD_SYS_PWROK                    : PP  | input (I) | 0(0)
[16 ] FM_HSC_TIMER                       : OD  | input (I) | 0(0)
[17 ] IRQ_SMB_IO_LVC3_STBY_ALRT_N        : OD  | input (I) | 1(1)
[18 ] IRQ_CPU0_VRHOT_N                   : OD  | input (I) | 1(1)
[19 ] DBP_CPU_PREQ_BIC_N                 : OD  | output(I) | 1(1)
[20 ] FM_CPU_THERMTRIP_LATCH_LVT3_N      : OD  | input (I) | 1(1)
[21 ] FM_CPU_SKTOCC_LVT3_PLD_N           : OD  | input (I) | 0(0)
[22 ] H_CPU_MEMHOT_OUT_LVC3_N            : PP  | input (I) | 1(1)
[23 ] RST_PLTRST_PLD_N                   : PP  | input (I) | 0(0)
[24 ] PWRBTN_N                           : OD  | input (I) | 1(1)
[25 ] RST_BMC_R_N                        : OD  | output(I) | 1(1)
[26 ] H_BMC_PRDY_BUF_N                   : OD  | input (I) | 1(1)
[27 ] BMC_READY                          : PP  | output(O) | 1(1)
[28 ] BIC_READY                          : PP  | output(O) | 1(1)
[29 ] FM_RMCA_LVT3_N                     : PP  | input (I) | 1(1)
[30 ] HSC_MUX_SWITCH_R                   : PP  | output(O) | 0(0)
[31 ] FM_FORCE_ADR_N_R                   : OD  | output(I) | 1(1)
[32 ] PWRGD_CPU_LVC3                     : PP  | input (I) | 0(0)
[33 ] FM_PCH_BMC_THERMTRIP_N             : OD  | output(I) | 1(1)
[34 ] FM_THROTTLE_R_N                    : OD  | input (I) | 1(1)
[35 ] IRQ_HSC_ALERT2_N                   : OD  | input (I) | 0(0)
[36 ] SMB_SENSOR_LVC3_ALERT_N            : OD  | input (I) | 1(1)
[37 ] FM_CATERR_LVT3_N                   : PP  | input (I) | 1(1)
[38 ] SYS_PWRBTN_N                       : OD  | input (I) | 1(1)
[39 ] RST_PLTRST_BUF_N                   : PP  | input (I) | 0(0)
[40 ] IRQ_BMC_PCH_NMI_R                  : PP  | output(O) | 0(0)
[41 ] IRQ_SML1_PMBUS_ALERT_N             : OD  | input (I) | 1(1)
[42 ] IRQ_PCH_CPU_NMI_EVENT_N            : OD  | input (I) | 1(1)
[43 ] FM_BMC_DEBUG_ENABLE_N              : OD  | output(I) | 1(1)
[44 ] FM_DBP_PRESENT_N                   : OD  | input (I) | 1(1)
[45 ] FM_FAST_PROCHOT_EN_N_R             : PP  | output(O) | 0(0)
[46 ] FM_SPI_MUX_OE_CTL_PLD_N            : PP  | output(O) | 0(0)
[47 ] FBRK_N_R                           : OD  | output(I) | 1(1)
[48 ] FM_PEHPCPU_INT                     : PP  | input (I) | 0(0)
[49 ] FM_BIOS_MRC_DEBUG_MSG_DIS_R        : OD  | output(I) | 1(1)
[50 ] FAST_PROCHOT_N                     : OD  | input (I) | 1(1)
[51 ] FM_JTAG_TCK_MUX_SEL_R              : PP  | output(O) | 0(0)
[52 ] BMC_JTAG_SEL_R                     : PP  | output(O) | 0(0)
[53 ] H_CPU_ERR0_LVC3_N                  : PP  | input (I) | 1(1)
[54 ] H_CPU_ERR1_LVC3_N                  : PP  | input (I) | 1(1)
[55 ] H_CPU_ERR2_LVC3_N                  : PP  | input (I) | 1(1)
[56 ] RST_RSMRST_BMC_N                   : PP  | input (I) | 1(1)
[57 ] FM_MP_PS_FAIL_N                    : OD  | input (I) | 0(0)
[58 ] H_CPU_MEMTRIP_LVC3_N               : OD  | input (I) | 1(1)
[59 ] FM_CPU_BIC_PROCHOT_LVT3_N          : PP  | input (I) | 0(0)
[91 ] BOARD_ID2                          : PP  | input (I) | 0(0)
[92 ] IRQ_PVCCD_CPU0_VRHOT_LVC3_N        : OD  | input (I) | 1(1)
[93 ] FM_PVCCIN_CPU0_PWR_IN_ALERT_N      : OD  | input (I) | 1(1)
[94 ] BOARD_ID0                          : PP  | input (I) | 0(0)
[95 ] BOARD_ID1                          : PP  | input (I) | 0(0)
[97 ] BOARD_ID3                          : PP  | input (I) | 0(0)
[99 ] FM_THROTTLE_IN_N                   : OD  | output(I) | 1(1)
[100] AUTH_COMPLETE                      : PP  | input (I) | 0(0)
[101] AUTH_PRSNT_N                       : OD  | input (I) | 1(1)
[104] SGPIO_BMC_CLK_R                    : PP  | input (I) | 0(0)
[105] SGPIO_BMC_LD_R_N                   : PP  | input (I) | 0(0)
[106] SGPIO_BMC_DOUT_R                   : PP  | input (I) | 0(0)
[107] SGPIO_BMC_DIN                      : PP  | input (I) | 0(0)