### PR TITLE
Marshall/ol2 op sensor reading checking e1s present

### DIFF
--- a/meta-facebook/op2-op/boards/ast1030_evb.overlay
+++ b/meta-facebook/op2-op/boards/ast1030_evb.overlay
@@ -8,6 +8,15 @@
 		&pinctrl_adc3_default
 		&pinctrl_adc4_default
 		&pinctrl_adc5_default
+		&pinctrl_adc6_default
+		&pinctrl_adc7_default>;
+};
+
+&adc1 {
+	status = "okay";
+	pinctrl-0 = <
+		&pinctrl_adc0_default
+		&pinctrl_adc3_default
 		&pinctrl_adc6_default>;
 };
 

--- a/meta-facebook/op2-op/src/platform/plat_hook.c
+++ b/meta-facebook/op2-op/src/platform/plat_hook.c
@@ -35,6 +35,11 @@ adc_asd_init_arg adc_asd_init_args[] = { [0] = { .is_init = false } };
 
 ina233_init_arg ina233_init_args[] = {
 	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
 };
 
 i2c_proc_arg i2c_proc_args[] = {

--- a/meta-facebook/op2-op/src/platform/plat_hook.c
+++ b/meta-facebook/op2-op/src/platform/plat_hook.c
@@ -43,9 +43,12 @@ ina233_init_arg ina233_init_args[] = {
 };
 
 i2c_proc_arg i2c_proc_args[] = {
-	[0] = { .bus = I2C_BUS2, .channel = 0x01 }, [1] = { .bus = I2C_BUS2, .channel = 0x02 },
-	[2] = { .bus = I2C_BUS2, .channel = 0x04 }, [3] = { .bus = I2C_BUS2, .channel = 0x08 },
-	[4] = { .bus = I2C_BUS2, .channel = 0x10 }, [5] = { .bus = I2C_BUS2, .channel = 0x20 },
+	[0] = { .bus = I2C_BUS2, .channel = I2C_HUB_CHANNEL_0 },
+	[1] = { .bus = I2C_BUS2, .channel = I2C_HUB_CHANNEL_1 },
+	[2] = { .bus = I2C_BUS2, .channel = I2C_HUB_CHANNEL_2 },
+	[3] = { .bus = I2C_BUS2, .channel = I2C_HUB_CHANNEL_3 },
+	[4] = { .bus = I2C_BUS2, .channel = I2C_HUB_CHANNEL_4 },
+	[5] = { .bus = I2C_BUS2, .channel = I2C_HUB_CHANNEL_5 },
 };
 
 /**************************************************************************************************

--- a/meta-facebook/op2-op/src/platform/plat_hook.h
+++ b/meta-facebook/op2-op/src/platform/plat_hook.h
@@ -31,6 +31,12 @@ extern i2c_proc_arg i2c_proc_args[];
 extern struct k_mutex i2c_hub_mutex;
 
 #define I2C_HUB_MUTEX_TIMEOUT_MS 300
+#define I2C_HUB_CHANNEL_0 0x01
+#define I2C_HUB_CHANNEL_1 0x02
+#define I2C_HUB_CHANNEL_2 0x04
+#define I2C_HUB_CHANNEL_3 0x08
+#define I2C_HUB_CHANNEL_4 0x10
+#define I2C_HUB_CHANNEL_5 0x20
 
 bool pre_i2c_bus_read(uint8_t sensor_num, void *args);
 bool post_i2c_bus_read(uint8_t sensor_num, void *args, int *reading);

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.c
@@ -18,13 +18,17 @@
 
 #include "ast_adc.h"
 #include "sensor.h"
+#include "power_status.h"
 
 #include "plat_i2c.h"
 #include "plat_sensor_table.h"
 #include "plat_hook.h"
 #include "plat_class.h"
+#include "plat_power_seq.h"
 
 LOG_MODULE_REGISTER(plat_sensor);
+
+bool e1s_access(uint8_t sensor_num);
 
 sensor_cfg plat_sensor_config[] = {
 	/*  number,
@@ -48,17 +52,17 @@ sensor_cfg plat_sensor_config[] = {
 
 	//INA233 VOL
 	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
-	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[0] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
-	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[1] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
-	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[2] },
 
@@ -69,17 +73,17 @@ sensor_cfg plat_sensor_config[] = {
 
 	//INA233 CURR
 	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
-	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[0] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
-	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[1] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
-	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[2] },
 
@@ -90,17 +94,17 @@ sensor_cfg plat_sensor_config[] = {
 
 	//INA233 PWR
 	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
-	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[0] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
-	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[1] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
-	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[2] },
 
@@ -111,12 +115,12 @@ sensor_cfg plat_sensor_config[] = {
 
 	//E1S Temp
 	{ SENSOR_NUM_1OU_E1S_SSD0_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
-	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[0], post_i2c_bus_read,
 	  &i2c_proc_args[0], NULL },
 
 	{ SENSOR_NUM_1OU_E1S_SSD1_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
-	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[1], post_i2c_bus_read,
 	  &i2c_proc_args[1], NULL },
 };
@@ -124,7 +128,7 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 
 	//E1S Temp
 	{ SENSOR_NUM_1OU_E1S_SSD2_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
-	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[5], post_i2c_bus_read,
 	  &i2c_proc_args[5], NULL },
 
@@ -139,15 +143,15 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE,
-	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD1_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE,
-	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD2_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE,
-	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	{ SENSOR_NUM_1OU_P1V8_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, dc_access, 1, 1,
@@ -167,17 +171,17 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 
 	//E1S Temp
 	{ SENSOR_NUM_2OU_E1S_SSD2_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
-	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[2], post_i2c_bus_read,
 	  &i2c_proc_args[2], NULL },
 
 	{ SENSOR_NUM_2OU_E1S_SSD3_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
-	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[3], post_i2c_bus_read,
 	  &i2c_proc_args[3], NULL },
 
 	{ SENSOR_NUM_2OU_E1S_SSD4_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
-	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[4], post_i2c_bus_read,
 	  &i2c_proc_args[4], NULL },
 
@@ -188,23 +192,23 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 
 	//adc
 	{ SENSOR_NUM_2OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE,
-	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	{ SENSOR_NUM_2OU_E1S_SSD1_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE,
-	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	{ SENSOR_NUM_2OU_E1S_SSD2_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE,
-	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	{ SENSOR_NUM_2OU_E1S_SSD3_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT3, NONE, NONE,
-	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	{ SENSOR_NUM_2OU_E1S_SSD4_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT4, NONE, NONE,
-	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	{ SENSOR_NUM_2OU_P3V3_STBY_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT5, NONE, NONE, stby_access,
@@ -221,34 +225,34 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 
 	//INA233 VOL
 	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
-	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[3] },
 
 	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_4_ADDR,
-	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[4] },
 
 	//INA233 CURR
 	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
-	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[3] },
 
 	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_4_ADDR,
-	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[4] },
 
 	//INA233 PWR
 	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
-	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[3] },
 
 	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_4_ADDR,
-	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[4] },
 };
@@ -385,4 +389,87 @@ void pal_extend_sensor_config()
 		LOG_ERR("Unsupported card type, Card type: 0x%x", card_type);
 		break;
 	}
+}
+
+bool e1s_access(uint8_t sensor_num)
+{
+	sensor_cfg *sensor_cfgs = &sensor_config[sensor_config_index_map[sensor_num]];
+	uint8_t e1s_index = 0xff;
+	uint8_t card_type = get_card_type();
+	i2c_proc_arg *nvme_i2c_mux = NULL;
+
+	switch (sensor_cfgs->type) {
+	case sensor_dev_ina233:
+		switch (sensor_cfgs->target_addr) {
+		case INA233_EXPA_E1S_0_ADDR:
+		case INA233_EXPB_E1S_0_ADDR:
+			e1s_index = 0;
+			break;
+		case INA233_EXPA_E1S_1_ADDR:
+			//check the card type because address is the same as INA233_EXPB_E1S_2_ADDR
+			if (card_type == CARD_TYPE_OPA) {
+				e1s_index = 1;
+			} else {
+				e1s_index = 2;
+			}
+			break;
+		case INA233_EXPA_E1S_2_ADDR:
+			//check the card type because address is the same as INA233_EXPB_E1S_4_ADDR
+			if (card_type == CARD_TYPE_OPA) {
+				e1s_index = 2;
+			} else {
+				e1s_index = 4;
+			}
+			break;
+		case INA233_EXPB_E1S_1_ADDR:
+			e1s_index = 1;
+			break;
+		case INA233_EXPB_E1S_3_ADDR:
+			e1s_index = 3;
+			break;
+		default:
+			break;
+		}
+		break;
+	case sensor_dev_nvme:
+		nvme_i2c_mux = (i2c_proc_arg *)(sensor_cfgs->pre_sensor_read_args);
+		/* For OPA expansion, the I3C HUB connect slave port-0/1/5.
+		 * For OPB expansion, the I3C HUB connect slave port-0/1/2/3/4.
+		 */
+		switch (nvme_i2c_mux->channel) {
+		case I2C_HUB_CHANNEL_0:
+			// i2c hub channel 0 connect to E1S 0
+			e1s_index = 0;
+			break;
+		case I2C_HUB_CHANNEL_1:
+			// i2c hub channel 1 connect to E1S 1
+			e1s_index = 1;
+			break;
+		case I2C_HUB_CHANNEL_2:
+		case I2C_HUB_CHANNEL_5:
+			// i2c hub channel 5 connect to E1S 2 on opa
+			// i2c hub channel 2 connect to E1S 2 on opb
+			e1s_index = 2;
+			break;
+		case I2C_HUB_CHANNEL_3:
+			// i2c hub channel 3 connect to E1S 3
+			e1s_index = 3;
+			break;
+		case I2C_HUB_CHANNEL_4:
+			// i2c hub channel 4 connect to E1S 4
+			e1s_index = 4;
+			break;
+		default:
+			break;
+		}
+		break;
+	case sensor_dev_ast_adc:
+		e1s_index = sensor_cfgs->port;
+		break;
+	default:
+		LOG_ERR("Unsupported sensor device for e1s checking.");
+		break;
+	}
+
+	return get_e1s_present(e1s_index) && get_DC_on_delayed_status();
 }

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.c
@@ -47,67 +47,67 @@ sensor_cfg plat_sensor_config[] = {
     */
 
 	//INA233 VOL
-	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_E1S_0_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_E1S_1_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[1] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_E1S_2_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[2] },
 
