### PR TITLE
GT: Version commit for obgt-cc-2022.50.01

### DIFF
--- a/common/hal/hal_i2c_target.h
+++ b/common/hal/hal_i2c_target.h
@@ -20,7 +20,7 @@
 #include <drivers/i2c.h>
 #include "hal_i2c.h"
 
-#define MAX_I2C_TARGET_BUFF 512
+#define MAX_I2C_TARGET_BUFF 256
 #define MAX_TARGET_NUM 16
 #define I2C_DEVICE_PREFIX "I2C_"
 #define I2C_CONTROLLER_NAME_GET(inst) I2C_DEVICE_PREFIX #inst

--- a/common/service/pldm/pldm_monitor.c
+++ b/common/service/pldm/pldm_monitor.c
@@ -472,7 +472,7 @@ static void oem_set_effecter_type_gpio_handler(uint8_t *buf, uint16_t len, uint8
 	}
 
 	/* Set output pin value only */
-	if (!gpio_get_direction(gpio_pin)) {
+	if (gpio_cfg[gpio_pin].direction == GPIO_INPUT) {
 		LOG_ERR("Can't set input pin (%d) value", gpio_pin);
 		*completion_code_p = PLDM_OEM_GPIO_EFFECTER_VALUE_UNKNOWN;
 		return;
@@ -567,8 +567,9 @@ static void oem_get_effecter_type_gpio_handler(uint8_t *buf, uint16_t len, uint8
 		gpio_dir_state->effecter_op_state = gpio_val_state->effecter_op_state =
 			PLDM_EFFECTER_ENABLED_NOUPDATEPENDING;
 		gpio_dir_state->previous_state = gpio_dir_state->pending_state =
-			(!gpio_get_direction(gpio_pin) ? EFFECTER_STATE_GPIO_DIRECTION_INPUT :
-							 EFFECTER_STATE_GPIO_DIRECTION_OUTPUT);
+			((gpio_cfg[gpio_pin].direction == GPIO_INPUT) ?
+				 EFFECTER_STATE_GPIO_DIRECTION_INPUT :
+				 EFFECTER_STATE_GPIO_DIRECTION_OUTPUT);
 		gpio_val_state->previous_state = gpio_val_state->pending_state =
 			(!gpio_get(gpio_pin) ? EFFECTER_STATE_GPIO_VALUE_LOW :
 					       EFFECTER_STATE_GPIO_VALUE_HIGH);

--- a/meta-facebook/gt-cc/src/platform/plat_version.h
+++ b/meta-facebook/gt-cc/src/platform/plat_version.h
@@ -31,7 +31,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x03
+#define FIRMWARE_REVISION_2 0x04
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -40,7 +40,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x49
+#define BIC_FW_WEEK 0x50
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x47 // char: G
 #define BIC_FW_platform_1 0x54 // char: T


### PR DESCRIPTION
Summary:
- Version commit for Grand Teton switch board BIC obgt-cc-2022.50.01

Test Plan:
- Build code: Pass
- Check BIC version: Pass
Log:
```
root@bmc-oob:~# fw-util swb --version bic
SWB BIC Version: 2022.50.01
```

Dependency: #753 