### PR TITLE
fby35: gl: Supported to get/set system GUID

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_guid.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_guid.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <logging/log.h>
+
+#include "libutil.h"
+#include "guid.h"
+#include "plat_guid.h"
+#include "fru.h"
+
+#define MB_GUID_PORT 0x01
+#define MB_GUID_ADDR 0x54
+
+LOG_MODULE_REGISTER(plat_guid);
+
+const EEPROM_CFG guid_config[] = {
+	{
+		NV_ATMEL_24C128,
+		MB_SYS_GUID_ID,
+		MB_GUID_PORT,
+		MB_GUID_ADDR,
+		GUID_ACCESS_BYTE,
+		GUID_START,
+		GUID_SIZE,
+	},
+};
+
+uint8_t get_system_guid(uint16_t *data_len, uint8_t *data)
+{
+	EEPROM_ENTRY guid_entry;
+
+	CHECK_NULL_ARG_WITH_RETURN(data, GUID_FAIL_TO_ACCESS);
+
+	guid_entry.offset = 0;
+	guid_entry.data_len = 16;
+	guid_entry.config.dev_id = MB_SYS_GUID_ID;
+
+	uint8_t status = GUID_read(&guid_entry);
+	if (status == GUID_READ_SUCCESS) {
+		*data_len = guid_entry.data_len;
+		memcpy(data, &guid_entry.data, guid_entry.data_len);
+	}
+
+	return status;
+}
+
+uint8_t set_system_guid(uint16_t *data_len, uint8_t *data)
+{
+	EEPROM_ENTRY guid_entry;
+
+	CHECK_NULL_ARG_WITH_RETURN(data, GUID_FAIL_TO_ACCESS);
+
+	guid_entry.offset = 0;
+	guid_entry.data_len = *data_len;
+	guid_entry.config.dev_id = MB_SYS_GUID_ID;
+	memcpy(&guid_entry.data[0], data, guid_entry.data_len);
+	return GUID_write(&guid_entry);
+}


### PR DESCRIPTION
Summary:
- Configure GUID's information and support BIC to get/set GUID.
  - GUID's information : model, GUID ID, I2C bus, I2C address, access type, start offset and GUID size.

Test Plan:
- Get system GUID : Pass
- Set system GUID with the checksum of FRU information : Pass

Test Log:
- Get system GUID : root@bmc-oob:~# guid-util slot1  sys --get 0xFF:0xFF:0xFF:0xFF:0xFF:0xFF:0xFF:0xFF:0xFF:0xFF:0xFF:0xFF:0xFF:0xFF:0xFF:0xFF

- Set system GUID with the checksum of FRU information : 
root@bmc-oob:~# md5sum FRU_info.bin bc58f1fc62cdd314b4db73b09f8d455a  FRU_info.bin 
root@bmc-oob:~# guid-util slot3 sys --set bc58f1fc62cdd314b4db73b09f8d455a 
root@bmc-oob:~# guid-util slot3 sys --get 0x30:0x07:0x04:0x00:0xA1:0x22:0xF4:0x13:0x7D:0x5E:0x66:0x08:0x64:0x04:0x55:0x61