### PR TITLE
ol2: op: Modify exp B main P12V power threshold

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_sdr_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sdr_table.c
@@ -2076,21 +2076,21 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x07, // [7:0] M bits
+		0x0B, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xE0, // Rexp, Bexp
+		0xF0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xDD, // UNRT
-		0xDB, // UCT
-		0xD9, // UNCT
+		0xB5, // UNRT
+		0xB4, // UCT
+		0xB2, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT


### PR DESCRIPTION
Summary:
- Modify main P12V power threshold of 2OU and 4OU.

Test plan:
- Build code: Pass
- Check threshold: Pass

Log:
- Before modify root@bmc-oob:~# sensor-util slot1 --thre | grep MAIN_P12V_PWR
2OU_BIC_MAIN_P12V_PWR_W      (0x8B) :    6.43 Watts  | (ok) | UCR: 15.33 | UNC: 15.19 | UNR: 15.47 | LCR: NA | LNC: NA | LNR: NA
4OU_BIC_MAIN_P12V_PWR_W      (0xEB) :    8.85 Watts  | (ok) | UCR: 15.33 | UNC: 15.19 | UNR: 15.47 | LCR: NA | LNC: NA | LNR: NA

- After modify root@bmc-oob:~# sensor-util slot1 --thre | grep MAIN_P12V_PWR
2OU_BIC_MAIN_P12V_PWR_W      (0x8B) :    6.18 Watts  | (ok) | UCR: 198.00 | UNC: 195.80 | UNR: 199.10 | LCR: NA | LNC: NA | LNR: NA
4OU_BIC_MAIN_P12V_PWR_W      (0xEB) :    8.85 Watts  | (ok) | UCR: 198.00 | UNC: 195.80 | UNR: 199.10 | LCR: NA | LNC: NA | LNR: NA