### PR TITLE
fby3.5: cl: Version commit for oby35-cl-2023.02.01

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_version.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_version.h
@@ -21,7 +21,7 @@
 
 #define PLATFORM_NAME "Yosemite V3.5"
 #define PROJECT_NAME "Crater Lake"
-#define PROJECT_STAGE DVT
+#define PROJECT_STAGE PVT
 
 /*
  * 0x01 motherboard
@@ -32,7 +32,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x10
+#define FIRMWARE_REVISION_2 0x01
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -40,8 +40,8 @@
 #define AUXILIARY_FW_REVISION 0x00000000
 
 #define BIC_FW_YEAR_MSB 0x20
-#define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x51
+#define BIC_FW_YEAR_LSB 0x23
+#define BIC_FW_WEEK 0x02
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x63 // char: c
 #define BIC_FW_platform_1 0x6c // char: l


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Craterlake BIC oby35-cl-2023.02.01.

Test Plan:
- Build code: Pass
- Get BIC version: Pass

Log:
1. Get firmware version. root@bmc-oob:~# fw-util slot1 --version bic
SB Bridge-IC Version: oby35-cl-v2023.02.01

2. Get firmware revision root@bmc-oob:~# bic-util slot1 0x18 0x1
00 80 31 01 02 BF 15 A0 00 00 00 00 00 00 00