### PR TITLE
Artemis: mc: Workaround: Skip to check JCN13 and 14 card type

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_class.c
+++ b/meta-facebook/at-mc/src/platform/plat_class.c
@@ -156,6 +156,12 @@ void check_pcie_card_type()
 	I2C_MSG i2c_msg = { 0 };
 
 	for (index = 0; index < ARRAY_SIZE(pcie_card_info); ++index) {
+		/* Workaround: Skip to check JCN 13 and 14 card type */
+		if (index == CARD_13_INDEX || index == CARD_14_INDEX) {
+			pcie_card_info[index].card_device_type = CARD_NOT_PRESENT;
+			continue;
+		}
+
 		memset(&i2c_msg, 0, sizeof(I2C_MSG));
 		i2c_msg.bus = CPLD_BUS;
 		i2c_msg.target_addr = CPLD_ADDR;
@@ -170,11 +176,6 @@ void check_pcie_card_type()
 
 		val = ((i2c_msg.data[0]) >> pcie_card_info[index].value_shift_bit) &
 		      pcie_card_info[index].value_bit;
-		if ((index == CARD_13_INDEX) || (index == CARD_14_INDEX)) {
-			/* CPLD register reads back the presence value of PCIE card 13/14 doesn't include present_1 bit */
-			/* Add present_1 bit value to map card type from presence status */
-			val = (val << 1) + 1;
-		}
 
 		pcie_card_info[index].card_device_type = prsnt_status_to_card_type(val);
 


### PR DESCRIPTION
Summary:
- Due to hardware issue, BIC get error jcn 13 and 14 card type, so report card not present to avoid BIC can't access nvme and print error logs. BIC will redefine how to use jcn 13 and 14 in EVT2 layout.

Test Plan:
- Build code: Pass
- BIC report to BMC that JCN13 and 14 not present: Pass

Log:
- Before root@bmc-oob:~# sensor-util meb_jcn13
meb_jcn13:
MEB_JCN13_E1S_0_TEMP_C       (0x1) : NA | (na)
MEB_JCN13_E1S_1_TEMP_C       (0x2) : NA | (na)

root@bmc-oob:~# sensor-util meb_jcn14
meb_jcn14:
MEB_JCN14_E1S_0_TEMP_C       (0x1) : NA | (na)
MEB_JCN14_E1S_1_TEMP_C       (0x2) : NA | (na)

- After root@bmc-oob:~# sensor-util meb_jcn13
meb_jcn13 is not present!

root@bmc-oob:~# sensor-util meb_jcn14
meb_jcn14 is not present!