### PR TITLE
fby35: gl: support virtual wire gpio

### DIFF
--- a/common/hal/hal_vw_gpio.c
+++ b/common/hal/hal_vw_gpio.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "hal_vw_gpio.h"
+#include <logging/log.h>
+#include <stdlib.h>
+#include <string.h>
+#include "libutil.h"
+
+LOG_MODULE_REGISTER(hal_vw_gpio);
+
+// Aspeed ESPI register definition
+#define AST_ESPI_BASE 0x7E6EE000
+#define AST_ESPI_GPIO_VAL 0x9C
+#define AST_ESPI_GPIO_DIR 0xC0
+
+static const struct device *espi_dev;
+static struct espi_callback vw_cb;
+static vw_gpio *vw_gpio_cfg;
+static uint8_t vw_gpio_size = 0;
+
+bool vw_gpio_set(int number, uint8_t value)
+{
+#ifdef CONFIG_ESPI_ASPEED
+	// Check if the vw gpio is master input and bic output pin
+	uint32_t reg_value = sys_read32(AST_ESPI_BASE + AST_ESPI_GPIO_DIR);
+	if (!GETBIT(reg_value, number))
+		return false;
+
+	uint8_t i;
+	for (i = 0; i < vw_gpio_size; i++) {
+		if ((vw_gpio_cfg[i].number == number) &&
+		    (vw_gpio_cfg[i].is_enabled) &&
+		    (vw_gpio_cfg[i].direction == VW_GPIO_OUTPUT)) {
+			reg_value = sys_read32(AST_ESPI_BASE + AST_ESPI_GPIO_VAL);
+			if (value == VW_GPIO_HIGH)
+				reg_value = SETBIT(reg_value, number);
+			else
+				reg_value = CLEARBIT(reg_value, number);
+			sys_write32(reg_value, AST_ESPI_BASE + AST_ESPI_GPIO_VAL);
+			return true;
+		}
+	}
+#endif
+	return false;
+}
+
+#ifdef CONFIG_ESPI_ASPEED
+static void ast_vw_gpio_scan(void)
+{
+	uint8_t i;
+	for (i = 0; i < vw_gpio_size; i++) {
+		if (!vw_gpio_cfg[i].is_enabled)
+			continue;
+
+		if (vw_gpio_cfg[i].direction == VW_GPIO_INPUT) {
+			/* Check if controller direction setting
+			 * ESPI9C: GPIO direction of virtual wire channel
+			 */
+			uint32_t reg_value = sys_read32(AST_ESPI_BASE + AST_ESPI_GPIO_DIR);
+			if (GETBIT(reg_value, vw_gpio_cfg[i].number) != VW_GPIO_INPUT) {
+				LOG_ERR("the vgpio setting at controller side is incorrect.");
+				continue;
+			}
+
+			/* Get virtual gpio value
+			 * ESPI09C: GPIO through virtual wire channel
+			 */
+			reg_value = sys_read32(AST_ESPI_BASE + AST_ESPI_GPIO_VAL);
+			uint8_t gpio_value = GETBIT(reg_value, vw_gpio_cfg[i].number)? VW_GPIO_HIGH: VW_GPIO_LOW;
+			if (gpio_value != vw_gpio_cfg[i].value) {
+				vw_gpio_cfg[i].value = gpio_value;
+				if (vw_gpio_cfg[i].int_cb)
+					vw_gpio_cfg[i].int_cb(gpio_value);
+			}
+		}
+	}
+}
+#endif
+
+/* Handler for virtual GPIO from eSPI virtual wire channel */
+static void vw_handler(const struct device *dev, struct espi_callback *cb,
+			    struct espi_event event)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cb);
+
+#ifdef CONFIG_ESPI_ASPEED
+	if (event.evt_type == ESPI_BUS_EVENT_VWIRE_RECEIVED) {
+		/* Check if the virtual wire GPIO interrupt is happened
+		 * ESPI008: Interrupt Status
+		 *   bit[9] - Virtual Wire GPIO Event
+		 */
+		if (!GETBIT(event.evt_data, 9))
+			return;
+
+		ast_vw_gpio_scan();
+	}
+#endif
+}
+
+bool vw_gpio_init(vw_gpio *config, uint8_t size)
+{
+	CHECK_NULL_ARG_WITH_RETURN(config, false);
+
+	espi_dev = device_get_binding("ESPI");
+	if (!espi_dev) {
+		LOG_ERR("failed to get espi device");
+		return false;
+	}
+
+	vw_gpio_cfg = (vw_gpio *)malloc(size * sizeof(vw_gpio));
+	if (!vw_gpio_cfg) {
+		LOG_ERR("failed to allocate memory");
+		return false;
+	}
+	memcpy(vw_gpio_cfg, config, size * sizeof(vw_gpio));
+	vw_gpio_size = size;
+
+	espi_init_callback(&vw_cb, vw_handler,
+			   ESPI_BUS_EVENT_VWIRE_RECEIVED);
+	if (espi_add_callback(espi_dev, &vw_cb) < 0) {
+		LOG_ERR("failed to add espi callback function");
+		SAFE_FREE(vw_gpio_cfg);
+		vw_gpio_size = 0;
+		return false;
+	}
+
+	// Initialize vGPIO status during BIC bootup
+#ifdef CONFIG_ESPI_ASPEED
+	ast_vw_gpio_scan();
+	return true;
+#endif
+
+	SAFE_FREE(vw_gpio_cfg);
+	vw_gpio_size = 0;
+	return false;
+}

