### PR TITLE
Common: Modify PLDM monitor related function

### DIFF
--- a/common/service/pldm/pldm.h
+++ b/common/service/pldm/pldm.h
@@ -26,6 +26,7 @@ extern "C" {
 #include "pldm_oem.h"
 #include "pldm_monitor.h"
 #include "pldm_firmware_update.h"
+#include "pldm_state_set.h"
 
 #define MONITOR_THREAD_STACK_SIZE 1024
 

--- a/common/service/pldm/pldm_monitor.h
+++ b/common/service/pldm/pldm_monitor.h
@@ -22,6 +22,11 @@ extern "C" {
 #endif
 
 #include "pldm.h"
+#if defined __has_include
+#if __has_include("plat_pldm_monitor.h")
+#include "plat_pldm_monitor.h"
+#endif
+#endif
 
 /* command number of pldm type 0x02 : PLDM for platform monitor and control */
 typedef enum pldm_platform_monitor_commands {
@@ -41,8 +46,8 @@ typedef enum pldm_platform_monitor_commands {
 
 /* The maximum event data size of event type currently support */
 #define PLDM_MONITOR_EVENT_DATA_SIZE_MAX 7
-/* The maximum event message number in the queue */
-#define PLDM_MONITOR_EVENT_QUEUE_MSG_NUM_MAX 15
+/* The default maximum event message number in the queue */
+#define PLDM_MONITOR_EVENT_QUEUE_MSG_NUM_MAX_DEFAULT 10
 #define PLDM_MONITOR_SENSOR_SUPPORT_MAX 0xFF
 #define PLDM_MONITOR_SENSOR_EVENT_SENSOR_OP_STATE_DATA_LENGTH 2
 #define PLDM_MONITOR_SENSOR_EVENT_STATE_SENSOR_STATE_DATA_LENGTH 3

--- a/common/service/pldm/pldm_state_set.h
+++ b/common/service/pldm/pldm_state_set.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef PLDM_STATE_SET_H
+#define PLDM_STATE_SET_H
+
+/* Follow the PLDM state set specification (DSP0249_1.1.0) */
+enum pldm_state_set_id_num {
+	PLDM_STATE_SET_PRESENCE = 13,
+	PLDM_STATE_SET_BOOT_RESTART_CAUSE = 192,
+
+	/* OEM reserved state sets 32768 - 65535 */
+	PLDM_STATE_SET_OEM_DEVICE_STATUS = 32768,
+};
+
+enum pldm_state_set_presense {
+	PLDM_STATE_SET_PRESENT = 1,
+	PLDM_STATE_SET_NOT_PRESENT = 2,
+};
+
+/**
+ * @brief List of states for the Boot Restart Cause state set (ID 192).
+ */
+enum pldm_state_set_boot_restart_cause {
+	PLDM_STATE_SET_BOOT_RESTART_CAUSE_POWERED_UP = 1,
+	PLDM_STATE_SET_BOOT_RESTART_CAUSE_HARD_RESET = 2,
+	PLDM_STATE_SET_BOOT_RESTART_CAUSE_WARM_RESET = 3,
+	PLDM_STATE_SET_BOOT_RESTART_CAUSE_MANUAL_HARD_RESET = 4,
+	PLDM_STATE_SET_BOOT_RESTART_CAUSE_MANUAL_WARM_RESET = 5,
+	PLDM_STATE_SET_BOOT_RESTART_CAUSE_SYSTEM_RESTART = 6,
+	PLDM_STATE_SET_BOOT_RESTART_CAUSE_WATCHDOG_TIMEOUT = 7
+};
+
+/**
+ * @brief List of oem states for the device status (ID 32768)
+ * @todo Can define other common status for device using.
+ */
+enum pldm_state_set_oem_device_status {
+	PLDM_STATE_SET_OEM_DEVICE_STATUS_NORMAL = 1,
+	PLDM_STATE_SET_OEM_DEVICE_STATUS_ALERT = 2,
+};
+
+#endif


### PR DESCRIPTION
Summary:
- Add PLDM state set define header file.
- Define PLDM event message queue maximum number from the default value or platform.
- Send each PLDM event then re-schedule the worker to avoid causing the system work queue stuck.

Test Plan:
- Build code: Pass