### PR TITLE
fby35: cl: Fix error messages after host power cycle

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -277,6 +277,10 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 	sensor_cfg *cfg = &sensor_config[sensor_config_index_map[sensor_num]];
 	bool post_ret = false;
 
+	if (cfg->cache_status == SENSOR_NOT_PRESENT) {
+		return cfg->cache_status;
+	}
+
 	if (!access_check(sensor_num)) { // sensor not accessable
 		clear_unaccessible_sensor_cache(sensor_num);
 		cfg->cache_status = SENSOR_NOT_ACCESSIBLE;
@@ -288,7 +292,8 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 		if (cfg->pre_sensor_read_hook) {
 			if (cfg->pre_sensor_read_hook(sensor_num, cfg->pre_sensor_read_args) ==
 			    false) {
-				LOG_ERR("Failed to do pre sensor read function, sensor number: 0x%x", sensor_num);
+				LOG_ERR("Failed to do pre sensor read function, sensor number: 0x%x",
+					sensor_num);
 				cfg->cache_status = SENSOR_PRE_READ_ERROR;
 				return cfg->cache_status;
 			}
@@ -317,7 +322,8 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 			}
 
 			if (cfg->post_sensor_read_hook && post_ret == false) {
-				LOG_ERR("Failed to do post sensor read function, sensor number: 0x%x", sensor_num);
+				LOG_ERR("Failed to do post sensor read function, sensor number: 0x%x",
+					sensor_num);
 				cfg->cache_status = SENSOR_POST_READ_ERROR;
 				return cfg->cache_status;
 			}
@@ -341,7 +347,8 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 				if (cfg->post_sensor_read_hook(sensor_num,
 							       cfg->post_sensor_read_args,
 							       NULL) == false) {
-					LOG_ERR("Sensor number 0x%x reading and post_read fail", sensor_num);
+					LOG_ERR("Sensor number 0x%x reading and post_read fail",
+						sensor_num);
 				}
 			}
 
@@ -369,7 +376,7 @@ uint8_t get_sensor_reading(uint8_t sensor_num, int *reading, uint8_t read_mode)
 		default:
 			cfg->cache = SENSOR_FAIL;
 			LOG_ERR("Failed to read sensor value from cache, sensor number: 0x%x, cache status: 0x%x",
-			       sensor_num, cfg->cache_status);
+				sensor_num, cfg->cache_status);
 			return cfg->cache_status;
 		}
 		break;
@@ -428,7 +435,8 @@ void sensor_poll_handler(void *arug0, void *arug1, void *arug2)
 			}
 
 			if (sdr_index_map[sensor_num] == SENSOR_NULL) { // Check sensor info
-				LOG_ERR("Fail to find sensor SDR info, sensor number: 0x%x", sensor_num);
+				LOG_ERR("Fail to find sensor SDR info, sensor number: 0x%x",
+					sensor_num);
 				continue;
 			}
 
@@ -488,7 +496,8 @@ void check_init_sensor_size()
 
 	if (init_sdr_size != init_sensor_config_size) {
 		enable_sensor_poll_thread = false;
-		LOG_ERR("Init sdr size is not equal to config size, sdr size: 0x%x, config size: 0x%x", init_sdr_size, init_sensor_config_size);
+		LOG_ERR("Init sdr size is not equal to config size, sdr size: 0x%x, config size: 0x%x",
+			init_sdr_size, init_sensor_config_size);
 		LOG_ERR("BIC should not monitor sensors if SDR size and sensor config size is not match, BIC would not start sensor thread");
 		return;
 	}


### PR DESCRIPTION
Summary.
- Run clang-format.
- Fix BMC var/log/messages and BIC console show error messages after the host power cycle if DIMM is not present.

Root cause:
- The root cause is that status of DIMM is changed to NOT_ACCESSIBLE after access check (host not post completely). And then change to POLLING_DISABLE due to the flag of polling being disabled.

Solution:
- If sensor status is not present, return cache status and avoid changing sensor status after access checking.

Test plan:
- Build code: Pass
- Present status maintain: Pass
- No error message: Pass

