### PR TITLE
fby3.5: common: Fix INA233's sensor to show correct value

### DIFF
--- a/common/dev/ina233.c
+++ b/common/dev/ina233.c
@@ -82,6 +82,10 @@ uint8_t ina233_read(uint8_t sensor_num, int *reading)
 		parameter = 800;
 		break;
 	case PMBUS_READ_IOUT:
+		if (GETBIT(msg.data[1], 7)) {
+			// If raw value is negative, set it zero.
+			val = 0;
+		}
 		// 1 mA/LSB, 2's complement
 		// current convert formula = val / (1 / current_lsb)
 		parameter = (1 / init_arg->current_lsb);


### PR DESCRIPTION
Summary:
- If the raw data read from INA233 is negative, BIC would show zero.

Test Plan:
- Confirm Rainbow Fall's sensor "RF P12V_STBY Cur" is normal : Pass

Test Log:
    uart:~$ platform sensor get 0x6c
    [0x6c] RF P12V_STBY Cur         : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.276