### PR TITLE
hd: op: Support BMC read, write, dump and modify FRU information

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_fru.c
+++ b/meta-facebook/op2-op/src/platform/plat_fru.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <sys/util.h>
+#include <string.h>
+#include <stdio.h>
+#include <logging/log.h>
+
+#include "fru.h"
+#include "plat_fru.h"
+#include "plat_class.h"
+
+LOG_MODULE_REGISTER(plat_fru);
+
+const EEPROM_CFG plat_OPA_fru_config[] = {
+	{
+		NV_ATMEL_24C128,
+		OP_FRU_ID,
+		OP_FRU_PORT,
+		OPA_FRU_ADDR,
+		FRU_DEV_ACCESS_BYTE,
+		FRU_START,
+		FRU_SIZE,
+	},
+};
+
+const EEPROM_CFG plat_OPB_fru_config[] = {
+	{
+		NV_ATMEL_24C128,
+		OP_FRU_ID,
+		OP_FRU_PORT,
+		OPB_FRU_ADDR,
+		FRU_DEV_ACCESS_BYTE,
+		FRU_START,
+		FRU_SIZE,
+	},
+};
+
+void fru_config_oversize_handle(const EEPROM_CFG *plat_fru_config, uint8_t card_type)
+{
+	LOG_WRN("Failed to load OP%s's fru configuration. Index: %d is over than max value: %d",
+		((card_type == 0) ? "A" : "B"), sizeof(plat_fru_config), FRU_CFG_NUM);
+	memcpy(&fru_config, &plat_fru_config, FRU_CFG_NUM);
+}
+
+void pal_load_fru_config(void)
+{
+	uint8_t card_type = get_card_type();
+
+	if (card_type == CARD_TYPE_OPA) {
+		if (ARRAY_SIZE(plat_OPA_fru_config) > FRU_CFG_NUM) {
+			fru_config_oversize_handle(plat_OPA_fru_config, CARD_TYPE_OPA);
+			goto out;
+		}
+		memcpy(&fru_config, &plat_OPA_fru_config, sizeof(plat_OPA_fru_config));
+	}
+
+	else if (card_type == CARD_TYPE_OPB) {
+		if (ARRAY_SIZE(plat_OPB_fru_config) > FRU_CFG_NUM) {
+			fru_config_oversize_handle(plat_OPB_fru_config, CARD_TYPE_OPB);
+			goto out;
+		}
+		memcpy(&fru_config, &plat_OPB_fru_config, sizeof(plat_OPB_fru_config));
+	} else {
+		LOG_ERR("Unsupported card type, Card type: 0x%x", card_type);
+	}
+out:
+	return;
+}

--- a/meta-facebook/op2-op/src/platform/plat_fru.h
+++ b/meta-facebook/op2-op/src/platform/plat_fru.h
@@ -17,6 +17,12 @@
 #ifndef PLAT_FRU_H
 #define PLAT_FRU_H
 
+#define OP_FRU_PORT 0x03
+#define OPA_FRU_ADDR (0xA8 >> 1)
+#define OPB_FRU_ADDR (0xAA >> 1)
+
+#define FRU_CFG_NUM MAX_FRU_ID
+
 enum {
 	OP_FRU_ID,
 	MAX_FRU_ID,


### PR DESCRIPTION
Summary:
- Identify card type and initialize OPA/OPB's FRU information.
- If plat_fru_config's members are more than fru_config's, just copy the max size(FRU_CFG_NUM) onto fru_config.

Test Plan:
1. build code: Pass
2. Access to BIC console: Pass

Test Log:
1. Build code
```
[268/275] Linking C executable zephyr/zephyr_prebuilt.elf

[275/275] Linking C executable zephyr/OP2BOP.elf
Memory region         Used Size  Region Size  %age Used
        SRAM_NC:         12 KB       320 KB      3.75%
        FLASH:          0 GB         0 GB
            SRAM:      401272 B       448 KB     87.47%
        IDT_LIST:          0 GB         2 KB      0.00%

2. Access to BIC console

2-1. Set SB CPLD to change board type. 0x1 is class 1.
2-2. Set SB CPLD to switch mux. 0x1 is channel 1.
2-3. Switch to uart console
------------------TERMINAL MULTIPLEXER---------------------
CTRL-l ?   : Display help message.
CTRL-l x : Terminate the connection.
/var/log/mTerm_slot3.log : Log location
CTRL-l + b : Send Break

-----------------------------------------------------------
========================{SHELL COMMAND INFO}========================================
* NAME:          Platform command
* DESCRIPTION:   Commands that could be used to debug or validate.
* DATE/VERSION:  none
* CHIP/OS:       ast1030_evb - Zephyr
* Note:          none
------------------------------------------------------------------
* PLATFORM:      Olympic 2.0-Olmsted Point
* BOARD ID:      2
* STAGE:         0
* SYSTEM:        255
* FW VERSION:    2.0
* FW DATE:       2022.48.1
* FW IMAGE:      OP2BOP.bin
========================{SHELL COMMAND INFO}========================================