Log:
- Before Fix
1. Check sensor status [BIC console]
uart:~$ platform sensor list_all
--------------------------------------------------------------------------------- ...
[0x6 ] MB_DIMMA0_TEMP_C         : peci       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x7 ] MB_DIMMA2_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0x9 ] MB_DIMMA3_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0xa ] MB_DIMMA4_TEMP_C         : peci       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0xb ] MB_DIMMA6_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0xc ] MB_DIMMA7_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    36.000
...
[0x1e] MB_VR_DIMMA0_PMIC_PWR_W  : pmic       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x1f] MB_VR_DIMMA2_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.875
[0x36] MB_VR_DIMMA3_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.125
[0x37] MB_VR_DIMMA4_PMIC_PWR_W  : pmic       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x42] MB_VR_DIMMA6_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.375
[0x47] MB_VR_DIMMA7_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.625
---------------------------------------------------------------------------------

2. Host power cycle [BIC console]
uart:~$ [02:32:05.750,000] <wrn> power_status: POST_COMPLETE: no [02:32:05.750,000] <inf> plat_isr: Send gpio interrupt to BMC, gpio number(39) status(0) [02:32:05.752,000] <wrn> power_status: DC_STATUS: off [02:32:05.756,000] <wrn> power_status: CPU_PWR_GOOD: no [02:32:05.756,000] <inf> plat_isr: Send gpio interrupt to BMC, gpio number(32) status(0) [02:32:05.750,000] <wrn> power_status: POST_COMPLETE: no [02:32:05.752,000] <wrn> power_status: DC_STATUS: off [02:32:05.756,000] <wrn> power_status: CPU_PWR_GOOD: no uart:~$ slp3
[02:32:15.060,000] <wrn> power_status: DC_STATUS: on [02:32:15.200,000] <wrn> power_status: CPU_PWR_GOOD: yes [02:32:15.200,000] <inf> plat_isr: Send gpio interrupt to BMC, gpio number(32) status(1) [02:32:15.843,000] <inf> plat_isr: Send gpio interrupt to BMC, gpio number(39) status(1) [02:32:15.060,000] <wrn> power_status: DC_STATUS: on [02:32:15.200,000] <wrn> power_status: CPU_PWR_GOOD: yes

3. Check sensor status after host cycle and post not complete [BIC console]
uart:~$ platform sensor list_all
--------------------------------------------------------------------------------- ...
[0x6 ] MB_DIMMA0_TEMP_C         : peci       | access[X] | poll[X] 1    sec | not_accesible             | na
[0x7 ] MB_DIMMA2_TEMP_C         : peci       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x9 ] MB_DIMMA3_TEMP_C         : peci       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xa ] MB_DIMMA4_TEMP_C         : peci       | access[X] | poll[X] 1    sec | not_accesible             | na
[0xb ] MB_DIMMA6_TEMP_C         : peci       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xc ] MB_DIMMA7_TEMP_C         : peci       | access[X] | poll[O] 1    sec | not_accesible             | na
...
[0x1e] MB_VR_DIMMA0_PMIC_PWR_W  : pmic       | access[X] | poll[X] 1    sec | polling_disable           | na
[0x1f] MB_VR_DIMMA2_PMIC_PWR_W  : pmic       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x36] MB_VR_DIMMA3_PMIC_PWR_W  : pmic       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x37] MB_VR_DIMMA4_PMIC_PWR_W  : pmic       | access[X] | poll[X] 1    sec | polling_disable           | na
[0x42] MB_VR_DIMMA6_PMIC_PWR_W  : pmic       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x47] MB_VR_DIMMA7_PMIC_PWR_W  : pmic       | access[X] | poll[O] 1    sec | not_accesible             | na
...
---------------------------------------------------------------------------------