-	{ SENSOR_NUM_1OU_P12V_EDGE_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_MAIN_ADDR,
+	{ SENSOR_NUM_1OU_P12V_EDGE_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[5] },
 
 	//INA233 CURR
-	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_0_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_1_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[1] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_2_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[2] },
 
-	{ SENSOR_NUM_1OU_P12V_EDGE_CURR, sensor_dev_ina233, I2C_BUS3, INA233_MAIN_ADDR,
+	{ SENSOR_NUM_1OU_P12V_EDGE_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[5] },
 
 	//INA233 PWR
-	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_0_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_1_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[1] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_2_ADDR,
+	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[2] },
 
-	{ SENSOR_NUM_1OU_P12V_EDGE_PWR, sensor_dev_ina233, I2C_BUS3, INA233_MAIN_ADDR,
+	{ SENSOR_NUM_1OU_P12V_EDGE_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[5] },
 
 	//E1S Temp
 	{ SENSOR_NUM_1OU_E1S_SSD0_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
@@ -134,31 +134,31 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
 	//adc
-	{ SENSOR_NUM_1OU_P3V3_STBY_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE, stby_access,
+	{ SENSOR_NUM_1OU_P3V3_STBY_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT5, NONE, NONE, stby_access,
 	  2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE,
+	{ SENSOR_NUM_1OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE,
 	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD1_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE,
+	{ SENSOR_NUM_1OU_E1S_SSD1_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE,
 	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD2_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT3, NONE, NONE,
+	{ SENSOR_NUM_1OU_E1S_SSD2_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE,
 	  dc_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_P1V8_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT4, NONE, NONE, dc_access, 1, 1,
+	{ SENSOR_NUM_1OU_P1V8_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, dc_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_P0V9_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT5, NONE, NONE, dc_access, 1, 1,
+	{ SENSOR_NUM_1OU_P0V9_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT7, NONE, NONE, dc_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_P1V2_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, dc_access, 1, 1,
+	{ SENSOR_NUM_1OU_P1V2_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT8, NONE, NONE, dc_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 };
@@ -220,43 +220,47 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	//INA233 VOL
-	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_E1S_3_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[3] },
 
-	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_E1S_4_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_4_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[4] },
 
 	//INA233 CURR
-	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_3_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[3] },
 
-	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_4_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_4_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[4] },
 
 	//INA233 PWR
-	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_3_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[3] },
 
-	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_E1S_4_ADDR,
+	{ SENSOR_NUM_2OU_E1S_SSD4_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_4_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
+	  &ina233_init_args[4] },
 };
 
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
 
 void load_sensor_config(void)
 {
+	// According to card type change address of INA233 sensor
+	change_ina233_sensor_addr();
+
+	// According to card position change sensor number
 	pal_change_sensor_config_number();
 
 	memcpy(sensor_config, plat_sensor_config, sizeof(plat_sensor_config));
@@ -284,6 +288,41 @@ uint8_t pal_get_extend_sensor_config()
 	}
 
 	return extend_sensor_table_size;
+}
+
+void change_ina233_sensor_addr()
+{
+	int index = 0;
+	uint8_t card_type = get_card_type();
+
+	// Default sensor table is defined for OPA
+	// if the card type is OPB, change INA233 device address
+	if (card_type == CARD_TYPE_OPB) {
+		for (index = 0; index < SENSOR_CONFIG_SIZE; index++) {
+			if (plat_sensor_config[index].type == sensor_dev_ina233) {
+				switch (plat_sensor_config[index].target_addr) {
+				case INA233_EXPA_E1S_0_ADDR:
+					plat_sensor_config[index].target_addr =
+						INA233_EXPB_E1S_0_ADDR;
+					break;
+				case INA233_EXPA_E1S_1_ADDR:
+					plat_sensor_config[index].target_addr =
+						INA233_EXPB_E1S_1_ADDR;
+					break;
+				case INA233_EXPA_E1S_2_ADDR:
+					plat_sensor_config[index].target_addr =
+						INA233_EXPB_E1S_2_ADDR;
+					break;
+				case INA233_EXPA_MAIN_ADDR:
+					plat_sensor_config[index].target_addr =
+						INA233_EXPB_MAIN_ADDR;
+					break;
+				default:
+					break;
+				}
+			}
+		}
+	}
 }
 
 void pal_change_sensor_config_number()

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.h
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.h
@@ -24,12 +24,16 @@
 
 #define TMP75_EXPA_TEMP_ADDR (0x94 >> 1)
 #define TMP75_EXPB_TEMP_ADDR (0x9A >> 1)
-#define INA233_E1S_0_ADDR (0x8A >> 1)
-#define INA233_E1S_1_ADDR (0x82 >> 1)
-#define INA233_E1S_2_ADDR (0x88 >> 1)
-#define INA233_E1S_3_ADDR (0x92 >> 1)
-#define INA233_E1S_4_ADDR (0x98 >> 1)
-#define INA233_MAIN_ADDR (0x90 >> 1)
+#define INA233_EXPA_E1S_0_ADDR (0x8C >> 1)
+#define INA233_EXPA_E1S_1_ADDR (0x88 >> 1)
+#define INA233_EXPA_E1S_2_ADDR (0x98 >> 1)
+#define INA233_EXPA_MAIN_ADDR (0x9A >> 1)
+#define INA233_EXPB_E1S_0_ADDR (0x8A >> 1)
+#define INA233_EXPB_E1S_1_ADDR (0x82 >> 1)
+#define INA233_EXPB_E1S_2_ADDR (0x88 >> 1)
+#define INA233_EXPB_E1S_3_ADDR (0x92 >> 1)
+#define INA233_EXPB_E1S_4_ADDR (0x98 >> 1)
+#define INA233_EXPB_MAIN_ADDR (0x90 >> 1)
 #define NVME_ADDR (0xD4 >> 1)
 
 #define TMP75_TEMP_OFFSET 0x00
@@ -194,5 +198,6 @@ void pal_change_sensor_config_number(void);
 void pal_extend_sensor_config(void);
 void load_sensor_config(void);
 uint8_t pal_get_extend_sensor_config(void);
+void change_ina233_sensor_addr(void);
 
 #endif


### PR DESCRIPTION
Summary:
- Checking e1s accessable before bic polling the sensor reading.

Test Plan:
-Build code: pass

uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x41] 1OU_E1S_SSD0_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x42] 1OU_E1S_SSD1_P12V_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.522
[0x43] 1OU_E1S_SSD2_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x46] 1OU_BIC_P12V_EDGE_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.493
[0x50] 1OU_E1S_SSD0_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x51] 1OU_E1S_SSD1_P12V_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.096
[0x52] 1OU_E1S_SSD2_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x55] 1OU_E1S_P12V_EDGE_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.218
[0x56] 1OU_E1S_SSD0_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x57] 1OU_E1S_SSD1_P12V_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.200
[0x58] 1OU_E1S_SSD2_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5b] 1OU_E1S_P12V_EDGE_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.750
[0x5c] 1OU_E1S_SSD0_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5d] 1OU_E1S_SSD1_TEMP_C      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    32.000
[0x5e] 1OU_E1S_SSD2_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x40] 1OU_BIC_TEMP_C           : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    25.000
[0x4c] 1OU_ADC_P3V3_STBY_VOLT_V : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.338
[0x47] 1OU_E1S_ADC_SSD0_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x48] 1OU_E1S_ADC_SSD1_P3V3_VOLT_V: adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.320
[0x49] 1OU_E1S_ADC_SSD2_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x4d] 1OU_ADC_P1V8_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.843
[0x4e] 1OU_ADC_P0V9_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.930
[0x4f] 1OU_ADC_P1V2_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.213