### PR TITLE
ol2: op: Correct sensor reading

### DIFF
--- a/meta-facebook/op2-op/boards/ast1030_evb.overlay
+++ b/meta-facebook/op2-op/boards/ast1030_evb.overlay
@@ -8,6 +8,15 @@
 		&pinctrl_adc3_default
 		&pinctrl_adc4_default
 		&pinctrl_adc5_default
+		&pinctrl_adc6_default
+		&pinctrl_adc7_default>;
+};
+
+&adc1 {
+	status = "okay";
+	pinctrl-0 = <
+		&pinctrl_adc0_default
+		&pinctrl_adc3_default
 		&pinctrl_adc6_default>;
 };
 

--- a/meta-facebook/op2-op/src/platform/plat_hook.c
+++ b/meta-facebook/op2-op/src/platform/plat_hook.c
@@ -35,6 +35,11 @@ adc_asd_init_arg adc_asd_init_args[] = { [0] = { .is_init = false } };
 
 ina233_init_arg ina233_init_args[] = {
 	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
 };
 
 i2c_proc_arg i2c_proc_args[] = {

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.c
@@ -47,67 +47,67 @@ sensor_cfg plat_sensor_config[] = {
     */
 
 	//INA233 VOL
-	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_E1S_0_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_E1S_1_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[1] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_E1S_2_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[2] },
 
-	{ SENSOR_NUM_1OU_P12V_EDGE_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_MAIN_ADDR,
+	{ SENSOR_NUM_1OU_P12V_EDGE_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[5] },
 
 	//INA233 CURR
-	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_0_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_1_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[1] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_2_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[2] },
 
-	{ SENSOR_NUM_1OU_P12V_EDGE_CURR, sensor_dev_ina233, I2C_BUS3, INA233_MAIN_ADDR,
+	{ SENSOR_NUM_1OU_P12V_EDGE_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[5] },
 
 	//INA233 PWR
-	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_0_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_1_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[1] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_2_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[2] },
 
-	{ SENSOR_NUM_1OU_P12V_EDGE_PWR, sensor_dev_ina233, I2C_BUS3, INA233_MAIN_ADDR,
+	{ SENSOR_NUM_1OU_P12V_EDGE_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[5] },
 
 	//E1S Temp
 	{ SENSOR_NUM_1OU_E1S_SSD0_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
@@ -134,31 +134,31 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
 	//adc
-	{ SENSOR_NUM_1OU_P3V3_STBY_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE, stby_access,
+	{ SENSOR_NUM_1OU_P3V3_STBY_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT5, NONE, NONE, stby_access,
 	  2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE,
+	{ SENSOR_NUM_1OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE,
 	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD1_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE,
+	{ SENSOR_NUM_1OU_E1S_SSD1_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE,
 	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD2_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT3, NONE, NONE,
+	{ SENSOR_NUM_1OU_E1S_SSD2_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE,
 	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_P1V8_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT4, NONE, NONE, dc_access, 1, 1,
+	{ SENSOR_NUM_1OU_P1V8_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, dc_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_P0V9_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT5, NONE, NONE, dc_access, 1, 1,
+	{ SENSOR_NUM_1OU_P0V9_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT7, NONE, NONE, dc_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_P1V2_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, dc_access, 1, 1,
+	{ SENSOR_NUM_1OU_P1V2_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT8, NONE, NONE, dc_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 };
@@ -220,43 +220,47 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	//INA233 VOL
-	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_E1S_3_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[3] },
 
-	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_E1S_4_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_4_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[4] },
 
 	//INA233 CURR
-	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_3_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[3] },
 
-	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_4_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_4_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[4] },
 
 	//INA233 PWR
-	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_3_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[3] },
 
-	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_4_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_4_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[4] },
 };
 
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
 
 void load_sensor_config(void)
 {
+	// According to card type change address of INA233 sensor
+	change_ina233_sensor_addr();
+
+	// According to card position change sensor number
 	pal_change_sensor_config_number();
 
 	memcpy(sensor_config, plat_sensor_config, sizeof(plat_sensor_config));
@@ -284,6 +288,41 @@ uint8_t pal_get_extend_sensor_config()
 	}
 
 	return extend_sensor_table_size;
+}
+
+void change_ina233_sensor_addr()
+{
+	int index = 0;
+	uint8_t card_type = get_card_type();
+
+	// Default sensor table is defined for OPA
+	// if the card type is OPB, change INA233 device address
+	if (card_type == CARD_TYPE_OPB) {
+		for (index = 0; index < SENSOR_CONFIG_SIZE; index++) {
+			if (plat_sensor_config[index].type == sensor_dev_ina233) {
+				switch (plat_sensor_config[index].target_addr) {
+				case INA233_EXPA_E1S_0_ADDR:
+					plat_sensor_config[index].target_addr =
+						INA233_EXPB_E1S_0_ADDR;
+					break;
+				case INA233_EXPA_E1S_1_ADDR:
+					plat_sensor_config[index].target_addr =
+						INA233_EXPB_E1S_1_ADDR;
+					break;
+				case INA233_EXPA_E1S_2_ADDR:
+					plat_sensor_config[index].target_addr =
+						INA233_EXPB_E1S_2_ADDR;
+					break;
+				case INA233_EXPA_MAIN_ADDR:
+					plat_sensor_config[index].target_addr =
+						INA233_EXPB_MAIN_ADDR;
+					break;
+				default:
+					break;
+				}
+			}
+		}
+	}
 }
 
 void pal_change_sensor_config_number()

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.h
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.h
@@ -24,12 +24,16 @@
 
 #define TMP75_EXPA_TEMP_ADDR (0x94 >> 1)
 #define TMP75_EXPB_TEMP_ADDR (0x9A >> 1)
-#define INA233_E1S_0_ADDR (0x8A >> 1)
-#define INA233_E1S_1_ADDR (0x82 >> 1)
-#define INA233_E1S_2_ADDR (0x88 >> 1)
-#define INA233_E1S_3_ADDR (0x92 >> 1)
-#define INA233_E1S_4_ADDR (0x98 >> 1)
-#define INA233_MAIN_ADDR (0x90 >> 1)
+#define INA233_EXPA_E1S_0_ADDR (0x8C >> 1)
+#define INA233_EXPA_E1S_1_ADDR (0x88 >> 1)
+#define INA233_EXPA_E1S_2_ADDR (0x98 >> 1)
+#define INA233_EXPA_MAIN_ADDR (0x9A >> 1)
+#define INA233_EXPB_E1S_0_ADDR (0x8A >> 1)
+#define INA233_EXPB_E1S_1_ADDR (0x82 >> 1)
+#define INA233_EXPB_E1S_2_ADDR (0x88 >> 1)
+#define INA233_EXPB_E1S_3_ADDR (0x92 >> 1)
+#define INA233_EXPB_E1S_4_ADDR (0x98 >> 1)
+#define INA233_EXPB_MAIN_ADDR (0x90 >> 1)
 #define NVME_ADDR (0xD4 >> 1)
 
 #define TMP75_TEMP_OFFSET 0x00
@@ -194,5 +198,6 @@ void pal_change_sensor_config_number(void);
 void pal_extend_sensor_config(void);
 void load_sensor_config(void);
 uint8_t pal_get_extend_sensor_config(void);
+void change_ina233_sensor_addr(void);
 
 #endif


### PR DESCRIPTION
Summary:
- Correct INA233 sensor address and init config.
- Correct ADC config and ADC port.

Test plan:
- Build code: pass
- Get sensor reading: Pass

Log:
1. Read 1OU card sensor (only E1S1 is inserted). [BIC console]
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x41] 1OU_E1S_SSD0_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x42] 1OU_E1S_SSD1_P12V_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.512
[0x43] 1OU_E1S_SSD2_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x46] 1OU_BIC_P12V_EDGE_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.494
[0x50] 1OU_E1S_SSD0_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x51] 1OU_E1S_SSD1_P12V_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.095
[0x52] 1OU_E1S_SSD2_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x55] 1OU_E1S_P12V_EDGE_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.217
[0x56] 1OU_E1S_SSD0_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x57] 1OU_E1S_SSD1_P12V_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.200
[0x58] 1OU_E1S_SSD2_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5b] 1OU_E1S_P12V_EDGE_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.700
[0x5c] 1OU_E1S_SSD0_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5d] 1OU_E1S_SSD1_TEMP_C      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    32.000
[0x5e] 1OU_E1S_SSD2_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x40] 1OU_BIC_TEMP_C           : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    25.000
[0x4c] 1OU_ADC_P3V3_STBY_VOLT_V : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.338
[0x47] 1OU_E1S_ADC_SSD0_P3V3_VOLT_V: adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.320
[0x48] 1OU_E1S_ADC_SSD1_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x49] 1OU_E1S_ADC_SSD2_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x4d] 1OU_ADC_P1V8_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.843
[0x4e] 1OU_ADC_P0V9_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.930
[0x4f] 1OU_ADC_P1V2_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.213