4. Check sensor status after post complete [BIC console]
uart:~$ [02:33:17.551,000] <wrn> power_status: POST_COMPLETE: yes [02:33:17.551,000] <wrn> power_status: POST_COMPLETE: yes uart:~$ [02:33:19.343,000] <err> plat_pmic: Failed to get PMIC error, dimm id0 bus 0 addr 0x90 status 0x0 CC 0xad [02:33:19.394,000] <err> plat_pmic: Failed to get PMIC error, dimm id3 bus 1 addr 0x90 status 0x0 CC 0xad [02:33:19.343,000] <err> plat_pmic: Failed to get PMIC error, dimm id0 bus 0 addr 0x90 status 0x0 CC 0xad [02:33:19.394,000] <err> plat_pmic: Failed to get PMIC error, dimm id3 bus 1 addr 0x90 status 0x0 CC 0xad uart:~$ [02:33:22.441,000] <err> plat_pmic: Failed to get PMIC error, dimm id0 bus 0 addr 0x90 status 0x0 CC 0xad [02:33:22.493,000] <err> plat_pmic: Failed to get PMIC error, dimm id3 bus 1 addr 0x90 status 0x0 CC 0xad [02:33:22.441,000] <err> plat_pmic: Failed to get PMIC error, dimm id0 bus 0 addr 0x90 status 0x0 CC 0xad [02:33:22.493,000] <err> plat_pmic: Failed to get PMIC error, dimm id3 bus 1 addr 0x90 status 0x0 CC 0xad uart:~$ [02:33:25.537,000] <err> plat_pmic: Failed to get PMIC error, dimm id0 bus 0 addr 0x90 status 0x0 CC 0xad [02:33:25.588,000] <err> plat_pmic: Failed to get PMIC error, dimm id3 bus 1 addr 0x90 status 0x0 CC 0xad [02:33:25.537,000] <err> plat_pmic: Failed to get PMIC error, dimm id0 bus 0 addr 0x90 status 0x0 CC 0xad [02:33:25.588,000] <err> plat_pmic: Failed to get PMIC error, dimm id3 bus 1 addr 0x90 status 0x0 CC 0xad uart:~$ [02:33:28.633,000] <err> plat_pmic: Failed to get PMIC error, dimm id0 bus 0 addr 0x90 status 0x0 CC 0xad [02:33:28.686,000] <err> plat_pmic: Failed to get PMIC error, dimm id3 bus 1 addr 0x90 status 0x0 CC 0xad [02:33:28.633,000] <err> plat_pmic: Failed to get PMIC error, dimm id0 bus 0 addr 0x90 status 0x0 CC 0xad [02:33:28.686,000] <err> plat_pmic: Failed to get PMIC error, dimm id3 bus 1 addr 0x90 status 0x0 CC 0xad uart:~$ platform sensor list_all
--------------------------------------------------------------------------------- ...
[0x6 ] MB_DIMMA0_TEMP_C         : peci       | access[O] | poll[X] 1    sec | polling_disable           | na
[0x7 ] MB_DIMMA2_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.000
[0x9 ] MB_DIMMA3_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.000
[0xa ] MB_DIMMA4_TEMP_C         : peci       | access[O] | poll[X] 1    sec | polling_disable           | na
[0xb ] MB_DIMMA6_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0xc ] MB_DIMMA7_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    37.000
...
[0x1e] MB_VR_DIMMA0_PMIC_PWR_W  : pmic       | access[O] | poll[X] 1    sec | polling_disable           | na
[0x1f] MB_VR_DIMMA2_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.000
[0x36] MB_VR_DIMMA3_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.125
[0x37] MB_VR_DIMMA4_PMIC_PWR_W  : pmic       | access[O] | poll[X] 1    sec | polling_disable           | na
[0x42] MB_VR_DIMMA6_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.125
[0x47] MB_VR_DIMMA7_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.750
...
---------------------------------------------------------------------------------

