### PR TITLE
OL2: op: Support IPMI command to control E1.S LED

### DIFF
--- a/meta-facebook/op2-op/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/op2-op/src/ipmi/plat_ipmi.c
@@ -28,6 +28,7 @@
 #include "plat_power_seq.h"
 #include "plat_sensor_table.h"
 #include "plat_hook.h"
+#include "plat_led.h"
 
 LOG_MODULE_REGISTER(plat_ipmi);
 
@@ -239,6 +240,87 @@ void OEM_1S_SAFE_WRITE_READ_M2_DATA(ipmi_msg *msg)
 	if (k_mutex_unlock(&i2c_hub_mutex)) {
 		LOG_ERR("Failed to unlock mutex");
 	}
+
+	return;
+}
+
+/* Control amber LED behavior
+ * Request:
+ * Data 0: Device ID
+ *   00h E1S 0
+ *   01h E1S 1
+ *   02h E1S 2
+ *   03h E1S 3
+ *   04h E1S 4
+ * Data 1: Control option
+ *   00h LED turn off
+ *   01h LED turn on
+ *   02h LED start blink
+ *   03h LED stop blink
+*/
+void OEM_1S_SET_SSD_LED(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 2) {
+		msg->data_len = 0;
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	uint8_t device = msg->data[0];
+
+	msg->data_len = 0;
+
+	if (!get_e1s_present(device)) {
+		msg->completion_code = CC_SENSOR_NOT_PRESENT;
+		return;
+	}
+
+	if (control_e1s_amber_led(device, msg->data[1]) < 0) {
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
+	} else {
+		msg->completion_code = CC_SUCCESS;
+	}
+
+	return;
+}
+
+/* Get amber LED status
+ * Request:
+ * Data 0: Device ID
+ *   00h E1S 0
+ *   01h E1S 1
+ *   02h E1S 2
+ *   03h E1S 3
+ *   04h E1S 4
+ * Response
+ * Data 0: Status
+ *   00h LED off
+ *   01h LED on
+ *   02h LED blink
+*/
+void OEM_1S_GET_SSD_STATUS(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 1) {
+		msg->data_len = 0;
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	uint8_t device = msg->data[0];
+
+	if (!get_e1s_present(device)) {
+		msg->data_len = 0;
+		msg->completion_code = CC_SENSOR_NOT_PRESENT;
+		return;
+	}
+
+	msg->data_len = 1;
+	msg->data[0] = get_e1s_amber_led_status(device);
+	msg->completion_code = CC_SUCCESS;
 
 	return;
 }

