### PR TITLE
fby3.5: hd: Version commit for oby35-hd-2023.02.01

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_version.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_version.h
@@ -34,7 +34,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x00
+#define FIRMWARE_REVISION_2 0x01
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -42,8 +42,8 @@
 #define AUXILIARY_FW_REVISION 0x00000000
 
 #define BIC_FW_YEAR_MSB 0x20
-#define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x49
+#define BIC_FW_YEAR_LSB 0x23
+#define BIC_FW_WEEK 0x02
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x68 // char: h
 #define BIC_FW_platform_1 0x64 // char: d


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 HalfDome BIC oby35-hd-2023.02.01.

Test Plan:
- Build code: PASS
- Get BIC version: PASS

Log:
```
root@bmc-oob:~# fw-util slot1 --version bic
SB Bridge-IC Version: oby35-hd-v2023.02.01
root@bmc-oob:~# bic-util slot1 0x18 0x1
00 80 24 01 02 BF 15 A0 00 00 00 00 00 00 00
```