### PR TITLE
Artemis: meb: Support cxl fru write/read

### DIFF
--- a/common/dev/include/i2c-mux-pca954x.h
+++ b/common/dev/include/i2c-mux-pca954x.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef I2C_MUX_PCA9548A_H
-#define I2C_MUX_PCA9548A_H
+#ifndef I2C_MUX_PCA954X_H
+#define I2C_MUX_PCA954X_H
 
 enum PCA9548A_CHANNEL {
 	PCA9548A_CHANNEL_0 = BIT(0),

--- a/common/dev/include/i2c-mux-pca984x.h
+++ b/common/dev/include/i2c-mux-pca984x.h
@@ -27,6 +27,17 @@ enum PCA9846_CHANNEL {
 	PCA9846_CHANNEL_3 = BIT(3),
 };
 
+enum PCA9848_CHANNEL {
+	PCA9848_CHANNEL_0 = BIT(0),
+	PCA9848_CHANNEL_1 = BIT(1),
+	PCA9848_CHANNEL_2 = BIT(2),
+	PCA9848_CHANNEL_3 = BIT(3),
+	PCA9848_CHANNEL_4 = BIT(4),
+	PCA9848_CHANNEL_5 = BIT(5),
+	PCA9848_CHANNEL_6 = BIT(6),
+	PCA9848_CHANNEL_7 = BIT(7),
+};
+
 bool set_pca9846_channel_and_transfer(uint8_t bus, uint8_t mux_addr, uint8_t mux_channel,
 				      uint8_t tran_type, I2C_MSG *msg);
 

--- a/meta-facebook/at-mc/boards/ast1030_evb.overlay
+++ b/meta-facebook/at-mc/boards/ast1030_evb.overlay
@@ -36,6 +36,7 @@
 
 &i2c4 {
 	pinctrl-0 = <&pinctrl_i2c4_default>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 };
 
@@ -55,7 +56,7 @@
 };
 
 &i2c8 {
-	pinctrl-0 = <&pinctrl_i2c7_default>;
+	pinctrl-0 = <&pinctrl_i2c8_default>;
 	status = "okay";
 };
 
@@ -64,12 +65,22 @@
 	status = "okay";
 };
 
+&i2c10 {
+	pinctrl-0 = <&pinctrl_i2c10_default>;
+	status = "okay";
+};
+
 &i2c11 {
-	pinctrl-0 = <&pinctrl_i2c12_default>;
+	pinctrl-0 = <&pinctrl_i2c11_default>;
 	status = "okay";
 };
 
 &i2c12 {
+	pinctrl-0 = <&pinctrl_i2c12_default>;
+	status = "okay";
+};
+
+&i2c13 {
 	pinctrl-0 = <&pinctrl_i2c13_default>;
 	status = "okay";
 };

