### PR TITLE
treewide: logging: remove '<error>' marks

### DIFF
--- a/common/dev/isl69254iraz_t.c
+++ b/common/dev/isl69254iraz_t.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(isl69254iraz_t);
 bool isl69254iraz_t_get_checksum(uint8_t bus, uint8_t target_addr, uint8_t *checksum)
 {
 	if (checksum == NULL) {
-		LOG_ERR("<error> isl69254iraz_t checksum is NULL");
+		LOG_ERR("isl69254iraz_t checksum is NULL");
 		return false;
 	}
 
@@ -44,7 +44,7 @@ bool isl69254iraz_t_get_checksum(uint8_t bus, uint8_t target_addr, uint8_t *chec
 	i2c_msg.data[2] = 0x00; //dummy data
 
 	if (i2c_master_write(&i2c_msg, retry)) {
-		LOG_ERR("<error> isl69254iraz_t get checksum while i2c writing");
+		LOG_ERR("isl69254iraz_t get checksum while i2c writing");
 		return false;
 	}
 
@@ -53,7 +53,7 @@ bool isl69254iraz_t_get_checksum(uint8_t bus, uint8_t target_addr, uint8_t *chec
 	i2c_msg.data[0] = 0xC5; //DMAFIX command code
 
 	if (i2c_master_read(&i2c_msg, retry)) {
-		LOG_ERR("<error> isl69254iraz_t get checksum while i2c reading");
+		LOG_ERR("isl69254iraz_t get checksum while i2c reading");
 		return false;
 	}
 
@@ -76,7 +76,7 @@ bool isl69254iraz_t_get_remaining_write(uint8_t bus, uint8_t target_addr, uint8_
 	i2c_msg.data[2] = 0x00; //dummy data
 
 	if (i2c_master_write(&i2c_msg, retry)) {
-		LOG_ERR("<error> isl69254iraz_t get remaining write while i2c writing");
+		LOG_ERR("isl69254iraz_t get remaining write while i2c writing");
 		return false;
 	}
 
@@ -85,7 +85,7 @@ bool isl69254iraz_t_get_remaining_write(uint8_t bus, uint8_t target_addr, uint8_
 	i2c_msg.data[0] = 0xC5; //DMAFIX command code
 
 	if (i2c_master_read(&i2c_msg, retry)) {
-		LOG_ERR("<error> isl69254iraz_t get remaining write while i2c reading");
+		LOG_ERR("isl69254iraz_t get remaining write while i2c reading");
 		return false;
 	}
 

--- a/common/dev/ltc4286.c
+++ b/common/dev/ltc4286.c
@@ -170,7 +170,7 @@ uint8_t ltc4286_read(uint8_t sensor_num, int *reading)
 uint8_t ltc4286_init(uint8_t sensor_num)
 {
 	if (!sensor_config[sensor_config_index_map[sensor_num]].init_args) {
-		LOG_ERR("<error> LTC4286 init args are not provided!");
+		LOG_ERR("LTC4286 init args are not provided!");
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
 

--- a/common/dev/mp5990.c
+++ b/common/dev/mp5990.c
@@ -33,7 +33,6 @@ LOG_MODULE_REGISTER(mp5990);
 #define MP5990_EIN_SAMPLE_CNT_MAX 0x1000000
 #define MP5990_EIN_ENERGY_CNT_MAX 0x8000
 
-
 int mp5990_read_ein(double *val, uint8_t sensor_num)
 {
 	if ((val == NULL) || (sensor_num > SENSOR_NUM_MAX)) {

--- a/common/dev/mp5990.c
+++ b/common/dev/mp5990.c
@@ -176,7 +176,7 @@ uint8_t mp5990_init(uint8_t sensor_num)
 	}
 
 	if (!sensor_config[sensor_config_index_map[sensor_num]].init_args) {
-		LOG_ERR("<error> MP5990 init args are not provided!");
+		LOG_ERR("MP5990 init args are not provided!");
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
 

--- a/common/dev/xdpe12284c.c
+++ b/common/dev/xdpe12284c.c
@@ -48,12 +48,14 @@ LOG_MODULE_REGISTER(xdpe12284c);
 
 #define MAX_CMD_LINE 1080
 
-enum { VR12 = 1,
-       VR13,
-       IMVP9,
+enum {
+	VR12 = 1,
+	VR13,
+	IMVP9,
 };
 
-enum { VID_IDENTIFIER = 1,
+enum {
+	VID_IDENTIFIER = 1,
 };
 
 struct xdpe_config {

--- a/common/dev/xdpe12284c.c
+++ b/common/dev/xdpe12284c.c
@@ -144,7 +144,7 @@ bool xdpe12284c_get_remaining_write(uint8_t bus, uint8_t target_addr, uint16_t *
 	i2c_msg.rx_len = 2;
 	i2c_msg.data[0] = VR_XDPE_REG_REMAIN_WR;
 	if (i2c_master_read(&i2c_msg, retry)) {
-		LOG_ERR("<error> XDPE12284C get remaining write while i2c reading");
+		LOG_ERR("XDPE12284C get remaining write while i2c reading");
 		return false;
 	}
 


### PR DESCRIPTION
Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
