### PR TITLE
common: I3C: Fix issue that IBI signal triggered before it enable

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0039-i3c-aspeed-Slove-the-timeout-condition-when-sending-.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0039-i3c-aspeed-Slove-the-timeout-condition-when-sending-.patch
@@ -1,0 +1,95 @@
+From eadf11549deceb2128a63210281c4154d98b8097 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Wed, 1 Mar 2023 16:43:41 +0800
+Subject: [PATCH 1/2] i3c: aspeed: Slove the timeout condition when sending
+ ibi.
+
+This commit fixes an issue in the i3c_aspeed_slave_put_read_data function
+where timeout errors could occur, leading to communication errors with the
+I3C master. If slave gets timeout at SIR transfer status, the i3c master
+may enter ibi storm when the controller is recovering. Thus, this patch
+will calls i3c_aspeed_init to reinitialize the I3C controller. If the
+timeout of the slave is due to waiting for the master to read the pedning
+data, the slave should reset the FIFO queue.
+
+The i3c_aspeed_slave_reset_queue function isolates the SCL and SDA lines,
+disables the I3C controller, toggles the SCL line eight times, resets the
+I3C queue, enables the I3C controller, and waits for the I3C bus to become
+free. If the I3C controller fails to disable or enable, the function logs
+a warning message and calls i3c_aspeed_init to reinitialize the I3C
+controller.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I035fac3f508bc550cbd29aa121a74b4ccf83a527
+---
+ drivers/i3c/i3c_aspeed.c | 41 +++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 40 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 27e9768d88..e6e0c2312c 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1469,6 +1469,43 @@ int i3c_aspeed_slave_register(const struct device *dev, struct i3c_slave_setup *
+ 	return 0;
+ }
+ 
++static void i3c_aspeed_slave_reset_queue(const struct device *dev)
++{
++	struct i3c_aspeed_config *config = DEV_CFG(dev);
++	struct i3c_register_s *i3c_register = config->base;
++	union i3c_reset_ctrl_s reset_ctrl;
++	int i;
++
++	i3c_aspeed_isolate_scl_sda(config->inst_id, true);
++	i3c_register->device_ctrl.fields.enable = 0;
++	for (i = 0; i < 8; i++)
++		i3c_aspeed_toggle_scl_in(config->inst_id);
++	if (i3c_register->device_ctrl.fields.enable) {
++		LOG_ERR("failed to disable controller: reset i3c controller\n");
++		i3c_aspeed_isolate_scl_sda(config->inst_id, false);
++		i3c_aspeed_init(dev);
++		return;
++	}
++	reset_ctrl.value = 0;
++	reset_ctrl.fields.tx_queue_reset = 1;
++	reset_ctrl.fields.rx_queue_reset = 1;
++	reset_ctrl.fields.ibi_queue_reset = 1;
++	reset_ctrl.fields.cmd_queue_reset = 1;
++	reset_ctrl.fields.resp_queue_reset = 1;
++	i3c_register->reset_ctrl.value = reset_ctrl.value;
++	i3c_register->device_ctrl.fields.enable = 1;
++	k_busy_wait(DIV_ROUND_UP(config->core_period *
++					 i3c_register->bus_free_timing.fields.i3c_ibi_free,
++				 NSEC_PER_USEC));
++	for (i = 0; i < 8; i++)
++		i3c_aspeed_toggle_scl_in(config->inst_id);
++	if (!i3c_register->device_ctrl.fields.enable) {
++		LOG_ERR("failed to enable controller: reset i3c controller\n");
++		i3c_aspeed_isolate_scl_sda(config->inst_id, false);
++		i3c_aspeed_init(dev);
++	}
++}
++
+ static uint32_t i3c_aspeed_slave_wait_data_consume(const struct device *dev)
+ {
+ 	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
+@@ -1546,6 +1583,7 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 		flag_ret = osEventFlagsWait(obj->ibi_event, events.value, osFlagsWaitAll,
+ 					    K_SECONDS(1).ticks);
+ 		if (flag_ret & osFlagsError) {
++			LOG_WRN("SIR timeout: reset i3c controller\n");
+ 			i3c_aspeed_init(dev);
+ 			ret = -EIO;
+ 			goto ibi_err;
+@@ -1555,7 +1593,8 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 	flag_ret = osEventFlagsWait(obj->data_event, data_events.value, osFlagsWaitAny,
+ 				    K_SECONDS(3).ticks);
+ 	if (flag_ret & osFlagsError) {
+-		i3c_aspeed_init(dev);
++		LOG_WRN("Wait master read timeout: reset queue\n");
++		i3c_aspeed_slave_reset_queue(dev);
+ 		ret = -EIO;
+ 	}
+ ibi_err:
+-- 
+2.25.1

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0040-i3c-aspeed-Add-software-flag-for-allowing-SIR.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0040-i3c-aspeed-Add-software-flag-for-allowing-SIR.patch
@@ -1,0 +1,88 @@
+From c07066bf3db78ed69a3777af6f163fd4d98e8430 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Fri, 3 Mar 2023 18:34:51 +0800
+Subject: [PATCH 2/2] i3c: aspeed: Add software flag for allowing SIR.
+
+The hardware flag sir_allowed has a default value of 1, and it cannot be
+cleared by the software, causing the software to lack a suitable flag to
+determine when the master is ready to receive the IBI.
+In order to solve this issue, a new boolean variable sir_allowed_by_sw
+should be introduced in the i3c_aspeed_init() function, with an initial
+value of 0. Furthermore, a new worker function called sir_allowed_worker()
+should also be incorporated into the system. This worker will be submitted
+only after the dynamic address of the slave has been assigned. Its primary
+responsibility is to set the value of the sir_allowed_by_sw variable 1
+after a delay of 1second which is sufficient for the i3c master to
+complete the bus initialization process.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I0668e705bf394882a6e587d8acd7c710e5213989
+---
+ drivers/i3c/i3c_aspeed.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index e6e0c2312c..7a6092b1f4 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -527,6 +527,8 @@ struct i3c_aspeed_obj {
+ 	struct i3c_aspeed_config *config;
+ 	struct k_spinlock lock;
+ 	struct i3c_aspeed_xfer *curr_xfer;
++	struct k_work work;
++	bool sir_allowed_by_sw;
+ 	struct {
+ 		uint32_t ibi_status_correct : 1;
+ 		uint32_t ibi_pec_force_enable : 1;
+@@ -887,11 +889,13 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ static void i3c_aspeed_slave_event(const struct device *dev, union i3c_intr_s status)
+ {
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
++	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
+ 	struct i3c_register_s *i3c_register = config->base;
+ 	uint32_t cm_tfr_sts = i3c_register->present_state.fields.cm_tfr_sts;
+ 
+ 	if (status.fields.dyn_addr_assign) {
+ 		LOG_DBG("dynamic address assigned\n");
++		k_work_submit(&obj->work);
+ 	}
+ 
+ 	if (status.fields.ccc_update) {
+@@ -1540,6 +1544,11 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 			return -EACCES;
+ 		}
+ 
++		if (obj->sir_allowed_by_sw == 0) {
++			LOG_ERR("SIR is not allowed by software\n");
++			return -EACCES;
++		}
++
+ 		osEventFlagsClear(obj->ibi_event, ~osFlagsError);
+ 		events.value = 0;
+ 		events.fields.ibi_update = 1;
+@@ -1788,6 +1797,14 @@ int i3c_aspeed_master_send_ccc(const struct device *dev, struct i3c_ccc_cmd *ccc
+ 	return ret;
+ }
+ 
++static void sir_allowed_worker(struct k_work *work)
++{
++	struct i3c_aspeed_obj *obj = CONTAINER_OF(work, struct i3c_aspeed_obj, work);
++
++	k_msleep(1000);
++	obj->sir_allowed_by_sw = 1;
++}
++
+ static int i3c_aspeed_init(const struct device *dev)
+ {
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
+@@ -1855,6 +1872,8 @@ static int i3c_aspeed_init(const struct device *dev)
+ 				return -ENOSPC;
+ 			}
+ 		}
++		obj->sir_allowed_by_sw = 0;
++		k_work_init(&obj->work, sir_allowed_worker);
+ 	} else {
+ 		union i3c_device_addr_s reg;
+ 
+-- 
+2.25.1


### PR DESCRIPTION
Summary:
Fix issue that IBI signal would be triggered before hot join completed while BIC try to send ibi to BMC.

i3c: aspeed: Slove the timeout condition when sending ibi.
i3c: aspeed: Add software flag for allowing SIR.

Test plan:
Build and test pass on fby35 system.

I3C communication works normally. root@bmc-oob:~# bic-util slot1 0x18 0x1
00 80 31 02 02 BF 15 A0 00 00 00 00 00 00 00**