--- a/meta-facebook/at-mc/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/at-mc/src/ipmi/include/plat_ipmi.h
@@ -24,8 +24,8 @@
 
 /** enum number follow GT for now since bmc hasn't ready **/
 enum MC_FIRMWARE_COMPONENT {
-	MC_COMPNT_BIC,
-	MC_COMPNT_CPLD,
+	MC_COMPNT_BIC = 2,
+	MC_COMPNT_CPLD = 7,
 	MC_COMPNT_CXL1,
 	MC_COMPNT_CXL2,
 	MC_COMPNT_CXL3,
@@ -35,6 +35,11 @@ enum MC_FIRMWARE_COMPONENT {
 	MC_COMPNT_CXL7,
 	MC_COMPNT_CXL8,
 	MC_COMPNT_MAX,
+};
+
+enum CXL_FRU_OPTIONAL {
+	CXL_FRU_WRITE,
+	CXL_FRU_READ,
 };
 
 #endif

--- a/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
@@ -22,8 +22,73 @@
 #include "libutil.h"
 #include "ipmi.h"
 #include "util_spi.h"
+#include "fru.h"
+#include "plat_fru.h"
+#include "hal_i2c.h"
+#include "plat_sensor_table.h"
+#include "common_i2c_mux.h"
+#include "plat_sensor_table.h"
 
 LOG_MODULE_REGISTER(plat_ipmi);
+
+int pal_write_read_cxl_fru(uint8_t optional, uint8_t fru_id, EEPROM_ENTRY *fru_entry,
+			   uint8_t *status)
+{
+	CHECK_NULL_ARG_WITH_RETURN(fru_entry, -1);
+	CHECK_NULL_ARG_WITH_RETURN(status, -1);
+
+	bool ret = 0;
+
+	if (optional != CXL_FRU_WRITE && optional != CXL_FRU_READ) {
+		LOG_ERR("CXL fru optional is invalid, optional: %d", optional);
+		return -1;
+	}
+
+	/* Switch mux channel */
+	mux_config cxl_mux = { 0 };
+	cxl_mux.bus = I2C_BUS2;
+	cxl_mux.target_addr = CXL_FRU_MUX0_ADDR;
+	cxl_mux.channel = pal_cxl_map_mux0_channel(fru_id);
+	if (cxl_mux.channel < 0) {
+		LOG_ERR("Get cxl mux0 channel fail");
+		return -1;
+	}
+
+	struct k_mutex *mutex = get_i2c_mux_mutex(cxl_mux.bus);
+	int mutex_status = k_mutex_lock(mutex, K_MSEC(MUTEX_LOCK_INTERVAL_MS));
+	if (mutex_status != 0) {
+		LOG_ERR("Mutex lock fail, status: %d", mutex_status);
+		return -1;
+	}
+
+	ret = set_mux_channel(cxl_mux);
+	if (ret == false) {
+		LOG_ERR("Switch mux channel fail");
+		k_mutex_unlock(mutex);
+		return -1;
+	}
+
+	if (optional == CXL_FRU_WRITE) {
+		*status = FRU_write(fru_entry);
+	} else {
+		*status = FRU_read(fru_entry);
+	}
+
+	/* Disable mux channel */
+	cxl_mux.channel = 0;
+
+	ret = set_mux_channel(cxl_mux);
+	if (ret == false) {
+		LOG_ERR("Disable mux channel fail");
+	}
+
+	mutex_status = k_mutex_unlock(mutex);
+	if (mutex_status != 0) {
+		LOG_ERR("Mutex unlock fail, status: %d", mutex_status);
+	}
+
+	return 0;
+}
 
 void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 {
@@ -65,5 +130,125 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 		msg->completion_code = CC_UNSPECIFIED_ERROR;
 		break;
 	}
+	return;
+}
+
+void STORAGE_READ_FRUID_DATA(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	int ret = -1;
+	uint8_t status = 0;
+	EEPROM_ENTRY fru_entry;
+
+	if (msg->data_len != 4) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	fru_entry.config.dev_id = msg->data[0];
+	fru_entry.offset = (msg->data[2] << 8) | msg->data[1];
+	fru_entry.data_len = msg->data[3];
+
+	// According to IPMI, messages are limited to 32 bytes
+	if (fru_entry.data_len > 32) {
+		msg->completion_code = CC_LENGTH_EXCEEDED;
+		return;
+	}
+
+	if (fru_entry.config.dev_id != MC_FRU_ID) {
+		ret = pal_write_read_cxl_fru(CXL_FRU_READ, fru_entry.config.dev_id, &fru_entry,
+					     &status);
+		if (ret < 0) {
+			msg->completion_code = CC_INVALID_PARAM;
+			return;
+		}
+		goto exit;
+	}
+
+	status = FRU_read(&fru_entry);
+
+exit:
+	msg->data_len = fru_entry.data_len + 1;
+	msg->data[0] = fru_entry.data_len;
+	memcpy(&msg->data[1], &fru_entry.data[0], fru_entry.data_len);
+
+	switch (status) {
+	case FRU_READ_SUCCESS:
+		msg->completion_code = CC_SUCCESS;
+		break;
+	case FRU_INVALID_ID:
+		msg->completion_code = CC_INVALID_PARAM;
+		break;
+	case FRU_OUT_OF_RANGE:
+		msg->completion_code = CC_PARAM_OUT_OF_RANGE;
+		break;
+	case FRU_FAIL_TO_ACCESS:
+		msg->completion_code = CC_FRU_DEV_BUSY;
+		break;
+	default:
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
+		break;
+	}
+
+	return;
+}
+
+void STORAGE_WRITE_FRUID_DATA(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	int ret = -1;
+	uint8_t status;
+	EEPROM_ENTRY fru_entry;
+
+	if (msg->data_len < 4) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	fru_entry.config.dev_id = msg->data[0];
+	fru_entry.offset = (msg->data[2] << 8) | msg->data[1];
+	fru_entry.data_len = msg->data_len - 3; // skip id and offset
+	if (fru_entry.data_len > 32) { // According to IPMI, messages are limited to 32 bytes
+		msg->completion_code = CC_LENGTH_EXCEEDED;
+		return;
+	}
+	memcpy(&fru_entry.data[0], &msg->data[3], fru_entry.data_len);
+
+	msg->data[0] = msg->data_len - 3;
+	msg->data_len = 1;
+
+	if (fru_entry.config.dev_id != MC_FRU_ID) {
+		ret = pal_write_read_cxl_fru(CXL_FRU_WRITE, fru_entry.config.dev_id, &fru_entry,
+					     &status);
+		if (ret < 0) {
+			msg->completion_code = CC_INVALID_PARAM;
+			return;
+		}
+		goto exit;
+	}
+
+	status = FRU_write(&fru_entry);
+
+exit:
+	switch (status) {
+	case FRU_WRITE_SUCCESS:
+		msg->completion_code = CC_SUCCESS;
+		break;
+	case FRU_INVALID_ID:
+		msg->completion_code = CC_INVALID_PARAM;
+		break;
+	case FRU_OUT_OF_RANGE:
+		msg->completion_code = CC_PARAM_OUT_OF_RANGE;
+		break;
+	case FRU_FAIL_TO_ACCESS:
+		msg->completion_code = CC_FRU_DEV_BUSY;
+		break;
+	default:
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
+		break;
+	}
+
 	return;
 }