--- a/common/hal/hal_vw_gpio.h
+++ b/common/hal/hal_vw_gpio.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,25 +14,28 @@
  * limitations under the License.
  */
 
-#ifndef POWER_STATUS_H
-#define POWER_STATUS_H
+#include <drivers/espi.h>
 
-#include <stdbool.h>
-#include <stdint.h>
+#define VW_GPIO_ENABLE true
+#define VW_GPIO_DISABLE false
 
-void set_DC_status(uint8_t gpio_num);
-bool get_DC_status();
-void set_DC_on_delayed_status();
-bool get_DC_on_delayed_status();
-void set_DC_off_delayed_status();
-bool get_DC_off_delayed_status();
-void set_post_status(uint8_t gpio_num);
-void set_post_complete(bool status);
-bool get_post_status();
-void set_CPU_power_status(uint8_t gpio_num);
-bool CPU_power_good();
-void set_post_thread();
-void set_vr_monitor_status(bool value);
-bool get_vr_monitor_status();
+enum vw_gpio_direction {
+	VW_GPIO_INPUT = 0,
+	VW_GPIO_OUTPUT,
+};
 
-#endif
+enum vw_gpio_value {
+	VW_GPIO_LOW = 0,
+	VW_GPIO_HIGH,
+};
+
+typedef struct _vw_gpio_ {
+	uint8_t number;
+	bool is_enabled;
+	uint8_t direction;
+	uint8_t value;
+	void (*int_cb)(uint8_t value);
+} vw_gpio;
+
+bool vw_gpio_set(int number, uint8_t value);
+bool vw_gpio_init(vw_gpio *config, uint8_t size);

--- a/common/lib/power_status.c
+++ b/common/lib/power_status.c
@@ -68,6 +68,12 @@ void set_post_status(uint8_t gpio_num)
 	LOG_WRN("POST_COMPLETE: %s", (is_post_complete) ? "yes" : "no");
 }
 
+void set_post_complete(bool status)
+{
+	is_post_complete = status;
+	LOG_WRN("POST_COMPLETE: %s", (status) ? "yes" : "no");
+}
+
 bool get_post_status()
 {
 	return is_post_complete;

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0034-espi-aspeed-support-callback-management.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0034-espi-aspeed-support-callback-management.patch
@@ -1,0 +1,74 @@
+From 6f8ec5ae06a093b1fa254b87f6777c3d552ca5b1 Mon Sep 17 00:00:00 2001
+From: RenChen-wiwynn <ren_chen@wiwynn.com>
+Date: Thu, 29 Dec 2022 14:37:51 +0800
+Subject: [PATCH] espi: aspeed: support callback management
+
+The eSPI driver fires callback if there is virtual wire interrupt.
+
+Signed-off-by: RenChen-wiwynn <ren_chen@wiwynn.com>
+---
+ drivers/espi/espi_aspeed.c | 19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/espi/espi_aspeed.c b/drivers/espi/espi_aspeed.c
+index 270e955ac8..ddddbb90bf 100644
+--- a/drivers/espi/espi_aspeed.c
++++ b/drivers/espi/espi_aspeed.c
+@@ -14,6 +14,7 @@
+ #include <drivers/espi.h>
+ #include <drivers/espi_aspeed.h>
+ #include <logging/log.h>
++#include "espi_utils.h"
+ LOG_MODULE_REGISTER(espi, CONFIG_ESPI_LOG_LEVEL);
+ 
+ /* SCU register offset */
+@@ -611,6 +612,7 @@ struct espi_aspeed_data {
+ 	struct espi_aspeed_vw vw;
+ 	struct espi_aspeed_oob oob;
+ 	struct espi_aspeed_flash flash;
++	sys_slist_t callbacks;
+ };
+ 
+ static struct espi_aspeed_data espi_aspeed_data;
+@@ -672,8 +674,13 @@ static void espi_aspeed_isr(const struct device *dev)
+ 	if (sts & ESPI_INT_STS_PERIF_BITS)
+ 		espi_aspeed_perif_isr(sts, &data->perif);
+ 
+-	if (sts & ESPI_INT_STS_VW_BITS)
++	if (sts & ESPI_INT_STS_VW_BITS) {
++		struct espi_event evt = {
++			ESPI_BUS_EVENT_VWIRE_RECEIVED,
++			ESPI_CHANNEL_VWIRE, sts };
++		espi_send_callbacks(&data->callbacks, dev, evt);
+ 		espi_aspeed_vw_isr(sts, &data->vw);
++	}
+ 
+ 	if (sts & (ESPI_INT_STS_OOB_BITS | ESPI_INT_STS_HW_RST_DEASSERT))
+ 		espi_aspeed_oob_isr(sts, &data->oob);
+@@ -1388,6 +1395,15 @@ static int espi_aspeed_flash_erase(const struct device *dev, struct espi_flash_p
+ 	return espi_aspeed_flash_rwe(dev, pckt, FLASH_ERASE);
+ }
+ 
++static int espi_aspeed_manage_callback(const struct device *dev,
++					struct espi_callback *callback,
++					bool set)
++{
++	struct espi_aspeed_data *data = (struct espi_aspeed_data *)dev->data;
++
++	return espi_manage_callback(&data->callbacks, callback, set);
++}
++
+ static const struct espi_driver_api espi_aspeed_driver_api = {
+ 	.get_channel_status = espi_aspeed_channel_ready,
+ 	.send_oob = espi_aspeed_send_oob,
+@@ -1395,6 +1411,7 @@ static const struct espi_driver_api espi_aspeed_driver_api = {
+ 	.flash_read = espi_aspeed_flash_read,
+ 	.flash_write = espi_aspeed_flash_write,
+ 	.flash_erase = espi_aspeed_flash_erase,
++	.manage_callback = espi_aspeed_manage_callback,
+ };
+ 
+ DEVICE_DT_INST_DEFINE(0, &espi_aspeed_init, NULL,
+-- 
+2.38.1.windows.1
+

--- a/meta-facebook/yv35-gl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_init.c
@@ -15,6 +15,7 @@
  */
 
 #include "hal_gpio.h"
+#include "plat_vw_gpio.h"
 #include "power_status.h"
 #include "util_sys.h"
 #include "plat_gpio.h"
@@ -47,6 +48,9 @@ SCU_CFG scu_cfg[] = {
 void pal_pre_init()
 {
 	scu_init(scu_cfg, ARRAY_SIZE(scu_cfg));
+	if (!pal_load_vw_gpio_config()) {
+		printk("failed to initialize vw gpio\n");
+	}
 }
 
 void pal_post_init()

--- a/meta-facebook/yv35-gl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_isr.c
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,25 +14,15 @@
  * limitations under the License.
  */
 
-#ifndef POWER_STATUS_H
-#define POWER_STATUS_H
+#include "plat_isr.h"
+#include "hal_vw_gpio.h"
+#include "power_status.h"
+#include <logging/log.h>
 
-#include <stdbool.h>
-#include <stdint.h>
+LOG_MODULE_REGISTER(plat_isr);
 
-void set_DC_status(uint8_t gpio_num);
-bool get_DC_status();
-void set_DC_on_delayed_status();
-bool get_DC_on_delayed_status();
-void set_DC_off_delayed_status();
-bool get_DC_off_delayed_status();
-void set_post_status(uint8_t gpio_num);
-void set_post_complete(bool status);
-bool get_post_status();
-void set_CPU_power_status(uint8_t gpio_num);
-bool CPU_power_good();
-void set_post_thread();
-void set_vr_monitor_status(bool value);
-bool get_vr_monitor_status();
-
-#endif
+void ISR_POST_COMPLETE(uint8_t gpio_value)
+{
+	bool is_post_completed = (gpio_value == VW_GPIO_HIGH)? true: false;
+	set_post_complete(is_post_completed);
+}

--- a/meta-facebook/yv35-gl/src/platform/plat_isr.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_isr.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,25 +14,11 @@
  * limitations under the License.
  */
 
-#ifndef POWER_STATUS_H
-#define POWER_STATUS_H
+#ifndef PLAT_FUNC_H
+#define PLAT_FUNC_H
 
-#include <stdbool.h>
 #include <stdint.h>
 
-void set_DC_status(uint8_t gpio_num);
-bool get_DC_status();
-void set_DC_on_delayed_status();
-bool get_DC_on_delayed_status();
-void set_DC_off_delayed_status();
-bool get_DC_off_delayed_status();
-void set_post_status(uint8_t gpio_num);
-void set_post_complete(bool status);
-bool get_post_status();
-void set_CPU_power_status(uint8_t gpio_num);
-bool CPU_power_good();
-void set_post_thread();
-void set_vr_monitor_status(bool value);
-bool get_vr_monitor_status();
+void ISR_POST_COMPLETE(uint8_t gpio_value);
 
 #endif

--- a/meta-facebook/yv35-gl/src/platform/plat_vw_gpio.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_vw_gpio.c
@@ -1,0 +1,12 @@
+#include "plat_vw_gpio.h"
+#include "plat_isr.h"
+
+vw_gpio plat_vw_gpio_cfg[] = {
+	{0, VW_GPIO_ENABLE, VW_GPIO_INPUT, VW_GPIO_HIGH, ISR_POST_COMPLETE},
+	{1, VW_GPIO_ENABLE, VW_GPIO_OUTPUT, VW_GPIO_LOW, NULL},
+};
+
+bool pal_load_vw_gpio_config(void)
+{
+	return vw_gpio_init(plat_vw_gpio_cfg, ARRAY_SIZE(plat_vw_gpio_cfg));
+};

--- a/meta-facebook/yv35-gl/src/platform/plat_vw_gpio.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_vw_gpio.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,25 +14,11 @@
  * limitations under the License.
  */
 
-#ifndef POWER_STATUS_H
-#define POWER_STATUS_H
+#ifndef PLAT_VW_GPIO_H
+#define PLAT_VW_GPIO_H
 
-#include <stdbool.h>
-#include <stdint.h>
+#include "hal_vw_gpio.h"
 
-void set_DC_status(uint8_t gpio_num);
-bool get_DC_status();
-void set_DC_on_delayed_status();
-bool get_DC_on_delayed_status();
-void set_DC_off_delayed_status();
-bool get_DC_off_delayed_status();
-void set_post_status(uint8_t gpio_num);
-void set_post_complete(bool status);
-bool get_post_status();
-void set_CPU_power_status(uint8_t gpio_num);
-bool CPU_power_good();
-void set_post_thread();
-void set_vr_monitor_status(bool value);
-bool get_vr_monitor_status();
+bool pal_load_vw_gpio_config(void);
 
 #endif


### PR DESCRIPTION
Summary:
- There are only five physical GPIOs in Intel BHS CPU. BIC reveives vGPIOs status from BIOS through eSPI virtual wire channel.
- There are two vGPIOs on Great Lakes Bit[0]: BIOS POST complete.
  - BIC input and BIOS output. 1'b for POST completed. Bit[1]: BIOS debug message disabled.
  - BIC output and BIOS input. 1'b: debug message is enabled.
- Add zepher patch to support aspeed eSPI callback management
- Add vGPIO hanlder to monitor vGPIO status in application

Test Case:
1. Build code: pass
2. BIC boot: pass