### PR TITLE
fby35: gl: Correct sensors' base unit

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
@@ -2820,7 +2820,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x23, // [7:0] M bits
@@ -2880,7 +2880,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x1D, // [7:0] M bits
@@ -2940,7 +2940,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x2B, // [7:0] M bits
@@ -3000,7 +3000,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x2F, // [7:0] M bits
@@ -3060,7 +3060,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x18, // [7:0] M bits
@@ -3120,7 +3120,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x10, // [7:0] M bits
@@ -3180,7 +3180,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
 		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
 		0x10, // [7:0] M bits


### PR DESCRIPTION
Summary:
- Correct the following sensors' base unit.
    MB_HSC_INPUT_PWR_W   C -> Watts
    MB_VR_VCCIN_PWR_W    C -> Watts
    MB_VR_EHV_PWR_W      C -> Watts
    MB_VR_FIVRA_PWR_W    C -> Watts
    MB_VR_VCCINF_PWR_W   C -> Watts
    MB_VR_VCCD0_PWR_W    C -> Watts
    MB_VR_VCCD1_PWR_W    C -> Watts

Test Plan:
- Build code: Pass
- Check sensors' unit by "sensor-util": Pass

Test log:

Before

root@bmc-oob:~# sensor-util slot3 | grep _W
MB_HSC_INPUT_PWR_W           (0x2F) :  119.16 C     | (ok)
MB_VR_VCCIN_PWR_W            (0x30) :   73.38 C     | (ok)
MB_VR_EHV_PWR_W              (0x31) :    0.75 C     | (ok)
MB_VR_FIVRA_PWR_W            (0x32) :    7.25 C     | (ok)
MB_VR_VCCINF_PWR_W           (0x33) :   10.50 C     | (ok)
MB_VR_VCCD0_PWR_W            (0x34) :    0.50 C     | (ok)
MB_VR_VCCD1_PWR_W            (0x35) :    1.25 C     | (ok)
-----------------------------------------------------------------
After

root@bmc-oob:~# sensor-util slot3 | grep _W
MB_HSC_INPUT_PWR_W           (0x2F) :  119.88 Watts  | (ok)
MB_VR_VCCIN_PWR_W            (0x30) :   73.25 Watts  | (ok)
MB_VR_EHV_PWR_W              (0x31) :    1.00 Watts  | (ok)
MB_VR_FIVRA_PWR_W            (0x32) :    7.25 Watts  | (ok)
MB_VR_VCCINF_PWR_W           (0x33) :   10.12 Watts  | (ok)
MB_VR_VCCD0_PWR_W            (0x34) :    0.50 Watts  | (ok)
MB_VR_VCCD1_PWR_W            (0x35) :    1.25 Watts  | (ok)