### PR TITLE
common: fix LOG V1 string issue

### DIFF
--- a/common/dev/lattice.c
+++ b/common/dev/lattice.c
@@ -596,7 +596,7 @@ static bool x02x03_i2c_update(lattice_update_config_t *config)
 
 	/* Step1. Before update */
 	if (config->data_ofs == 0) {
-		LOG_INF("update lattice type %s", LATTICE_CFG_TABLE[config->type].name);
+		LOG_INF("update lattice type %s", log_strdup(LATTICE_CFG_TABLE[config->type].name));
 
 		uint32_t dev_id;
 		if (cpld_i2c_get_id(config->bus, config->addr, &dev_id) == false) {

--- a/common/lib/util_worker.c
+++ b/common/lib/util_worker.c
@@ -65,8 +65,7 @@ static void work_handler(struct k_work *item)
 		/* Processing time too long, print warning message */
 		if ((fn_finish_time - fn_start_time) > WARN_WORK_PROC_TIME_MS) {
 			LOG_ERR("WARN: work %s Processing time too long, %llu ms",
-			       work_job->name,
-			       (fn_finish_time - fn_start_time));
+				log_strdup(work_job->name), (fn_finish_time - fn_start_time));
 		}
 	}
 	if (k_mutex_lock(&mutex_use_count, K_MSEC(1000))) {

--- a/common/service/ipmb/ipmb.c
+++ b/common/service/ipmb/ipmb.c
@@ -1248,8 +1248,8 @@ void create_ipmb_threads(uint8_t index)
 	}
 	if (i > retry) {
 		LOG_ERR("Failed to create threads,Tx(%s) Rx(%s) retry time(%d)",
-			IPMB_config_table[index].tx_thread_name,
-			IPMB_config_table[index].rx_thread_name, retry);
+			log_strdup(IPMB_config_table[index].tx_thread_name),
+			log_strdup(IPMB_config_table[index].rx_thread_name), retry);
 		return;
 	}
 

--- a/common/service/pldm/pldm_firmware_update.c
+++ b/common/service/pldm/pldm_firmware_update.c
@@ -151,7 +151,8 @@ uint8_t pldm_vr_update(void *fw_update_param)
 		if (mp2971_fwupdate(p->bus, p->addr, hex_buff) == false)
 			goto exit;
 	} else {
-		LOG_ERR("Non-support VR detected with component string %s!", p->comp_version_str);
+		LOG_ERR("Non-support VR detected with component string %s!",
+			log_strdup(p->comp_version_str));
 		goto exit;
 	}
 
@@ -187,7 +188,7 @@ uint8_t pldm_cpld_update(void *fw_update_param)
 		p->next_ofs = cpld_update_cfg.next_ofs;
 	} else {
 		LOG_ERR("Component version string %s not contains support device's keyword",
-			p->comp_version_str);
+			log_strdup(p->comp_version_str));
 		return 1;
 	}
 

