### PR TITLE
fby3.5: cl: Version commit for oby35-cl-2023.05.01

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_version.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_version.h
@@ -32,7 +32,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x01
+#define FIRMWARE_REVISION_2 0x02
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -41,7 +41,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x23
-#define BIC_FW_WEEK 0x02
+#define BIC_FW_WEEK 0x05
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x63 // char: c
 #define BIC_FW_platform_1 0x6c // char: l


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 Craterlake BIC oby35-cl-2023.05.01.

Test Plan:
- Build code: Pass
- Get BIC version: Pass

Log:
root@bmc-oob:~# fw-util slot4 --version bic
SB Bridge-IC Version: oby35-cl-v2023.05.01

get firmware revision
root@bmc-oob:~# bic-util slot4 0x18 0x1
00 80 31 02 02 BF 15 A0 00 00 00 00 00 00 00