### PR TITLE
Artemis: cb: Fix to get switch firmware version and temperature fail

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -693,3 +693,25 @@ bool check_reading_pointer_null_is_allowed(uint8_t sensor_num)
 		return true;
 	}
 }
+
+bool init_drive_type_delayed(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+
+	int ret = -1;
+	uint8_t index = 0;
+	const uint16_t max_drive_num = ARRAY_SIZE(sensor_drive_tbl);
+
+	for (index = 0; index < max_drive_num; index++) {
+		if (cfg->type == sensor_drive_tbl[index].dev) {
+			ret = sensor_drive_tbl[index].init(cfg->num);
+			if (ret != SENSOR_INIT_SUCCESS) {
+				return false;
+			}
+
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -506,5 +506,6 @@ uint8_t plat_get_config_size();
 void load_sensor_config(void);
 void control_sensor_polling(uint8_t sensor_num, uint8_t optional, uint8_t cache_status);
 bool check_reading_pointer_null_is_allowed(uint8_t sensor_num);
+bool init_drive_type_delayed(sensor_cfg *cfg);
 
 #endif


### PR DESCRIPTION
Summary:
- Fix to get switch firmware version and temperature fail after sled-cycle.
  - Root cause: ACB BIC can't initialize pex switch because pex switch power is not ready after sled-cycle.
  - Solution: The pre-read function adds the pex switch initial check, and BIC does pex switch initial function if the pex switch is not initialized in pre-read function.
- Fix the problem that ina233/pex switch mutex doesn't unlock if switching mux fails.

Test Plan:
- Build code: Pass
- Get switch firmware version after sled-cycle: Pass
- Get switch temperature after sled-cycle: Pass

Log:
- Get switch firmware version after sled-cycle root@bmc-oob:~# fw-util acb --version pesw1
ACB PESW1 Version: 50.00.01.04

- Get switch temperature after sled-cycle root@bmc-oob:~# sensor-util acb | grep "PEX1"
ACB_PEX1 TEMP_C              (0x6) :   76.57 C     | (ok)