### PR TITLE
at: cb: Version commit for obat-cb-2022.51.01

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_version.h
+++ b/meta-facebook/at-cb/src/platform/plat_version.h
@@ -33,7 +33,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x02
+#define FIRMWARE_REVISION_2 0x03
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -42,7 +42,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x47
+#define BIC_FW_WEEK 0x51
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x63 // char: c
 #define BIC_FW_platform_1 0x62 // char: b


### PR DESCRIPTION
Summary:
[Summary]
- Version commit for ColterBay BIC obat-cb-2022.51.01
- Release for basic support include GPIO, FRU, sensors and firmwares

[Test Plan & Log]
1. Build code:	Artemis CB			[ Pass ]