### PR TITLE
fby3.5: rf: Version commit for oby35-rf-2023.03.01

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_version.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_version.h
@@ -21,7 +21,7 @@
 
 #define PLATFORM_NAME "Yosemite 3.5"
 #define PROJECT_NAME "Rainbow Falls"
-#define PROJECT_STAGE EVT
+#define PROJECT_STAGE DVT
 
 /*
  * 0x01 Motherboard
@@ -41,8 +41,8 @@
 #define AUXILIARY_FW_REVISION 0x00000000
 
 #define BIC_FW_YEAR_MSB 0x20
-#define BIC_FW_YEAR_LSB 0x22
-#define BIC_FW_WEEK 0x46
+#define BIC_FW_YEAR_LSB 0x23
+#define BIC_FW_WEEK 0x03
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x72 // char: r
 #define BIC_FW_platform_1 0x66 // char: f


### PR DESCRIPTION
- Summary: 
Version commit for Yv3.5 RainbowFalls BIC oby35-rf-2023.03.01.

- Test Plan:
 Build code: Pass
 Get BIC version: Pass

```
root@bmc-oob:~# fw-util slot1 --version 1ou_bic
1OU Bridge-IC Version: oby35-rf-v2023.03.01
```

Signed-off-by: Irene <Irene.Lin@quantatw.com>