### PR TITLE
op2: op: Version commit for obop2-op-2023.02.01

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_version.h
+++ b/meta-facebook/op2-op/src/platform/plat_version.h
@@ -21,7 +21,7 @@
 
 #define PLATFORM_NAME "Olympic 2.0"
 #define PROJECT_NAME "Olmsted Point"
-#define PROJECT_STAGE POC
+#define PROJECT_STAGE EVT
 
 /*
  * 0x01 mother board
@@ -32,7 +32,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x0
+#define FIRMWARE_REVISION_2 0x02
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -40,8 +40,8 @@
 #define AUXILIARY_FW_REVISION 0x00000000
 
 #define BIC_FW_YEAR_MSB 0x20
-#define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x48
+#define BIC_FW_YEAR_LSB 0x23
+#define BIC_FW_WEEK 0x02
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x6f // char: o
 #define BIC_FW_platform_1 0x70 // char: p


### PR DESCRIPTION
Summary:
- Version commit for Olympic 2.0 Olmsted Point BIC obop2-op-2023.02.01.

Test plan:
- Build code: Pass

Log:
1. Build pass. ...
[280/280] Linking C executable zephyr/OP2BOP.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:         12 KB       320 KB      3.75%
           FLASH:          0 GB         0 GB
            SRAM:      419232 B       448 KB     91.39%
        IDT_LIST:          0 GB         2 KB      0.00%