### PR TITLE
fby3.5: rf: Support to get CXL FW Version

### DIFF
--- a/meta-facebook/yv35-rf/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/yv35-rf/src/ipmi/include/plat_ipmi.h
@@ -17,4 +17,7 @@
 #ifndef PLAT_IPMI_H
 #define PLAT_IPMI_H
 
+#define RF_COMPNT_BIC 2
+#define RF_COMPNT_CXL 10
+
 #endif

--- a/meta-facebook/yv35-rf/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-rf/src/ipmi/plat_ipmi.c
@@ -81,10 +81,13 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 		}
 		CHECK_NULL_ARG(mctp_inst);
 		ret = cci_get_chip_fw_version(mctp_inst, ext_params, resp_buf, &read_len);
-		msg->data[0] = component;
-		memcpy(&msg->data[0], resp_buf, read_len);
-		msg->data_len = read_len;
-		msg->completion_code = CC_SUCCESS;
+		if (ret == false) {
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+		} else {
+			memcpy(&msg->data[0], resp_buf, read_len);
+			msg->data_len = read_len;
+			msg->completion_code = CC_SUCCESS;
+		}
 		break;
 	default:
 		msg->completion_code = CC_UNSPECIFIED_ERROR;

--- a/meta-facebook/yv35-rf/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-rf/src/ipmi/plat_ipmi.c
@@ -22,6 +22,10 @@
 #include "plat_ipmb.h"
 #include "expansion_board.h"
 #include <logging/log.h>
+#include "oem_1s_handler.h"
+#include "cci.h"
+#include "mctp.h"
+#include "plat_mctp.h"
 
 LOG_MODULE_REGISTER(plat_ipmi);
 
@@ -41,5 +45,51 @@ void OEM_1S_GET_BOARD_ID(ipmi_msg *msg)
 	msg->data_len = 1;
 	msg->data[0] = get_board_id();
 	msg->completion_code = CC_SUCCESS;
+	return;
+}
+
+void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+	if (msg->data_len != 1) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+	bool ret = false;
+	uint8_t component = msg->data[0];
+	mctp *mctp_inst = NULL;
+	mctp_ext_params ext_params = { 0 };
+	uint8_t read_len = 0;
+	uint8_t resp_buf[GET_FW_INFO_REVISION_LEN] = { 0 };
+
+	switch (component) {
+	case RF_COMPNT_BIC:
+		msg->data[0] = BIC_FW_YEAR_MSB;
+		msg->data[1] = BIC_FW_YEAR_LSB;
+		msg->data[2] = BIC_FW_WEEK;
+		msg->data[3] = BIC_FW_VER;
+		msg->data[4] = BIC_FW_platform_0;
+		msg->data[5] = BIC_FW_platform_1;
+		msg->data[6] = BIC_FW_platform_2;
+		msg->data_len = 7;
+		msg->completion_code = CC_SUCCESS;
+		break;
+	case RF_COMPNT_CXL:
+		if (get_mctp_info_by_eid(CXL_EID, &mctp_inst, &ext_params) == false) {
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+			return;
+		}
+		CHECK_NULL_ARG(mctp_inst);
+		ret = cci_get_chip_fw_version(mctp_inst, ext_params, resp_buf, &read_len);
+		msg->data[0] = component;
+		memcpy(&msg->data[0], resp_buf, read_len);
+		msg->data_len = read_len;
+		msg->completion_code = CC_SUCCESS;
+		break;
+	default:
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
+		break;
+	}
+
 	return;
 }


### PR DESCRIPTION
Summary:

- Support to get CXL FW Version

Test Plan:
- Build code: Pass
- Get CXL version: Pass
```
root@bmc-oob:~# fw-util slot1 --version | grep CXL
CXL Version: 01.002.000.01
```
