### PR TITLE
ol2: op: Correct sensor threshold

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_sdr_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sdr_table.c
@@ -72,8 +72,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x55, // UNRT
-		0x30, // UCT
+		0x00, // UNRT
+		0x37, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -121,24 +121,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x54, // [7:0] M bits
+		0x0B, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xD0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFD, // UNRT
-		0xFA, // UCT
-		0xF8, // UNCT
-		0xD3, // LNRT
-		0xD5, // LCT
-		0xD7, // LNCT
+		0x7E, // UNRT
+		0x7D, // UCT
+		0x7C, // UNCT
+		0x65, // LNRT
+		0x66, // LCT
+		0x67, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -182,24 +182,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x54, // [7:0] M bits
+		0x0B, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xD0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFD, // UNRT
-		0xFA, // UCT
-		0xF8, // UNCT
-		0xD3, // LNRT
-		0xD5, // LCT
-		0xD7, // LNCT
+		0x7E, // UNRT
+		0x7D, // UCT
+		0x7C, // UNCT
+		0x65, // LNRT
+		0x66, // LCT
+		0x67, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -243,24 +243,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x54, // [7:0] M bits
+		0x0B, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xD0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFD, // UNRT
-		0xFA, // UCT
-		0xF8, // UNCT
-		0xD3, // LNRT
-		0xD5, // LCT
-		0xD7, // LNCT
+		0x7E, // UNRT
+		0x7D, // UCT
+		0x7C, // UNCT
+		0x65, // LNRT
+		0x66, // LCT
+		0x67, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -304,24 +304,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x54, // [7:0] M bits
+		0x0B, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xD0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFD, // UNRT
-		0xFA, // UCT
-		0xF8, // UNCT
-		0xD3, // LNRT
-		0xD5, // LCT
-		0xD7, // LNCT
+		0x7E, // UNRT
+		0x7D, // UCT
+		0x7C, // UNCT
+		0x65, // LNRT
+		0x66, // LCT
+		0x67, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -365,24 +365,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x74, // [7:0] M bits
+		0x03, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF3, // UNRT
-		0xF1, // UCT
-		0xEF, // UNCT
-		0xCB, // LNRT
-		0xCD, // LCT
-		0xD0, // LNCT
+		0x7F, // UNRT
+		0x77, // UCT
+		0x76, // UNCT
+		0x5D, // LNRT
+		0x65, // LCT
+		0x66, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -426,24 +426,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x74, // [7:0] M bits
+		0x03, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF3, // UNRT
-		0xF1, // UCT
-		0xEF, // UNCT
-		0xCB, // LNRT
-		0xCD, // LCT
-		0xD0, // LNCT
+		0x7F, // UNRT
+		0x77, // UCT
+		0x76, // UNCT
+		0x5D, // LNRT
+		0x65, // LCT
+		0x66, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -487,24 +487,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x74, // [7:0] M bits
+		0x03, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF3, // UNRT
-		0xF1, // UCT
-		0xEF, // UNCT
-		0xCB, // LNRT
-		0xCD, // LCT
-		0xD0, // LNCT
+		0x7F, // UNRT
+		0x77, // UCT
+		0x76, // UNCT
+		0x5D, // LNRT
+		0x65, // LCT
+		0x66, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -548,24 +548,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x74, // [7:0] M bits
+		0x03, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF3, // UNRT
-		0xF1, // UCT
-		0xEF, // UNCT
-		0xCB, // LNRT
-		0xCD, // LCT
-		0xD0, // LNCT
+		0x7F, // UNRT
+		0x77, // UCT
+		0x76, // UNCT
+		0x5D, // LNRT
+		0x65, // LCT
+		0x66, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -609,24 +609,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x78, // [7:0] M bits
+		0x01, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFC, // UNRT
-		0xFA, // UCT
-		0xF7, // UNCT
-		0xD2, // LNRT
-		0xD5, // LCT
-		0xD7, // LNCT
+		0xC4, // UNRT
+		0xC2, // UCT
+		0xC0, // UNCT
+		0xA4, // LNRT
+		0xA5, // LCT
+		0xA7, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -670,24 +670,24 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x52, // [7:0] M bits
+		0x01, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFC, // UNRT
-		0xFA, // UCT
-		0xF7, // UNCT
-		0xD2, // LNRT
-		0xD5, // LCT
-		0xD7, // LNCT
+		0x83, // UNRT
+		0x82, // UCT
+		0x80, // UNCT
+		0x6D, // LNRT
+		0x6E, // LCT
+		0x70, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -731,21 +731,21 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x86, // [7:0] M bits
+		0x01, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFC, // UNRT
-		0xFA, // UCT
-		0xF8, // UNCT
+		0xD7, // UNRT
+		0xD5, // UCT
+		0xD2, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -792,21 +792,21 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x86, // [7:0] M bits
+		0x01, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFC, // UNRT
-		0xFA, // UCT
-		0xF8, // UNCT
+		0xD7, // UNRT
+		0xD5, // UCT
+		0xD2, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -853,21 +853,21 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x86, // [7:0] M bits
+		0x01, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFC, // UNRT
-		0xFA, // UCT
-		0xF8, // UNCT
+		0xD7, // UNRT
+		0xD5, // UCT
+		0xD2, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -914,21 +914,21 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x0C, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFA, // UNRT
-		0xF7, // UCT
-		0xF5, // UNCT
+		0xD0, // UNRT
+		0xCE, // UCT
+		0xCC, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -975,21 +975,21 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x0C, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFA, // UNRT
-		0xF7, // UCT
-		0xF5, // UNCT
+		0xD0, // UNRT
+		0xCE, // UCT
+		0xCC, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1036,21 +1036,21 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x0C, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFA, // UNRT
-		0xF7, // UCT
-		0xF5, // UNCT
+		0xD0, // UNRT
+		0xCE, // UCT
+		0xCC, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1282,24 +1282,24 @@ SDR_Full_sensor plat_EXPA_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x39, // [7:0] M bits
+		0x01, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFC, // UNRT
-		0xFA, // UCT
-		0xF7, // UNCT
-		0xD2, // LNRT
-		0xD5, // LCT
-		0xD7, // LNCT
+		0x62, // UNRT
+		0x61, // UCT
+		0x60, // UNCT
+		0x52, // LNRT
+		0x53, // LCT
+		0x54, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -1343,21 +1343,21 @@ SDR_Full_sensor plat_EXPA_sdr_table[] = {
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x94, // [7:0] M bits
+		0x01, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF6, // UNRT
-		0xF3, // UCT
-		0xF1, // UNCT
+		0xE4, // UNRT
+		0xE2, // UCT
+		0xE0, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1404,7 +1404,7 @@ SDR_Full_sensor plat_EXPA_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x12, // [7:0] M bits
+		0x11, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -1416,9 +1416,9 @@ SDR_Full_sensor plat_EXPA_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF1, // UNRT
-		0xEE, // UCT
-		0xEC, // UNCT
+		0xA8, // UNRT
+		0xA7, // UCT
+		0xA5, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1466,24 +1466,24 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x54, // [7:0] M bits
+		0x0B, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xD0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFD, // UNRT
-		0xFA, // UCT
-		0xF8, // UNCT
-		0xD3, // LNRT
-		0xD5, // LCT
-		0xD7, // LNCT
+		0x7E, // UNRT
+		0x7D, // UCT
+		0x7C, // UNCT
+		0x65, // LNRT
+		0x66, // LCT
+		0x67, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -1527,24 +1527,24 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x54, // [7:0] M bits
+		0x0B, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xD0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFD, // UNRT
-		0xFA, // UCT
-		0xF8, // UNCT
-		0xD3, // LNRT
-		0xD5, // LCT
-		0xD7, // LNCT
+		0x7E, // UNRT
+		0x7D, // UCT
+		0x7C, // UNCT
+		0x65, // LNRT
+		0x66, // LCT
+		0x67, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -1588,24 +1588,24 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x74, // [7:0] M bits
+		0x03, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF3, // UNRT
-		0xF1, // UCT
-		0xEF, // UNCT
-		0xCB, // LNRT
-		0xCD, // LCT
-		0xD0, // LNCT
+		0x7F, // UNRT
+		0x77, // UCT
+		0x76, // UNCT
+		0x5D, // LNRT
+		0x65, // LCT
+		0x66, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -1649,24 +1649,24 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x74, // [7:0] M bits
+		0x03, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF3, // UNRT
-		0xF1, // UCT
-		0xEF, // UNCT
-		0xCB, // LNRT
-		0xCD, // LCT
-		0xD0, // LNCT
+		0x7F, // UNRT
+		0x77, // UCT
+		0x76, // UNCT
+		0x5D, // LNRT
+		0x65, // LCT
+		0x66, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved
@@ -1710,21 +1710,21 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x86, // [7:0] M bits
+		0x01, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF4, // UNRT
-		0xF2, // UCT
-		0xF0, // UNCT
+		0xD7, // UNRT
+		0xD5, // UCT
+		0xD2, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1771,21 +1771,21 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x86, // [7:0] M bits
+		0x01, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xC0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF4, // UNRT
-		0xF2, // UCT
-		0xF0, // UNCT
+		0xD7, // UNRT
+		0xD5, // UCT
+		0xD2, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1832,21 +1832,21 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x68, // [7:0] M bits
+		0x07, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xD0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF7, // UNRT
-		0xF5, // UCT
-		0xF3, // UNCT
+		0xF5, // UNRT
+		0xF3, // UCT
+		0xF1, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2015,7 +2015,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x82, // [7:0] M bits
+		0x07, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -2027,9 +2027,9 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xF4, // UNRT
-		0xF1, // UCT
-		0xEF, // UNCT
+		0xDD, // UNRT
+		0xDB, // UCT
+		0xD9, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT


### PR DESCRIPTION
Summary:
- Correct sensor threshold.

Test plan:
- Build code: Pass
- Get sensor threshold: Pass

Log:
1. Get 1OU sensor threshold. root@bmc-oob:~# sensor-util slot1 --thre | grep 1OU
1OU_BIC_TEMP_C               (0x40) :   24.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
1OU_E1S_SSD0_P12V_VOLT_V     (0x41) : NA | (na)
1OU_E1S_SSD1_P12V_VOLT_V     (0x42) :   12.52 Volts  | (ok) | UCR: 13.75 | UNC: 13.64 | UNR: 13.86 | LCR: 11.22 | LNC: 11.33 | LNR: 11.11
1OU_E1S_SSD2_P12V_VOLT_V     (0x43) : NA | (na)
1OU_BIC_P12V_EDGE_VOLT_V     (0x46) :   12.48 Volts  | (ok) | UCR: 13.75 | UNC: 13.64 | UNR: 13.86 | LCR: 11.22 | LNC: 11.33 | LNR: 11.11
1OU_E1S_ADC_SSD0_P3V3_VOLT_V (0x47) : NA | (na)
1OU_E1S_ADC_SSD1_P3V3_VOLT_V (0x48) :    3.32 Volts  | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
1OU_E1S_ADC_SSD2_P3V3_VOLT_V (0x49) : NA | (na)
1OU_ADC_P3V3_STBY_VOLT_V     (0x4C) :    3.34 Volts  | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
1OU_ADC_P1V8_VOLT_V          (0x4D) :    1.84 Volts  | (ok) | UCR: 1.94 | UNC: 1.92 | UNR: 1.96 | LCR: 1.65 | LNC: 1.67 | LNR: 1.64
1OU_ADC_P0V9_VOLT_V          (0x4E) :    0.93 Volts  | (ok) | UCR: 0.97 | UNC: 0.96 | UNR: 0.98 | LCR: 0.83 | LNC: 0.84 | LNR: 0.82
1OU_ADC_P1V2_VOLT_V          (0x4F) :    1.21 Volts  | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.31 | LCR: 1.10 | LNC: 1.12 | LNR: 1.09
1OU_E1S_SSD0_P12V_CURR_A     (0x50) : NA | (na)
1OU_E1S_SSD1_P12V_CURR_A     (0x51) :    0.10 Amps  | (ok) | UCR: 2.13 | UNC: 2.10 | UNR: 2.15 | LCR: NA | LNC: NA | LNR: NA
1OU_E1S_SSD2_P12V_CURR_A     (0x52) : NA | (na)
1OU_E1S_P12V_EDGE_CURR_A     (0x55) :    0.22 Amps  | (ok) | UCR: 2.26 | UNC: 2.24 | UNR: 2.28 | LCR: NA | LNC: NA | LNR: NA
1OU_E1S_SSD0_P12V_PWR_W      (0x56) : NA | (na)
1OU_E1S_SSD1_P12V_PWR_W      (0x57) :    1.20 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
1OU_E1S_SSD2_P12V_PWR_W      (0x58) : NA | (na)
1OU_E1S_P12V_EDGE_PWR_W      (0x5B) :    2.70 Watts  | (ok) | UCR: 28.39 | UNC: 28.05 | UNR: 28.56 | LCR: NA | LNC: NA | LNR: NA
1OU_E1S_SSD0_TEMP_C          (0x5C) : NA | (na)
1OU_E1S_SSD1_TEMP_C          (0x5D) :   31.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
1OU_E1S_SSD2_TEMP_C          (0x5E) : NA | (na)

2. Get 2OU sensor threshold. root@bmc-oob:~# sensor-util slot1 --thre | grep 2OU
2OU_BIC_TEMP_C               (0x70) :   23.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD0_P12V_VOLT_V     (0x71) : NA | (na)
2OU_E1S_SSD1_P12V_VOLT_V     (0x72) : NA | (na)
2OU_E1S_SSD2_P12V_VOLT_V     (0x73) :   12.52 Volts  | (ok) | UCR: 13.75 | UNC: 13.64 | UNR: 13.86 | LCR: 11.22 | LNC: 11.33 | LNR: 11.11
2OU_E1S_SSD3_P12V_VOLT_V     (0x74) : NA | (na)
2OU_E1S_SSD4_P12V_VOLT_V     (0x75) : NA | (na)
2OU_BIC_MAIN_P12V_VOLT_V     (0x76) :   12.53 Volts  | (ok) | UCR: 13.75 | UNC: 13.64 | UNR: 13.86 | LCR: 11.22 | LNC: 11.33 | LNR: 11.11
2OU_E1S_ADC_SSD0_P3V3_VOLT_V (0x77) : NA | (na)
2OU_E1S_ADC_SSD1_P3V3_VOLT_V (0x78) : NA | (na)
2OU_E1S_ADC_SSD2_P3V3_VOLT_V (0x79) :    3.33 Volts  | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
2OU_E1S_ADC_SSD3_P3V3_VOLT_V (0x7A) : NA | (na)
2OU_E1S_ADC_SSD4_P3V3_VOLT_V (0x7B) : NA | (na)
2OU_ADC_P3V3_STBY_VOLT_V     (0x7C) :    3.32 Volts  | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
2OU_ADC_P1V8_VOLT_V          (0x7D) :    1.83 Volts  | (ok) | UCR: 1.94 | UNC: 1.92 | UNR: 1.96 | LCR: 1.65 | LNC: 1.67 | LNR: 1.64
2OU_ADC_P1V2_VOLT_V          (0x7F) :    1.19 Volts  | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.31 | LCR: 1.10 | LNC: 1.12 | LNR: 1.09
2OU_E1S_SSD0_P12V_CURR_A     (0x80) : NA | (na)
2OU_E1S_SSD1_P12V_CURR_A     (0x81) : NA | (na)
2OU_E1S_SSD2_P12V_CURR_A     (0x82) :    0.10 Amps  | (ok) | UCR: 2.13 | UNC: 2.10 | UNR: 2.15 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD3_P12V_CURR_A     (0x83) : NA | (na)
2OU_E1S_SSD4_P12V_CURR_A     (0x84) : NA | (na)
2OU_BIC_MAIN_P12V_CURR_A     (0x85) :    0.20 Amps  | (ok) | UCR: 17.01 | UNC: 16.87 | UNR: 17.15 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD0_P12V_PWR_W      (0x86) : NA | (na)
2OU_E1S_SSD1_P12V_PWR_W      (0x87) : NA | (na)
2OU_E1S_SSD2_P12V_PWR_W      (0x88) :    1.23 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD3_P12V_PWR_W      (0x89) : NA | (na)
2OU_E1S_SSD4_P12V_PWR_W      (0x8A) : NA | (na)
2OU_BIC_MAIN_P12V_PWR_W      (0x8B) :    2.45 Watts  | (ok) | UCR: 15.33 | UNC: 15.19 | UNR: 15.47 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD0_TEMP_C          (0x8C) : NA | (na)
2OU_E1S_SSD1_TEMP_C          (0x8D) : NA | (na)
2OU_E1S_SSD2_TEMP_C          (0x8E) :   31.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD3_TEMP_C          (0x8F) : NA | (na)
2OU_E1S_SSD4_TEMP_C          (0x90) : NA | (na)

3. Get 3OU sensor threshold. root@bmc-oob:~# sensor-util slot1 --thre | grep 3OU
3OU_BIC_TEMP_C               (0xA0) :   24.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD0_P12V_VOLT_V     (0xA1) : NA | (na)
3OU_E1S_SSD1_P12V_VOLT_V     (0xA2) :   12.52 Volts  | (ok) | UCR: 13.75 | UNC: 13.64 | UNR: 13.86 | LCR: 11.22 | LNC: 11.33 | LNR: 11.11
3OU_E1S_SSD2_P12V_VOLT_V     (0xA3) : NA | (na)
3OU_P12V_EDGE_VOLT_V         (0xA6) :   12.49 Volts  | (ok) | UCR: 13.75 | UNC: 13.64 | UNR: 13.86 | LCR: 11.22 | LNC: 11.33 | LNR: 11.11
3OU_E1S_ADC_SSD0_P3V3_VOLT_V (0xA7) : NA | (na)
3OU_E1S_ADC_SSD1_P3V3_VOLT_V (0xA8) :    3.31 Volts  | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
3OU_E1S_ADC_SSD2_P3V3_VOLT_V (0xA9) : NA | (na)
3OU_ADC_P3V3_STBY_VOLT_V     (0xAC) :    3.33 Volts  | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
3OU_ADC_P1V8_VOLT_V          (0xAD) :    1.82 Volts  | (ok) | UCR: 1.94 | UNC: 1.92 | UNR: 1.96 | LCR: 1.65 | LNC: 1.67 | LNR: 1.64
3OU_ADC_P0V9_VOLT_V          (0xAE) :    0.92 Volts  | (ok) | UCR: 0.97 | UNC: 0.96 | UNR: 0.98 | LCR: 0.83 | LNC: 0.84 | LNR: 0.82
3OU_ADC_P1V2_VOLT_V          (0xAF) :    1.20 Volts  | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.31 | LCR: 1.10 | LNC: 1.12 | LNR: 1.09
3OU_E1S_SSD0_P12V_CURR_A     (0xB0) : NA | (na)
3OU_E1S_SSD1_P12V_CURR_A     (0xB1) :    0.14 Amps  | (ok) | UCR: 2.13 | UNC: 2.10 | UNR: 2.15 | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD2_P12V_CURR_A     (0xB2) : NA | (na)
3OU_E1S_P12V_EDGE_CURR_A     (0xB5) :    0.22 Amps  | (ok) | UCR: 2.26 | UNC: 2.24 | UNR: 2.28 | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD0_P12V_PWR_W      (0xB6) : NA | (na)
3OU_E1S_SSD1_P12V_PWR_W      (0xB7) :    1.73 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD2_P12V_PWR_W      (0xB8) : NA | (na)
3OU_E1S_P12V_EDGE_PWR_W      (0xBB) :    2.75 Watts  | (ok) | UCR: 28.39 | UNC: 28.05 | UNR: 28.56 | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD0_TEMP_C          (0xBC) : NA | (na)
3OU_E1S_SSD1_TEMP_C          (0xBD) :   29.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD2_TEMP_C          (0xBE) : NA | (na)

4. Get 4OU sensor threshold. root@bmc-oob:~# sensor-util slot1 --thre --force | grep 4OU
4OU_BIC_TEMP_C               (0xD0) :   24.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD0_P12V_VOLT_V     (0xD1) : NA | (na)
4OU_E1S_SSD1_P12V_VOLT_V     (0xD2) : NA | (na)
4OU_E1S_SSD2_P12V_VOLT_V     (0xD3) : NA | (na)
4OU_E1S_SSD3_P12V_VOLT_V     (0xD4) : NA | (na)
4OU_E1S_SSD4_P12V_VOLT_V     (0xD5) :   12.53 Volts  | (ok) | UCR: 13.75 | UNC: 13.64 | UNR: 13.86 | LCR: 11.22 | LNC: 11.33 | LNR: 11.11
4OU_BIC_MAIN_P12V_VOLT_V     (0xD6) :   12.53 Volts  | (ok) | UCR: 13.75 | UNC: 13.64 | UNR: 13.86 | LCR: 11.22 | LNC: 11.33 | LNR: 11.11
4OU_E1S_ADC_SSD0_P3V3_VOLT_V (0xD7) : NA | (na)
4OU_E1S_ADC_SSD1_P3V3_VOLT_V (0xD8) : NA | (na)
4OU_E1S_ADC_SSD2_P3V3_VOLT_V (0xD9) : NA | (na)
4OU_E1S_ADC_SSD3_P3V3_VOLT_V (0xDA) : NA | (na)
4OU_E1S_ADC_SSD4_P3V3_VOLT_V (0xDB) :    3.35 Volts  | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
4OU_ADC_P3V3_STBY_VOLT_V     (0xDC) :    3.35 Volts  | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
4OU_ADC_P1V8_VOLT_V          (0xDD) :    1.82 Volts  | (ok) | UCR: 1.94 | UNC: 1.92 | UNR: 1.96 | LCR: 1.65 | LNC: 1.67 | LNR: 1.64
4OU_ADC_P1V2_VOLT_V          (0xDF) :    1.19 Volts  | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.31 | LCR: 1.10 | LNC: 1.12 | LNR: 1.09
4OU_E1S_SSD0_P12V_CURR_A     (0xE0) : NA | (na)
4OU_E1S_SSD1_P12V_CURR_A     (0xE1) : NA | (na)
4OU_E1S_SSD2_P12V_CURR_A     (0xE2) : NA | (na)
4OU_E1S_SSD3_P12V_CURR_A     (0xE3) : NA | (na)
4OU_E1S_SSD4_P12V_CURR_A     (0xE4) :    0.13 Amps  | (ok) | UCR: 2.13 | UNC: 2.10 | UNR: 2.15 | LCR: NA | LNC: NA | LNR: NA
4OU_BIC_MAIN_P12V_CURR_A     (0xE5) :    0.28 Amps  | (ok) | UCR: 17.01 | UNC: 16.87 | UNR: 17.15 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD0_P12V_PWR_W      (0xE6) : NA | (na)
4OU_E1S_SSD1_P12V_PWR_W      (0xE7) : NA | (na)
4OU_E1S_SSD2_P12V_PWR_W      (0xE8) : NA | (na)
4OU_E1S_SSD3_P12V_PWR_W      (0xE9) : NA | (na)
4OU_E1S_SSD4_P12V_PWR_W      (0xEA) :    1.67 Watts  | (ok) | UCR: 24.70 | UNC: 24.50 | UNR: 25.00 | LCR: NA | LNC: NA | LNR: NA
4OU_BIC_MAIN_P12V_PWR_W      (0xEB) :    3.47 Watts  | (ok) | UCR: 15.33 | UNC: 15.19 | UNR: 15.47 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD0_TEMP_C          (0xEC) : NA | (na)
4OU_E1S_SSD1_TEMP_C          (0xED) : NA | (na)
4OU_E1S_SSD2_TEMP_C          (0xEE) : NA | (na)
4OU_E1S_SSD3_TEMP_C          (0xEF) : NA | (na)
4OU_E1S_SSD4_TEMP_C          (0xF0) :   28.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA