### PR TITLE
fby3.5: cl: shorten the path to get sys guid from KCS

### DIFF
--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -29,6 +29,22 @@
 
 LOG_MODULE_REGISTER(plat_ipmi);
 
+bool pal_request_msg_to_BIC_from_KCS(uint8_t netfn, uint8_t cmd)
+{
+	if (netfn == NETFN_OEM_1S_REQ) {
+		if ((cmd == CMD_OEM_1S_FW_UPDATE) || (cmd == CMD_OEM_1S_RESET_BMC) ||
+		    (cmd == CMD_OEM_1S_GET_BIC_STATUS) || (cmd == CMD_OEM_1S_RESET_BIC) ||
+		    (cmd == CMD_OEM_1S_GET_BIC_FW_INFO))
+			return true;
+	} else if (netfn == NETFN_APP_REQ) {
+		if (cmd == CMD_APP_GET_SYSTEM_GUID) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
 {
 	CHECK_NULL_ARG_WITH_RETURN(buf, -1);


### PR DESCRIPTION
Summary:
  The original path for KCS to get sys GUID is:
    HOST -> BIC -> BMC -> BIC -> BMC -> BIC -> HOST

  Since we could get sys GUID from BIC so let BIC reply to KCS directly:
    HOST -> BIC -> HOST

Teat plan:
  1. Build and test pass on yv35-cl.

  2. Get sys GUID from host with ipmi command - PASS [root@Stream8_220610 ~]# ipmitool raw 0x6 0x37 99 c8 0a 00 7c ee 76 13 81 44 00 00 00 d2 f4 d6