--- a/meta-facebook/op2-op/src/platform/plat_led.c
+++ b/meta-facebook/op2-op/src/platform/plat_led.c
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <logging/log.h>
+#include "libutil.h"
+#include "plat_gpio.h"
+#include "plat_class.h"
+#include "plat_power_seq.h"
+#include "plat_led.h"
+
+LOG_MODULE_REGISTER(plat_led);
+
+static uint8_t e1s_amber_led_pre_status[MAX_E1S_IDX] = { LED_STATUS_OFF, LED_STATUS_OFF,
+							 LED_STATUS_OFF, LED_STATUS_OFF,
+							 LED_STATUS_OFF };
+static uint8_t e1s_amber_led_status[MAX_E1S_IDX] = { LED_STATUS_OFF, LED_STATUS_OFF, LED_STATUS_OFF,
+						     LED_STATUS_OFF, LED_STATUS_OFF };
+
+#define E1S_LED_BLINK_INIT(device)                                                                 \
+	void blink_handler_##device(struct k_timer *timer)                                         \
+	{                                                                                          \
+		CHECK_NULL_ARG(timer);                                                             \
+		set_e1s_amber_led(E1S_##device, CTRL_LED_START_BLINK);                             \
+	}                                                                                          \
+	void stop_blink_handler_##device(struct k_timer *timer)                                    \
+	{                                                                                          \
+		CHECK_NULL_ARG(timer);                                                             \
+		set_e1s_amber_led(E1S_##device, e1s_amber_led_pre_status[E1S_##device]);           \
+	}                                                                                          \
+	K_TIMER_DEFINE(e1s_led_blink_timer_##device, blink_handler_##device,                       \
+		       stop_blink_handler_##device);
+
+E1S_LED_BLINK_INIT(0);
+E1S_LED_BLINK_INIT(1);
+E1S_LED_BLINK_INIT(2);
+E1S_LED_BLINK_INIT(3);
+E1S_LED_BLINK_INIT(4);
+
+uint8_t get_e1s_led_gpio(uint8_t device_id)
+{
+	uint8_t gpio_num = UNKNOWN_LED_GPIO;
+
+	switch (device_id) {
+	case E1S_0:
+		gpio_num = OPA_LED_E1S_0_ATTN_R;
+		break;
+	case E1S_1:
+		gpio_num = OPA_LED_E1S_1_ATTN_R;
+		break;
+	case E1S_2:
+		gpio_num = OPA_LED_E1S_2_ATTN_R;
+		break;
+	case E1S_3:
+		gpio_num = OPB_LED_E1S_3_ATTN_R;
+		break;
+	case E1S_4:
+		gpio_num = OPB_LED_E1S_4_ATTN_R;
+		break;
+	default:
+		gpio_num = UNKNOWN_LED_GPIO;
+		break;
+	}
+
+	return gpio_num;
+}
+
+struct k_timer *get_e1s_led_timer(uint8_t device_id)
+{
+	switch (device_id) {
+	case E1S_0:
+		return &e1s_led_blink_timer_0;
+	case E1S_1:
+		return &e1s_led_blink_timer_1;
+	case E1S_2:
+		return &e1s_led_blink_timer_2;
+	case E1S_3:
+		return &e1s_led_blink_timer_3;
+	case E1S_4:
+		return &e1s_led_blink_timer_4;
+	default:
+		return NULL;
+	}
+}
+
+void stop_blink_timer(uint8_t device_id)
+{
+	struct k_timer *timer = get_e1s_led_timer(device_id);
+
+	CHECK_NULL_ARG(timer);
+
+	k_timer_stop(timer);
+}
+
+void set_e1s_amber_led(uint8_t device_id, uint8_t ctrl_option)
+{
+	uint8_t led_gpio = get_e1s_led_gpio(device_id);
+	if (led_gpio == UNKNOWN_LED_GPIO) {
+		return;
+	}
+
+	switch (ctrl_option) {
+	case CTRL_LED_TURN_OFF:
+		gpio_set(led_gpio, GPIO_LOW);
+		break;
+	case CTRL_LED_TURN_ON:
+		gpio_set(led_gpio, GPIO_HIGH);
+		break;
+	case CTRL_LED_START_BLINK:
+		gpio_set(led_gpio, !gpio_get(led_gpio));
+		break;
+	default:
+		LOG_ERR("Failed to control LED%d due to unknown control command %d", device_id,
+			ctrl_option);
+		break;
+	}
+
+	return;
+}
+
+uint8_t get_e1s_amber_led_status(uint8_t device_id)
+{
+	if (device_id >= MAX_E1S_IDX) {
+		return LED_STATUS_UNKNOWN;
+	}
+
+	return e1s_amber_led_status[device_id];
+}
+
+int control_e1s_amber_led(uint8_t device_id, uint8_t ctrl_option)
+{
+	uint8_t card_type = get_card_type();
+	uint8_t max_device_num = 0;
+	int ret = 0;
+
+	if (card_type == CARD_TYPE_OPA) {
+		max_device_num = OPA_MAX_E1S_IDX;
+	} else {
+		max_device_num = MAX_E1S_IDX;
+	}
+
+	if (device_id >= max_device_num) {
+		return -1;
+	}
+
+	stop_blink_timer(device_id);
+
+	switch (ctrl_option) {
+	case CTRL_LED_TURN_OFF:
+	case CTRL_LED_TURN_ON:
+		e1s_amber_led_pre_status[device_id] = ctrl_option;
+		e1s_amber_led_status[device_id] = ctrl_option;
+		set_e1s_amber_led(device_id, ctrl_option);
+		break;
+	case CTRL_LED_START_BLINK:
+		e1s_amber_led_status[device_id] = ctrl_option;
+		k_timer_start(get_e1s_led_timer(device_id), K_MSEC(AMBER_LED_BLINK_INTERVAL_MS),
+			      K_MSEC(AMBER_LED_BLINK_INTERVAL_MS));
+		break;
+	case CTRL_LED_STOP_BLINK:
+		e1s_amber_led_status[device_id] = e1s_amber_led_pre_status[device_id];
+		stop_blink_timer(device_id);
+		break;
+	default:
+		LOG_ERR("Failed to control LED%d due to unknown control command %d", device_id,
+			ctrl_option);
+		ret = -1;
+		break;
+	}
+
+	return ret;
+}

--- a/meta-facebook/op2-op/src/platform/plat_led.h
+++ b/meta-facebook/op2-op/src/platform/plat_led.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+
+#define AMBER_LED_BLINK_INTERVAL_MS 500
+#define UNKNOWN_LED_GPIO 0xFF
+
+enum AMBER_LED_CONTROL_OPTION {
+	CTRL_LED_TURN_OFF = 0x00,
+	CTRL_LED_TURN_ON,
+	CTRL_LED_START_BLINK,
+	CTRL_LED_STOP_BLINK,
+	CTRL_LED_UNKNOWN = 0xFF,
+};
+
+enum AMBER_LED_STATUS {
+	LED_STATUS_OFF = 0x00,
+	LED_STATUS_ON,
+	LED_STATUS_BLINK,
+	LED_STATUS_UNKNOWN = 0xFF,
+};
+
+uint8_t get_e1s_led_gpio(uint8_t device_id);
+struct k_timer *get_e1s_led_timer(uint8_t device_id);
+void stop_blink_timer(uint8_t device_id);
+void set_e1s_amber_led(uint8_t device_id, uint8_t ctrl_option);
+uint8_t get_e1s_amber_led_status(uint8_t device_id);
+int control_e1s_amber_led(uint8_t device_id, uint8_t ctrl_option);


### PR DESCRIPTION
Summary:
- Support IPMI command to control E1.S amber LED.
- OEM_1S_SET_SSD_LED format: Netfn - 0x38 Code - 0x39 Request - Data 0: Device ID 00h E1S 0 01h E1S 1 02h E1S 2 03h E1S 3 04h E1S 4 Data 1: Control option 00h LED turn off 01h LED turn on 02h LED start blink 03h LED stop blink
- OEM_1S_GET_SSD_STATUS format: Netfn - 0x38 Code - 0x3A Request - Data 0: Device ID 00h E1S 0 01h E1S 1 02h E1S 2 03h E1S 3 04h E1S 4 Response - Data 0: Complete code Data 1:3: IANA Data 4: LED status 00h LED off 01h LED on 02h LED blink

Test plan:
- Build code: Pass
- Control E1.S LED: Pass

Log:
1. Set E1.S LED on, blinking and check status.
- 1OU E1.S 1
* Check amber LED status. root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x3A 0x15 0xA0 0x0 0x01 15 A0 00 05 39 3A 00 15 A0 00 00
* Set abmer LED on. root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x39 0x15 0xA0 0x0 0x01 0x01 15 A0 00 05 39 39 00 15 A0 00
* Check amber LED status is on. root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x3A 0x15 0xA0 0x0 0x01 15 A0 00 05 39 3A 00 15 A0 00 01
* Set abmer LED blink. root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x39 0x15 0xA0 0x0 0x01 0x02 15 A0 00 05 39 39 00 15 A0 00
* Check amber LED status is blink. root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x3A 0x15 0xA0 0x0 0x01 15 A0 00 05 39 3A 00 15 A0 00 02

- 2OU E1.S 2 root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x3A 0x15 0xA0 0x0 0x02 15 A0 00 15 39 3A 00 15 A0 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x39 0x15 0xA0 0x0 0x02 0x01 15 A0 00 15 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x3A 0x15 0xA0 0x0 0x02 15 A0 00 15 39 3A 00 15 A0 00 01
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x39 0x15 0xA0 0x0 0x02 0x02 15 A0 00 15 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x3A 0x15 0xA0 0x0 0x02 15 A0 00 15 39 3A 00 15 A0 00 02

- 3OU E1.S 0 root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x3A 0x15 0xA0 0x0 0x00 15 A0 00 25 39 3A 00 15 A0 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x39 0x15 0xA0 0x0 0x00 0x01 15 A0 00 25 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x3A 0x15 0xA0 0x0 0x00 15 A0 00 25 39 3A 00 15 A0 00 01
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x39 0x15 0xA0 0x0 0x00 0x02 15 A0 00 25 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x3A 0x15 0xA0 0x0 0x00 15 A0 00 25 39 3A 00 15 A0 00 02

- 4OU E1.S 3 root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x3A 0x15 0xA0 0x0 0x03 15 A0 00 30 39 3A 00 15 A0 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x39 0x15 0xA0 0x0 0x03 0x01 15 A0 00 30 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x3A 0x15 0xA0 0x0 0x03 15 A0 00 30 39 3A 00 15 A0 00 01
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x39 0x15 0xA0 0x0 0x03 0x02 15 A0 00 30 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x3A 0x15 0xA0 0x0 0x03 15 A0 00 30 39 3A 00 15 A0 00 02

2. Check status is the same before blinking when E1.S LED is set stop blinking. (1) 1OU E1.S 1
- Pre status is off root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x3A 0x15 0xA0 0x0 0x01 15 A0 00 05 39 3A 00 15 A0 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x39 0x15 0xA0 0x0 0x01 0x02 15 A0 00 05 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x3A 0x15 0xA0 0x0 0x01 15 A0 00 05 39 3A 00 15 A0 00 02
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x39 0x15 0xA0 0x0 0x01 0x03 15 A0 00 05 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x3A 0x15 0xA0 0x0 0x01 15 A0 00 05 39 3A 00 15 A0 00 00

- Pre status is on root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x3A 0x15 0xA0 0x0 0x01 15 A0 00 05 39 3A 00 15 A0 00 01
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x39 0x15 0xA0 0x0 0x01 0x02 15 A0 00 05 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x3A 0x15 0xA0 0x0 0x01 15 A0 00 05 39 3A 00 15 A0 00 02
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x39 0x15 0xA0 0x0 0x01 0x03 15 A0 00 05 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x05 0xe0 0x3A 0x15 0xA0 0x0 0x01 15 A0 00 0

(2) 2OU E1.S 2
- Pre status is off root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x3A 0x15 0xA0 0x0 0x02 15 A0 00 15 39 3A 00 15 A0 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x39 0x15 0xA0 0x0 0x02 0x02 15 A0 00 15 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x3A 0x15 0xA0 0x0 0x02 15 A0 00 15 39 3A 00 15 A0 00 02
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x39 0x15 0xA0 0x0 0x02 0x03 15 A0 00 15 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x3A 0x15 0xA0 0x0 0x02 15 A0 00 15 39 3A 00 15 A0 00 00

- Pre status is on root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x3A 0x15 0xA0 0x0 0x02 15 A0 00 15 39 3A 00 15 A0 00 01
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x39 0x15 0xA0 0x0 0x02 0x02 15 A0 00 15 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x3A 0x15 0xA0 0x0 0x02 15 A0 00 15 39 3A 00 15 A0 00 02
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x39 0x15 0xA0 0x0 0x02 0x03 15 A0 00 15 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x15 0xe0 0x3A 0x15 0xA0 0x0 0x02 15 A0 00 15 39 3A 00 15 A0 00 01

(3) 3OU E1.S 0
- Pre status is off root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x3A 0x15 0xA0 0x0 0x00 15 A0 00 25 39 3A 00 15 A0 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x39 0x15 0xA0 0x0 0x00 0x02 15 A0 00 25 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x3A 0x15 0xA0 0x0 0x00 15 A0 00 25 39 3A 00 15 A0 00 02
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x39 0x15 0xA0 0x0 0x00 0x03 15 A0 00 25 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x3A 0x15 0xA0 0x0 0x00 15 A0 00 25 39 3A 00 15 A0 00 00

- Pre status is on root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x3A 0x15 0xA0 0x0 0x00 15 A0 00 25 39 3A 00 15 A0 00 01
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x39 0x15 0xA0 0x0 0x00 0x02 15 A0 00 25 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x3A 0x15 0xA0 0x0 0x00 15 A0 00 25 39 3A 00 15 A0 00 02
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x39 0x15 0xA0 0x0 0x00 0x03 15 A0 00 25 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x25 0xe0 0x3A 0x15 0xA0 0x0 0x00 15 A0 00 25 39 3A 00 15 A0 00 01

(4) 4OU E1.S 3
- Pre status is off root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x3A 0x15 0xA0 0x0 0x03 15 A0 00 30 39 3A 00 15 A0 00 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x39 0x15 0xA0 0x0 0x03 0x02 15 A0 00 30 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x3A 0x15 0xA0 0x0 0x03 15 A0 00 30 39 3A 00 15 A0 00 02
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x39 0x15 0xA0 0x0 0x03 0x03 15 A0 00 30 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x3A 0x15 0xA0 0x0 0x03 15 A0 00 30 39 3A 00 15 A0 00 00

- Pre status is on root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x3A 0x15 0xA0 0x0 0x03 15 A0 00 30 39 3A 00 15 A0 00 01
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x39 0x15 0xA0 0x0 0x03 0x02 15 A0 00 30 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x3A 0x15 0xA0 0x0 0x03 15 A0 00 30 39 3A 00 15 A0 00 02
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x39 0x15 0xA0 0x0 0x03 0x03 15 A0 00 30 39 39 00 15 A0 00
root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x3A 0x15 0xA0 0x0 0x03 15 A0 00 30 39 3A 00 15 A0 00 01

3. If E1.S is not present. root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xA0 0x00 0x30 0xe0 0x3A 0x15 0xA0 0x0 0x00 15 A0 00 30 39 3A CB