### PR TITLE
hd: op: configure i3c hub as i2c mode

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_init.c
+++ b/meta-facebook/op2-op/src/platform/plat_init.c
@@ -17,9 +17,37 @@
 #include "hal_gpio.h"
 #include "plat_gpio.h"
 #include "plat_class.h"
+#include "plat_i2c.h"
+#include "rg3mxxb12.h"
 
 #define DEF_PLAT_CONFIG_PRIORITY 77
 #define DEF_PROJ_GPIO_PRIORITY 78
+
+void pal_pre_init()
+{
+	/* Initialize I3C HUB (connects to E1.s)
+	 * For OPA expansion,
+	 * the I3C HUB slave port-0/1/5 should be enabled.
+	 * For OPB expansion,
+	 * the I3C HUB slave port-0/1/2/3/4 should be enabled.
+	 */
+	uint8_t type = get_card_type();
+	uint8_t slave_port = 0x0;
+	if (type == CARD_TYPE_OPA) {
+		slave_port = BIT(0)|BIT(1)|BIT(5);
+	}
+	else if(type == CARD_TYPE_OPB) {
+		slave_port = BIT(0)|BIT(1)|BIT(2)|BIT(3)|BIT(4);
+	}
+	else {
+		printk("No need to initialize rg3mxxb12\n");
+		return;
+	}
+
+	if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS1, slave_port)) {
+		printk("failed to initialize rg3mxxb12\n");
+	}
+}
 
 DEVICE_DEFINE(PRE_DEF_PLAT_CONFIG, "PRE_DEF_PLATFOMR", &init_platform_config, NULL, NULL, NULL,
 	      POST_KERNEL, DEF_PLAT_CONFIG_PRIORITY, NULL);


### PR DESCRIPTION
Summary:
- The I3C HUB is connected to OP20 BIC and E1.S.
- Now, the I3C HUB should be configured as I2C mode because the E1.2 only support I2C interface.
- For OPA expansion card, the slave port-0/1/5 of I3C HUB should be enabled. And the port-0/1/2/3/4 should be enabled in OPB expansion card.

Test Plan:
1. Build code: pass