### PR TITLE
yv3: dl: adjust the function of init me firmware to after bic set rea…

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_init.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_init.c
@@ -45,11 +45,6 @@ void pal_post_init()
 	kcs_init();
 }
 
-void pal_device_init()
-{
-	init_me_firmware();
-}
-
 void pal_set_sys_status()
 {
 	set_DC_status(PWRGD_SYS_PWROK);
@@ -59,6 +54,7 @@ void pal_set_sys_status()
 	set_CPU_power_status(PWRGD_CPU_LVC3_R);
 	set_post_thread();
 	set_sys_ready_pin(BIC_READY);
+	init_me_firmware();
 }
 
 #define DEF_PROJ_GPIO_PRIORITY 78


### PR DESCRIPTION
…dy pin

Summary
- The function of init_me_firmware will have delay according to me firmware status.
- Therefore, init me firmware will delay bic set ready pin.
- Since BIC can already communicate with BMC, BIC should set the ready pin first.

Test plan:
- build code : pass
- Get fru after sled cycle : pass root@bmc-oob:~# power-util sled-cycle

root@bmc-oob:~# fruid-util slot1

FRU Information           : Server board 1
---------------           : ------------------
Chassis Type              : Rack Mount Chassis
Chassis Part Number       : N/A
Chassis Serial Number     : aaa
Chassis Custom Data 1     : M0Y861L100272
Board Mfg Date            : Sun Nov 27 19:38:00 2022
Board Mfg                 : Wiwynn
Board Product             : Delta Lake-Class1
Board Serial              : WN3302201DN1A
Board Part Number         : B81.02610.0133
Board FRU ID              : 1.0
Board Custom Data 1       : 02-000342
Board Custom Data 2       : PCB Supplier - GCE
Product Manufacturer      : Wiwynn
Product Name              : Delta Lake DVT
Product Part Number       : BZA.02601.0094
Product Version           : YoDL03
Product Serial            : BZA02400026N01A
Product Asset Tag         : N/A
Product FRU ID            : 1.0
Product Custom Data 1     : 01-005128
Product Custom Data 2     : N/A
Product Custom Data 3     : 0000
Part Number BIC           : AST1030A1-GP
Part Number CPLD          : 10MXYDFF484C8GDL