### PR TITLE
GT: Modify HSC LTC4282 and LTC4286 initial value

### DIFF
--- a/common/dev/ltc4286.c
+++ b/common/dev/ltc4286.c
@@ -126,7 +126,7 @@ uint8_t ltc4286_read(uint8_t sensor_num, int *reading)
 	/* Iterate the LTC4286 MBR table to
 	 * find the corresponding MBR values by the sensor type and voltage range selection
 	 */
-	uint8_t index = 0xFF;
+	uint8_t index = 0;
 	for (int cnt = 0; cnt < ARRAY_SIZE(ltc4286_mbr_table); cnt++) {
 		if (type == ltc4286_mbr_table[cnt].type) {
 			if ((ltc4286_mbr_table[cnt].voltage_range == BOTH) ||
@@ -181,15 +181,18 @@ uint8_t ltc4286_init(uint8_t sensor_num)
 		goto init_param;
 	}
 
-	// Set MFR_CONFIG_1 register value
-	msg.tx_len = 3;
-	msg.rx_len = 0;
-	msg.data[0] = LTC4286_MFR_CONFIG1;
-	msg.data[1] = init_args->mfr_config_1.value & 0xFF;
-	msg.data[2] = (init_args->mfr_config_1.value >> 8) & 0xFF;
-	if (i2c_master_write(&msg, retry) != 0) {
-		LOG_ERR("Failed to set LTC4286 register(0x%x)", msg.data[0]);
-		goto cleanup;
+	/* if the value is equal to 0xFFFF, use the default value on the chip */
+	if (init_args->mfr_config_1.value != 0xFFFF) {
+		// Set MFR_CONFIG_1 register value
+		msg.tx_len = 3;
+		msg.rx_len = 0;
+		msg.data[0] = LTC4286_MFR_CONFIG1;
+		msg.data[1] = init_args->mfr_config_1.value & 0xFF;
+		msg.data[2] = (init_args->mfr_config_1.value >> 8) & 0xFF;
+		if (i2c_master_write(&msg, retry) != 0) {
+			LOG_ERR("Failed to set LTC4286 register(0x%x)", msg.data[0]);
+			goto cleanup;
+		}
 	}
 
 init_param:

--- a/meta-facebook/gt-cc/src/platform/plat_hook.c
+++ b/meta-facebook/gt-cc/src/platform/plat_hook.c
@@ -245,20 +245,19 @@ mp5990_init_arg mp5990_hsc_init_args[] = {
 	[0] = { .is_init = false,
 		.iout_cal_gain = 0xFFFF,
 		.iout_oc_fault_limit = 0xFFFF,
-		.ocw_sc_ref = 0xFFFF },
+		.ocw_sc_ref = 0xFFFF, 
+		},
 };
 
 ltc4282_init_arg ltc4282_hsc_init_args[] = {
-	[0] = {
-    .is_init = false,
+	[0] = { .is_init = false,
 		.r_sense_mohm = 0.142,
-		.is_register_setting_needed = 0x01,
-		.ilim_adjust = { 0x76 },
-  },
+		.is_register_setting_needed = 0x00,
+		},
 };
 
 ltc4286_init_arg ltc4286_hsc_init_args[] = {
-	[0] = { .is_init = false, .r_sense_mohm = 0.142, .mfr_config_1 = { 0x3C72 } },
+	[0] = { .is_init = false, .r_sense_mohm = 0.142, .mfr_config_1 = { 0xFFFF } },
 };
 
 adc_asd_init_arg adc_asd_init_args[] = { [0] = { .is_init = false } };


### PR DESCRIPTION
Summary:
- Because some HSC chip has the setting value by the manufacturer, so use the default value on those two HSCs.
- If initial value mfr_config_1 of the LTC4286 is equal to 0xFFFF, use the default value on the chip.
- Set the value is_register_setting_needed of the LTC4282 to 0x00.

Test Plan:
- Build code: Pass