### PR TITLE
Artemis: cb: Correct ACCL fru address

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_fru.h
+++ b/meta-facebook/at-cb/src/platform/plat_fru.h
@@ -48,7 +48,7 @@ enum FRU_ID {
 #define FIO_FRU_ADDR (0xA2 >> 1)
 #define ACCL_1_6_FRU_PORT I2C_BUS7
 #define ACCL_7_12_FRU_PORT I2C_BUS8
-#define ACCL_FRU_ADDR (0xAC >> 1)
+#define ACCL_FRU_ADDR (0xA6 >> 1)
 #define ACCL_1_6_FRU_MUX_ADDR (0xE0 >> 1)
 #define ACCL_7_12_FRU_MUX_ADDR (0xE8 >> 1)
 #define ACCL_1_7_FRU_MUX_CHAN 0


### PR DESCRIPTION
Summary:
- Correct ACCL fru address on EVT1 stage.

Test Plan:
- Build code: Pass
- ACCL fru read: Pass

Log:
root@bmc-oob:~# fruid-util acb_accl8

FRU Information           : ACB ACCL8 Card
---------------           : ------------------
Board Mfg Date            : Sat Dec 17 01:46:00 2022
Board Mfg                 : Wiwynn
Board Product             : T17 GT Artemis FAC EVT1
Board Serial              : WM67248001KNSB
Board Part Number         : BZA.Y0002.0001
Board FRU ID              : 1.0
Board Custom Data 1       : 19-002461
Board Custom Data 2       : PCB Supplier - WUS
Product Manufacturer      : Wiwynn
Product Name              : T17 GT Artemis
Product Part Number       : N/A
Product Version           : N/A
Product Serial            : N/A
Product Asset Tag         : N/A
Product FRU ID            : 1.0
Product Custom Data 1     : N/A
Product Custom Data 2     : N/A
Product Custom Data 3     : N/A