### PR TITLE
ol2: op: modify the Rshunt setting in INA233.

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_hook.c
+++ b/meta-facebook/op2-op/src/platform/plat_hook.c
@@ -36,12 +36,12 @@ K_MUTEX_DEFINE(i2c_hub_mutex);
 adc_asd_init_arg adc_asd_init_args[] = { [0] = { .is_init = false } };
 
 ina233_init_arg ina233_init_args[] = {
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002 },
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002 },
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002 },
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002 },
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002 },
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002 },
 };
 
 i2c_proc_arg i2c_proc_args[] = {


### PR DESCRIPTION
Summary:
- Modify the Rshunt setting in ina233 according to OLYMPIC2_EXPA_20221117.pdf

Test Plan:
- Build code:Pass
- EE measurement the current and power: pass

log:
root@bmc-oob:# sensor-util slot1 |grep "1OU_E1S_SSD0" 1OU_E1S_SSD0_P12V_VOLT_V     (0x41) :   12.25 Volts  | (ok) 1OU_E1S_SSD0_P12V_CURR_A     (0x50) :    1.02 Amps  | (ok) 1OU_E1S_SSD0_P12V_PWR_W      (0x56) :   12.40 Watts  | (ok) 1OU_E1S_SSD0_TEMP_C          (0x5C) : NA | (na)