### PR TITLE
common: support I3C driver

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0010-i3c-slave-mqueue-add-build-assertion-for-init-priori.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0010-i3c-slave-mqueue-add-build-assertion-for-init-priori.patch
@@ -1,0 +1,32 @@
+From d4e727aeda6b2bbde0af262cdf327c9e146e385b Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Tue, 5 Jul 2022 16:43:21 +0800
+Subject: [PATCH 10/30] i3c: slave: mqueue: add build assertion for init
+ priority
+
+Add a build assertion to ensure the i3c controller is initialized prior
+to the target/slave device driver.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: I32b6a30f48b59735052542fe8e63343fc96e7ba3
+---
+ drivers/i3c/slave/i3c_slave_mqueue.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/i3c/slave/i3c_slave_mqueue.c b/drivers/i3c/slave/i3c_slave_mqueue.c
+index a6908c0b60..ad511d6740 100644
+--- a/drivers/i3c/slave/i3c_slave_mqueue.c
++++ b/drivers/i3c/slave/i3c_slave_mqueue.c
+@@ -177,6 +177,9 @@ static void i3c_slave_mqueue_init(const struct device *dev)
+ 	i3c_slave_register(obj->i3c_controller, &slave_data);
+ }
+ 
++BUILD_ASSERT(CONFIG_I3C_SLAVE_INIT_PRIORITY > CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
++	     "I3C controller must be initialized prior to target device initialization");
++
+ #define I3C_SLAVE_MQUEUE_INIT(n)                                                                   \
+ 	static int i3c_slave_mqueue_config_func_##n(const struct device *dev);                     \
+ 	static const struct i3c_slave_mqueue_config i3c_slave_mqueue_config_##n = {                \
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0011-i3c-add-SETHID-CCC-support.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0011-i3c-add-SETHID-CCC-support.patch
@@ -1,0 +1,64 @@
+From 03bf8eef42212333c145577b7ef226affdae30c6 Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Fri, 15 Jul 2022 17:18:16 +0800
+Subject: [PATCH 11/30] i3c: add SETHID CCC support
+
+Add SETHID CCC support, this CCC shall be sent before SETAASA as
+specified in JESD403 standard.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: I439c7c7aa2ec27c98990724ce1f9d8861f7ca79f
+---
+ drivers/i3c/i3c_common.c  | 15 +++++++++++++++
+ include/drivers/i3c/i3c.h |  2 ++
+ 2 files changed, 17 insertions(+)
+
+diff --git a/drivers/i3c/i3c_common.c b/drivers/i3c/i3c_common.c
+index 261c4de5ea..400a572f1e 100644
+--- a/drivers/i3c/i3c_common.c
++++ b/drivers/i3c/i3c_common.c
+@@ -54,6 +54,21 @@ int i3c_master_send_rstdaa(const struct device *master)
+ 	return i3c_master_send_ccc(master, &ccc);
+ }
+ 
++int i3c_master_send_sethid(const struct device *master)
++{
++	struct i3c_ccc_cmd ccc;
++	uint8_t hid = 0;
++
++	ccc.addr = I3C_BROADCAST_ADDR;
++	ccc.id = I3C_CCC_SETHID;
++	ccc.payload.length = 1;
++	ccc.payload.data = &hid;
++	ccc.rnw = 0;
++	ccc.ret = 0;
++
++	return i3c_master_send_ccc(master, &ccc);
++}
++
+ int i3c_master_send_aasa(const struct device *master)
+ {
+ 	struct i3c_ccc_cmd ccc;
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index 084a69f695..48b4634bda 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -21,6 +21,7 @@
+ /* broadcast only commands */
+ #define I3C_CCC_ENTDAA          0x07
+ #define I3C_CCC_SETAASA         0x29
++#define I3C_CCC_SETHID		0x61
+ 
+ /* unicast only commands */
+ #define I3C_CCC_SETDASA         (0x7 | I3C_CCC_DIRECT)
+@@ -220,6 +221,7 @@ int i3c_aspeed_slave_wait_data_consume(const struct device *dev);
+ int i3c_master_send_enec(const struct device *master, uint8_t addr, uint8_t evt);
+ int i3c_master_send_disec(const struct device *master, uint8_t addr, uint8_t evt);
+ int i3c_master_send_rstdaa(const struct device *master);
++int i3c_master_send_sethid(const struct device *master);
+ int i3c_master_send_aasa(const struct device *master);
+ int i3c_master_send_setmrl(const struct device *master, uint8_t addr, uint16_t mrl,
+ 			   uint8_t ibi_payload_size);
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0012-i3c-aspeed-use-OD-SCL-as-PP-SCL-when-sending-SETHID-.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0012-i3c-aspeed-use-OD-SCL-as-PP-SCL-when-sending-SETHID-.patch
@@ -1,0 +1,63 @@
+From 72b8d794a325b2e65167f68e089516cd972d0be2 Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Fri, 15 Jul 2022 17:23:50 +0800
+Subject: [PATCH 12/30] i3c: aspeed: use OD SCL as PP SCL when sending SETHID
+ CCC
+
+According to section 3.5.2.7 in JESD403 spec. v1.1:
+
+"The host shall send this CCC at a speed not exceeding 1MHz to ensure
+error probability is minimized."
+
+So we use OD timing for PP timing when sending SETHID, then pop the
+setting when existing send_ccc function.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: Ica21575fbfb00ede24fdad412dadab47ebb79c32
+---
+ drivers/i3c/i3c_aspeed.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index ecf8dece96..dd09a9724c 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1467,9 +1467,13 @@ int i3c_aspeed_slave_get_event_enabling(const struct device *dev, uint32_t *even
+ int i3c_aspeed_master_send_ccc(const struct device *dev, struct i3c_ccc_cmd *ccc)
+ {
+ 	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
++	struct i3c_aspeed_config *config = DEV_CFG(dev);
++	struct i3c_register_s *i3c_register = config->base;
+ 	struct i3c_aspeed_xfer xfer;
+ 	struct i3c_aspeed_cmd cmd;
+ 	union i3c_device_cmd_queue_port_s cmd_hi, cmd_lo;
++	uint32_t pp_timing = i3c_register->pp_timing.value;
++	uint32_t od_timing = i3c_register->od_timing.value;
+ 	int pos = 0;
+ 	int ret;
+ 
+@@ -1480,6 +1484,10 @@ int i3c_aspeed_master_send_ccc(const struct device *dev, struct i3c_ccc_cmd *ccc
+ 		}
+ 	}
+ 
++	if (ccc->id == I3C_CCC_SETHID) {
++		i3c_register->pp_timing.value = od_timing;
++	}
++
+ 	xfer.ncmds = 1;
+ 	xfer.cmds = &cmd;
+ 	xfer.ret = 0;
+@@ -1519,6 +1527,10 @@ int i3c_aspeed_master_send_ccc(const struct device *dev, struct i3c_ccc_cmd *ccc
+ 
+ 	ret = xfer.ret;
+ 
++	if (ccc->id == I3C_CCC_SETHID) {
++		i3c_register->pp_timing.value = pp_timing;
++	}
++
+ 	return ret;
+ }
+ 
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0013-i3c-aspeed-add-API-to-set-the-static-address-in-slav.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0013-i3c-aspeed-add-API-to-set-the-static-address-in-slav.patch
@@ -1,0 +1,98 @@
+From 10f3c3cebf2fb8dd8f9a2d72dfeda24dca7f2b2a Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Mon, 18 Jul 2022 13:56:42 +0800
+Subject: [PATCH 13/30] i3c: aspeed: add API to set the static address in slave
+ mode
+
+When the I3C controller runs in slave mode, it is necessary for the
+slave application to set the new static address according to different
+user scenario in run time.  For example, there are two AST1030 BIC
+boards with the same firmware attached on the same bus, it is needed to
+set different static addresses for these two BIC boards to avoid address
+confliction.  The firmware developer can refer to the sample code below
+to set the new address:
+
+```
+&i3c1 {
+	...
+	// the static address of i3c1 was 0x9
+	i3c1_smq:i3c-slave-mqueue@9 {
+		...
+		reg = <0x9>;
+	};
+};
+
+const struct device *slave_controller;
+uint8_t new_addr = 0x10
+
+slave_controller =
+device_get_binding(DT_BUS_LABEL(DT_NODELABEL(i3c1_smq)));
+
+ret = i3c_slave_set_static_addr(slave_controller, new_addr);
+```
+
+then the static address of i3c1 will be updated to 0x10.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: Ibeb698f76a90a3c4bce3b0ae2d766b8f7603ea85
+---
+ drivers/i3c/i3c_aspeed.c  | 15 +++++++++++++++
+ include/drivers/i3c/i3c.h |  9 +++++++++
+ 2 files changed, 24 insertions(+)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index dd09a9724c..b3bb9fc9e6 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1429,6 +1429,21 @@ int i3c_aspeed_slave_wait_data_consume(const struct device *dev)
+ 	return 0;
+ }
+ 
++int i3c_aspeed_slave_set_static_addr(const struct device *dev, uint8_t static_addr)
++{
++	struct i3c_aspeed_config *config = DEV_CFG(dev);
++	struct i3c_register_s *i3c_register = config->base;
++	union i3c_device_addr_s device_addr;
++
++	config->assigned_addr = static_addr;
++
++	device_addr.value = i3c_register->device_addr.value;
++	device_addr.fields.static_addr = static_addr;
++	i3c_register->device_addr.value = device_addr.value;
++
++	return 0;
++}
++
+ int i3c_aspeed_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynamic_addr)
+ {
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index 48b4634bda..d258439b5b 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -164,6 +164,14 @@ int i3c_aspeed_master_request_ibi(struct i3c_dev_desc *i3cdev, struct i3c_ibi_ca
+ int i3c_aspeed_master_enable_ibi(struct i3c_dev_desc *i3cdev);
+ int i3c_aspeed_slave_register(const struct device *dev, struct i3c_slave_setup *slave_data);
+ 
++/**
++ * @brief set the static address of the i3c controller in slave mode
++ * @param dev the I3C controller in slave mode
++ * @param static_addr the new static address
++ * @return 0 if the static address is set
++ */
++int i3c_aspeed_slave_set_static_addr(const struct device *dev, uint8_t static_addr);
++
+ /**
+  * @brief get the assigned dynamic address of the i3c controller
+  * @param dev the I3C controller in slave mode
+@@ -235,6 +243,7 @@ int i3c_master_send_getbcr(const struct device *master, uint8_t addr, uint8_t *b
+ #define i3c_master_request_ibi		i3c_aspeed_master_request_ibi
+ #define i3c_master_enable_ibi		i3c_aspeed_master_enable_ibi
+ #define i3c_slave_register		i3c_aspeed_slave_register
++#define i3c_slave_set_static_addr	i3c_aspeed_slave_set_static_addr
+ #define i3c_slave_send_sir		i3c_aspeed_slave_send_sir
+ #define i3c_slave_put_read_data		i3c_aspeed_slave_put_read_data
+ #define i3c_slave_wait_data_consume	i3c_aspeed_slave_wait_data_consume
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0014-i3c-aspeed-wait-resp_q_ready-when-slave-send-sir.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0014-i3c-aspeed-wait-resp_q_ready-when-slave-send-sir.patch
@@ -1,0 +1,33 @@
+From 878c53c0aaa748a7fd9295059677fb9fbe9dc9eb Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Wed, 24 Aug 2022 13:23:50 +0800
+Subject: [PATCH 14/30] i3c: aspeed: wait resp_q_ready when slave send sir.
+
+When i3c send the sir request, the controller will have the two interrupt
+to indicate the procedure of the transfer:
+1. ibi_update: Master ack the sir request.
+2. resp_q_ready: IBI data is sent. (limited: resp_q_thld == 0)
+This patch adds the event flag to wait for resp_q_ready to ensure that the
+ibi data is sent before clearing the pec enabe bit.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I29ce7706ff6c7cdd197407747584a5e56eb77631
+---
+ drivers/i3c/i3c_aspeed.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index b3bb9fc9e6..4a33228aeb 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1393,6 +1393,7 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+ 	osEventFlagsClear(obj->event_id, ~osFlagsError);
+ 	events.value = 0;
+ 	events.fields.ibi_update = 1;
++	events.fields.resp_q_ready = 1;
+ 
+ 	i3c_register->queue_thld_ctrl.fields.resp_q_thld = 1 - 1;
+ 	i3c_register->device_ctrl.fields.slave_mdb = payload->buf[0];
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0015-i3c-aspeed-wait-resp_q_ready-when-slave-send-ibi_not.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0015-i3c-aspeed-wait-resp_q_ready-when-slave-send-ibi_not.patch
@@ -1,0 +1,30 @@
+From b9a92ed4f96592d5f96c1de4c6672a4a1fec7b54 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Tue, 30 Aug 2022 16:26:44 +0800
+Subject: [PATCH 15/30] i3c: aspeed: wait resp_q_ready when slave send
+ ibi_notify.
+
+same as the patch:
+commit 2e799a0fc952 ("i3c: aspeed: wait resp_q_ready when slave send sir.")
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: Ifff8166b9977c419f12277126b57d737cb44eea1
+---
+ drivers/i3c/i3c_aspeed.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 4a33228aeb..d6f20ab4be 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1342,6 +1342,7 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 		osEventFlagsClear(obj->event_id, ~osFlagsError);
+ 		events.value = 0;
+ 		events.fields.ibi_update = 1;
++		events.fields.resp_q_ready = 1;
+ 
+ 		i3c_register->queue_thld_ctrl.fields.resp_q_thld = 1 - 1;
+ 		i3c_register->device_ctrl.fields.slave_mdb = ibi_notify->buf[0];
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0016-i3c-aspeed-Add-the-option-to-enable-the-pec-for-priv.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0016-i3c-aspeed-Add-the-option-to-enable-the-pec-for-priv.patch
@@ -1,0 +1,165 @@
+From 50914fdc81a3840579c29d1f4e4198584328ba02 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Tue, 6 Sep 2022 18:06:29 +0800
+Subject: [PATCH 16/30] i3c: aspeed: Add the option to enable the pec for
+ priv-xfer.
+
+Enable the priv-xfer-pec property when i3c want to communicate with data
+that have PEC. The PEC will auto append to the tail of the data when doing
+private transfer and verify the PEC when receiving the data from master.
+The reason for using software pec instead of the hardware pec is that
+latter can't distinguish whether the PEC is used in CCC or private
+transfer and the controller can't aware DEVCTRL CCC to decide the time to
+enable/disable the PEC function.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I8762c7d323fc04d29afd4076597c2baf117501aa
+---
+ drivers/i3c/i3c_aspeed.c         | 61 ++++++++++++++++++++++++++++++--
+ dts/bindings/i3c/aspeed,i3c.yaml |  8 +++++
+ 2 files changed, 67 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index d6f20ab4be..f2ff191f25 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -15,6 +15,7 @@
+ #include <init.h>
+ #include <sys/sys_io.h>
+ #include <logging/log.h>
++#include <sys/crc.h>
+ #define LOG_LEVEL CONFIG_I3C_LOG_LEVEL
+ LOG_MODULE_REGISTER(i3c);
+ 
+@@ -480,6 +481,7 @@ struct i3c_aspeed_config {
+ 	int assigned_addr;
+ 	int inst_id;
+ 	int ibi_append_pec;
++	int priv_xfer_pec;
+ 	int sda_tx_hold_ns;
+ 	int i3c_pp_scl_hi_period_ns;
+ 	int i3c_pp_scl_lo_period_ns;
+@@ -541,6 +543,44 @@ struct i3c_aspeed_obj {
+ #define DEV_DATA(dev)			((struct i3c_aspeed_obj *)(dev)->data)
+ #define DESC_PRIV(desc)			((struct i3c_aspeed_dev_priv *)(desc)->priv_data)
+ 
++static uint8_t *pec_append(const struct device *dev, uint8_t *ptr, uint8_t len)
++{
++	struct i3c_aspeed_config *config = DEV_CFG(dev);
++	struct i3c_register_s *i3c_register = config->base;
++	uint8_t *xfer_buf;
++	uint8_t pec_v;
++	uint8_t addr_rnw;
++
++	addr_rnw = i3c_register->device_addr.fields.dynamic_addr << 1 | 0x1;
++	xfer_buf = k_malloc(len + 1);
++	memcpy(xfer_buf, ptr, len);
++
++	pec_v = crc8_ccitt(0, &addr_rnw, 1);
++	pec_v = crc8_ccitt(pec_v, xfer_buf, len);
++	LOG_DBG("pec = %x", pec_v);
++	xfer_buf[len] = pec_v;
++
++	return xfer_buf;
++}
++
++static int pec_valid(const struct device *dev, uint8_t *ptr, uint8_t len)
++{
++	struct i3c_aspeed_config *config = DEV_CFG(dev);
++	struct i3c_register_s *i3c_register = config->base;
++	uint8_t pec_v;
++	uint8_t addr_rnw;
++
++	if (len == 0 || ptr == NULL)
++		return -EINVAL;
++
++	addr_rnw = i3c_register->device_addr.fields.dynamic_addr << 1;
++
++	pec_v = crc8_ccitt(0, &addr_rnw, 1);
++	pec_v = crc8_ccitt(pec_v, ptr, len - 1);
++	LOG_DBG("pec = %x %x", pec_v, ptr[len - 1]);
++	return (pec_v == ptr[len - 1]) ? 0 : -EIO;
++}
++
+ static int i3c_aspeed_get_pos(struct i3c_aspeed_obj *obj, uint8_t addr)
+ {
+ 	int pos;
+@@ -560,6 +600,7 @@ static void i3c_aspeed_rd_rx_fifo(struct i3c_aspeed_obj *obj, uint8_t *bytes, in
+ 	struct i3c_register_s *i3c_register = obj->config->base;
+ 	uint32_t *dst = (uint32_t *)bytes;
+ 	int nwords = nbytes >> 2;
++	int ret;
+ 	int i;
+ 
+ 	for (i = 0; i < nwords; i++) {
+@@ -572,6 +613,13 @@ static void i3c_aspeed_rd_rx_fifo(struct i3c_aspeed_obj *obj, uint8_t *bytes, in
+ 		tmp = i3c_register->rx_tx_data_port;
+ 		memcpy(bytes + (nbytes & ~0x3), &tmp, nbytes & 3);
+ 	}
++	if (obj->config->priv_xfer_pec) {
++		ret = pec_valid(obj->dev, bytes, nbytes);
++		if (ret) {
++			LOG_ERR("PEC error\n");
++			memset(bytes, 0, nbytes);
++		}
++	}
+ }
+ 
+ static void i3c_aspeed_end_xfer(struct i3c_aspeed_obj *obj)
+@@ -1328,6 +1376,7 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 	struct i3c_register_s *i3c_register = config->base;
+ 	union i3c_intr_s events;
+ 	union i3c_device_cmd_queue_port_s cmd;
++	uint8_t *xfer_buf;
+ 
+ 	__ASSERT_NO_MSG(data);
+ 	__ASSERT_NO_MSG(data->buf);
+@@ -1357,9 +1406,16 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 		}
+ 	}
+ 
+-	i3c_aspeed_wr_tx_fifo(obj, data->buf, data->size);
++	if (config->priv_xfer_pec) {
++		xfer_buf = pec_append(dev, data->buf, data->size);
++		i3c_aspeed_wr_tx_fifo(obj, xfer_buf, data->size + 1);
++		cmd.slave_data_cmd.dl = data->size + 1;
++		k_free(xfer_buf);
++	} else {
++		i3c_aspeed_wr_tx_fifo(obj, data->buf, data->size);
++		cmd.slave_data_cmd.dl = data->size;
++	}
+ 	cmd.slave_data_cmd.cmd_attr = COMMAND_PORT_SLAVE_DATA_CMD;
+-	cmd.slave_data_cmd.dl = data->size;
+ 	i3c_register->cmd_queue_port.value = cmd.value;
+ 
+ 	if (ibi_notify) {
+@@ -1640,6 +1696,7 @@ static int i3c_aspeed_init(const struct device *dev)
+ 		.assigned_addr = DT_INST_PROP_OR(n, assigned_address, 0),                          \
+ 		.inst_id = DT_INST_PROP_OR(n, instance_id, 0),                                     \
+ 		.ibi_append_pec = DT_INST_PROP_OR(n, ibi_append_pec, 0),                           \
++		.priv_xfer_pec = DT_INST_PROP_OR(n, priv_xfer_pec, 0),                             \
+ 		.sda_tx_hold_ns = DT_INST_PROP_OR(n, sda_tx_hold_ns, 0),                           \
+ 		.i3c_pp_scl_hi_period_ns = DT_INST_PROP_OR(n, i3c_pp_scl_hi_period_ns, 0),         \
+ 		.i3c_pp_scl_lo_period_ns = DT_INST_PROP_OR(n, i3c_pp_scl_lo_period_ns, 0),         \
+diff --git a/dts/bindings/i3c/aspeed,i3c.yaml b/dts/bindings/i3c/aspeed,i3c.yaml
+index 225c87f2c6..9a993b2d24 100644
+--- a/dts/bindings/i3c/aspeed,i3c.yaml
++++ b/dts/bindings/i3c/aspeed,i3c.yaml
+@@ -28,6 +28,14 @@ properties:
+     type: boolean
+     description: Append PEC byte to the IBI data.  Enable this option in slave mode if the master device is AST2600 or AST1030A0.
+ 
++  priv-xfer-pec:
++    required: false
++    type: boolean
++    description: |
++      Enable this option in slave mode if the i3c want to communicate with data that have PEC.
++      The PEC will auto append to the tail of the data when doing private transfer and verify
++      the PEC when receiving the data from master.
++
+   i3c-pp-scl-hi-period-ns:
+     required: false
+     type: int
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0017-i3c-aspeed-Read-rx-fifo-when-tid-0x8-in-slave-mode.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0017-i3c-aspeed-Read-rx-fifo-when-tid-0x8-in-slave-mode.patch
@@ -1,0 +1,41 @@
+From 518b51265928bc50d36e4814a050fe9cd66795c8 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Wed, 7 Sep 2022 15:24:05 +0800
+Subject: [PATCH 17/30] i3c: aspeed: Read rx fifo when tid == 0x8 in slave mode
+
+In slave mode, tid will only be 0x8 (master) or 0xf (DEFSLAVE CCC)
+If it is 0xf the data will auto update to the DCR and rx fifo won't get
+any data. So, we only need to read rx fifo when tid == 0x8
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I7cafa54d1522969f3cabe1bafafa71e33c84fec9
+---
+ drivers/i3c/i3c_aspeed.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index f2ff191f25..51decfb743 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -144,6 +144,8 @@ union i3c_device_resp_queue_port_s {
+ 		volatile uint32_t err_status : 4;		/* bit[31:28] */
+ 	} fields;
+ }; /* offset 0x10 */
++#define SLAVE_TID_MASTER_WRITE_DATA 0x8
++#define SLAVE_TID_DEFSLV_WRITE_DATA 0xF
+ 
+ union i3c_ibi_queue_status_s {
+ 	volatile uint32_t value;
+@@ -686,7 +688,8 @@ static void i3c_aspeed_slave_rx_data(struct i3c_aspeed_obj *obj)
+ 		struct i3c_slave_payload *payload;
+ 
+ 		resp.value = i3c_register->resp_queue_port.value;
+-		if (resp.fields.data_length && !resp.fields.err_status) {
++		if (resp.fields.data_length && !resp.fields.err_status &&
++		    resp.fields.tid == SLAVE_TID_MASTER_WRITE_DATA) {
+ 			if (cb->write_requested) {
+ 				payload = cb->write_requested(obj->slave_data.dev);
+ 				payload->size = resp.fields.data_length;
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0018-i3c-aspeed-Change-the-meaning-of-the-PID-11-0.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0018-i3c-aspeed-Change-the-meaning-of-the-PID-11-0.patch
@@ -1,0 +1,113 @@
+From 6303295c287ec48e3423034f9e11337a72006ad5 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Tue, 13 Sep 2022 18:32:15 +0800
+Subject: [PATCH 18/30] i3c: aspeed: Change the meaning of the PID[11:0]
+
+This patch change the meaning of the PID[11:0] to extra information
+which can be used to identify the different BIC instead of the dcr.
+The user can use the API i3c_set_pid_extra_info to change this fields in
+application layer.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I6bacea87cacd343295d4193dab0681c5c45505bf
+---
+ drivers/i3c/i3c_aspeed.c         | 16 +++++++++++++++-
+ dts/bindings/i3c/aspeed,i3c.yaml |  7 ++++++-
+ include/drivers/i3c/i3c.h        |  1 +
+ 3 files changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 51decfb743..303e1f8940 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -305,7 +305,7 @@ union i3c_slave_pid_hi_s {
+ union i3c_slave_pid_lo_s {
+ 	volatile uint32_t value;
+ 	struct {
+-		volatile uint32_t dcr : 12;			/* bit[11:0] */
++		volatile uint32_t extra_info : 12;		/* bit[11:0] */
+ 		volatile uint32_t inst_id : 4;			/* bit[15:12] */
+ 		volatile uint32_t part_id : 16;			/* bit[31:16] */
+ 	} fields;
+@@ -479,6 +479,7 @@ struct i3c_aspeed_config {
+ 	const clock_control_subsys_t clock_id;
+ 	uint32_t i3c_scl_hz;
+ 	uint32_t i2c_scl_hz;
++	uint16_t pid_extra_info;
+ 	int secondary;
+ 	int assigned_addr;
+ 	int inst_id;
+@@ -1014,6 +1015,7 @@ static void i3c_aspeed_init_pid(struct i3c_aspeed_obj *obj)
+ 	i3c_register->slave_pid_hi.value = slave_pid_hi.value;
+ 
+ 	slave_pid_lo.value = 0;
++	slave_pid_lo.fields.extra_info = config->pid_extra_info;
+ 	slave_pid_lo.fields.part_id = rev_id;
+ 	slave_pid_lo.fields.inst_id = config->inst_id;
+ 	i3c_register->slave_pid_lo.value = slave_pid_lo.value;
+@@ -1505,6 +1507,17 @@ int i3c_aspeed_slave_set_static_addr(const struct device *dev, uint8_t static_ad
+ 	return 0;
+ }
+ 
++void i3c_aspeed_set_pid_extra_info(const struct device *dev, uint16_t extra_info)
++{
++	struct i3c_aspeed_config *config = DEV_CFG(dev);
++	struct i3c_register_s *i3c_register = config->base;
++	union i3c_slave_pid_lo_s slave_pid_lo;
++
++	slave_pid_lo.value = i3c_register->slave_pid_lo.value;
++	slave_pid_lo.fields.extra_info = extra_info;
++	i3c_register->slave_pid_lo.value = slave_pid_lo.value;
++}
++
+ int i3c_aspeed_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynamic_addr)
+ {
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
+@@ -1701,6 +1714,7 @@ static int i3c_aspeed_init(const struct device *dev)
+ 		.ibi_append_pec = DT_INST_PROP_OR(n, ibi_append_pec, 0),                           \
+ 		.priv_xfer_pec = DT_INST_PROP_OR(n, priv_xfer_pec, 0),                             \
+ 		.sda_tx_hold_ns = DT_INST_PROP_OR(n, sda_tx_hold_ns, 0),                           \
++		.pid_extra_info = DT_INST_PROP_OR(n, pid_extra_info, 0),                           \
+ 		.i3c_pp_scl_hi_period_ns = DT_INST_PROP_OR(n, i3c_pp_scl_hi_period_ns, 0),         \
+ 		.i3c_pp_scl_lo_period_ns = DT_INST_PROP_OR(n, i3c_pp_scl_lo_period_ns, 0),         \
+ 		.i3c_od_scl_hi_period_ns = DT_INST_PROP_OR(n, i3c_od_scl_hi_period_ns, 0),         \
+diff --git a/dts/bindings/i3c/aspeed,i3c.yaml b/dts/bindings/i3c/aspeed,i3c.yaml
+index 9a993b2d24..de9054e88b 100644
+--- a/dts/bindings/i3c/aspeed,i3c.yaml
++++ b/dts/bindings/i3c/aspeed,i3c.yaml
+@@ -16,7 +16,7 @@ properties:
+   assigned-address:
+     required: true
+     type: int
+-    description: Dynamic address when playing the role as the main master
++    description: Dynamic address when playing the role as the main master. Static address when playing the role as the slave.
+ 
+   instance-id:
+     required: true
+@@ -36,6 +36,11 @@ properties:
+       The PEC will auto append to the tail of the data when doing private transfer and verify
+       the PEC when receiving the data from master.
+ 
++  pid-extra-info:
++    required: false
++    type: int
++    description: Extra information of the PID Bits[11:0]. Use to identify the different BIC.
++
+   i3c-pp-scl-hi-period-ns:
+     required: false
+     type: int
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index d258439b5b..c7409b864c 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -249,6 +249,7 @@ int i3c_master_send_getbcr(const struct device *master, uint8_t addr, uint8_t *b
+ #define i3c_slave_wait_data_consume	i3c_aspeed_slave_wait_data_consume
+ #define i3c_slave_get_dynamic_addr	i3c_aspeed_slave_get_dynamic_addr
+ #define i3c_slave_get_event_enabling	i3c_aspeed_slave_get_event_enabling
++#define i3c_set_pid_extra_info		i3c_aspeed_set_pid_extra_info
+ 
+ int i3c_jesd403_read(struct i3c_dev_desc *slave, uint8_t *addr, int addr_size, uint8_t *data,
+ 		     int data_size);
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0019-i3c-aspeed-Declare-i3c_aspeed_set_pid_extra_info-in-.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0019-i3c-aspeed-Declare-i3c_aspeed_set_pid_extra_info-in-.patch
@@ -1,0 +1,37 @@
+From d540156ec085e82cfaecd6279795ddc338d4c176 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Fri, 16 Sep 2022 10:41:58 +0800
+Subject: [PATCH 19/30] i3c: aspeed: Declare i3c_aspeed_set_pid_extra_info in
+ i3c.h
+
+This patch add the declartion of the i3c_aspeed_set_pid_extra_info to
+avoid the compiler warning of the implicit-function-declaration.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I7b218ead583b88fb4ce76d178a2a1ab04fb4ac57
+---
+ include/drivers/i3c/i3c.h | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index c7409b864c..d3970a3c18 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -225,6 +225,14 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+  */
+ int i3c_aspeed_slave_wait_data_consume(const struct device *dev);
+ 
++/**
++ * @brief set the pid extra info of the i3c controller
++ * @param dev the I3C controller
++ * @param extra_info the extra info of the pid bits[11:0]
++ * @return
++ */
++void i3c_aspeed_set_pid_extra_info(const struct device *dev, uint16_t extra_info);
++
+ /* common API */
+ int i3c_master_send_enec(const struct device *master, uint8_t addr, uint8_t evt);
+ int i3c_master_send_disec(const struct device *master, uint8_t addr, uint8_t evt);
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0020-i3c-aspeed-Check-the-value-of-pid-extra-info.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0020-i3c-aspeed-Check-the-value-of-pid-extra-info.patch
@@ -1,0 +1,60 @@
+From 148dc5d7d2ebed5caad3d993e915c5f9009c5f67 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Fri, 16 Sep 2022 11:31:36 +0800
+Subject: [PATCH 20/30] i3c: aspeed: Check the value of pid extra info.
+
+This patch add the condition to check the value of extra info to ensure
+that the value will be contained in bits[11:0].
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I56d667e2a830678a2ad963101deb93b5a16efe16
+---
+ drivers/i3c/i3c_aspeed.c  | 7 ++++++-
+ include/drivers/i3c/i3c.h | 4 ++--
+ 2 files changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 303e1f8940..5e8c621c46 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1507,15 +1507,20 @@ int i3c_aspeed_slave_set_static_addr(const struct device *dev, uint8_t static_ad
+ 	return 0;
+ }
+ 
+-void i3c_aspeed_set_pid_extra_info(const struct device *dev, uint16_t extra_info)
++int i3c_aspeed_set_pid_extra_info(const struct device *dev, uint16_t extra_info)
+ {
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
+ 	struct i3c_register_s *i3c_register = config->base;
+ 	union i3c_slave_pid_lo_s slave_pid_lo;
+ 
++	if (extra_info > GENMASK(11, 0))
++		return -EINVAL;
++
+ 	slave_pid_lo.value = i3c_register->slave_pid_lo.value;
+ 	slave_pid_lo.fields.extra_info = extra_info;
+ 	i3c_register->slave_pid_lo.value = slave_pid_lo.value;
++
++	return 0;
+ }
+ 
+ int i3c_aspeed_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynamic_addr)
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index d3970a3c18..094492d5c3 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -229,9 +229,9 @@ int i3c_aspeed_slave_wait_data_consume(const struct device *dev);
+  * @brief set the pid extra info of the i3c controller
+  * @param dev the I3C controller
+  * @param extra_info the extra info of the pid bits[11:0]
+- * @return
++ * @return int 0 = success
+  */
+-void i3c_aspeed_set_pid_extra_info(const struct device *dev, uint16_t extra_info);
++int i3c_aspeed_set_pid_extra_info(const struct device *dev, uint16_t extra_info);
+ 
+ /* common API */
+ int i3c_master_send_enec(const struct device *master, uint8_t addr, uint8_t evt);
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0021-i3c-aspeed-reset-the-IBI-queue-if-unregistered-IBI-s.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0021-i3c-aspeed-reset-the-IBI-queue-if-unregistered-IBI-s.patch
@@ -1,0 +1,34 @@
+From 79f7511d8b8d92b940e227f056f3e4e0947c0a20 Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Fri, 23 Sep 2022 17:09:23 +0800
+Subject: [PATCH 21/30] i3c: aspeed: reset the IBI queue if unregistered IBI
+ source
+
+If the IBI source is not registered, ignore the IBI request by resetting
+the IBI queue.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: I661b7f8642f3717ff50d2f6e6174a3f4c6618ec1
+---
+ drivers/i3c/i3c_aspeed.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 5e8c621c46..5d767442d6 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -763,6 +763,11 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 		}
+ 
+ 		pos = i3c_aspeed_get_pos(obj, ibi_status.id >> 1);
++		if (pos < 0) {
++			LOG_ERR("unregistered IBI source: 0x%x\n", ibi_status.id >> 1);
++			i3c_register->reset_ctrl.fields.ibi_queue_reset = 1;
++			continue;
++		}
+ 
+ 		i3cdev = obj->dev_descs[pos];
+ 		priv = DESC_PRIV(i3cdev);
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0022-drivers-i3c-fix-uninitialized-value-of-ccc.id.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0022-drivers-i3c-fix-uninitialized-value-of-ccc.id.patch
@@ -1,0 +1,41 @@
+From f528f23d9fe6e010059e2ce6543ca64cd5f3644f Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Fri, 23 Sep 2022 17:18:44 +0800
+Subject: [PATCH 22/30] drivers: i3c: fix uninitialized value of ccc.id
+
+The ccc.id was uninitialized and be used.  Assign an initial value for
+it and check if it has been assigne a value in cmd_send_ccc.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: I05e1ba2ff155b6d871b987308aca7b4631699294
+---
+ drivers/i3c/i3c_shell.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/i3c/i3c_shell.c b/drivers/i3c/i3c_shell.c
+index 396963e86f..d689af0d3d 100644
+--- a/drivers/i3c/i3c_shell.c
++++ b/drivers/i3c/i3c_shell.c
+@@ -158,6 +158,7 @@ static int cmd_send_ccc(const struct shell *shell, size_t argc, char **argv)
+ 	}
+ 
+ 	ccc.rnw = 0;
++	ccc.id = 0;
+ 
+ 	while ((c = shell_getopt(shell, argc - 1, &argv[1], "ha:i:w:r:")) != -1) {
+ 		state = shell_getopt_state_get(shell);
+@@ -198,6 +199,11 @@ static int cmd_send_ccc(const struct shell *shell, size_t argc, char **argv)
+ 		}
+ 	}
+ 
++	if (ccc.id == 0) {
++		shell_print(shell, "CCC ID not assigned\n");
++		return SHELL_CMD_HELP_PRINTED;
++	}
++
+ 	ccc.ret = 0;
+ 	if (ccc.addr != I3C_BROADCAST_ADDR) {
+ 		ccc.id |= I3C_CCC_DIRECT;
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0023-i3c-aspeed-Automatically-hj-when-i3c-as-slave-mode.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0023-i3c-aspeed-Automatically-hj-when-i3c-as-slave-mode.patch
@@ -1,0 +1,35 @@
+From 004bc05c4d90781e07066d19af7a325611fa52ea Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Wed, 28 Sep 2022 10:35:17 +0800
+Subject: [PATCH 23/30] i3c: aspeed: Automatically hj when i3c as slave mode.
+
+With this patch, i3c slave will automatically send the hot-join request
+when the slave is activated by the i3c master.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: Ie77c2ae727f0ce7fd43528d5579f05ae64e54f1d
+---
+ drivers/i3c/i3c_aspeed.c | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 5d767442d6..dbba405792 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1079,12 +1079,7 @@ static void i3c_aspeed_enable(struct i3c_aspeed_obj *obj)
+ 	reg.fields.enable = 1;
+ 	reg.fields.slave_ibi_payload_en = 1;
+ 	if (config->secondary) {
+-		/*
+-		 * We don't support hot-join on master mode, so disable auto-mode-adaption for
+-		 * slave mode accordingly.  Since the only master device we may connect with is
+-		 * our ourself.
+-		 */
+-		reg.fields.slave_auto_mode_adapt = 1;
++		reg.fields.slave_auto_mode_adapt = 0;
+ 	}
+ 	i3c_register->device_ctrl.value = reg.value;
+ }
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0024-i3c-aspeed-reject-hot-join-by-default.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0024-i3c-aspeed-reject-hot-join-by-default.patch
@@ -1,0 +1,29 @@
+From 0bd71faf584365a9507f441f02c54eec9c3a7110 Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Fri, 30 Sep 2022 15:21:30 +0800
+Subject: [PATCH 24/30] i3c: aspeed: reject hot-join by default
+
+I3C master code does not support hot-join yet.  So just NACK the
+hot-join request by default.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: I6642170ad79b2bdc47ab565e8296314b0fdee90a
+---
+ drivers/i3c/i3c_aspeed.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index dbba405792..2676443032 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1077,6 +1077,7 @@ static void i3c_aspeed_enable(struct i3c_aspeed_obj *obj)
+ 
+ 	reg.value = i3c_register->device_ctrl.value;
+ 	reg.fields.enable = 1;
++	reg.fields.hj_ack_ctrl = 1;
+ 	reg.fields.slave_ibi_payload_en = 1;
+ 	if (config->secondary) {
+ 		reg.fields.slave_auto_mode_adapt = 0;
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0025-drivers-i3c-shell-Fix-the-flow-of-desc-find.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0025-drivers-i3c-shell-Fix-the-flow-of-desc-find.patch
@@ -1,0 +1,32 @@
+From 60655af25091ccb3d6fd1082516e1c935e673a4d Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Thu, 10 Nov 2022 14:33:37 +0800
+Subject: [PATCH 25/30] drivers: i3c: shell: Fix the flow of desc find.
+
+Return NULL when desc table doesn't find the same address on the bus.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I25dd8b71efbf8ec35c9b97d52a3aa9a4aed44f84
+---
+ drivers/i3c/i3c_shell.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/i3c/i3c_shell.c b/drivers/i3c/i3c_shell.c
+index d689af0d3d..b38d7a0f2c 100644
+--- a/drivers/i3c/i3c_shell.c
++++ b/drivers/i3c/i3c_shell.c
+@@ -35,8 +35,9 @@ static struct i3c_dev_desc *find_matching_desc(const struct device *dev, uint8_t
+ 	int i;
+ 
+ 	for (i = 0; i < I3C_SHELL_MAX_DESC_NUM; i++) {
+-		desc = &i3c_shell_desc_tbl[i];
+-		if (desc->master_dev == dev && desc->info.dynamic_addr == desc_addr) {
++		if (i3c_shell_desc_tbl[i].master_dev == dev &&
++		    i3c_shell_desc_tbl[i].info.dynamic_addr == desc_addr) {
++			desc = &i3c_shell_desc_tbl[i];
+ 			break;
+ 		}
+ 	}
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0026-i3c-aspeed-make-slave_put_read_data-be-a-blocking-fu.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0026-i3c-aspeed-make-slave_put_read_data-be-a-blocking-fu.patch
@@ -1,0 +1,114 @@
+From f1d09c70c5b4dbd36286e0d567d8265369c7fdb9 Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Wed, 30 Nov 2022 16:49:26 +0800
+Subject: [PATCH 26/30] i3c: aspeed: make slave_put_read_data be a blocking
+ function
+
+In slave mode, the pending read data was put to the TX FIFO then
+returned directly. The application needed to call another API to know if
+the data is consumed.  This commit makes the slave_put_read_data wait
+for the data consumed so that the application needn't to know the data
+status after it calls this function.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: I39be9d4612caa463126534b91f08fdf68b790beb
+---
+ drivers/i3c/i3c_aspeed.c  | 26 ++++++++++++++------------
+ include/drivers/i3c/i3c.h | 19 ++++++-------------
+ 2 files changed, 20 insertions(+), 25 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 2676443032..c1bd5cfef5 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1374,6 +1374,18 @@ int i3c_aspeed_slave_register(const struct device *dev, struct i3c_slave_setup *
+ 	return 0;
+ }
+ 
++static int i3c_aspeed_slave_wait_data_consume(const struct device *dev)
++{
++	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
++	union i3c_intr_s events;
++
++	events.value = 0;
++	events.fields.resp_q_ready = 1;
++	osEventFlagsWait(obj->event_id, events.value, osFlagsWaitAny, osWaitForever);
++
++	return 0;
++}
++
+ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_payload *data,
+ 				   struct i3c_ibi_payload *ibi_notify)
+ {
+@@ -1433,6 +1445,8 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 		}
+ 	}
+ 
++	i3c_aspeed_slave_wait_data_consume(dev);
++
+ 	return 0;
+ }
+ 
+@@ -1481,18 +1495,6 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+ 	return 0;
+ }
+ 
+-int i3c_aspeed_slave_wait_data_consume(const struct device *dev)
+-{
+-	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
+-	union i3c_intr_s events;
+-
+-	events.value = 0;
+-	events.fields.resp_q_ready = 1;
+-	osEventFlagsWait(obj->event_id, events.value, osFlagsWaitAny, osWaitForever);
+-
+-	return 0;
+-}
+-
+ int i3c_aspeed_slave_set_static_addr(const struct device *dev, uint8_t static_addr)
+ {
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index 094492d5c3..69e25add28 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -209,22 +209,16 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+  * @param ibi_notify pointer to the IBI notification structure (optional)
+  * @return int 0 = success
+  *
+- * This function puts the pending read data to the TX FIFO.  If @ibi_notify is
+- * specified, a slave interrupt with the IBI payload will be issued to notify
+- * the master device that there is a pending read data.  The master device shall
+- * issue a private read transfer to read the data back.
++ * This function puts the pending read data to the TX FIFO and waits until the
++ * pending read data is consumed.  The API uses osEventFlagsWait and will make
++ * the caller thread sleep so do not call it in the ISR.
++ * If @ibi_notify is specified, a slave interrupt with the IBI payload will be
++ * issued to notify the master device that there is a pending read data.  The
++ * master device shall issue a private read transfer to read the data back.
+  */
+ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_payload *data,
+ 				   struct i3c_ibi_payload *ibi_notify);
+ 
+-/**
+- * @brief slave device waits for the private read data be consumed
+- *
+- * @param dev the slave device
+- * @return int 0 = success
+- */
+-int i3c_aspeed_slave_wait_data_consume(const struct device *dev);
+-
+ /**
+  * @brief set the pid extra info of the i3c controller
+  * @param dev the I3C controller
+@@ -254,7 +248,6 @@ int i3c_master_send_getbcr(const struct device *master, uint8_t addr, uint8_t *b
+ #define i3c_slave_set_static_addr	i3c_aspeed_slave_set_static_addr
+ #define i3c_slave_send_sir		i3c_aspeed_slave_send_sir
+ #define i3c_slave_put_read_data		i3c_aspeed_slave_put_read_data
+-#define i3c_slave_wait_data_consume	i3c_aspeed_slave_wait_data_consume
+ #define i3c_slave_get_dynamic_addr	i3c_aspeed_slave_get_dynamic_addr
+ #define i3c_slave_get_event_enabling	i3c_aspeed_slave_get_event_enabling
+ #define i3c_set_pid_extra_info		i3c_aspeed_set_pid_extra_info
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0027-i3c-aspeed-Remove-the-usage-of-hw-pec.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0027-i3c-aspeed-Remove-the-usage-of-hw-pec.patch
@@ -1,0 +1,98 @@
+From 8f76e34018875389cd6c35d64668733895c1c10c Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Fri, 9 Dec 2022 18:13:52 +0800
+Subject: [PATCH 27/30] i3c: aspeed: Remove the usage of hw pec.
+
+Use sw pec to replace the hw pec.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I2fa54934a6c127f6a9d4a33cf46e30150cc46cfe
+---
+ drivers/i3c/i3c_aspeed.c | 40 +++++++++++++++++++---------------------
+ 1 file changed, 19 insertions(+), 21 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index c1bd5cfef5..7d633b561d 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1413,15 +1413,17 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 
+ 		i3c_register->queue_thld_ctrl.fields.resp_q_thld = 1 - 1;
+ 		i3c_register->device_ctrl.fields.slave_mdb = ibi_notify->buf[0];
+-		i3c_aspeed_wr_tx_fifo(obj, ibi_notify->buf, ibi_notify->size);
+-
+-		cmd.slave_data_cmd.cmd_attr = COMMAND_PORT_SLAVE_DATA_CMD;
+-		cmd.slave_data_cmd.dl = ibi_notify->size;
+-		i3c_register->cmd_queue_port.value = cmd.value;
+-
+ 		if (config->ibi_append_pec) {
+-			i3c_register->device_ctrl.fields.slave_pec_en = 1;
++			xfer_buf = pec_append(dev, ibi_notify->buf, ibi_notify->size);
++			i3c_aspeed_wr_tx_fifo(obj, xfer_buf, ibi_notify->size + 1);
++			cmd.slave_data_cmd.dl = ibi_notify->size + 1;
++			k_free(xfer_buf);
++		} else {
++			i3c_aspeed_wr_tx_fifo(obj, ibi_notify->buf, ibi_notify->size);
++			cmd.slave_data_cmd.dl = ibi_notify->size;
+ 		}
++		cmd.slave_data_cmd.cmd_attr = COMMAND_PORT_SLAVE_DATA_CMD;
++		i3c_register->cmd_queue_port.value = cmd.value;
+ 	}
+ 
+ 	if (config->priv_xfer_pec) {
+@@ -1439,10 +1441,6 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 	if (ibi_notify) {
+ 		i3c_register->i3c_slave_intr_req.fields.sir = 1;
+ 		osEventFlagsWait(obj->event_id, events.value, osFlagsWaitAll, osWaitForever);
+-
+-		if (config->ibi_append_pec) {
+-			i3c_register->device_ctrl.fields.slave_pec_en = 0;
+-		}
+ 	}
+ 
+ 	i3c_aspeed_slave_wait_data_consume(dev);
+@@ -1457,6 +1455,7 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+ 	struct i3c_register_s *i3c_register = config->base;
+ 	union i3c_intr_s events;
+ 	union i3c_device_cmd_queue_port_s cmd;
++	uint8_t *xfer_buf;
+ 
+ 	__ASSERT_NO_MSG(payload);
+ 	__ASSERT_NO_MSG(payload->buf);
+@@ -1474,24 +1473,23 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+ 
+ 	i3c_register->queue_thld_ctrl.fields.resp_q_thld = 1 - 1;
+ 	i3c_register->device_ctrl.fields.slave_mdb = payload->buf[0];
+-	i3c_aspeed_wr_tx_fifo(obj, payload->buf, payload->size);
++	if (config->ibi_append_pec) {
++		xfer_buf = pec_append(dev, payload->buf, payload->size);
++		i3c_aspeed_wr_tx_fifo(obj, xfer_buf, payload->size + 1);
++		cmd.slave_data_cmd.dl = payload->size + 1;
++		k_free(xfer_buf);
++	} else {
++		i3c_aspeed_wr_tx_fifo(obj, payload->buf, payload->size);
++		cmd.slave_data_cmd.dl = payload->size;
++	}
+ 
+ 	cmd.slave_data_cmd.cmd_attr = COMMAND_PORT_SLAVE_DATA_CMD;
+-	cmd.slave_data_cmd.dl = payload->size;
+ 	i3c_register->cmd_queue_port.value = cmd.value;
+ 
+-	if (config->ibi_append_pec) {
+-		i3c_register->device_ctrl.fields.slave_pec_en = 1;
+-	}
+-
+ 	/* trigger the hw and wait done */
+ 	i3c_register->i3c_slave_intr_req.fields.sir = 1;
+ 	osEventFlagsWait(obj->event_id, events.value, osFlagsWaitAll, osWaitForever);
+ 
+-	if (config->ibi_append_pec) {
+-		i3c_register->device_ctrl.fields.slave_pec_en = 0;
+-	}
+-
+ 	return 0;
+ }
+ 
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0028-i3c-aspeed-Organize-the-interrupt-register-setting.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0028-i3c-aspeed-Organize-the-interrupt-register-setting.patch
@@ -1,0 +1,79 @@
+From ba7529085c770d6d00331688f68697a742fa02d0 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Mon, 19 Dec 2022 17:53:06 +0800
+Subject: [PATCH 28/30] i3c: aspeed: Organize the interrupt register setting.
+
+The interrupt register setting of the master and slave are different.
+This patch organize the usage of them.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I62b79ff1409528fd80659a5befffaa35026deff4
+---
+ drivers/i3c/i3c_aspeed.c | 32 +++++++++++++++++++++-----------
+ 1 file changed, 21 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 7d633b561d..392fb1279a 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -841,6 +841,9 @@ static void i3c_aspeed_isr(const struct device *dev)
+ 
+ 	status.value = i3c_register->intr_status.value;
+ 	if (config->secondary) {
++		if (status.fields.read_q_recv)
++			LOG_WRN("Master read when CMDQ is empty\n");
++
+ 		if (status.fields.resp_q_ready) {
+ 			i3c_aspeed_slave_rx_data(obj);
+ 		}
+@@ -1663,21 +1666,23 @@ static int i3c_aspeed_init(const struct device *dev)
+ 	intr_reg.fields.xfr_error = 1;
+ 	intr_reg.fields.resp_q_ready = 1;
+ 
+-	/* for slave mode */
+-	intr_reg.fields.ibi_update = 1;
+-	intr_reg.fields.ccc_update = 1;
+-	intr_reg.fields.dyn_addr_assign = 1;
+-	i3c_register->intr_status_en.value = intr_reg.value;
+-	i3c_register->intr_signal_en.value = intr_reg.value;
+-
+-	i3c_aspeed_init_hw_feature(obj);
+-	i3c_aspeed_set_role(obj, config->secondary);
+-	i3c_aspeed_init_clock(obj);
+-
+ 	if (config->secondary) {
+ 		/* setup static address so that we can support SETAASA and SETDASA */
+ 		i3c_register->device_addr.fields.static_addr = config->assigned_addr;
+ 		i3c_register->device_addr.fields.static_addr_valid = 1;
++
++		/* for slave mode */
++		intr_reg.fields.ccc_update = 1;
++		intr_reg.fields.dyn_addr_assign = 1;
++		intr_reg.fields.read_q_recv = 1;
++		i3c_register->intr_signal_en.value = intr_reg.value;
++		/*
++		 * No need for INTR_IBI_UPDATED_STAT signal, check this bit
++		 * when INTR_RESP_READY_STAT signal is up.  This can guarantee
++		 * the SIR payload is ACKed by the master.
++		 */
++		intr_reg.fields.ibi_update = 1;
++		i3c_register->intr_status_en.value = intr_reg.value;
+ 	} else {
+ 		union i3c_device_addr_s reg;
+ 
+@@ -1685,7 +1690,12 @@ static int i3c_aspeed_init(const struct device *dev)
+ 		reg.fields.dynamic_addr = config->assigned_addr;
+ 		reg.fields.dynamic_addr_valid = 1;
+ 		i3c_register->device_addr.value = reg.value;
++		i3c_register->intr_signal_en.value = intr_reg.value;
++		i3c_register->intr_status_en.value = intr_reg.value;
+ 	}
++	i3c_aspeed_init_hw_feature(obj);
++	i3c_aspeed_set_role(obj, config->secondary);
++	i3c_aspeed_init_clock(obj);
+ 
+ 	i3c_aspeed_init_queues(obj);
+ 	i3c_aspeed_init_pid(obj);
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0029-i3c-aspeed-Separates-the-event-of-ibi-and-data-consu.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0029-i3c-aspeed-Separates-the-event-of-ibi-and-data-consu.patch
@@ -1,0 +1,171 @@
+From 6445a07e852ae34a91ce5117588ebd0681f92de0 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Mon, 19 Dec 2022 18:03:00 +0800
+Subject: [PATCH 29/30] i3c: aspeed: Separates the event of ibi and data
+ consume.
+
+The interrupt resp_q_ready indicate the event of ibi transfer done, data
+read by master and master write data. The differnet of these events list
+below:
+1. if it include the signal ibi_update: ibi transfer done
+2. if the response data contain the data length > 0: master write data.
+3. others: data read by master.
+This patch separates the wait event of the ibi and data consume, making
+ISR can signal the appropriate event.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I2f741d2031efc27d1611050db924116983f4ba64
+---
+ drivers/i3c/i3c_aspeed.c | 45 ++++++++++++++++++++++------------------
+ 1 file changed, 25 insertions(+), 20 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 392fb1279a..c704e36fde 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -539,7 +539,8 @@ struct i3c_aspeed_obj {
+ 
+ 	/* slave mode data */
+ 	struct i3c_slave_setup slave_data;
+-	osEventFlagsId_t event_id;
++	osEventFlagsId_t ibi_event;
++	osEventFlagsId_t data_event;
+ };
+ 
+ #define DEV_CFG(dev)			((struct i3c_aspeed_config *)(dev)->config)
+@@ -672,25 +673,29 @@ static void i3c_aspeed_end_xfer(struct i3c_aspeed_obj *obj)
+ 	k_sem_give(&obj->curr_xfer->sem);
+ }
+ 
+-static void i3c_aspeed_slave_rx_data(struct i3c_aspeed_obj *obj)
++static void i3c_aspeed_slave_resp_handler(struct i3c_aspeed_obj *obj, union i3c_intr_s status)
+ {
+ 	struct i3c_register_s *i3c_register = obj->config->base;
+ 	const struct i3c_slave_callbacks *cb;
+ 	uint32_t nresp, i;
+ 
+ 	cb = obj->slave_data.callbacks;
+-	if (!cb) {
+-		goto flush;
+-	}
+-
+ 	nresp = i3c_register->queue_status_level.fields.resp_buf_blr;
+ 	for (i = 0; i < nresp; i++) {
+ 		union i3c_device_resp_queue_port_s resp;
+ 		struct i3c_slave_payload *payload;
+ 
+ 		resp.value = i3c_register->resp_queue_port.value;
++		if (resp.fields.err_status) {
++			LOG_ERR("Respons Error: 0x%x\n", resp.fields.err_status);
++		}
++
+ 		if (resp.fields.data_length && !resp.fields.err_status &&
+ 		    resp.fields.tid == SLAVE_TID_MASTER_WRITE_DATA) {
++			if (!cb) {
++				__ASSERT(0, "flush rx fifo is TBD\n");
++				continue;
++			}
+ 			if (cb->write_requested) {
+ 				payload = cb->write_requested(obj->slave_data.dev);
+ 				payload->size = resp.fields.data_length;
+@@ -700,11 +705,13 @@ static void i3c_aspeed_slave_rx_data(struct i3c_aspeed_obj *obj)
+ 			if (cb->write_done) {
+ 				cb->write_done(obj->slave_data.dev);
+ 			}
++		} else {
++			if (status.fields.ibi_update)
++				osEventFlagsSet(obj->ibi_event, status.value);
++			else
++				osEventFlagsSet(obj->data_event, status.value);
+ 		}
+ 	}
+-	return;
+-flush:
+-	__ASSERT(0, "flush rx fifo is TBD\n");
+ }
+ 
+ static int i3c_aspeed_parse_ibi_status(uint32_t value, struct i3c_ibi_status *result)
+@@ -845,13 +852,10 @@ static void i3c_aspeed_isr(const struct device *dev)
+ 			LOG_WRN("Master read when CMDQ is empty\n");
+ 
+ 		if (status.fields.resp_q_ready) {
+-			i3c_aspeed_slave_rx_data(obj);
++			i3c_aspeed_slave_resp_handler(obj, status);
+ 		}
+ 
+ 		i3c_aspeed_slave_event(dev, status);
+-
+-		osEventFlagsSet(obj->event_id, status.value);
+-
+ 	} else {
+ 		if (status.fields.resp_q_ready) {
+ 			i3c_aspeed_end_xfer(obj);
+@@ -862,7 +866,6 @@ static void i3c_aspeed_isr(const struct device *dev)
+ 		}
+ 	}
+ 
+-
+ 	if (status.fields.xfr_error) {
+ 		i3c_register->device_ctrl.fields.resume = 1;
+ 	}
+@@ -1382,9 +1385,10 @@ static int i3c_aspeed_slave_wait_data_consume(const struct device *dev)
+ 	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
+ 	union i3c_intr_s events;
+ 
++	osEventFlagsClear(obj->data_event, ~osFlagsError);
+ 	events.value = 0;
+ 	events.fields.resp_q_ready = 1;
+-	osEventFlagsWait(obj->event_id, events.value, osFlagsWaitAny, osWaitForever);
++	osEventFlagsWait(obj->data_event, events.value, osFlagsWaitAny, osWaitForever);
+ 
+ 	return 0;
+ }
+@@ -1409,7 +1413,7 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 			return -EACCES;
+ 		}
+ 
+-		osEventFlagsClear(obj->event_id, ~osFlagsError);
++		osEventFlagsClear(obj->ibi_event, ~osFlagsError);
+ 		events.value = 0;
+ 		events.fields.ibi_update = 1;
+ 		events.fields.resp_q_ready = 1;
+@@ -1443,7 +1447,7 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 
+ 	if (ibi_notify) {
+ 		i3c_register->i3c_slave_intr_req.fields.sir = 1;
+-		osEventFlagsWait(obj->event_id, events.value, osFlagsWaitAll, osWaitForever);
++		osEventFlagsWait(obj->ibi_event, events.value, osFlagsWaitAll, osWaitForever);
+ 	}
+ 
+ 	i3c_aspeed_slave_wait_data_consume(dev);
+@@ -1469,7 +1473,7 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+ 		return -EACCES;
+ 	}
+ 
+-	osEventFlagsClear(obj->event_id, ~osFlagsError);
++	osEventFlagsClear(obj->ibi_event, ~osFlagsError);
+ 	events.value = 0;
+ 	events.fields.ibi_update = 1;
+ 	events.fields.resp_q_ready = 1;
+@@ -1491,7 +1495,7 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+ 
+ 	/* trigger the hw and wait done */
+ 	i3c_register->i3c_slave_intr_req.fields.sir = 1;
+-	osEventFlagsWait(obj->event_id, events.value, osFlagsWaitAll, osWaitForever);
++	osEventFlagsWait(obj->ibi_event, events.value, osFlagsWaitAll, osWaitForever);
+ 
+ 	return 0;
+ }
+@@ -1710,7 +1714,8 @@ static int i3c_aspeed_init(const struct device *dev)
+ 
+ 	i3c_aspeed_enable(obj);
+ 
+-	obj->event_id = osEventFlagsNew(NULL);
++	obj->ibi_event = osEventFlagsNew(NULL);
++	obj->data_event = osEventFlagsNew(NULL);
+ 
+ 	return 0;
+ }
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0030-i3c-aspeed-Transfer-error-interrupt-has-the-response.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0030-i3c-aspeed-Transfer-error-interrupt-has-the-response.patch
@@ -1,0 +1,31 @@
+From 8a4791483fd9a02ae7749077cecded692d5b2896 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Wed, 4 Jan 2023 14:52:05 +0800
+Subject: [PATCH 30/30] i3c: aspeed: Transfer error interrupt has the response
+ data.
+
+Transfer error interrupt will generate one response data, so append this
+condition to handle the response data for the xfer error.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I29e4a3d66fc086a221694e77d953a936ac71f842
+---
+ drivers/i3c/i3c_aspeed.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index c704e36fde..13f38c007a 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -857,7 +857,7 @@ static void i3c_aspeed_isr(const struct device *dev)
+ 
+ 		i3c_aspeed_slave_event(dev, status);
+ 	} else {
+-		if (status.fields.resp_q_ready) {
++		if (status.fields.resp_q_ready || status.fields.xfr_error) {
+ 			i3c_aspeed_end_xfer(obj);
+ 		}
+ 
+-- 
+2.24.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0031-i3c-aspeed-Reset-the-i3c-when-ibi-wait-data-consume-.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0031-i3c-aspeed-Reset-the-i3c-when-ibi-wait-data-consume-.patch
@@ -1,0 +1,201 @@
+From acc858c21476300d9f678fef56786bd6244032c9 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Tue, 10 Jan 2023 13:41:32 +0800
+Subject: [PATCH 1/3] i3c: aspeed: Reset the i3c when ibi/wait data consume
+ timeout.
+
+I3C controller will retry the IBI infinitely. So, this patch adds the
+timeout:1s to avoid the IBI storm from destroying the master. In addition,
+if the data for the pending read doesn't consume by the master the i3c
+controller will stuck at read data prefetch state, this patch will also
+add timeout:3s to solve it.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I0ee5a2ac568ed1dc77aaa0543228d206e99d6065
+---
+ drivers/i3c/i3c_aspeed.c | 61 +++++++++++++++++++++++++++++++---------
+ 1 file changed, 47 insertions(+), 14 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 13f38c007a..c83742fe7b 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -130,7 +130,8 @@ union i3c_device_cmd_queue_port_s {
+ 
+ 	struct {
+ 		volatile uint32_t cmd_attr : 3;			/* bit[2:0] */
+-		volatile uint32_t reserved0 : 13;		/* bit[15:3] */
++		volatile uint32_t tid : 3;			/* bit[5:3] */
++		volatile uint32_t reserved0 : 10;		/* bit[15:5] */
+ 		volatile uint32_t dl : 16;			/* bit[31:16] */
+ 	} slave_data_cmd;
+ }; /* offset 0x0c */
+@@ -144,6 +145,8 @@ union i3c_device_resp_queue_port_s {
+ 		volatile uint32_t err_status : 4;		/* bit[31:28] */
+ 	} fields;
+ }; /* offset 0x10 */
++#define SLAVE_TID_IBI_DONE 0x1
++#define SLAVE_TID_MASTER_READ_DATA 0x2
+ #define SLAVE_TID_MASTER_WRITE_DATA 0x8
+ #define SLAVE_TID_DEFSLV_WRITE_DATA 0xF
+ 
+@@ -546,6 +549,7 @@ struct i3c_aspeed_obj {
+ #define DEV_CFG(dev)			((struct i3c_aspeed_config *)(dev)->config)
+ #define DEV_DATA(dev)			((struct i3c_aspeed_obj *)(dev)->data)
+ #define DESC_PRIV(desc)			((struct i3c_aspeed_dev_priv *)(desc)->priv_data)
++static int i3c_aspeed_init(const struct device *dev);
+ 
+ static uint8_t *pec_append(const struct device *dev, uint8_t *ptr, uint8_t len)
+ {
+@@ -706,10 +710,11 @@ static void i3c_aspeed_slave_resp_handler(struct i3c_aspeed_obj *obj, union i3c_
+ 				cb->write_done(obj->slave_data.dev);
+ 			}
+ 		} else {
+-			if (status.fields.ibi_update)
++			if (status.fields.ibi_update && resp.fields.tid == SLAVE_TID_IBI_DONE) {
+ 				osEventFlagsSet(obj->ibi_event, status.value);
+-			else
++			} else if (resp.fields.tid == SLAVE_TID_MASTER_READ_DATA) {
+ 				osEventFlagsSet(obj->data_event, status.value);
++			}
+ 		}
+ 	}
+ }
+@@ -1380,7 +1385,7 @@ int i3c_aspeed_slave_register(const struct device *dev, struct i3c_slave_setup *
+ 	return 0;
+ }
+ 
+-static int i3c_aspeed_slave_wait_data_consume(const struct device *dev)
++static uint32_t i3c_aspeed_slave_wait_data_consume(const struct device *dev)
+ {
+ 	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
+ 	union i3c_intr_s events;
+@@ -1388,9 +1393,8 @@ static int i3c_aspeed_slave_wait_data_consume(const struct device *dev)
+ 	osEventFlagsClear(obj->data_event, ~osFlagsError);
+ 	events.value = 0;
+ 	events.fields.resp_q_ready = 1;
+-	osEventFlagsWait(obj->data_event, events.value, osFlagsWaitAny, osWaitForever);
+ 
+-	return 0;
++	return osEventFlagsWait(obj->data_event, events.value, osFlagsWaitAny, K_SECONDS(3).ticks);
+ }
+ 
+ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_payload *data,
+@@ -1402,6 +1406,8 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 	union i3c_intr_s events;
+ 	union i3c_device_cmd_queue_port_s cmd;
+ 	uint8_t *xfer_buf;
++	uint32_t flag_ret;
++	int ret = 0;
+ 
+ 	__ASSERT_NO_MSG(data);
+ 	__ASSERT_NO_MSG(data->buf);
+@@ -1429,6 +1435,7 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 			i3c_aspeed_wr_tx_fifo(obj, ibi_notify->buf, ibi_notify->size);
+ 			cmd.slave_data_cmd.dl = ibi_notify->size;
+ 		}
++		cmd.slave_data_cmd.tid = SLAVE_TID_IBI_DONE;
+ 		cmd.slave_data_cmd.cmd_attr = COMMAND_PORT_SLAVE_DATA_CMD;
+ 		i3c_register->cmd_queue_port.value = cmd.value;
+ 	}
+@@ -1442,17 +1449,28 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 		i3c_aspeed_wr_tx_fifo(obj, data->buf, data->size);
+ 		cmd.slave_data_cmd.dl = data->size;
+ 	}
++	cmd.slave_data_cmd.tid = SLAVE_TID_MASTER_READ_DATA;
+ 	cmd.slave_data_cmd.cmd_attr = COMMAND_PORT_SLAVE_DATA_CMD;
+ 	i3c_register->cmd_queue_port.value = cmd.value;
+ 
+ 	if (ibi_notify) {
+ 		i3c_register->i3c_slave_intr_req.fields.sir = 1;
+-		osEventFlagsWait(obj->ibi_event, events.value, osFlagsWaitAll, osWaitForever);
++		flag_ret = osEventFlagsWait(obj->ibi_event, events.value, osFlagsWaitAll,
++					    K_SECONDS(1).ticks);
++		if (flag_ret & osFlagsError) {
++			i3c_aspeed_init(dev);
++			ret = -EIO;
++			goto ibi_err;
++		}
+ 	}
+ 
+-	i3c_aspeed_slave_wait_data_consume(dev);
+-
+-	return 0;
++	flag_ret = i3c_aspeed_slave_wait_data_consume(dev);
++	if (flag_ret & osFlagsError) {
++		i3c_aspeed_init(dev);
++		ret = -EIO;
++	}
++ibi_err:
++	return ret;
+ }
+ 
+ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *payload)
+@@ -1463,6 +1481,7 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+ 	union i3c_intr_s events;
+ 	union i3c_device_cmd_queue_port_s cmd;
+ 	uint8_t *xfer_buf;
++	uint32_t flag_ret;
+ 
+ 	__ASSERT_NO_MSG(payload);
+ 	__ASSERT_NO_MSG(payload->buf);
+@@ -1495,7 +1514,12 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+ 
+ 	/* trigger the hw and wait done */
+ 	i3c_register->i3c_slave_intr_req.fields.sir = 1;
+-	osEventFlagsWait(obj->ibi_event, events.value, osFlagsWaitAll, osWaitForever);
++	flag_ret =
++		osEventFlagsWait(obj->ibi_event, events.value, osFlagsWaitAll, K_SECONDS(1).ticks);
++	if (flag_ret & osFlagsError) {
++		i3c_aspeed_init(dev);
++		return -EIO;
++	}
+ 
+ 	return 0;
+ }
+@@ -1648,6 +1672,7 @@ static int i3c_aspeed_init(const struct device *dev)
+ 
+ 	obj->dev = dev;
+ 	obj->config = config;
++	reset_control_assert(reset_dev, config->reset_id);
+ 	clock_control_on(config->clock_dev, config->clock_id);
+ 	reset_control_deassert(reset_dev, config->reset_id);
+ 
+@@ -1667,6 +1692,7 @@ static int i3c_aspeed_init(const struct device *dev)
+ 
+ 	i3c_register->intr_status.value = GENMASK(31, 0);
+ 	intr_reg.value = 0;
++	intr_reg.fields.xfr_abort = 1;
+ 	intr_reg.fields.xfr_error = 1;
+ 	intr_reg.fields.resp_q_ready = 1;
+ 
+@@ -1687,6 +1713,16 @@ static int i3c_aspeed_init(const struct device *dev)
+ 		 */
+ 		intr_reg.fields.ibi_update = 1;
+ 		i3c_register->intr_status_en.value = intr_reg.value;
++		if (obj->ibi_event == NULL) {
++			obj->ibi_event = osEventFlagsNew(NULL);
++			if (obj->ibi_event == NULL)
++				LOG_ERR("Creat ibi event flags failed");
++		}
++		if (obj->data_event == NULL) {
++			obj->data_event = osEventFlagsNew(NULL);
++			if (obj->data_event == NULL)
++				LOG_ERR("Creat data event flags failed");
++		}
+ 	} else {
+ 		union i3c_device_addr_s reg;
+ 
+@@ -1714,9 +1750,6 @@ static int i3c_aspeed_init(const struct device *dev)
+ 
+ 	i3c_aspeed_enable(obj);
+ 
+-	obj->ibi_event = osEventFlagsNew(NULL);
+-	obj->data_event = osEventFlagsNew(NULL);
+-
+ 	return 0;
+ }
+ 
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0032-i3c-aspeed-Return-error-when-event-flag-is-exhausted.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0032-i3c-aspeed-Return-error-when-event-flag-is-exhausted.patch
@@ -1,0 +1,64 @@
+From 762ac6310095f8dbccf09000abbed2fe540796d4 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Thu, 12 Jan 2023 18:44:11 +0800
+Subject: [PATCH 2/3] i3c: aspeed: Return error when event flag is exhausted.
+
+Return error -ENOSPC to avoid the device being used without an event flag
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I654fbddbe47951354dd853d2f4e619407a87fea0
+---
+ drivers/i3c/i3c_aspeed.c | 19 +++++++++++++------
+ 1 file changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index c83742fe7b..d91490514c 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1715,13 +1715,17 @@ static int i3c_aspeed_init(const struct device *dev)
+ 		i3c_register->intr_status_en.value = intr_reg.value;
+ 		if (obj->ibi_event == NULL) {
+ 			obj->ibi_event = osEventFlagsNew(NULL);
+-			if (obj->ibi_event == NULL)
++			if (obj->ibi_event == NULL) {
+ 				LOG_ERR("Creat ibi event flags failed");
++				return -ENOSPC;
++			}
+ 		}
+ 		if (obj->data_event == NULL) {
+ 			obj->data_event = osEventFlagsNew(NULL);
+-			if (obj->data_event == NULL)
++			if (obj->data_event == NULL) {
+ 				LOG_ERR("Creat data event flags failed");
++				return -ENOSPC;
++			}
+ 		}
+ 	} else {
+ 		union i3c_device_addr_s reg;
+@@ -1774,16 +1778,19 @@ static int i3c_aspeed_init(const struct device *dev)
+ 		.i3c_od_scl_hi_period_ns = DT_INST_PROP_OR(n, i3c_od_scl_hi_period_ns, 0),         \
+ 		.i3c_od_scl_lo_period_ns = DT_INST_PROP_OR(n, i3c_od_scl_lo_period_ns, 0),         \
+ 	};                                                                                         \
+-												   \
++                                                                                                   \
+ 	static struct i3c_aspeed_obj i3c_aspeed_obj##n;                                            \
+-												   \
++                                                                                                   \
+ 	DEVICE_DT_INST_DEFINE(n, &i3c_aspeed_config_func_##n, NULL, &i3c_aspeed_obj##n,            \
+ 			      &i3c_aspeed_config_##n, POST_KERNEL,                                 \
+ 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);                           \
+-												   \
++                                                                                                   \
+ 	static int i3c_aspeed_config_func_##n(const struct device *dev)                            \
+ 	{                                                                                          \
+-		i3c_aspeed_init(dev);                                                              \
++		int ret;                                                                           \
++		ret = i3c_aspeed_init(dev);                                                        \
++		if (ret < 0)                                                                       \
++			return ret;                                                                \
+ 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), i3c_aspeed_isr,             \
+ 			    DEVICE_DT_INST_GET(n), 0);                                             \
+ 		irq_enable(DT_INST_IRQN(n));                                                       \
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0033-decrease_the_instruction_before_wait_data_consume.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0033-decrease_the_instruction_before_wait_data_consume.patch
@@ -1,0 +1,48 @@
+From 2627b3de8082e04d6e283e2b5a194541e1b3df90 Mon Sep 17 00:00:00 2001
+From: Andy Chung <Andy_Chung@wiwynn.com>
+Date: Fri, 13 Jan 2023 00:51:06 +0800
+Subject: [PATCH] i3c: aspeed: Decrease the intrusion before wait data consumed
+
+Summary:
+Decrease the intrusion before wait data consumed.
+---
+ drivers/i3c/i3c_aspeed.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index d91490514c..40446314a0 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1403,7 +1403,7 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
+ 	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
+ 	struct i3c_register_s *i3c_register = config->base;
+-	union i3c_intr_s events;
++	union i3c_intr_s events, data_events;
+ 	union i3c_device_cmd_queue_port_s cmd;
+ 	uint8_t *xfer_buf;
+ 	uint32_t flag_ret;
+@@ -1440,6 +1440,10 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 		i3c_register->cmd_queue_port.value = cmd.value;
+ 	}
+ 
++	osEventFlagsClear(obj->data_event, ~osFlagsError);
++	data_events.value = 0;
++	data_events.fields.resp_q_ready = 1;
++
+ 	if (config->priv_xfer_pec) {
+ 		xfer_buf = pec_append(dev, data->buf, data->size);
+ 		i3c_aspeed_wr_tx_fifo(obj, xfer_buf, data->size + 1);
+@@ -1464,7 +1468,8 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 		}
+ 	}
+ 
+-	flag_ret = i3c_aspeed_slave_wait_data_consume(dev);
++	flag_ret = osEventFlagsWait(obj->data_event, data_events.value, osFlagsWaitAny,
++				    K_SECONDS(3).ticks);
+ 	if (flag_ret & osFlagsError) {
+ 		i3c_aspeed_init(dev);
+ 		ret = -EIO;
+-- 
+2.24.1
+


### PR DESCRIPTION
common: support I3C driver
Summary:
- This commit include the change as follow:
     - Add sem to lock the put_read_data function
     - Remove the usage of hw pec.
     - Make slave_put_read_data be a blocking function
     - Reject hot-join by default
     - Automatically hj when i3c as slave mode.
     - Fix uninitialized value of ccc.id
     - Reset the IBI queue if unregistered IBI source
     - Check the value of pid extra info.
     - Change the meaning of the PID[11:0]
     - Read rx fifo when tid == 0x8 in slave mode
     - Add the option to enable the pec for priv-xfer.
     - Wait resp_q_ready when slave send ibi_notify.
     - Wait resp_q_ready when slave send sir.
     - Add API to set the static address in slave mode
     - Use OD SCL as PP SCL when sending SETHID CCC
     - Add SETHID CCC support
     - Add build assertion for init priority in slave mqueue
     - Transfer error interrupt has the response data
     - Separates the event of ibi and data consume.
     - Organize the interrupt register setting
     - Revert to use the hw pec

Test plan:
Build and stress pass on fby35 platform.