### PR TITLE
kcs: Avoid to sending response data twice from added SEL command

### DIFF
--- a/common/service/host/kcs.c
+++ b/common/service/host/kcs.c
@@ -131,7 +131,6 @@ static void kcs_read_task(void *arvg0, void *arvg1, void *arvg2)
 					SAFE_FREE(kcs_buff);
 				} while (0);
 			}
-
 			if ((req->netfn == NETFN_APP_REQ) &&
 			    (req->cmd == CMD_APP_SET_SYS_INFO_PARAMS) &&
 			    (req->data[0] == CMD_SYS_INFO_FW_VERSION)) {
@@ -174,7 +173,10 @@ static void kcs_read_task(void *arvg0, void *arvg1, void *arvg2)
 				kcs_buff[1] = bridge_msg.cmd;
 				kcs_buff[2] = bridge_msg.completion_code;
 				memcpy(&kcs_buff[3], &bridge_msg.data, bridge_msg.data_len);
-				kcs_write(kcs_inst->index, kcs_buff, 3 + bridge_msg.data_len);
+
+				if(!pal_immediate_respond_from_KCS(req->netfn, req->cmd)) {
+					kcs_write(kcs_inst->index, kcs_buff, 3 + bridge_msg.data_len);
+				}
 
 				SAFE_FREE(kcs_buff);
 			} else {


### PR DESCRIPTION
Summary:
- Because BIC will return response data of added SEL command immediately, KCS service should not return again after the handler complete.

Test plan:
- Power cycle and check BIC console

Test log:
[00:00:17.552,000] <inf> plat_isr: Send gpio interrupt to BMC, gpio number(39) status(0)
[00:00:19.241,000] <inf> plat_isr: Send gpio interrupt to BMC, gpio number(39) status(1)
[00:01:09.695,000] <wrn> power_status: POST_COMPLETE: yes
[00:01:09.695,000] <wrn> power_status: POST_COMPLETE: yes