--- a/meta-facebook/at-mc/src/platform/plat_fru.c
+++ b/meta-facebook/at-mc/src/platform/plat_fru.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "fru.h"
+#include "i2c-mux-pca954x.h"
 
 const EEPROM_CFG plat_fru_config[] = {
 	{
@@ -39,8 +40,8 @@ const EEPROM_CFG plat_fru_config[] = {
 		FRU_START,
 		FRU_SIZE,
 		true,
-		CXL_FRU_MUX0_ADDR,
-		CXL_FRU_MUX0_CHANNEL0,
+		CXL_FRU_MUX1_ADDR,
+		CXL_FRU_MUX1_CHANNEL,
 	},
 	{
 		ST_M24128_BW,
@@ -51,8 +52,8 @@ const EEPROM_CFG plat_fru_config[] = {
 		FRU_START,
 		FRU_SIZE,
 		true,
-		CXL_FRU_MUX0_ADDR,
-		CXL_FRU_MUX0_CHANNEL1,
+		CXL_FRU_MUX1_ADDR,
+		CXL_FRU_MUX1_CHANNEL,
 	},
 	{
 		ST_M24128_BW,
@@ -63,8 +64,8 @@ const EEPROM_CFG plat_fru_config[] = {
 		FRU_START,
 		FRU_SIZE,
 		true,
-		CXL_FRU_MUX0_ADDR,
-		CXL_FRU_MUX0_CHANNEL2,
+		CXL_FRU_MUX1_ADDR,
+		CXL_FRU_MUX1_CHANNEL,
 	},
 	{
 		ST_M24128_BW,
@@ -75,8 +76,8 @@ const EEPROM_CFG plat_fru_config[] = {
 		FRU_START,
 		FRU_SIZE,
 		true,
-		CXL_FRU_MUX0_ADDR,
-		CXL_FRU_MUX0_CHANNEL3,
+		CXL_FRU_MUX1_ADDR,
+		CXL_FRU_MUX1_CHANNEL,
 	},
 	{
 		ST_M24128_BW,
@@ -87,8 +88,8 @@ const EEPROM_CFG plat_fru_config[] = {
 		FRU_START,
 		FRU_SIZE,
 		true,
-		CXL_FRU_MUX0_ADDR,
-		CXL_FRU_MUX0_CHANNEL4,
+		CXL_FRU_MUX1_ADDR,
+		CXL_FRU_MUX1_CHANNEL,
 	},
 	{
 		ST_M24128_BW,
@@ -99,8 +100,8 @@ const EEPROM_CFG plat_fru_config[] = {
 		FRU_START,
 		FRU_SIZE,
 		true,
-		CXL_FRU_MUX0_ADDR,
-		CXL_FRU_MUX0_CHANNEL5,
+		CXL_FRU_MUX1_ADDR,
+		CXL_FRU_MUX1_CHANNEL,
 	},
 	{
 		ST_M24128_BW,
@@ -111,8 +112,8 @@ const EEPROM_CFG plat_fru_config[] = {
 		FRU_START,
 		FRU_SIZE,
 		true,
-		CXL_FRU_MUX0_ADDR,
-		CXL_FRU_MUX0_CHANNEL6,
+		CXL_FRU_MUX1_ADDR,
+		CXL_FRU_MUX1_CHANNEL,
 	},
 	{
 		ST_M24128_BW,
@@ -123,12 +124,49 @@ const EEPROM_CFG plat_fru_config[] = {
 		FRU_START,
 		FRU_SIZE,
 		true,
-		CXL_FRU_MUX0_ADDR,
-		CXL_FRU_MUX0_CHANNEL7,
+		CXL_FRU_MUX1_ADDR,
+		CXL_FRU_MUX1_CHANNEL,
 	},
 };
 
 void pal_load_fru_config(void)
 {
 	memcpy(&fru_config, &plat_fru_config, sizeof(plat_fru_config));
+}
+
+int pal_cxl_map_mux0_channel(uint8_t cxl_id)
+{
+	int channel = -1;
+
+	switch (cxl_id) {
+	case CXL_FRU_ID1:
+		channel = PCA9548A_CHANNEL_0;
+		break;
+	case CXL_FRU_ID2:
+		channel = PCA9548A_CHANNEL_1;
+		break;
+	case CXL_FRU_ID3:
+		channel = PCA9548A_CHANNEL_2;
+		break;
+	case CXL_FRU_ID4:
+		channel = PCA9548A_CHANNEL_3;
+		break;
+	case CXL_FRU_ID5:
+		channel = PCA9548A_CHANNEL_4;
+		break;
+	case CXL_FRU_ID6:
+		channel = PCA9548A_CHANNEL_5;
+		break;
+	case CXL_FRU_ID7:
+		channel = PCA9548A_CHANNEL_6;
+		break;
+	case CXL_FRU_ID8:
+		channel = PCA9548A_CHANNEL_7;
+		break;
+	default:
+		channel = -1;
+		break;
+	}
+
+	return channel;
 }

--- a/meta-facebook/at-mc/src/platform/plat_fru.h
+++ b/meta-facebook/at-mc/src/platform/plat_fru.h
@@ -18,6 +18,7 @@
 #define PLAT_FRU_H
 
 #include "plat_i2c.h"
+#include "i2c-mux-pca984x.h"
 
 #define MC_FRU_PORT I2C_BUS1
 #define MC_FRU_ADDR (0xA0 >> 1)
@@ -25,14 +26,15 @@
 #define CXL_FRU_ADDR (0xA8 >> 1)
 #define CXL_FRU_MUX0_ADDR (0xE0 >> 1)
 #define CXL_FRU_MUX1_ADDR (0xE2 >> 1)
+#define CXL_FRU_MUX1_CHANNEL 2
 
-enum {
-	MC_FRU_ID,
-	CXL_FRU_ID1,
+enum FRU_ID {
+	MC_FRU_ID = 0x11,
+	CXL_FRU_ID1 = 0x1E,
 	CXL_FRU_ID2,
 	CXL_FRU_ID3,
 	CXL_FRU_ID4,
-	CXL_FRU_ID5,
+	CXL_FRU_ID5 = 0x26,
 	CXL_FRU_ID6,
 	CXL_FRU_ID7,
 	CXL_FRU_ID8,
@@ -51,6 +53,9 @@ enum {
 	CXL_FRU_MUX0_CHANNEL7,
 };
 
-#define FRU_CFG_NUM MAX_FRU_ID
+/* Skip fru id 0~16, 18~29 */
+#define FRU_CFG_NUM 9
+
+int pal_cxl_map_mux0_channel(uint8_t cxl_id);
 
 #endif

--- a/meta-facebook/at-mc/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-mc/src/platform/plat_sensor_table.c
@@ -19,13 +19,20 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-
+#include <logging/log.h>
 #include "ast_adc.h"
 #include "sensor.h"
 #include "hal_gpio.h"
 #include "plat_i2c.h"
 #include "plat_gpio.h"
 #include "plat_hook.h"
+
+LOG_MODULE_REGISTER(plat_sensor_table);
+
+struct k_mutex i2c_2_pca9548a_mutex;
+struct k_mutex i2c_3_pca9546a_mutex;
+struct k_mutex i2c_4_pca9546a_mutex;
+struct k_mutex i2c_8_pca9548a_mutex;
 
 sensor_cfg plat_sensor_config[] = {
 	/* number,                  type,       port,      address,      offset,
@@ -53,4 +60,29 @@ void load_sensor_config(void)
 
 	// Fix config table in different system/config
 	pal_extend_sensor_config();
+}
+
+struct k_mutex *get_i2c_mux_mutex(uint8_t i2c_bus)
+{
+	struct k_mutex *mutex = NULL;
+
+	switch (i2c_bus) {
+	case I2C_BUS2:
+		mutex = &i2c_2_pca9548a_mutex;
+		break;
+	case I2C_BUS3:
+		mutex = &i2c_3_pca9546a_mutex;
+		break;
+	case I2C_BUS4:
+		mutex = &i2c_4_pca9546a_mutex;
+		break;
+	case I2C_BUS8:
+		mutex = &i2c_8_pca9548a_mutex;
+		break;
+	default:
+		LOG_ERR("No support for i2c bus %d mutex", i2c_bus);
+		break;
+	}
+
+	return mutex;
 }

--- a/meta-facebook/at-mc/src/platform/plat_sensor_table.h
+++ b/meta-facebook/at-mc/src/platform/plat_sensor_table.h
@@ -20,10 +20,13 @@
 #include <stdint.h>
 #include "sensor.h"
 
+#define MUTEX_LOCK_INTERVAL_MS 1000
+
 /*  define config for sensors  */
 
 /*  threshold sensor number, 1 based  */
 
 void load_sensor_config(void);
+struct k_mutex *get_i2c_mux_mutex(uint8_t i2c_bus);
 
 #endif


### PR DESCRIPTION
Summary:
- Support MEB cxl fru write/read command.
- Set the i2c clock frequency for communication with BMC to 400K.

Test Plan:
- Build code: Pass
- Read/Write cxl fru information: Pass

Log:
- Write/Read CXL 1 fru root@bmc-oob:~# mctp-util 9 0x40 0x0a 0x01 0x80 0x3f 0x01 0x15 0xa0 0x00 0x28 0x11 0x1E 0x00 0x00 0x10 00 1c 01 00 3f 01 00 15 a0 00 2c 11 00 10 ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff root@bmc-oob:~# mctp-util 9 0x40 0x0a 0x01 0x80 0x3f 0x01 0x15 0xa0 0x00 0x28 0x12 0x1E 0x00 0x00 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x0A 0x0B 0x0C 0x0D 0x0E 0x0F 0x10 00 0c 01 00 3f 01 00 15 a0 00 2c 12 00 10
root@bmc-oob:~# mctp-util 9 0x40 0x0a 0x01 0x80 0x3f 0x01 0x15 0xa0 0x00 0x28 0x11 0x1E 0x00 0x00 0x10 00 1c 01 00 3f 01 00 15 a0 00 2c 11 00 10 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 root@bmc-oob:~# mctp-util 9 0x40 0x0a 0x01 0x80 0x3f 0x01 0x15 0xa0 0x00 0x28 0x12 0x1E 0x00 0x00 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 00 0c 01 00 3f 01 00 15 a0 00 2c 12 00 10
root@bmc-oob:~# mctp-util 9 0x40 0x0a 0x01 0x80 0x3f 0x01 0x15 0xa0 0x00 0x28 0x11 0x1E 0x00 0x00 0x10 00 1c 01 00 3f 01 00 15 a0 00 2c 11 00 10 ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff