### PR TITLE
fby35: gl: Support multi-KCS channels

### DIFF
--- a/common/service/host/kcs.h
+++ b/common/service/host/kcs.h
@@ -21,12 +21,24 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <zephyr.h>
 
 #define KCS_POLL_STACK_SIZE 2560
 #define KCS_POLLING_INTERVAL 100
 #define KCS_BUFF_SIZE 256
+#define KCS_MAX_CHANNEL_NUM 0x0F
 
 #define CMD_SYS_INFO_FW_VERSION 0x01
+#define KCS_TASK_NAME_LEN 32
+
+typedef struct _kcs_dev {
+	const struct device *dev;
+	uint8_t index;
+	k_tid_t task_tid;
+	K_KERNEL_STACK_MEMBER(task_stack, KCS_POLL_STACK_SIZE);
+	uint8_t task_name[KCS_TASK_NAME_LEN];
+	struct k_thread task_thread;
+} kcs_dev;
 
 struct kcs_request {
 	uint8_t netfn;
@@ -41,8 +53,8 @@ struct kcs_response {
 	uint8_t data[0];
 };
 
-void kcs_write(uint8_t *buf, uint32_t buf_sz);
-void kcs_init(void);
+void kcs_device_init(char **config, uint8_t size);
+void kcs_write(uint8_t index, uint8_t *buf, uint32_t buf_sz);
 bool get_kcs_ok();
 void reset_kcs_ok();
 

--- a/common/service/ipmb/ipmb.h
+++ b/common/service/ipmb/ipmb.h
@@ -98,7 +98,6 @@ enum Channel_Target {
 	SELF = 0x0,
 	ME_IPMB = 0x01,
 	BMC_IPMB = 0x02,
-	HOST_KCS = 0x03,
 	SERVER_IPMB = 0x04,
 	EXP1_IPMB = 0x05,
 	SLOT1_BIC = 0x07,
@@ -115,6 +114,12 @@ enum Channel_Target {
 	BMC_USB = 0x20,
 	/* 21h-39h reserved. */
 	PLDM = 0x40,
+	/* 41h-4Fh reserved. */
+	HOST_KCS_1 = 0x50,
+	HOST_KCS_2 = 0x51,
+	HOST_KCS_3 = 0x52,
+	HOST_KCS_4 = 0x53,
+	/* 54h-5Fh are reserved for KCS */
 	RESERVED,
 };
 
@@ -172,13 +177,13 @@ typedef struct ipmi_msg {
                                          */
 	uint32_t timestamp; /**< Tick count at the beginning of the process */
 	uint8_t msg_chksum; /**< Message checksum */
-} __packed __aligned(4) ipmi_msg;
+} __attribute__((packed, aligned(4))) ipmi_msg;
 
 typedef struct ipmi_msg_cfg {
 	ipmi_msg buffer; /**< IPMI Message */
 	uint8_t retries; /**< Current retry counter */
 	struct ipmi_msg_cfg *next;
-} __packed __aligned(4) ipmi_msg_cfg;
+} __attribute__((packed, aligned(4))) ipmi_msg_cfg;
 
 bool pal_load_ipmb_config(void);
 void ipmb_init(void);

--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -316,7 +316,10 @@ void IPMI_handler(void *arug0, void *arug1, void *arug2)
 			break;
 #endif
 #ifdef CONFIG_IPMI_KCS_ASPEED
-		case HOST_KCS: {
+		case HOST_KCS_1:
+		case HOST_KCS_2:
+		case HOST_KCS_3:
+		case HOST_KCS_4: {
 			uint8_t *kcs_buff;
 			kcs_buff = malloc(KCS_BUFF_SIZE * sizeof(uint8_t));
 			if (kcs_buff == NULL) { // allocate fail, retry allocate
@@ -343,7 +346,8 @@ void IPMI_handler(void *arug0, void *arug1, void *arug2)
 			LOG_DBG("kcs from ipmi netfn %x, cmd %x, length %d, cc %x", kcs_buff[0],
 				kcs_buff[1], msg_cfg.buffer.data_len, kcs_buff[2]);
 
-			kcs_write(kcs_buff, msg_cfg.buffer.data_len + 3);
+			kcs_write(msg_cfg.buffer.InF_source - HOST_KCS_1, kcs_buff,
+				  msg_cfg.buffer.data_len + 3);
 			SAFE_FREE(kcs_buff);
 			break;
 		}

--- a/common/service/main.c
+++ b/common/service/main.c
@@ -62,9 +62,6 @@ void main(void)
 	sensor_init();
 	FRU_init();
 	ipmi_init();
-#ifdef CONFIG_IPMI_KCS_ASPEED
-	kcs_init();
-#endif
 #ifdef CONFIG_USB
 	usb_dev_init();
 #endif

--- a/meta-facebook/wc-mb/src/platform/plat_def.h
+++ b/meta-facebook/wc-mb/src/platform/plat_def.h
@@ -20,7 +20,6 @@
 #define ENABLE_ASD
 #define ENABLE_ISL69260
 
-#define HOST_KCS_PORT kcs3
 #define BMC_USB_PORT "CDC_ACM_0"
 
 #endif

--- a/meta-facebook/wc-mb/src/platform/plat_init.c
+++ b/meta-facebook/wc-mb/src/platform/plat_init.c
@@ -20,6 +20,7 @@
 #include "util_sys.h"
 #include "plat_class.h"
 #include "plat_gpio.h"
+#include "plat_kcs.h"
 #include "plat_pmic.h"
 
 SCU_CFG scu_cfg[] = {
@@ -87,6 +88,11 @@ void pal_pre_init()
 	disable_PRDY_interrupt();
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
 	postcode_led_ctl();
+}
+
+void pal_post_init()
+{
+	kcs_init();
 }
 
 void pal_device_init()

--- a/meta-facebook/wc-mb/src/platform/plat_kcs.c
+++ b/meta-facebook/wc-mb/src/platform/plat_kcs.c
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#include "plat_kcs.h"
+#include "kcs.h"
 
-#include "plat_i2c.h"
-
-#define BMC_USB_PORT "CDC_ACM_0"
-
-#define ENABLE_APML
-
-#endif
+void kcs_init(void)
+{
+	char *kcs_config[] = { "KCS3" };
+	kcs_device_init(kcs_config, ARRAY_SIZE(kcs_config));
+}

--- a/meta-facebook/wc-mb/src/platform/plat_kcs.h
+++ b/meta-facebook/wc-mb/src/platform/plat_kcs.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#ifndef PLAT_KCS_H
+#define PLAT_KCS_H
 
-#include "plat_i2c.h"
-
-#define BMC_USB_PORT "CDC_ACM_0"
-
-#define ENABLE_APML
+void kcs_init(void);
 
 #endif

--- a/meta-facebook/yv3-dl/src/platform/plat_def.h
+++ b/meta-facebook/yv3-dl/src/platform/plat_def.h
@@ -20,7 +20,6 @@
 #define ENABLE_ASD
 #define ENABLE_OEM_BRIDGE_NETFN_SHIFT
 
-#define HOST_KCS_PORT kcs4
 #define BMC_USB_PORT "CDC_ACM_0"
 
 #endif

--- a/meta-facebook/yv3-dl/src/platform/plat_init.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_init.c
@@ -20,6 +20,7 @@
 #include "util_sys.h"
 #include "plat_class.h"
 #include "plat_gpio.h"
+#include "plat_kcs.h"
 #include "util_worker.h"
 
 SCU_CFG scu_cfg[] = {
@@ -37,6 +38,11 @@ void pal_pre_init()
 	disable_PRDY_interrupt();
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
 	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
+}
+
+void pal_post_init()
+{
+	kcs_init();
 }
 
 void pal_device_init()

--- a/meta-facebook/yv3-dl/src/platform/plat_kcs.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_kcs.c
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#include "plat_kcs.h"
+#include "kcs.h"
 
-#include "plat_i2c.h"
-
-#define BMC_USB_PORT "CDC_ACM_0"
-
-#define ENABLE_APML
-
-#endif
+void kcs_init(void)
+{
+	char *kcs_config[] = { "KCS4" };
+	kcs_device_init(kcs_config, ARRAY_SIZE(kcs_config));
+}

--- a/meta-facebook/yv3-dl/src/platform/plat_kcs.h
+++ b/meta-facebook/yv3-dl/src/platform/plat_kcs.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#ifndef PLAT_KCS_H
+#define PLAT_KCS_H
 
-#include "plat_i2c.h"
-
-#define BMC_USB_PORT "CDC_ACM_0"
-
-#define ENABLE_APML
+void kcs_init(void);
 
 #endif

--- a/meta-facebook/yv35-cl/src/platform/plat_def.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_def.h
@@ -21,7 +21,6 @@
 #define ENABLE_ISL69260
 #define ENABLE_FIX_SENSOR
 
-#define HOST_KCS_PORT kcs3
 #define BMC_USB_PORT "CDC_ACM_0"
 
 #endif

--- a/meta-facebook/yv35-cl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_init.c
@@ -20,6 +20,7 @@
 #include "util_sys.h"
 #include "plat_class.h"
 #include "plat_gpio.h"
+#include "plat_kcs.h"
 #include "plat_pmic.h"
 #include "util_worker.h"
 
@@ -37,6 +38,11 @@ void pal_pre_init()
 	disable_PRDY_interrupt();
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
 	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
+}
+
+void pal_post_init()
+{
+	kcs_init();
 }
 
 void pal_device_init()

--- a/meta-facebook/yv35-cl/src/platform/plat_kcs.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_kcs.c
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#include "plat_kcs.h"
+#include "kcs.h"
 
-#include "plat_i2c.h"
-
-#define BMC_USB_PORT "CDC_ACM_0"
-
-#define ENABLE_APML
-
-#endif
+void kcs_init(void)
+{
+	char *kcs_config[] = { "KCS3" };
+	kcs_device_init(kcs_config, ARRAY_SIZE(kcs_config));
+}

--- a/meta-facebook/yv35-cl/src/platform/plat_kcs.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_kcs.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#ifndef PLAT_KCS_H
+#define PLAT_KCS_H
 
-#include "plat_i2c.h"
-
-#define BMC_USB_PORT "CDC_ACM_0"
-
-#define ENABLE_APML
+void kcs_init(void);
 
 #endif

--- a/meta-facebook/yv35-gl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-gl/boards/ast1030_evb.overlay
@@ -97,6 +97,11 @@
 	addr = <0xca2>;
 };
 