--- a/common/service/sensor/sdr.c
+++ b/common/service/sensor/sdr.c
@@ -133,7 +133,8 @@ void change_sensor_threshold(uint8_t sensor_num, uint8_t threshold_type, uint8_t
 
 	int sdr_index = get_sdr_index(sensor_num);
 	if ((sdr_index == SENSOR_NUM_MAX) || (sdr_index == -1)) {
-		LOG_ERR("Failed to find sensor index, sensor number(0x%02x), sdr index(%d)", sensor_num, sdr_index);
+		LOG_ERR("Failed to find sensor index, sensor number(0x%02x), sdr index(%d)",
+			sensor_num, sdr_index);
 		return;
 	}
 	switch (threshold_type) {
@@ -170,7 +171,8 @@ void change_sensor_mbr(uint8_t sensor_num, uint8_t mbr_type, uint16_t change_val
 
 	int sdr_index = get_sdr_index(sensor_num);
 	if ((sdr_index == SENSOR_NUM_MAX) || (sdr_index == -1)) {
-		LOG_ERR("Failed to find sensor index, sensor number(0x%02x), sdr index(%d)", sensor_num, sdr_index);
+		LOG_ERR("Failed to find sensor index, sensor number(0x%02x), sdr index(%d)",
+			sensor_num, sdr_index);
 		return;
 	}
 	switch (mbr_type) {
@@ -220,11 +222,9 @@ uint8_t sdr_init(void)
 
 		if (DEBUG_SENSOR) {
 			LOG_DBG("%s ID: 0x%x%x, size: %d, recordlen: %d",
-                               full_sdr_table[i].ID_str,
-			       full_sdr_table[i].record_id_h,
-			       full_sdr_table[i].record_id_l,
-			       full_sdr_table[i].ID_len,
-			       full_sdr_table[i].record_len);
+				log_strdup(full_sdr_table[i].ID_str), full_sdr_table[i].record_id_h,
+				full_sdr_table[i].record_id_l, full_sdr_table[i].ID_len,
+				full_sdr_table[i].record_len);
 		}
 	}
 

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -58,9 +58,9 @@ static bool sensor_poll_enable_flag = true;
 static bool is_sensor_initial_done = false;
 static bool is_sensor_ready_flag = false;
 
-const int negative_ten_power[16] = { 1,     1,		1,	 1,	1,       1,
-				     1,     1000000000, 100000000, 10000000, 1000000, 100000,
-				     10000, 1000,       100,       10 };
+const int negative_ten_power[16] = { 1,	    1,		1,	   1,	     1,	      1,
+				     1,	    1000000000, 100000000, 10000000, 1000000, 100000,
+				     10000, 1000,	100,	   10 };
 
 sensor_cfg *sensor_config;
 uint8_t sensor_config_count;

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -58,9 +58,9 @@ static bool sensor_poll_enable_flag = true;
 static bool is_sensor_initial_done = false;
 static bool is_sensor_ready_flag = false;
 
-const int negative_ten_power[16] = { 1,	    1,		1,	   1,	     1,	      1,
-				     1,	    1000000000, 100000000, 10000000, 1000000, 100000,
-				     10000, 1000,	100,	   10 };
+const int negative_ten_power[16] = { 1,     1,		1,	 1,	1,       1,
+				     1,     1000000000, 100000000, 10000000, 1000000, 100000,
+				     10000, 1000,       100,       10 };
 
 sensor_cfg *sensor_config;
 uint8_t sensor_config_count;
@@ -288,7 +288,8 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 		if (cfg->pre_sensor_read_hook) {
 			if (cfg->pre_sensor_read_hook(sensor_num, cfg->pre_sensor_read_args) ==
 			    false) {
-				LOG_ERR("Failed to do pre sensor read function, sensor number: 0x%x", sensor_num);
+				LOG_ERR("Failed to do pre sensor read function, sensor number: 0x%x",
+					sensor_num);
 				cfg->cache_status = SENSOR_PRE_READ_ERROR;
 				return cfg->cache_status;
 			}
@@ -317,7 +318,8 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 			}
 
 			if (cfg->post_sensor_read_hook && post_ret == false) {
-				LOG_ERR("Failed to do post sensor read function, sensor number: 0x%x", sensor_num);
+				LOG_ERR("Failed to do post sensor read function, sensor number: 0x%x",
+					sensor_num);
 				cfg->cache_status = SENSOR_POST_READ_ERROR;
 				return cfg->cache_status;
 			}
@@ -341,7 +343,8 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 				if (cfg->post_sensor_read_hook(sensor_num,
 							       cfg->post_sensor_read_args,
 							       NULL) == false) {
-					LOG_ERR("Sensor number 0x%x reading and post_read fail", sensor_num);
+					LOG_ERR("Sensor number 0x%x reading and post_read fail",
+						sensor_num);
 				}
 			}
 
@@ -369,7 +372,7 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 		default:
 			cfg->cache = SENSOR_FAIL;
 			LOG_ERR("Failed to read sensor value from cache, sensor number: 0x%x, cache status: 0x%x",
-			       sensor_num, cfg->cache_status);
+				sensor_num, cfg->cache_status);
 			return cfg->cache_status;
 		}
 		break;
@@ -428,7 +431,8 @@ void sensor_poll_handler(void *arug0, void *arug1, void *arug2)
 			}
 
 			if (sdr_index_map[sensor_num] == SENSOR_NULL) { // Check sensor info
-				LOG_ERR("Fail to find sensor SDR info, sensor number: 0x%x", sensor_num);
+				LOG_ERR("Fail to find sensor SDR info, sensor number: 0x%x",
+					sensor_num);
 				continue;
 			}
 
@@ -488,7 +492,8 @@ void check_init_sensor_size()
 
 	if (init_sdr_size != init_sensor_config_size) {
 		enable_sensor_poll_thread = false;
-		LOG_ERR("Init sdr size is not equal to config size, sdr size: 0x%x, config size: 0x%x", init_sdr_size, init_sensor_config_size);
+		LOG_ERR("Init sdr size is not equal to config size, sdr size: 0x%x, config size: 0x%x",
+			init_sdr_size, init_sensor_config_size);
 		LOG_ERR("BIC should not monitor sensors if SDR size and sensor config size is not match, BIC would not start sensor thread");
 		return;
 	}
@@ -655,7 +660,7 @@ bool sensor_init(void)
 	drive_init();
 
 	if (DEBUG_SENSOR) {
-		LOG_ERR("Sensor name: %s", full_sdr_table[sdr_index_map[1]].ID_str);
+		LOG_ERR("Sensor name: %s", log_strdup(full_sdr_table[sdr_index_map[1]].ID_str));
 	}
 
 	if (enable_sensor_poll_thread) {

--- a/meta-facebook/yv35-bb/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-bb/src/platform/plat_hook.c
@@ -90,7 +90,7 @@ bool pre_ltc4282_read(uint8_t sensor_num, void *args)
 		val = msg.data[0] & (~VOLTAGE_SELECT_BIT);
 
 	} else {
-		LOG_ERR("Unexpected vsource %s", pre_proc_args->vsource_status);
+		LOG_ERR("Unexpected vsource %s", log_strdup(pre_proc_args->vsource_status));
 		return false;
 	}
 


### PR DESCRIPTION
Summary:
- If a string argument is transient, the user must call log_strdup() to duplicate the passed string into a buffer from the pool.

Test Plan:
- Build code: Pass