2. Read 2OU card sensor (only E1S2 is inserted). [BIC console]
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x71] 2OU_E1S_SSD0_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x72] 2OU_E1S_SSD1_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x73] 2OU_E1S_SSD2_P12V_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.526
[0x76] 2OU_BIC_MAIN_P12V_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.531
[0x80] 2OU_E1S_SSD0_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x81] 2OU_E1S_SSD1_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x82] 2OU_E1S_SSD2_P12V_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.096
[0x85] 2OU_BIC_MAIN_P12V_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.195
[0x86] 2OU_E1S_SSD0_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x87] 2OU_E1S_SSD1_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x88] 2OU_E1S_SSD2_P12V_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.200
[0x8b] 2OU_BIC_MAIN_P12V_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.450
[0x8c] 2OU_E1S_SSD0_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x8d] 2OU_E1S_SSD1_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x8e] 2OU_E1S_SSD2_TEMP_C      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    32.000
[0x8f] 2OU_E1S_SSD3_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x90] 2OU_E1S_SSD4_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x70] 2OU_BIC_TEMP_C           : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    25.000
[0x77] 2OU_E1S_ADC_SSD0_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x78] 2OU_E1S_ADC_SSD1_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x79] 2OU_E1S_ADC_SSD2_P3V3_VOLT_V: adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.334
[0x7a] 2OU_E1S_ADC_SSD3_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x7b] 2OU_E1S_ADC_SSD4_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x7c] 2OU_ADC_P3V3_STBY_VOLT_V : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.320
[0x7d] 2OU_ADC_P1V8_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.828
[0x7f] 2OU_ADC_P1V2_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.186
[0x74] 2OU_E1S_SSD3_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x75] 2OU_E1S_SSD4_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x83] 2OU_E1S_SSD3_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x84] 2OU_E1S_SSD4_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x89] 2OU_E1S_SSD3_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x8a] 2OU_E1S_SSD4_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na

