### PR TITLE
fby35: gl: revise the sensor thresholds

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
@@ -2415,7 +2415,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor minimum reading
 		0xFC, // UNRT
 		0xCD, // UCT
-		0x01, // UNCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2475,7 +2475,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor minimum reading
 		0xFA, // UNRT
 		0xE0, // UCT
-		0x01, // UNCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2535,7 +2535,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor minimum reading
 		0x9A, // UNRT
 		0x79, // UCT
-		0x01, // UNCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2595,7 +2595,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor minimum reading
 		0xED, // UNRT
 		0xC4, // UCT
-		0x01, // UNCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2655,7 +2655,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor minimum reading
 		0xE9, // UNRT
 		0xC1, // UCT
-		0x01, // UNCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2715,7 +2715,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor minimum reading
 		0xEC, // UNRT
 		0xC4, // UCT
-		0x01, // UNCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2775,7 +2775,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor minimum reading
 		0xEC, // UNRT
 		0xC4, // UCT
-		0x01, // UNCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT


### PR DESCRIPTION
Summary:
- Revise the sensor threshold following the latest sensor table MB_HSC_OUTPUT_CURR_A MB_VR_VCCIN_CURR_A MB_VR_EHV_CURR_A MB_VR_FIVRA_CURR_A MB_VR_VCCINF_CURR_A MB_VR_VCCD0_CURR_A MB_VR_VCCD1_CURR_A

Test Plan:
- Check the sensor threshold: pass

Test Log:
root@bmc-oob:~# sensor-util slot1 --thres|grep "CURR"
MB_HSC_OUTPUT_CURR_A         (0x28) :    0.68 Amps  | (ok) | UCR: 55.35 | UNC: NA | UNR: 68.04 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_CURR_A           (0x29) : NA | (na)
MB_VR_EHV_CURR_A             (0x2A) : NA | (na)
MB_VR_FIVRA_CURR_A           (0x2B) : NA | (na)
MB_VR_VCCINF_CURR_A          (0x2C) : NA | (na)
MB_VR_VCCD0_CURR_A           (0x2D) : NA | (na)
MB_VR_VCCD1_CURR_A           (0x2E) : NA | (na)