### PR TITLE
fby3: vf: modify temp sensor UCR/LCR

### DIFF
--- a/meta-facebook/yv3-vf/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv3-vf/src/platform/plat_sdr_table.c
@@ -82,7 +82,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x46, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x0A, // LCT
+		0x00, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1669,10 +1669,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xFF, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x44, // UCT
+		0x4C, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x0A, // LCT
+		0x00, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1731,10 +1731,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xFF, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x44, // UCT
+		0x4C, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x0A, // LCT
+		0x00, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1793,10 +1793,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xFF, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x44, // UCT
+		0x4C, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x0A, // LCT
+		0x00, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1855,10 +1855,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xFF, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x44, // UCT
+		0x4C, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x0A, // LCT
+		0x00, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold


### PR DESCRIPTION
Summary:
- remove LCR of temp sensor
- modify UCR of device temp from 68 to 76

Test plan:
- Build code : Pass

E1S Outlet Temp              (0x50) :   28.00 C     | (ok) | UCR: 70.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
E1S DEV0 Temp                (0x62) :   29.00 C     | (ok) | UCR: 76.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
E1S DEV1 Temp                (0x6A) :   41.00 C     | (ok) | UCR: 76.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
E1S DEV2 Temp                (0x72) :   37.00 C     | (ok) | UCR: 76.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
E1S DEV3 Temp                (0x7A) :   36.00 C     | (ok) | UCR: 76.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA