### PR TITLE
fby35: hd: Speed down SPI1/2 frequency to 30MHz

### DIFF
--- a/meta-facebook/yv35-hd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-hd/boards/ast1030_evb.overlay
@@ -174,7 +174,7 @@
 &spi1_cs0 {
 	status = "okay";
 	spi-max-buswidth = <4>;
-	spi-max-frequency = <50000000>;
+	spi-max-frequency = <30000000>;
 	re-init-support;
 };
 
@@ -185,7 +185,7 @@
 &spi2_cs0 {
 	status = "okay";
 	spi-max-buswidth = <4>;
-	spi-max-frequency = <50000000>;
+	spi-max-frequency = <30000000>;
 	re-init-support;
 };
 


### PR DESCRIPTION
Summary:
- The BIOS firmware update is failed if the SPI frequency is 50MHz and the ADI MUX is on system.
- Speed down SPI1/2 frequency to 30 MHz to fix this issue.

Test Plan:
1. Build code: pass
2. BIOS firmware update: pass