### PR TITLE
ol2: op: Support retimer temperature

### DIFF
--- a/common/dev/include/pt5161l.h
+++ b/common/dev/include/pt5161l.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PT5161L_H
+#define PT5161L_H
+
+#define PT5161L_TEMP_OFFSET 0x42c
+
+#endif

--- a/common/dev/pt5161l.c
+++ b/common/dev/pt5161l.c
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <logging/log.h>
+
+#include "pt5161l.h"
+#include "hal_i2c.h"
+#include "libutil.h"
+#include "sensor.h"
+
+LOG_MODULE_REGISTER(dev_pt5161l);
+
+//Write multiple data bytes to retimer over I2C
+bool pt5161l_write_block_data(I2C_MSG *msg, uint32_t address, uint8_t num_bytes, uint8_t *values)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+	CHECK_NULL_ARG_WITH_RETURN(values, false);
+	uint8_t cmd_code;
+	uint8_t rsvd;
+	uint8_t func_code;
+	uint8_t start;
+	uint8_t end;
+	uint8_t upper_addr;
+	uint8_t lower_addr;
+	uint8_t retry = 3;
+
+	// If Address more than 16 bit, return with an error code
+	// Intel format only allows for 16 bit address
+	if (address > 0xffff) {
+		LOG_ERR("Address cannot be more than 16 bits in Intel format");
+		return false;
+	}
+
+	// If byte count is greater than 4, perform multiple iterations
+	// Hence keep track of remaining bytes each time we perform a
+	// transaction
+	uint8_t curr_bytes = 0;
+	uint8_t remaining_bytes = num_bytes;
+	while (remaining_bytes > 0) {
+		if (remaining_bytes > 4) {
+			curr_bytes = 4;
+			remaining_bytes -= 4;
+		} else {
+			curr_bytes = remaining_bytes;
+			remaining_bytes = 0;
+		}
+
+		rsvd = 0;
+		func_code = 1;
+		start = 1;
+		end = 1;
+
+		// Construct Command code
+		cmd_code = (rsvd << 5) + (func_code << 2) + (start << 1) + (end << 0);
+		upper_addr = (address & 0xff00) >> 8; // Get bits 16:8
+		lower_addr = address & 0xff; // Get bits 7:0
+
+		/* Set buffer length based on number of bytes being written
+         * 2 bytes of address in calculation
+         * 1 extra byte for num bytes in buffer
+        */
+		int write_num_bytes = 2 + 1 + curr_bytes;
+		msg->data[0] = cmd_code;
+		msg->data[1] = write_num_bytes - 1;
+		msg->data[2] = lower_addr;
+		msg->data[3] = upper_addr;
+
+		LOG_DBG("Write:");
+		LOG_DBG("msg->data[0] = 0x%02x", msg->data[0]);
+		LOG_DBG("msg->data[1] = 0x%02x", msg->data[1]);
+		LOG_DBG("msg->data[2] = 0x%02x", msg->data[2]);
+		LOG_DBG("msg->data[3] = 0x%02x", msg->data[3]);
+
+		memcpy(&(msg->data[4]), values, curr_bytes);
+
+		msg->tx_len = write_num_bytes + 1;
+
+		if (i2c_master_write(msg, retry)) {
+			LOG_ERR("pt5161l write block failed");
+			return false;
+		}
+
+		// Increment iteration count
+		values += curr_bytes;
+		address += curr_bytes;
+	}
+	return true;
+}
+
+/*
+ * Read multiple data bytes from Aries over I2C
+ */
+bool pt5161l_read_block_data(I2C_MSG *msg, uint32_t address, uint8_t num_bytes, uint8_t *values)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+	CHECK_NULL_ARG_WITH_RETURN(values, false);
+	uint8_t wr_cmd_code;
+	uint8_t rd_cmd_code;
+	uint8_t rsvd;
+	uint8_t func_code;
+	uint8_t start;
+	uint8_t end;
+
+	uint8_t upper_addr; // Get bits 16:8
+	uint8_t lower_addr; // Get bits 7:0
+
+	uint8_t retry = 3;
+
+	// If Address more than 16 bit, return with an error code
+	// Intel format only allows for 16 bit address
+	if (address > 0xffff) {
+		LOG_ERR("Address cannot be more than 16 bits in Intel format");
+		return false;
+	}
+
+	uint8_t remaining_bytes = num_bytes;
+	uint8_t curr_bytes = 0;
+	while (remaining_bytes > 0) {
+		if (remaining_bytes > 4) {
+			curr_bytes = 4;
+			remaining_bytes -= 4;
+		} else {
+			curr_bytes = remaining_bytes;
+			remaining_bytes = 0;
+		}
+
+		rsvd = 0;
+		func_code = 0;
+		start = 1;
+		end = 0;
+
+		wr_cmd_code = (rsvd << 5) + (func_code << 2) + (start << 1) + (end << 0);
+
+		upper_addr = (address & 0xff00) >> 8;
+		lower_addr = address & 0xff;
+
+		msg->data[0] = wr_cmd_code;
+		msg->data[1] = 3 - 1; //write Numbers Bytes - 1 byte wr_cmd_code
+		msg->data[2] = lower_addr;
+		msg->data[3] = upper_addr;
+		msg->tx_len = 4;
+
+		LOG_DBG("Write:");
+		LOG_DBG("cmd_code = 0x%02x", msg->data[0]);
+		LOG_DBG("msg->data[1] = 0x%02x", msg->data[1]);
+		LOG_DBG("msg->data[2] = 0x%02x", msg->data[2]);
+		LOG_DBG("msg->data[3] = 0x%02x", msg->data[3]);
+
+		// read buffer is 3 + data bytes always
+		// First byte is num.bytes read
+		// Second and third bytes are address
+		// Bytes 4 onwards is data (4 bytes)
+		uint8_t read_buf_len = 3 + 4;
+
+		if (i2c_master_write(msg, retry)) {
+			LOG_ERR("pt5161l write block failed");
+			return false;
+		}
+
+		start = 0;
+		end = 1;
+		func_code = 0;
+
+		rd_cmd_code = (rsvd << 5) + (func_code << 2) + (start << 1) + (end << 0);
+
+		msg->data[0] = rd_cmd_code;
+		msg->tx_len = 1;
+		msg->rx_len = read_buf_len;
+
+		LOG_DBG("Read:");
+		LOG_DBG("cmd_code = 0x%02x", rd_cmd_code);
+
+		if (i2c_master_read(msg, retry)) {
+			LOG_ERR("pt5161l read failed");
+			return false;
+		}
+
+		// Fill up user given array
+		memcpy(values, &(msg->data[3]), curr_bytes);
+
+		// Increment iteration count
+		values += curr_bytes;
+		address += curr_bytes;
+	}
+	return true;
+}
+
+//Get temp caliberation codes
+bool get_temp_calibration_codes(I2C_MSG *msg, pt5161l_init_arg *init_args)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+	CHECK_NULL_ARG_WITH_RETURN(init_args, false);
+	bool rc = false;
+	uint8_t data_byte[1];
+	uint8_t data_bytes5[5];
+	uint8_t invalid;
+	uint8_t flag;
+	uint8_t offset;
+	uint8_t cal_code;
+
+	// eFuse read procedure
+	// 1. Switch to refclk/8 clock for TCK
+	// self.csr.misc.efuse_cntl.sms_clk_sel = 1
+	rc = pt5161l_read_block_data(msg, 0x8ec, 5, data_bytes5);
+	if (!rc) {
+		LOG_ERR("Read refclk clock for TCK failed");
+		return rc;
+	}
+	// Assert bit 25
+	data_bytes5[3] = SETBIT(data_bytes5[3], 1);
+	rc = pt5161l_write_block_data(msg, 0x8ec, 5, data_bytes5);
+	if (!rc) {
+		LOG_ERR("Set refclk clock for TCK failed");
+		return rc;
+	}
+	// 2. Assert efuse_load
+	// self.csr.misc.sms_efuse_cntl.sms_efuse_load = 1
+	rc = pt5161l_read_block_data(msg, 0x8f6, 1, data_byte);
+	if (!rc) {
+		LOG_ERR("Read assert efuse_load failed");
+		return rc;
+	}
+	// Assert bit 7
+	data_byte[0] = SETBIT(data_byte[0], 7);
+	rc = pt5161l_write_block_data(msg, 0x8f6, 1, data_byte);
+	if (!rc) {
+		LOG_ERR("Set assert efuse_load failed");
+		return rc;
+	}
+	// 3. Assert smart_test
+	// self.csr.misc.efuse_cntl.smart_test = 1
+	rc = pt5161l_read_block_data(msg, 0x8ec, 5, data_bytes5);
+	if (!rc) {
+		LOG_ERR("Read assert smart_test failed");
+		return rc;
+	}
+	// Assert bit 24
+	data_bytes5[3] = SETBIT(data_bytes5[3], 0);
+	rc = pt5161l_write_block_data(msg, 0x8ec, 5, data_bytes5);
+	if (!rc) {
+		LOG_ERR("Set assert smart_test failed");
+		return rc;
+	}
+	// 4. De-assert smart_test
+	// self.csr.misc.efuse_cntl.smart_test = 0
+	rc = pt5161l_read_block_data(msg, 0x8ec, 5, data_bytes5);
+	if (!rc) {
+		LOG_ERR("Read De-assert smart_test failed");
+		return rc;
+	}
+	// De-assert bit 24
+	data_bytes5[3] = CLEARBIT(data_bytes5[3], 0);
+	rc = pt5161l_write_block_data(msg, 0x8ec, 5, data_bytes5);
+	if (!rc) {
+		LOG_ERR("Set De-assert smart_test failed");
+		return rc;
+	}
+	// 5. De-assert efuse_load
+	// self.csr.misc.sms_efuse_cntl.sms_efuse_load = 0
+	rc = pt5161l_read_block_data(msg, 0x8f6, 1, data_byte);
+	if (!rc) {
+		LOG_ERR("Read De-assert efuse_load failed");
+		return rc;
+	}
+	// De-assert bit 7
+	data_byte[0] = CLEARBIT(data_byte[0], 7);
+	rc = pt5161l_write_block_data(msg, 0x8f6, 1, data_byte);
+	if (!rc) {
+		LOG_ERR("Set De-assert efuse_load failed");
+		return rc;
+	}
+
+	// Read eFuse “primary page invalid” bit and adjust offset accordingly
+	// Set address
+	data_byte[0] = 63;
+	rc = pt5161l_write_block_data(msg, 0x8f6, 1, data_byte);
+	if (!rc) {
+		LOG_ERR("Set eFuse primary page invalid bit failed");
+		return rc;
+	}
+	// Read data
+	rc = pt5161l_read_block_data(msg, 0x8f7, 1, data_byte);
+	if (!rc) {
+		LOG_ERR("Read eFuse primary page invalid bit failed");
+		return rc;
+	}
+	invalid = data_byte[0];
+
+	if (invalid & 0x80) {
+		offset = 64;
+	} else {
+		offset = 0;
+	}
+
+	// Determine calibration codes
+	// Set address
+	data_byte[0] = 48 + offset;
+	rc = pt5161l_write_block_data(msg, 0x8f6, 1, data_byte);
+	if (!rc) {
+		LOG_ERR("Set Determine calibration codes failed");
+		return rc;
+	}
+	// Read data
+	rc = pt5161l_read_block_data(msg, 0x8f7, 1, data_byte);
+	if (!rc) {
+		LOG_ERR("Read Determine calibration codes failed");
+		return rc;
+	}
+	flag = data_byte[0];
+
+	// Compute PMA A calibration codes
+	int i;
+	for (i = 0; i < 4; i++) {
+		if (flag & 0x4) {
+			data_byte[0] = 34 + (i * 4) + offset;
+			rc = pt5161l_write_block_data(msg, 0x8f6, 1, data_byte);
+			if (!rc) {
+				LOG_ERR("Set PMA A[%d] calibration codes failed", i);
+				return rc;
+			}
+			rc = pt5161l_read_block_data(msg, 0x8f7, 1, data_byte);
+			if (!rc) {
+				LOG_ERR("Read PMA A[%d] calibration codes failed", i);
+				return rc;
+			}
+			cal_code = data_byte[0];
+			if (cal_code == 0) {
+				cal_code = 84;
+			}
+		} else {
+			cal_code = 84;
+		}
+		init_args->temp_cal_code_pma_a[i] = cal_code;
+	}
+
+	// Compute PMA B calibration codes
+	for (i = 0; i < 4; i++) {
+		if (flag & 0x04) {
+			data_byte[0] = 32 + (i * 4) + offset;
+			rc = pt5161l_write_block_data(msg, 0x8f6, 1, data_byte);
+			if (!rc) {
+				LOG_ERR("Set PMA B[%d] calibration codes failed", i);
+				return rc;
+			}
+			rc = pt5161l_read_block_data(msg, 0x8f7, 1, data_byte);
+			if (!rc) {
+				LOG_ERR("Read PMA B[%d] calibration codes failed", i);
+				return rc;
+			}
+			cal_code = data_byte[0];
+			if (cal_code == 0) {
+				cal_code = 84;
+			}
+		} else {
+			cal_code = 84;
+		}
+		init_args->temp_cal_code_pma_b[i] = cal_code;
+	}
+
+	// Calcualte the average PMA calibration code
+	init_args->temp_cal_code_avg =
+		(init_args->temp_cal_code_pma_a[0] + init_args->temp_cal_code_pma_a[1] +
+		 init_args->temp_cal_code_pma_a[2] + init_args->temp_cal_code_pma_a[3] +
+		 init_args->temp_cal_code_pma_b[0] + init_args->temp_cal_code_pma_b[1] +
+		 init_args->temp_cal_code_pma_b[2] + init_args->temp_cal_code_pma_b[3] + 8 / 2) /
+		8; // Add denominator/2 to cause integer rounding
+	return rc;
+}
+
+double pt5161l_read_avg_temp(I2C_MSG *i2c_msg, uint8_t temp_cal_code_avg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(i2c_msg, 0);
+	uint8_t data_bytes[4] = { 0 };
+	int adc_code;
+	double avg_temperature = 0;
+
+	if (!pt5161l_read_block_data(i2c_msg, PT5161L_TEMP_OFFSET, 4, data_bytes)) {
+		LOG_ERR("Read Avg Temperature failed");
+		return 0;
+	}
+
+	adc_code = (data_bytes[3] << 24) + (data_bytes[2] << 16) + (data_bytes[1] << 8) +
+		   data_bytes[0];
+
+	avg_temperature = 110 - ((adc_code - (temp_cal_code_avg + 250)) * 0.32);
+
+	return avg_temperature;
+}
+
+uint8_t pt5161l_read(uint8_t sensor_num, int *reading)
+{
+	if ((reading == NULL) || (sensor_num > SENSOR_NUM_MAX) ||
+	    (sensor_config[sensor_config_index_map[sensor_num]].init_args == NULL)) {
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	pt5161l_init_arg *init_arg =
+		(pt5161l_init_arg *)sensor_config[sensor_config_index_map[sensor_num]].init_args;
+
+	if (!init_arg->is_init) {
+		LOG_ERR("device isn't initialized");
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	double val = 0;
+	I2C_MSG msg = { 0 };
+
+	sensor_cfg *cfg = &sensor_config[sensor_config_index_map[sensor_num]];
+
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+
+	switch (cfg->offset) {
+	case PT5161L_TEMP_OFFSET:
+		val = pt5161l_read_avg_temp(&msg, init_arg->temp_cal_code_avg);
+		break;
+	default:
+		LOG_ERR("Invalid sensor 0x%x offset 0x%x", sensor_num, cfg->offset);
+		return SENSOR_NOT_FOUND;
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	memset(sval, 0, sizeof(*sval));
+
+	sval->integer = (int)val & 0xFFFF;
+	sval->fraction = (val - sval->integer) * 1000;
+
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t pt5161l_init(uint8_t sensor_num)
+{
+	if (sensor_num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	I2C_MSG msg;
+	msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
+	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
+
+	pt5161l_init_arg *init_args =
+		(pt5161l_init_arg *)sensor_config[sensor_config_index_map[sensor_num]].init_args;
+
+	if (init_args->is_init) {
+		goto exit;
+	}
+
+	// Get temp caliberation codes
+	if (!get_temp_calibration_codes(&msg, init_args)) {
+		goto error;
+	}
+
+	init_args->is_init = true;
+
+exit:
+	sensor_config[sensor_config_index_map[sensor_num]].read = pt5161l_read;
+	return SENSOR_INIT_SUCCESS;
+
+error:
+	return SENSOR_INIT_UNSPECIFIED_ERROR;
+}

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -100,10 +100,11 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(q50sn120a1)
 	sensor_name_to_num(mp2971)
 	sensor_name_to_num(pm8702)
-  sensor_name_to_num(ltc2991)
-  sensor_name_to_num(sq52205)
-  sensor_name_to_num(emc1412)
+	sensor_name_to_num(ltc2991)
+	sensor_name_to_num(sq52205)
+	sensor_name_to_num(emc1412)
 	sensor_name_to_num(i3c_dimm)
+	sensor_name_to_num(pt5161l)
 
 };
 // clang-format on
@@ -150,6 +151,7 @@ SENSOR_DRIVE_INIT_DECLARE(ltc2991);
 SENSOR_DRIVE_INIT_DECLARE(sq52205);
 SENSOR_DRIVE_INIT_DECLARE(emc1412);
 SENSOR_DRIVE_INIT_DECLARE(i3c_dimm);
+SENSOR_DRIVE_INIT_DECLARE(pt5161l);
 
 struct sensor_drive_api {
 	enum SENSOR_DEV dev;
@@ -197,6 +199,7 @@ struct sensor_drive_api {
 	SENSOR_DRIVE_TYPE_INIT_MAP(sq52205),
 	SENSOR_DRIVE_TYPE_INIT_MAP(emc1412),
 	SENSOR_DRIVE_TYPE_INIT_MAP(i3c_dimm),
+	SENSOR_DRIVE_TYPE_INIT_MAP(pt5161l),
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -135,6 +135,7 @@ enum SENSOR_DEV {
 	sensor_dev_sq52205 = 0x23,
 	sensor_dev_emc1412 = 0x24,
 	sensor_dev_i3c_dimm = 0x26,
+	sensor_dev_pt5161l = 0x27,
 	sensor_dev_max
 };
 
@@ -537,6 +538,13 @@ typedef struct _ltc2991_init_arg_ {
 		} fields;
 	} v5_v8_control_operation;
 } ltc2991_init_arg;
+
+typedef struct _pt5161l_init_arg_ {
+	uint8_t temp_cal_code_pma_a[4]; // temp calibration codes for PMA A
+	uint8_t temp_cal_code_pma_b[4]; // temp calibration codes for PMA B
+	uint8_t temp_cal_code_avg; // average temp calibration code
+	bool is_init;
+} pt5161l_init_arg;
 
 extern bool enable_sensor_poll_thread;
 extern sensor_cfg *sensor_config;

--- a/meta-facebook/op2-op/src/platform/plat_hook.c
+++ b/meta-facebook/op2-op/src/platform/plat_hook.c
@@ -51,6 +51,11 @@ i2c_proc_arg i2c_proc_args[] = {
 	[5] = { .bus = I2C_BUS2, .channel = I2C_HUB_CHANNEL_5 },
 };
 
+pt5161l_init_arg pt5161l_init_args[] = { [0] = { .is_init = false,
+						 .temp_cal_code_pma_a = { 0, 0, 0, 0 },
+						 .temp_cal_code_pma_b = { 0, 0, 0, 0 },
+						 .temp_cal_code_avg = 0 } };
+
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK FUNC
  **************************************************************************************************/

--- a/meta-facebook/op2-op/src/platform/plat_hook.h
+++ b/meta-facebook/op2-op/src/platform/plat_hook.h
@@ -28,6 +28,7 @@ typedef struct _i2c_proc_arg {
 extern adc_asd_init_arg adc_asd_init_args[];
 extern ina233_init_arg ina233_init_args[];
 extern i2c_proc_arg i2c_proc_args[];
+extern pt5161l_init_arg pt5161l_init_args[];
 extern struct k_mutex i2c_hub_mutex;
 
 #define I2C_HUB_MUTEX_TIMEOUT_MS 300

--- a/meta-facebook/op2-op/src/platform/plat_sdr_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sdr_table.c
@@ -1430,6 +1430,67 @@ SDR_Full_sensor plat_EXPA_sdr_table[] = {
 		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
 		"1OU_E1S_P12V_EDGE_PWR_W",
 	},
+
+	{
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_1OU_RE_TIMER_TEMP_C, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_POWER_SUPPLY, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x7D, // UNRT
+		0x64, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"1OU_RETIMER_TEMP_C",
+	},
 };
 SDR_Full_sensor plat_EXPB_sdr_table[] = {
 	{
@@ -2192,6 +2253,8 @@ char change_EXPA_name_table[][MAX_SDR_SENSOR_NAME_LEN] = {
 	{ "_ADC_P0V9_VOLT_V" },
 	{ "_E1S_P12V_EDGE_CURR_A" },
 	{ "_E1S_P12V_EDGE_PWR_W" },
+	{ "_RETIMER_TEMP_C" },
+
 };
 
 char change_EXPB_name_table[][MAX_SDR_SENSOR_NAME_LEN] = {

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.c
@@ -19,7 +19,7 @@
 #include "ast_adc.h"
 #include "sensor.h"
 #include "power_status.h"
-
+#include "pt5161l.h"
 #include "plat_i2c.h"
 #include "plat_sensor_table.h"
 #include "plat_hook.h"
@@ -136,6 +136,11 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 	{ SENSOR_NUM_1OU_TEMP, sensor_dev_tmp75, I2C_BUS4, TMP75_EXPA_TEMP_ADDR, TMP75_TEMP_OFFSET,
 	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+
+	{ SENSOR_NUM_1OU_RE_TIMER_TEMP_C, sensor_dev_pt5161l, I2C_BUS4, EXPA_RETIMER_ADDR,
+	  PT5161L_TEMP_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &pt5161l_init_args[0] },
 
 	//adc
 	{ SENSOR_NUM_1OU_P3V3_STBY_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT5, NONE, NONE, stby_access,

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.h
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.h
@@ -22,6 +22,7 @@
 
 #define SENSOR_NUM_POWER_ERROR 0x56
 
+#define EXPA_RETIMER_ADDR (0x46 >> 1)
 #define TMP75_EXPA_TEMP_ADDR (0x94 >> 1)
 #define TMP75_EXPB_TEMP_ADDR (0x9A >> 1)
 #define INA233_EXPA_E1S_0_ADDR (0x8C >> 1)


### PR DESCRIPTION
Summary:
- Support retimer(PT5161L) temperatrue.

Test Plan:
- Build code : pass.
- Test log

BMC:
root@bmc-oob:~# sensor-util slot1 | grep RETIMER
1OU_RETIMER_TEMP_C           (0x61) :   34.16 C     | (ok)
3OU_RETIMER_TEMP_C           (0xC1) :   34.80 C     | (ok)

1OU BIC console:
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x41] 1OU_E1S_SSD0_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x42] 1OU_E1S_SSD1_P12V_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.522
[0x43] 1OU_E1S_SSD2_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x46] 1OU_BIC_P12V_EDGE_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.493
[0x50] 1OU_E1S_SSD0_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x51] 1OU_E1S_SSD1_P12V_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.095
[0x52] 1OU_E1S_SSD2_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x55] 1OU_E1S_P12V_EDGE_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.217
[0x56] 1OU_E1S_SSD0_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x57] 1OU_E1S_SSD1_P12V_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.200
[0x58] 1OU_E1S_SSD2_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5b] 1OU_E1S_P12V_EDGE_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.700
[0x5c] 1OU_E1S_SSD0_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5d] 1OU_E1S_SSD1_TEMP_C      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    32.000
[0x5e] 1OU_E1S_SSD2_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x40] 1OU_BIC_TEMP_C           : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    24.000
[0x61] 1OU_RETIMER_TEMP_C       : pt5161l    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    32.879
[0x4c] 1OU_ADC_P3V3_STBY_VOLT_V : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.338
[0x47] 1OU_E1S_ADC_SSD0_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x48] 1OU_E1S_ADC_SSD1_P3V3_VOLT_V: adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.320
[0x49] 1OU_E1S_ADC_SSD2_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x4d] 1OU_ADC_P1V8_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.843
[0x4e] 1OU_ADC_P0V9_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.927
[0x4f] 1OU_ADC_P1V2_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.213
---------------------------------------------------------------------------------

