### PR TITLE
fby35: cl: Change VPP default value

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.c
@@ -579,8 +579,14 @@ void ISR_CPU_VPP_INT()
 		uint8_t vpp_pwr_status_bit = 0;
 		uint8_t device_id = 0;
 		uint8_t set_power_status = DEVICE_SET_POWER_OFF;
-		static uint8_t last_vpp_pwr_status =
-			0xE1; // default all devices are on (bit1~4 = 0)
+		// CPLD register define VPP PWREN# (1OU Expansion)
+		// Bit 4: M.2 device 3
+		// Bit 3: M.2 device 2
+		// Bit 2: M.2 device 1
+		// Bit 1: M.2 device 0
+		// Bit 0: RSVD
+		// default device0, 1, 3 are ON (bit1, 2, 4 = 0)
+		static uint8_t last_vpp_pwr_status = 0xE9;
 		I2C_MSG i2c_msg;
 		ipmi_msg msg;
 		common_addsel_msg_t sel_msg;


### PR DESCRIPTION
Summary:
- VF board doesn't have connector of device 2. Change default power status value of VPP device 0, 1, 3 is power on and device 2 is power off.

Test plan:
- Build code: Pass
- Remove all E1.S and check SEL: Pass

Known Issue:
- BMC decode VPP event SEL failed because the sensor number for SYSTEM_STATUS is different from CL (0x10) and VF (0x46). Current BMC only decodes the sensor number of SYSTEM_STATUS as 0x46 and doesn't handle 0x10.

Log:
1. Remove all E1.S and check no SEL about device 2.
- Before change root@bmc-oob:~# log-util --print slot4
2023 Feb 20 22:33:16 log-util: User cleared FRU: 4 logs
4    slot4    2023-02-20 22:33:54    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-02-20 22:33:54, Sensor: Unknown (0x10), Event Data: (0B013A) Unknown Assertion
4    slot4    2023-02-20 22:33:54    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-02-20 22:33:54, Sensor: Unknown (0x10), Event Data: (0B013C) Unknown Assertion
4    slot4    2023-02-20 22:33:54    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-02-20 22:33:54, Sensor: Unknown (0x10), Event Data: (0B013E) Unknown Assertion
4    slot4    2023-02-20 22:33:54    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-02-20 22:33:54, Sensor: Unknown (0x10), Event Data: (0B0137) Unknown Assertion

- After change root@bmc-oob:~# log-util --print slot4
2023 Feb 20 22:25:06 log-util: User cleared FRU: 4 logs
4    slot4    2023-02-20 22:25:11    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-02-20 22:25:11, Sensor: Unknown (0x10), Event Data: (0B0137) Unknown Assertion
4    slot4    2023-02-20 22:25:12    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-02-20 22:25:12, Sensor: Unknown (0x10), Event Data: (0B013A) Unknown Assertion
4    slot4    2023-02-20 22:25:12    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-02-20 22:25:12, Sensor: Unknown (0x10), Event Data: (0B013C) Unknown Assertion