5. Check BMC var/log/messages [BMC console]
root@bmc-oob:~# cat /var/log/messages | grep bic
...
 2023 Feb  7 21:39:25 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_pldm_wrapper: slot4 netfn: 0x38 cmd: 0x23, Completion Code: 0xFFFFFFF8
 2023 Feb  7 21:39:25 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_data_wrapper(): Failed to pack data to pldm.slot_id = 4, netfn = 0x38, cmd = 0x23
 2023 Feb  7 21:39:25 bmc-oob. user.warning fby35-v2023.06.1: sensord: pal_read_bic_sensor() Failed to run bic_get_sensor_reading(). fru: 4, snr#0x6
 2023 Feb  7 21:39:25 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_pldm_wrapper: slot4 netfn: 0x38 cmd: 0x23, Completion Code: 0xFFFFFFF8
 2023 Feb  7 21:39:25 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_data_wrapper(): Failed to pack data to pldm.slot_id = 4, netfn = 0x38, cmd = 0x23
 2023 Feb  7 21:39:25 bmc-oob. user.warning fby35-v2023.06.1: sensord: pal_read_bic_sensor() Failed to run bic_get_sensor_reading(). fru: 4, snr#0xa
 2023 Feb  7 21:39:26 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_pldm_wrapper: slot4 netfn: 0x38 cmd: 0x23, Completion Code: 0xFFFFFFF8
 2023 Feb  7 21:39:26 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_data_wrapper(): Failed to pack data to pldm.slot_id = 4, netfn = 0x38, cmd = 0x23
 2023 Feb  7 21:39:26 bmc-oob. user.warning fby35-v2023.06.1: sensord: pal_read_bic_sensor() Failed to run bic_get_sensor_reading(). fru: 4, snr#0x1e
 2023 Feb  7 21:39:26 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_pldm_wrapper: slot4 netfn: 0x38 cmd: 0x23, Completion Code: 0xFFFFFFF8
 2023 Feb  7 21:39:26 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_data_wrapper(): Failed to pack data to pldm.slot_id = 4, netfn = 0x38, cmd = 0x23
 2023 Feb  7 21:39:26 bmc-oob. user.warning fby35-v2023.06.1: sensord: pal_read_bic_sensor() Failed to run bic_get_sensor_reading(). fru: 4, snr#0x37
 2023 Feb  7 21:39:28 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_pldm_wrapper: slot4 netfn: 0x38 cmd: 0x23, Completion Code: 0xFFFFFFF8
 2023 Feb  7 21:39:28 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_data_wrapper(): Failed to pack data to pldm.slot_id = 4, netfn = 0x38, cmd = 0x23
 2023 Feb  7 21:39:28 bmc-oob. user.warning fby35-v2023.06.1: sensord: pal_read_bic_sensor() Failed to run bic_get_sensor_reading(). fru: 4, snr#0x6
 2023 Feb  7 21:39:28 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_pldm_wrapper: slot4 netfn: 0x38 cmd: 0x23, Completion Code: 0xFFFFFFF8
 2023 Feb  7 21:39:28 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_data_wrapper(): Failed to pack data to pldm.slot_id = 4, netfn = 0x38, cmd = 0x23
 2023 Feb  7 21:39:28 bmc-oob. user.warning fby35-v2023.06.1: sensord: pal_read_bic_sensor() Failed to run bic_get_sensor_reading(). fru: 4, snr#0xa
 2023 Feb  7 21:39:28 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_pldm_wrapper: slot4 netfn: 0x38 cmd: 0x23, Completion Code: 0xFFFFFFF8
 2023 Feb  7 21:39:28 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_data_wrapper(): Failed to pack data to pldm.slot_id = 4, netfn = 0x38, cmd = 0x23
 2023 Feb  7 21:39:28 bmc-oob. user.warning fby35-v2023.06.1: sensord: pal_read_bic_sensor() Failed to run bic_get_sensor_reading(). fru: 4, snr#0x1e
 2023 Feb  7 21:39:28 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_pldm_wrapper: slot4 netfn: 0x38 cmd: 0x23, Completion Code: 0xFFFFFFF8
 2023 Feb  7 21:39:28 bmc-oob. user.err fby35-v2023.06.1: sensord: bic_data_wrapper(): Failed to pack data to pldm.slot_id = 4, netfn = 0x38, cmd = 0x23
 2023 Feb  7 21:39:28 bmc-oob. user.warning fby35-v2023.06.1: sensord: pal_read_bic_sensor() Failed to run bic_get_sensor_reading(). fru: 4, snr#0x37

- After Fix
1. Check sensor status [BIC console]
uart:~$ platform sensor list_all
--------------------------------------------------------------------------------- ...
[0x6 ] MB_DIMMA0_TEMP_C         : peci       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x7 ] MB_DIMMA2_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.000
[0x9 ] MB_DIMMA3_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0xa ] MB_DIMMA4_TEMP_C         : peci       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0xb ] MB_DIMMA6_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0xc ] MB_DIMMA7_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    37.000
...
[0x1e] MB_VR_DIMMA0_PMIC_PWR_W  : pmic       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x1f] MB_VR_DIMMA2_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.000
[0x36] MB_VR_DIMMA3_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.875
[0x37] MB_VR_DIMMA4_PMIC_PWR_W  : pmic       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x42] MB_VR_DIMMA6_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.875
[0x47] MB_VR_DIMMA7_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.250
---------------------------------------------------------------------------------

