### PR TITLE
fby35: gl: revise the i2c frequecy setting

### DIFF
--- a/meta-facebook/yv35-gl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-gl/boards/ast1030_evb.overlay
@@ -36,12 +36,12 @@
 &i2c1 {
 	pinctrl-0 = <&pinctrl_i2c1_default>;
 	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &i2c2 {
 	pinctrl-0 = <&pinctrl_i2c2_default>;
-	clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 	status = "okay";
 };
 
@@ -54,7 +54,7 @@
 &i2c4 {
 	pinctrl-0 = <&pinctrl_i2c4_default>;
 	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &i2c5 {
@@ -77,6 +77,18 @@
 		status = "okay";
 #endif
 	};
+};
+
+&i2c7 {
+	pinctrl-0 = <&pinctrl_i2c7_default>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&i2c8 {
+	pinctrl-0 = <&pinctrl_i2c8_default>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
 &espi {

--- a/meta-facebook/yv35-gl/src/platform/plat_i2c.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_i2c.h
@@ -28,8 +28,10 @@
 #define I2C_BUS5 4
 #define I2C_BUS6 5
 #define I2C_BUS7 6
+#define I2C_BUS8 7
+#define I2C_BUS9 8
 
 #define IPMB_I2C_BMC I2C_BUS7
-#define I2C_BUS_MAX_NUM 7
+#define I2C_BUS_MAX_NUM 9
 
 #endif


### PR DESCRIPTION
Summary:
- Revise the i2c frequency following hardware design
- Enable i2c-7/8 controllers for 1OU and 2OU expansion board.

Test Plan:
- BIC boot pass
- Check if the i2c controller is enabled:

Test Log:
- I2C_GLOBAL (READY) requires: SYSCLK requires: SYSRST
- I2C_8 (READY) requires: SYSCLK requires: PINMUX
- I2C_7 (READY) requires: SYSCLK requires: PINMUX
- I2C_6 (READY) requires: SYSCLK requires: PINMUX
- I2C_5 (READY) requires: SYSCLK requires: PINMUX
- I2C_4 (READY) requires: SYSCLK requires: PINMUX
- I2C_3 (READY) requires: SYSCLK requires: PINMUX
- I2C_2 (READY) requires: SYSCLK requires: PINMUX
- I2C_1 (READY) requires: SYSCLK requires: PINMUX
- I2C_0 (READY)
  requires: SYSCLK
  requires: PINMUX