+&kcs4 {
+	status = "okay";
+	addr = <0xca4>;
+};
+
 &uart5 {
 	current-speed = <57600>;
 };
@@ -194,4 +199,8 @@
 
 &peci {
 	status = "okay";
+};
+
+&sram0 {
+	reg = <0 DT_SIZE_K(512)>, <0x80000 DT_SIZE_K(256)>;
 };

--- a/meta-facebook/yv35-gl/src/platform/plat_def.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_def.h
@@ -17,7 +17,6 @@
 #ifndef PLAT_DEF_H
 #define PLAT_DEF_H
 
-#define HOST_KCS_PORT kcs3
 #define BMC_USB_PORT "CDC_ACM_0"
 
 #endif

--- a/meta-facebook/yv35-gl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_init.c
@@ -18,6 +18,7 @@
 #include "power_status.h"
 #include "util_sys.h"
 #include "plat_gpio.h"
+#include "plat_kcs.h"
 
 /*
  * The operating voltage of GPIO input pins are lower than actual voltage because the chip 
@@ -46,6 +47,11 @@ SCU_CFG scu_cfg[] = {
 void pal_pre_init()
 {
 	scu_init(scu_cfg, ARRAY_SIZE(scu_cfg));
+}
+
+void pal_post_init()
+{
+	kcs_init();
 }
 
 void pal_set_sys_status()

--- a/meta-facebook/yv35-gl/src/platform/plat_kcs.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_kcs.c
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#include "plat_kcs.h"
+#include "kcs.h"
 
-#include "plat_i2c.h"
-
-#define BMC_USB_PORT "CDC_ACM_0"
-
-#define ENABLE_APML
-
-#endif
+void kcs_init(void)
+{
+	char *kcs_config[] = { "KCS3", "KCS4" };
+	kcs_device_init(kcs_config, ARRAY_SIZE(kcs_config));
+}

--- a/meta-facebook/yv35-gl/src/platform/plat_kcs.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_kcs.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#ifndef PLAT_KCS_H
+#define PLAT_KCS_H
 
-#include "plat_i2c.h"
-
-#define BMC_USB_PORT "CDC_ACM_0"
-
-#define ENABLE_APML
+void kcs_init(void);
 
 #endif

--- a/meta-facebook/yv35-hd/src/platform/plat_init.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_init.c
@@ -24,13 +24,13 @@
 #include "plat_i2c.h"
 #include "plat_pmic.h"
 #include "plat_apml.h"
+#include "plat_kcs.h"
 #include "rg3mxxb12.h"
 #include "util_worker.h"
 
 SCU_CFG scu_cfg[] = {
 	//register    value
 	{ 0x7e6e2610, 0xffffffff },
-	{ 0x7e6e2614, 0xffffffff },
 	{ 0x7e6e2618, 0xdc000000 },
 	{ 0x7e6e261c, 0x00000F32 },
 };
@@ -54,6 +54,11 @@ void pal_pre_init()
 	pcc_init();
 	apml_init();
 	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
+}
+
+void pal_post_init()
+{
+	kcs_init();
 }
 
 void pal_set_sys_status()

--- a/meta-facebook/yv35-hd/src/platform/plat_kcs.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_kcs.c
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#include "plat_kcs.h"
+#include "kcs.h"
 
-#include "plat_i2c.h"
-
-#define BMC_USB_PORT "CDC_ACM_0"
-
-#define ENABLE_APML
-
-#endif
+void kcs_init(void)
+{
+	char *kcs_config[] = { "KCS3" };
+	kcs_device_init(kcs_config, ARRAY_SIZE(kcs_config));
+}

--- a/meta-facebook/yv35-hd/src/platform/plat_kcs.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_kcs.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#ifndef PLAT_KCS_H
+#define PLAT_KCS_H
 
-#include "plat_i2c.h"
-
-#define BMC_USB_PORT "CDC_ACM_0"
-
-#define ENABLE_APML
+void kcs_init(void);
 
 #endif


### PR DESCRIPTION
Summary:
- BIC support multi-KCS channels.
- For Great Lakes, the IO address of KCS SMM mode is 0xCA4 and IPMI KCS port is 0xCA2 in POST mode.

Test Plan:
- Check IPMI command from OS is workable: pass
- Host boots into OS: pass

Log:
1. Check IPMI command from OS is workable. (Test with CL platform) uart:~$ kernel threads
Scheduler: 1 since last call
Threads:
 0x41420 KCS3_polling
        options: 0x0, priority: 0 timeout: 267416
        state: suspended, entry: 0xaf5d
        Total execution cycles: 1352900 (0 %)
        stack size 2560, unused 372, usage 2188 / 2560 (85 %)
...

root@bmc-oob:~# bic-util slot1 --reset
Performing BIC reset, status 0

uart:~$ ▒>)▒▒
...
uart:~$ [00:00:00.409,000] <inf> usb_cdc_acm: Device resumed [00:00:00.409,000] <inf> usb_cdc_acm: from suspend [00:00:00.715,000] <inf> usb_cdc_acm: Device configured BIC Ready

[root@FBK8_221107 ~]# ipmitool raw 0x6 0x1
 20 81 16 49 02 bf 15 a0 00 46 31 01 00 00 00

2. Host can boot into OS. ...
[92][99][92][92][92][A0][A0][A0][92][A0][92]
Version 2.22.1287. Copyright (C) 2022 AMI
BIOS Date: 11/30/2022 14:25:59 Ver: Y35CLD12
Press <DEL> or <ESC> to enter setup.[B6][AD]

>>Checking Media Presence......
>>Media Present......
>>Start PXE over IPv6 on MAC: 84-16-0C-8B-B5-30.
  PXE-E21: Remote boot cancelled.
[D9][AD]
...
[root@FBK8_221107 ~]#