### PR TITLE
fby3.5: cl: Check sensor poll for PMIC monitor

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -372,6 +372,11 @@ void enable_sensor_poll()
 	sensor_poll_enable_flag = true;
 }
 
+bool get_sensor_poll_enable_flag()
+{
+	return sensor_poll_enable_flag;
+}
+
 void sensor_poll_handler(void *arug0, void *arug1, void *arug2)
 {
 	uint8_t index = 0, sensor_num = 0;

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -469,6 +469,7 @@ bool vr_stby_access(uint8_t sensor_num);
 bool sensor_init(void);
 void disable_sensor_poll();
 void enable_sensor_poll();
+bool get_sensor_poll_enable_flag();
 void pal_extend_sensor_config(void);
 bool check_sensor_num_exist(uint8_t sensor_num);
 void add_sensor_config(sensor_cfg config);

--- a/meta-facebook/yv35-cl/src/platform/plat_pmic.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_pmic.c
@@ -24,6 +24,7 @@
 #include "ipmi.h"
 #include "intel_dimm.h"
 #include "pmic.h"
+#include "sensor.h"
 #include "libipmi.h"
 #include "power_status.h"
 #include "oem_1s_handler.h"
@@ -93,6 +94,12 @@ void monitor_pmic_error_handler()
 	memset(is_pmic_error_flag, false, sizeof(is_pmic_error_flag));
 
 	while (1) {
+		// Check sensor poll enable
+		if (get_sensor_poll_enable_flag() == false) {
+			k_msleep(MONITOR_PMIC_ERROR_TIME_MS);
+			continue;
+		}
+
 		// If post isn't complete, BIC doesn't monitor PMIC error
 		if (get_post_status() == false) {
 			k_msleep(MONITOR_PMIC_ERROR_TIME_MS);


### PR DESCRIPTION
Summary:
- Check sensor poll for PMIC monitor

Test plan:
- Build code: Pass
- Check PMIC error monitor with sensor poll enable