### PR TITLE
GT: Modify the register used to read the PEX firmware version

### DIFF
--- a/common/dev/include/pex89000.h
+++ b/common/dev/include/pex89000.h
@@ -28,6 +28,7 @@ typedef enum pex_access {
 	pex_access_rev_id,
 	pex_access_sbr_ver,
 	pex_access_flash_ver,
+	pex_access_register,
 	pex_access_unknown
 } pex_access_t;
 


### PR DESCRIPTION
Summary:

- Since the latest firmware of PEX changed the version register, add a condition to check the register of the firmware version to read the PEX version.

Test Plan:
- Build code: Pass

Dependency: #773 