### PR TITLE
fby35: cl: Fix showing PMIC error messages on BIC console when DIMM i…

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_pmic.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_pmic.c
@@ -122,6 +122,7 @@ void monitor_pmic_error_via_me_handler()
 	ipmb_error status = 0;
 	int ret = 0, dimm_id = 0;
 	uint8_t seq_source = 0xFF;
+	uint8_t dimm_status = SENSOR_INIT_STATUS;
 	memory_write_read_req pmic_req;
 	ipmi_msg pmic_msg;
 
@@ -143,7 +144,9 @@ void monitor_pmic_error_via_me_handler()
 
 		for (dimm_id = 0; dimm_id < MAX_COUNT_DIMM; dimm_id++) {
 			// If dimm isn't present, skip monitor
-			if (get_dimm_status(dimm_id) == SENSOR_NOT_PRESENT) {
+			dimm_status = get_dimm_status(dimm_id);
+			if ((dimm_status != SENSOR_NOT_SUPPORT) &&
+			    (dimm_status == SENSOR_NOT_PRESENT)) {
 				continue;
 			}
 
@@ -178,9 +181,9 @@ void monitor_pmic_error_via_me_handler()
 				}
 
 			} else {
-				LOG_ERR("Failed to get PMIC error, dimm id%d bus %d addr 0x%x status 0x%x",
+				LOG_ERR("Failed to get PMIC error, dimm id%d bus %d addr 0x%x status 0x%x CC 0x%x",
 					dimm_id, pmic_req.smbus_identifier, pmic_req.smbus_address,
-					status);
+					status, pmic_msg.completion_code);
 				continue;
 			}
 		}

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -652,7 +652,25 @@ bool disable_dimm_pmic_sensor(uint8_t sensor_num)
 	return false;
 }
 
+static int sensor_get_idx_by_sensor_num(uint16_t sensor_num)
+{
+	int sensor_idx = 0;
+	for (sensor_idx = 0; sensor_idx < sensor_config_count; sensor_idx++) {
+		if (sensor_num == sensor_config[sensor_idx].num)
+			return sensor_idx;
+	}
+
+	return -1;
+}
+
 uint8_t get_dimm_status(uint8_t dimm_index)
 {
-	return sensor_config[dimm_pmic_map_table[dimm_index].dimm_sensor_num].cache_status;
+	int sensor_index =
+		sensor_get_idx_by_sensor_num(dimm_pmic_map_table[dimm_index].dimm_sensor_num);
+	if (sensor_index < 0) {
+		return SENSOR_NOT_SUPPORT;
+	}
+
+	return sensor_config[sensor_index].cache_status;
 }
+


### PR DESCRIPTION
…s not present

Summary:
- Fix showing PMIC error messages on BIC console when DIMM is not present

Root cause:
- Using the wrong sensor index when getting DIMM status to check present status of DIMM.

Solution:
- Correct sensor index to get sensor status.

Test plan:
- Build code: Pass
- No error messages on BIC console: Pass

Log:
- Before fix uart:~$ [02:36:22.090,000] <err> plat_pmic: Failed to get PMIC error, dimm id0 bus 0 addr 0x90 status 0x0 [02:36:22.148,000] <err> plat_pmic: Failed to get PMIC error, dimm id3 bus 1 addr 0x90 status 0x0 [02:36:22.090,000] <err> plat_pmic: Failed to get PMIC error, dimm id0 bus 0 addr 0x90 status 0x0 [02:36:22.148,000] <err> plat_pmic: Failed to get PMIC error, dimm id3 bus 1 addr 0x90 status 0x0

- After fix uart:~$
uart:~$
uart:~$