### PR TITLE
OL2: OP: Fix pcie retimer power sequence and reinit retimer sensor

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_hook.h
+++ b/meta-facebook/op2-op/src/platform/plat_hook.h
@@ -41,5 +41,6 @@ extern struct k_mutex i2c_hub_mutex;
 
 bool pre_i2c_bus_read(uint8_t sensor_num, void *args);
 bool post_i2c_bus_read(uint8_t sensor_num, void *args, int *reading);
+bool pre_retimer_read(uint8_t sensor_num, void *args);
 
 #endif

--- a/meta-facebook/op2-op/src/platform/plat_isr.c
+++ b/meta-facebook/op2-op/src/platform/plat_isr.c
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -18,20 +18,21 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <ipmi.h>
-#include <pmbus.h>
-#include <libipmi.h>
-#include <ipmb.h>
-#include <libutil.h>
-
-#include <hal_i2c.h>
-
+#include <logging/log.h>
+#include "ipmi.h"
+#include "pmbus.h"
+#include "libipmi.h"
+#include "ipmb.h"
+#include "libutil.h"
+#include "hal_i2c.h"
 #include "plat_power_seq.h"
 #include "power_status.h"
 #include "plat_gpio.h"
 #include "plat_isr.h"
 #include "plat_i2c.h"
 #include "plat_sensor_table.h"
+
+LOG_MODULE_REGISTER(plat_isr);
 
 K_THREAD_STACK_DEFINE(power_thread, POWER_SEQ_CTRL_STACK_SIZE);
 struct k_thread power_thread_handler;
@@ -40,12 +41,12 @@ k_tid_t power_tid;
 void control_power_sequence()
 {
 	if (gpio_get(FM_EXP_MAIN_PWR_EN) == POWER_ON) { // op power on
-		if (check_all_e1s_sequence_status(POWER_ON) == false) {
+		if (!is_all_sequence_done(POWER_ON)) {
 			abort_power_thread();
 			init_power_on_thread();
 		}
 	} else { // op power off
-		if (check_all_e1s_sequence_status(POWER_OFF) == false) {
+		if (!is_all_sequence_done(POWER_OFF)) {
 			abort_power_thread();
 			init_power_off_thread();
 		}

--- a/meta-facebook/op2-op/src/platform/plat_power_seq.h
+++ b/meta-facebook/op2-op/src/platform/plat_power_seq.h
@@ -89,7 +89,7 @@ bool get_e1s_power_good(uint8_t index);
 uint8_t get_e1s_pcie_reset_status(uint8_t index);
 void init_sequence_status();
 void set_sequence_status(uint8_t index, bool status);
-bool check_all_e1s_sequence_status(uint8_t status);
+bool is_all_sequence_done(uint8_t status);
 void abort_e1s_power_thread(uint8_t index);
 void e1s_power_on_thread(uint8_t index);
 void e1s_power_off_thread(uint8_t index);

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.c
@@ -139,7 +139,7 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 
 	{ SENSOR_NUM_1OU_RE_TIMER_TEMP_C, sensor_dev_pt5161l, I2C_BUS4, EXPA_RETIMER_ADDR,
 	  PT5161L_TEMP_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_retimer_read, NULL, NULL, NULL,
 	  &pt5161l_init_args[0] },
 
 	//adc


### PR DESCRIPTION
Summary:
- Fix retimer sequence when there is no e1s on the system.
- Reinitialize the retimer sensor once after the system DC on.

Test Plan:
- Build code : pass
- Do DC on/off with no error log in bic console : pass

LOG:
uart:~$ [00:00:24.023,000] <wrn> power_status: DC_STATUS: off [00:00:24.023,000] <wrn> power_status: DC_STATUS: off uart:~$ [00:00:25.525,000] <inf> power_sequence: Power off success [00:00:31.025,000] <wrn> power_status: DC_STATUS: on [00:00:31.025,000] <wrn> power_status: DC_STATUS: on uart:~$ [00:00:33.726,000] <inf> power_sequence: Power on success [00:00:34.027,000] <inf> power_sequence: E1S 1 Power on success