2. Host power cycle [BIC console]
uart:~$ [00:01:54.146,000] <wrn> power_status: POST_COMPLETE: no [00:01:54.146,000] <inf> plat_isr: Send gpio interrupt to BMC, gpio number(39) status(0) [00:01:54.149,000] <wrn> power_status: DC_STATUS: off [00:01:54.153,000] <wrn> power_status: CPU_PWR_GOOD: no [00:01:54.153,000] <inf> plat_isr: Send gpio interrupt to BMC, gpio number(32) status(0) [00:01:54.146,000] <wrn> power_status: POST_COMPLETE: no [00:01:54.149,000] <wrn> power_status: DC_STATUS: off [00:01:54.153,000] <wrn> power_status: CPU_PWR_GOOD: no uart:~$ [00:02:03.404,000] <wrn> power_status: DC_STATUS: on [00:02:03.545,000] <wrn> power_status: CPU_PWR_GOOD: yes [00:02:03.545,000] <inf> plat_isr: Send gpio interrupt to BMC, gpio number(32) status(1) [00:02:04.187,000] <inf> plat_isr: Send gpio interrupt to BMC, gpio number(39) status(1) [00:02:03.404,000] <wrn> power_status: DC_STATUS: on [00:02:03.545,000] <wrn> power_status: CPU_PWR_GOOD: yes

3. Check sensor status after host cycle and post not complete [BIC console]
uart:~$ platform sensor list_all
--------------------------------------------------------------------------------- ...
[0x6 ] MB_DIMMA0_TEMP_C         : peci       | access[X] | poll[X] 1    sec | sensor_not_present        | na
[0x7 ] MB_DIMMA2_TEMP_C         : peci       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x9 ] MB_DIMMA3_TEMP_C         : peci       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xa ] MB_DIMMA4_TEMP_C         : peci       | access[X] | poll[X] 1    sec | sensor_not_present        | na
[0xb ] MB_DIMMA6_TEMP_C         : peci       | access[X] | poll[O] 1    sec | not_accesible             | na
[0xc ] MB_DIMMA7_TEMP_C         : peci       | access[X] | poll[O] 1    sec | not_accesible             | na
...
[0x1e] MB_VR_DIMMA0_PMIC_PWR_W  : pmic       | access[X] | poll[X] 1    sec | sensor_not_present        | na
[0x1f] MB_VR_DIMMA2_PMIC_PWR_W  : pmic       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x36] MB_VR_DIMMA3_PMIC_PWR_W  : pmic       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x37] MB_VR_DIMMA4_PMIC_PWR_W  : pmic       | access[X] | poll[X] 1    sec | sensor_not_present        | na
[0x42] MB_VR_DIMMA6_PMIC_PWR_W  : pmic       | access[X] | poll[O] 1    sec | not_accesible             | na
[0x47] MB_VR_DIMMA7_PMIC_PWR_W  : pmic       | access[X] | poll[O] 1    sec | not_accesible             | na
...
---------------------------------------------------------------------------------

4. Check sensor status after post complete [BIC console]
uart:~$ [00:03:05.925,000] <wrn> power_status: POST_COMPLETE: yes [00:03:05.925,000] <wrn> power_status: POST_COMPLETE: yes uart:~$ platform sensor list_all
--------------------------------------------------------------------------------- ...
[0x6 ] MB_DIMMA0_TEMP_C         : peci       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x7 ] MB_DIMMA2_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    41.000
[0x9 ] MB_DIMMA3_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.000
[0xa ] MB_DIMMA4_TEMP_C         : peci       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0xb ] MB_DIMMA6_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0xc ] MB_DIMMA7_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
...
[0x1e] MB_VR_DIMMA0_PMIC_PWR_W  : pmic       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x1f] MB_VR_DIMMA2_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.000
[0x36] MB_VR_DIMMA3_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.375
[0x37] MB_VR_DIMMA4_PMIC_PWR_W  : pmic       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x42] MB_VR_DIMMA6_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.125
[0x47] MB_VR_DIMMA7_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.750
...
---------------------------------------------------------------------------------

5. Check BMC var/log/messages [BMC console]
root@bmc-oob:~# cat /var/log/messages | grep bic
root@bmc-oob:~#