3OU BIC console:
uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0xa1] 3OU_E1S_SSD0_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xa2] 3OU_E1S_SSD1_P12V_VOLT_V : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.508
[0xa3] 3OU_E1S_SSD2_P12V_VOLT_V : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xa6] 3OU_P12V_EDGE_VOLT_V     : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.497
[0xb0] 3OU_E1S_SSD0_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xb1] 3OU_E1S_SSD1_P12V_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.138
[0xb2] 3OU_E1S_SSD2_P12V_CURR_A : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xb5] 3OU_E1S_P12V_EDGE_CURR_A : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.220
[0xb6] 3OU_E1S_SSD0_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xb7] 3OU_E1S_SSD1_P12V_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.725
[0xb8] 3OU_E1S_SSD2_P12V_PWR_W  : ina233     | access[X] | poll[O] 1    sec | not_accesible             | na
[0xbb] 3OU_E1S_P12V_EDGE_PWR_W  : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.750
[0xbc] 3OU_E1S_SSD0_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xbd] 3OU_E1S_SSD1_TEMP_C      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    30.000
[0xbe] 3OU_E1S_SSD2_TEMP_C      : nvme       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xa0] 3OU_BIC_TEMP_C           : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    24.000
[0xc1] 3OU_RETIMER_TEMP_C       : pt5161l    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    32.879
[0xac] 3OU_ADC_P3V3_STBY_VOLT_V : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.330
[0xa7] 3OU_E1S_ADC_SSD0_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0xa8] 3OU_E1S_ADC_SSD1_P3V3_VOLT_V: adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.314
[0xa9] 3OU_E1S_ADC_SSD2_P3V3_VOLT_V: adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0xad] 3OU_ADC_P1V8_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.818
[0xae] 3OU_ADC_P0V9_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.917
[0xaf] 3OU_ADC_P1V2_VOLT_V      : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.203
---------------------------------------------------------------------------------