### PR TITLE
fby3.5: hd: modify_platform_name

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_version.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_version.h
@@ -19,7 +19,7 @@
 
 #include "version.h"
 
-#define PLATFORM_NAME "Yosemite 3.5"
+#define PLATFORM_NAME "Yosemite V3.5"
 #define PROJECT_NAME "Half Dome"
 #define PROJECT_STAGE DVT
 


### PR DESCRIPTION
Summary:
- Modfiy platform name from "Yosemite 3.5" to "Yosemite V3.5". Fix the issue that inband update fail without force.

Test Plan:
- Build code: PASS
- Inband update: PASS

LOG:
```
[root@localhost ~]# ./host_update_test -i ./hd_test.bin
===============================================================================
* Name         : FW UPDATE TOOL
* Description  : Firmware update tool from host, including [BIC].
* Ver/Date     : v1.1.1/2022.08.24
* Note         : none
===============================================================================
<system> Start [BIC] update task with image [./hd_test.bin]

<system> STEP1. Read image
<system> PASS!

<system> STEP2. Create free-ipmi session
<system> PASS!

<system> STEP3. Verify image
Yosemite V3.5
Yosemite V3.5
<system> PASS!

<system> STEP4. Upload image
         update status 5%
         update status 10%
         update status 15%
         update status 20%
         update status 25%
         update status 30%
         update status 35%
         update status 40%
         update status 45%
         update status 50%
         update status 55%
         update status 60%
         update status 65%
         update status 70%
         update status 75%
         update status 80%
         update status 85%
         update status 90%
         update status 95%
         update status 100%
<system> PASS!
```