### PR TITLE
yv35: cl: Enable i3c communication with BMC

### DIFF
--- a/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
@@ -80,20 +80,6 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
-&i2c6 {
-  pinctrl-0 = <&pinctrl_i2c6_default>;
-  clock-frequency = <I2C_BITRATE_FAST>;
-  status = "okay";
-
-  ipmb6: ipmb@20 {
-    compatible = "aspeed,ipmb";
-    reg = <0x20>;
-    label = "IPMB_6";
-    size = <10>;
-    status = "okay";
-  };
-};
-
 &i2c7 {
 	pinctrl-0 = <&pinctrl_i2c7_default>;
 	clock-frequency = <I2C_BITRATE_FAST_PLUS>;

--- a/meta-facebook/yv35-cl/src/platform/plat_ipmb.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_ipmb.c
@@ -25,7 +25,7 @@
 IPMB_config pal_IPMB_config_table[] = {
 	// index, interface, channel, bus, channel_target_address, enable_status, self_address,
 	// rx_thread_name, tx_thread_name
-  { BMC_IPMB_IDX, I2C_IF, BMC_IPMB, IPMB_I2C_BMC, BMC_I2C_ADDRESS, ENABLE, SELF_I2C_ADDRESS,
+  { BMC_IPMB_IDX, I2C_IF, BMC_IPMB, IPMB_I2C_BMC, BMC_I2C_ADDRESS, DISABLE, SELF_I2C_ADDRESS,
     "RX_BMC_IPMB_TASK", "TX_BMC_IPMB_TASK" },
   { ME_IPMB_IDX, I2C_IF, ME_IPMB, IPMB_ME_BUS, ME_I2C_ADDRESS, ENABLE, SELF_I2C_ADDRESS,
 	  "RX_ME_IPMB_TASK", "TX_ME_IPMB_TASK" },


### PR DESCRIPTION
Summary:
- Remove i2c setting in DTS to enable i3c communication with BMC

Test Plan:
- Send command to BIC and check the response

Test Log:
root@bmc-oob:~# bic-util slot4 0x18 0x1
00 80 21 10 02 BF 15 A0 00 00 00 00 00 00 00