3. Read 3OU card sensor (only E1S1 is inserted). [BIC console]
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0xa1] 3OU_E1S_SSD0_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xa2] 3OU_E1S_SSD1_P12V_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.520
[0xa3] 3OU_E1S_SSD2_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xa6] 3OU_P12V_EDGE_VOLT_V     : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.491
[0xb0] 3OU_E1S_SSD0_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xb1] 3OU_E1S_SSD1_P12V_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.141
[0xb2] 3OU_E1S_SSD2_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xb5] 3OU_E1S_P12V_EDGE_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.220
[0xb6] 3OU_E1S_SSD0_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xb7] 3OU_E1S_SSD1_P12V_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.750
[0xb8] 3OU_E1S_SSD2_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xbb] 3OU_E1S_P12V_EDGE_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.750
[0xbc] 3OU_E1S_SSD0_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xbd] 3OU_E1S_SSD1_TEMP_C      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    31.000
[0xbe] 3OU_E1S_SSD2_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xa0] 3OU_BIC_TEMP_C           : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    26.000
[0xac] 3OU_ADC_P3V3_STBY_VOLT_V : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.330
[0xa7] 3OU_E1S_ADC_SSD0_P3V3_VOLT_V: adc        | access[O] | poll[O] 1    sec | not_accesible             | na
[0xa8] 3OU_E1S_ADC_SSD1_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | 4byte_acur_read_success   |     3.31
[0xa9] 3OU_E1S_ADC_SSD2_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0xad] 3OU_ADC_P1V8_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.821
[0xae] 3OU_ADC_P0V9_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.920
[0xaf] 3OU_ADC_P1V2_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.203
---------------------------------------------------------------------------------

4. Read 4OU card sensor  (only E1S4 is inserted). [BIC console]
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0xd1] 4OU_E1S_SSD0_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xd2] 4OU_E1S_SSD1_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xd3] 4OU_E1S_SSD2_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xd6] 4OU_BIC_MAIN_P12V_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.531
[0xe0] 4OU_E1S_SSD0_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xe1] 4OU_E1S_SSD1_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xe2] 4OU_E1S_SSD2_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xe5] 4OU_BIC_MAIN_P12V_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.283
[0xe6] 4OU_E1S_SSD0_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xe7] 4OU_E1S_SSD1_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xe8] 4OU_E1S_SSD2_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xeb] 4OU_BIC_MAIN_P12V_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.575
[0xec] 4OU_E1S_SSD0_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xed] 4OU_E1S_SSD1_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xee] 4OU_E1S_SSD2_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xef] 4OU_E1S_SSD3_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xf0] 4OU_E1S_SSD4_TEMP_C      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    31.000
[0xd0] 4OU_BIC_TEMP_C           : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    26.000
[0xd7] 4OU_E1S_ADC_SSD0_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0xd8] 4OU_E1S_ADC_SSD1_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0xd9] 4OU_E1S_ADC_SSD2_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0xda] 4OU_E1S_ADC_SSD3_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0xdb] 4OU_E1S_ADC_SSD4_P3V3_VOLT_V: adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.354
[0xdc] 4OU_ADC_P3V3_STBY_VOLT_V : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.348
[0xdd] 4OU_ADC_P1V8_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.826
[0xdf] 4OU_ADC_P1V2_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.191
[0xd4] 4OU_E1S_SSD3_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xd5] 4OU_E1S_SSD4_P12V_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.524
[0xe3] 4OU_E1S_SSD3_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xe4] 4OU_E1S_SSD4_P12V_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.136
[0xe9] 4OU_E1S_SSD3_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xea] 4OU_E1S_SSD4_P12V_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.725
---------------------------------------------------------------------------------