### PR TITLE
at: cb: Support to get ACCL device presence status and FAC sensor 

### DIFF
--- a/meta-facebook/at-cb/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/at-cb/src/ipmi/include/plat_ipmi.h
@@ -32,6 +32,10 @@
 #define PCIE_CARD_ID_OFFSET 18
 #define RESERVE_DEFAULT_VALUE 0
 
+#define PCIE_CARD_NOT_PRESENT_BIT BIT(0)
+#define PCIE_CARD_NOT_ACCESSIBLE_BIT BIT(1)
+#define PCIE_CARD_DEVICE_NOT_READY_BIT BIT(2)
+
 /* switch mux selection */
 struct SWITCH_MUX_INFO {
 	uint8_t device;

--- a/meta-facebook/at-cb/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/at-cb/src/ipmi/plat_ipmi.c
@@ -168,10 +168,18 @@ void OEM_1S_GET_PCIE_CARD_STATUS(ipmi_msg *msg)
 	}
 
 	/* BMC would check pcie card type via fru id and device id */
-
 	uint8_t fru_id = msg->data[0];
 	uint8_t pcie_card_id = fru_id - PCIE_CARD_ID_OFFSET;
 	uint8_t pcie_device_id = msg->data[1];
+	static bool is_check_accl_device_status = false;
+
+	if (pcie_device_id == PCIE_DEVICE_ID1 || pcie_device_id == PCIE_DEVICE_ID2) {
+		if (is_check_accl_device_status != true && is_mb_dc_on() == true) {
+			check_accl_device_presence_status(PEX_0_INDEX);
+			check_accl_device_presence_status(PEX_1_INDEX);
+			is_check_accl_device_status = true;
+		}
+	}
 
 	switch (fru_id) {
 	case FIO_FRU_ID:

--- a/meta-facebook/at-cb/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/at-cb/src/ipmi/plat_ipmi.c
@@ -31,6 +31,8 @@
 #include "xdpe15284.h"
 #include "hal_gpio.h"
 #include "plat_gpio.h"
+#include "plat_hook.h"
+#include "plat_dev.h"
 
 LOG_MODULE_REGISTER(plat_ipmi);
 
@@ -88,8 +90,8 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 			msg->completion_code = CC_PEX_NOT_POWER_ON;
 			return;
 		}
-		uint8_t pex_sensor_num_table[PEX_MAX_NUMBER] = { SENSOR_NUM_TEMP_PEX_0,
-								 SENSOR_NUM_TEMP_PEX_1 };
+		const uint8_t pex_sensor_num_table[PEX_MAX_NUMBER] = { SENSOR_NUM_TEMP_PEX_0,
+								       SENSOR_NUM_TEMP_PEX_1 };
 		int reading;
 
 		uint8_t pex_sensor_num = pex_sensor_num_table[component - CB_COMPNT_PCIE_SWITCH0];
@@ -171,7 +173,13 @@ void OEM_1S_GET_PCIE_CARD_STATUS(ipmi_msg *msg)
 	uint8_t fru_id = msg->data[0];
 	uint8_t pcie_card_id = fru_id - PCIE_CARD_ID_OFFSET;
 	uint8_t pcie_device_id = msg->data[1];
+	static bool is_check_accl_status = false;
 	static bool is_check_accl_device_status = false;
+
+	if (is_check_accl_status != true) {
+		check_asic_card_status();
+		is_check_accl_status = true;
+	}
 
 	if (pcie_device_id == PCIE_DEVICE_ID1 || pcie_device_id == PCIE_DEVICE_ID2) {
 		if (is_check_accl_device_status != true && is_mb_dc_on() == true) {
@@ -329,5 +337,112 @@ void OEM_1S_FW_UPDATE(ipmi_msg *msg)
 		LOG_ERR("firmware (0x%02X) update failed cc: %x", target, msg->completion_code);
 	}
 
+	return;
+}
+
+int pal_get_pcie_card_sensor_reading(uint8_t card_id, uint8_t sensor_num, uint8_t *card_status,
+				     int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(card_status, -1);
+	CHECK_NULL_ARG_WITH_RETURN(reading, -1);
+
+	bool ret = 0;
+	uint8_t index = 0;
+	uint8_t sensor_status = 0;
+
+	sensor_cfg *cfg = { 0 };
+
+	ret = get_accl_sensor_config_index(sensor_num, &index);
+	if (ret != true) {
+		LOG_ERR("Fail to find sensor config via sensor num: 0x%x", sensor_num);
+		return -1;
+	}
+
+	cfg = &plat_accl_sensor_config[index];
+
+	if (is_pcie_device_access(card_id, sensor_num) != true) {
+		*card_status |= PCIE_CARD_NOT_ACCESSIBLE_BIT;
+		*reading = 0;
+		return 0;
+	}
+
+	ret = pre_accl_mux_switch(card_id, sensor_num);
+	if (ret != true) {
+		LOG_ERR("Pre switch mux fail, sensor num: 0x%x, card id: 0x%x", sensor_num,
+			card_id);
+		return -1;
+	}
+
+	ret = pal_sensor_drive_read(card_id, cfg, reading, &sensor_status);
+	if (ret != true) {
+		LOG_ERR("sensor: 0x%x read fail", sensor_num);
+		ret = post_accl_mux_switch(card_id, sensor_num);
+		if (ret != true) {
+			LOG_ERR("Post switch mux fail, sensor num: 0x%x, card id: 0x%x", sensor_num,
+				card_id);
+		}
+		return -1;
+	}
+
+	ret = post_accl_mux_switch(card_id, sensor_num);
+	if (ret != true) {
+		LOG_ERR("Post switch mux fail, sensor num: 0x%x, card id: 0x%x", sensor_num,
+			card_id);
+	}
+
+	switch (sensor_status) {
+	case SENSOR_READ_SUCCESS:
+	case SENSOR_READ_ACUR_SUCCESS:
+		break;
+	case SENSOR_INIT_STATUS:
+	case SENSOR_NOT_ACCESSIBLE:
+		*card_status |= PCIE_CARD_DEVICE_NOT_READY_BIT;
+		*reading = 0;
+		break;
+	default:
+		*reading = 0;
+		return -1;
+	}
+
+	return 0;
+}
+
+void OEM_1S_GET_PCIE_CARD_SENSOR_READING(ipmi_msg *msg)
+{
+	/* IPMI command format
+  *  Request:
+  *    Byte 0: FRU id
+  *    Byte 1: Sensor number
+  *  Response:
+  *    Byte 0:   Device status (bit 0: presence status, bit 1: power status, bit 2: device status)
+  *    Byte 1~2: Integer bytes
+  *    Byte 3~4: Fraction bytes */
+
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 2) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	int ret = -1;
+	int reading = 0;
+	uint8_t device_status = 0;
+	uint8_t fru_id = msg->data[0];
+	uint8_t sensor_num = msg->data[1];
+	uint8_t card_id = fru_id - ACCL_1_FRU_ID;
+
+	ret = pal_get_pcie_card_sensor_reading(card_id, sensor_num, &device_status, &reading);
+	if (ret != 0) {
+		LOG_ERR("Get pcie card sensor reading fail, card id: 0x%x, sensor num: 0x%x",
+			card_id, sensor_num);
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
+		return;
+	}
+
+	msg->data_len = 5;
+	msg->data[0] = device_status;
+	memcpy(&msg->data[1], &reading, sizeof(reading));
+	msg->completion_code = CC_SUCCESS;
 	return;
 }

--- a/meta-facebook/at-cb/src/platform/plat_class.c
+++ b/meta-facebook/at-cb/src/platform/plat_class.c
@@ -24,6 +24,7 @@
 #include "plat_fru.h"
 #include "plat_class.h"
 #include "common_i2c_mux.h"
+#include "pex89000.h"
 
 LOG_MODULE_REGISTER(plat_class);
 
@@ -57,6 +58,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
     .card_status = ASIC_CARD_UNKNOWN_STATUS,
     .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
     .device_channel = PCA9546A_CHANNEL_0,
+    .device_reg_offset = 0x1D,
     .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
     .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
   [1] = { .bus = I2C_BUS7,
@@ -65,6 +67,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
     .card_status = ASIC_CARD_UNKNOWN_STATUS,
     .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
     .device_channel = PCA9546A_CHANNEL_0,
+    .device_reg_offset = 0x1A,
     .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
     .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
   [2] = { .bus = I2C_BUS7,
@@ -73,6 +76,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
     .card_status = ASIC_CARD_UNKNOWN_STATUS,
     .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
     .device_channel = PCA9546A_CHANNEL_0,
+    .device_reg_offset = 0x17,
     .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
     .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
   [3] = { .bus = I2C_BUS7,
@@ -81,6 +85,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
     .card_status = ASIC_CARD_UNKNOWN_STATUS,
     .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
     .device_channel = PCA9546A_CHANNEL_0,
+    .device_reg_offset = 0x14,
     .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
     .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
   [4] = { .bus = I2C_BUS7,
@@ -89,6 +94,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
     .card_status = ASIC_CARD_UNKNOWN_STATUS,
     .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
     .device_channel = PCA9546A_CHANNEL_0,
+    .device_reg_offset = 0x11,
     .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
     .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
   [5] = { .bus = I2C_BUS7,
@@ -97,6 +103,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
     .card_status = ASIC_CARD_UNKNOWN_STATUS,
     .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
     .device_channel = PCA9546A_CHANNEL_0,
+    .device_reg_offset = 0x0E,
     .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
     .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
   [6] = { .bus = I2C_BUS8,
@@ -105,6 +112,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
     .card_status = ASIC_CARD_UNKNOWN_STATUS,
     .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
     .device_channel = PCA9546A_CHANNEL_0,
+    .device_reg_offset = 0x1D,
     .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
     .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
   [7] = { .bus = I2C_BUS8,
@@ -113,6 +121,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
     .card_status = ASIC_CARD_UNKNOWN_STATUS,
     .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
     .device_channel = PCA9546A_CHANNEL_0,
+    .device_reg_offset = 0x1A,
     .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
     .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
   [8] = { .bus = I2C_BUS8,
@@ -121,6 +130,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
     .card_status = ASIC_CARD_UNKNOWN_STATUS,
     .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
     .device_channel = PCA9546A_CHANNEL_0,
+    .device_reg_offset = 0x17,
     .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
     .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
   [9] = { .bus = I2C_BUS8,
@@ -129,6 +139,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
     .card_status = ASIC_CARD_UNKNOWN_STATUS,
     .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
     .device_channel = PCA9546A_CHANNEL_0,
+    .device_reg_offset = 0x14,
     .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
     .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
   [10] = { .bus = I2C_BUS8,
@@ -137,6 +148,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
      .card_status = ASIC_CARD_UNKNOWN_STATUS,
      .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
      .device_channel = PCA9546A_CHANNEL_0,
+     .device_reg_offset = 0x11,
      .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
      .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
   [11] = { .bus = I2C_BUS8,
@@ -145,6 +157,7 @@ struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
      .card_status = ASIC_CARD_UNKNOWN_STATUS,
      .device_mux_addr = ASIC_CARD_DEVICE_MUX_ADDR,
      .device_channel = PCA9546A_CHANNEL_0,
+     .device_reg_offset = 0x0E,
      .asic_1_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS,
      .asic_2_status = ASIC_CARD_DEVICE_UNKNOWN_STATUS, },
 };
@@ -189,6 +202,67 @@ bool get_adc_voltage(int channel, float *voltage)
 	*voltage = (raw_value * reference_voltage) / 1024;
 
 	return true;
+}
+
+void check_accl_device_presence_status(uint8_t pex_id)
+{
+	uint8_t ret = 0;
+	uint8_t val = 0;
+	uint8_t index = 0;
+	uint8_t offset = 0;
+	uint8_t start_card_id = 0;
+	uint32_t reg = PEX_ACCL_DEV_PRESENT_REG;
+
+	switch (pex_id) {
+	case PEX_0_INDEX:
+		start_card_id = PEX_0_START_ACCL_ID;
+		ret = pex_access_engine(PEX_0_BUS, PEX_ADDR, pex_id, pex_access_register, &reg);
+		break;
+	case PEX_1_INDEX:
+		start_card_id = PEX_1_START_ACCL_ID;
+		ret = pex_access_engine(PEX_1_BUS, PEX_ADDR, pex_id, pex_access_register, &reg);
+		break;
+	default:
+		LOG_ERR("PEX id: %d is invalid", pex_id);
+		return;
+	}
+
+	if (ret != pex_api_success) {
+		LOG_ERR("Access ACCL register fail");
+		return;
+	}
+
+	for (offset = 0; offset < PEX_ACCL_DEV_PRESENT_REG_COUNT; ++offset) {
+		index = start_card_id + offset;
+		if (index >= ASIC_CARD_COUNT) {
+			LOG_ERR("ACCL card id: %d is invalid", index);
+			break;
+		}
+
+		val = (reg >> asic_card_info[index].device_reg_offset) & PEX_ACCL_PRESENT_MAP_VAL;
+		switch (val) {
+		case ASIC_CARD_NOT_PRESENT_VAL:
+		case ASIC_DEV_NOT_PRESENT_VAL:
+			asic_card_info[index].asic_1_status = ASIC_CARD_DEVICE_NOT_PRESENT;
+			asic_card_info[index].asic_2_status = ASIC_CARD_DEVICE_NOT_PRESENT;
+			break;
+		case ASIC_DEV_1_PRESENT_VAL:
+			asic_card_info[index].asic_1_status = ASIC_CARD_DEVICE_PRESENT;
+			asic_card_info[index].asic_2_status = ASIC_CARD_DEVICE_NOT_PRESENT;
+			break;
+		case ASIC_DEV_2_PRESENT_VAL:
+			asic_card_info[index].asic_1_status = ASIC_CARD_DEVICE_NOT_PRESENT;
+			asic_card_info[index].asic_2_status = ASIC_CARD_DEVICE_PRESENT;
+			break;
+		case ASIC_DEV_1_2_PRESENT_VAL:
+			asic_card_info[index].asic_1_status = ASIC_CARD_DEVICE_PRESENT;
+			asic_card_info[index].asic_2_status = ASIC_CARD_DEVICE_PRESENT;
+			break;
+		default:
+			LOG_ERR("Invalid register val: 0x%x", val);
+			break;
+		}
+	}
 }
 
 void check_asic_card_status()

--- a/meta-facebook/at-cb/src/platform/plat_class.h
+++ b/meta-facebook/at-cb/src/platform/plat_class.h
@@ -27,6 +27,23 @@
 #define ASIC_CARD_1_6_MUX_ADDR 0x70
 #define ASIC_CARD_7_12_MUX_ADDR 0x74
 #define ASIC_CARD_DEVICE_MUX_ADDR 0x72
+#define ASIC_CARD_NOT_PRESENT_VAL 0x07
+#define ASIC_DEV_NOT_PRESENT_VAL 0x06
+#define ASIC_DEV_1_PRESENT_VAL 0x02
+#define ASIC_DEV_2_PRESENT_VAL 0x04
+#define ASIC_DEV_1_2_PRESENT_VAL 0x00
+
+#define PEX_0_BUS I2C_BUS2
+#define PEX_1_BUS I2C_BUS3
+#define PEX_ADDR 0x59
+#define PEX_0_INDEX 0
+#define PEX_1_INDEX 1
+#define PEX_0_START_ACCL_ID 0
+#define PEX_1_START_ACCL_ID 6
+#define PEX_ACCL_DEV_PRESENT_REG_COUNT 6
+#define PEX_ACCL_DEV_PRESENT_RESP_COUNT 4
+#define PEX_ACCL_DEV_PRESENT_REG 0x2A080048
+#define PEX_ACCL_PRESENT_MAP_VAL 0x07
 
 enum ASIC_CARD_STATUS {
 	ASIC_CARD_NOT_PRESENT,
@@ -59,6 +76,7 @@ struct ASIC_CARD_INFO {
 	bool card_status;
 	uint8_t device_mux_addr;
 	uint8_t device_channel;
+	uint8_t device_reg_offset;
 	bool asic_1_status;
 	bool asic_2_status;
 };
@@ -67,5 +85,6 @@ extern struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT];
 
 void check_asic_card_status();
 bool get_adc_voltage(int channel, float *voltage);
+void check_accl_device_presence_status(uint8_t pex_id);
 
 #endif

--- a/meta-facebook/at-cb/src/platform/plat_dev.c
+++ b/meta-facebook/at-cb/src/platform/plat_dev.c
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <logging/log.h>
+#include "sensor.h"
+#include "pmbus.h"
+#include "libutil.h"
+#include "hal_i2c.h"
+#include "plat_dev.h"
+#include "plat_hook.h"
+#include "plat_class.h"
+#include "common_i2c_mux.h"
+#include "plat_sensor_table.h"
+
+LOG_MODULE_REGISTER(plat_dev);
+
+#define NVME_NOT_AVAILABLE 0x80
+#define NVME_TEMP_SENSOR_FAILURE 0x81
+#define NVME_DRIVE_NOT_READY_BIT BIT(6)
+
+#define INA233_CALIBRATION_OFFSET 0xD4
+
+bool pal_sensor_drive_init(uint8_t card_id, sensor_cfg *cfg, uint8_t *init_status)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(init_status, false);
+
+	switch (cfg->type) {
+	case sensor_dev_nvme:
+		*init_status = pal_nvme_init(card_id, cfg);
+		break;
+	case sensor_dev_ina233:
+		*init_status = pal_ina233_init(card_id, cfg);
+		break;
+	default:
+		LOG_ERR("Invalid initial drive type: 0x%x", cfg->type);
+		return false;
+	}
+
+	return true;
+}
+
+bool pal_sensor_drive_read(uint8_t card_id, sensor_cfg *cfg, int *reading, uint8_t *sensor_status)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(reading, false);
+	CHECK_NULL_ARG_WITH_RETURN(sensor_status, false);
+
+	switch (cfg->type) {
+	case sensor_dev_nvme:
+		*sensor_status = pal_nvme_read(card_id, cfg, reading);
+		break;
+	case sensor_dev_ina233:
+		*sensor_status = pal_ina233_read(card_id, cfg, reading);
+		break;
+	default:
+		LOG_ERR("Invalid reading drive type: 0x%x", cfg->type);
+		return false;
+	}
+
+	return true;
+}
+
+uint8_t pal_nvme_read(uint8_t card_id, sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("sensor nvme 0x%x input parameter is invalid", cfg->num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	int ret = 0;
+	int bus = 0;
+	uint8_t retry = 5;
+	uint8_t nvme_status = 0;
+	uint16_t val = 0;
+	I2C_MSG msg = { 0 };
+
+	bus = get_accl_bus(card_id, cfg->num);
+	if (bus < 0) {
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	msg.bus = bus;
+	msg.target_addr = cfg->target_addr;
+	msg.data[0] = cfg->offset;
+	msg.tx_len = 1;
+
+	if (cfg->offset == NVME_TEMP_OFFSET) {
+		msg.rx_len = 4;
+	} else {
+		msg.rx_len = 2;
+	}
+
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("nvme i2c read fail ret: %d, offset: 0x%x, addr: 0x%x", ret, cfg->offset,
+			msg.target_addr);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	switch (cfg->offset) {
+	case NVME_TEMP_OFFSET:
+		nvme_status = msg.data[1];
+		val = msg.data[3];
+
+		/* Check SSD drive ready */
+		if ((nvme_status & NVME_DRIVE_NOT_READY_BIT) != 0) {
+			return SENSOR_NOT_ACCESSIBLE;
+		}
+
+		/* Check reading value */
+		switch (val) {
+		case NVME_NOT_AVAILABLE:
+			return SENSOR_FAIL_TO_ACCESS;
+		case NVME_TEMP_SENSOR_FAILURE:
+			return SENSOR_UNSPECIFIED_ERROR;
+		default:
+			break;
+		}
+
+		sval->integer = (int8_t)val;
+		sval->fraction = 0;
+		return SENSOR_READ_SUCCESS;
+	case NVME_VOLTAGE_RAIL_1_OFFSET:
+	case NVME_VOLTAGE_RAIL_2_OFFSET:
+		// 100 uV/LSB
+		val = ((msg.data[0] << 8) | msg.data[1]) / 10;
+
+		sval->integer = (val / 1000) & 0xFFFF;
+		sval->fraction = (val - (sval->integer * 1000)) & 0xFFFF;
+		return SENSOR_READ_SUCCESS;
+	default:
+		LOG_ERR("Invalid offset: 0x%x", cfg->offset);
+		return SENSOR_PARAMETER_NOT_VALID;
+	}
+}
+
+uint8_t pal_nvme_init(uint8_t card_id, sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	return SENSOR_INIT_SUCCESS;
+}
+
+uint8_t pal_ina233_read(uint8_t card_id, sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("sensor 0x%x input parameter is invalid", cfg->num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	ina233_init_arg *init_arg = NULL;
+	if (cfg->init_args == NULL) {
+		init_arg = get_accl_init_sensor_config(card_id, cfg->num);
+		CHECK_NULL_ARG_WITH_RETURN(init_arg, SENSOR_UNSPECIFIED_ERROR);
+	} else {
+		init_arg = cfg->init_args;
+	}
+
+	if (init_arg->is_init != true) {
+		LOG_ERR("device isn't initialized");
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	uint8_t retry = 5;
+	int bus = 0;
+	int ret = 0;
+	int16_t val = 0;
+	float parameter = 0;
+	I2C_MSG msg;
+	memset(&msg, 0, sizeof(I2C_MSG));
+	*reading = 0;
+
+	bus = get_accl_bus(card_id, cfg->num);
+	if (bus < 0) {
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	msg.bus = bus;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = cfg->offset;
+
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("i2c read fail ret: %d", ret);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+	uint8_t offset = cfg->offset;
+	val = (msg.data[1] << 8) | msg.data[0];
+	sensor_val *sval = (sensor_val *)reading;
+	switch (offset) {
+	case PMBUS_READ_VOUT:
+		// 1 mV/LSB, unsigned integer
+		// m = 8 , b = 0 , r = 2
+		// voltage convert formula = ((val / 100) - 0) / 8
+		parameter = 800;
+		break;
+	case PMBUS_READ_IOUT:
+		if (GETBIT(msg.data[1], 7)) {
+			// If raw value is negative, set it zero.
+			val = 0;
+		}
+		// 1 mA/LSB, 2's complement
+		// current convert formula = val / (1 / current_lsb)
+		parameter = (1 / init_arg->current_lsb);
+		break;
+	case PMBUS_READ_POUT:
+		// 1 Watt/LSB, 2's complement
+		// power convert formula = val / (1 / (current_lsb * 25))
+		parameter = (1 / (init_arg->current_lsb * 25));
+		break;
+	default:
+		LOG_ERR("Offset not supported: 0x%x", offset);
+		return SENSOR_FAIL_TO_ACCESS;
+		break;
+	}
+
+	sval->integer = val / parameter;
+	sval->fraction = ((val / parameter) - sval->integer) * 1000;
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t pal_ina233_init(uint8_t card_id, sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	ina233_init_arg *init_arg = NULL;
+
+	if (cfg->init_args == NULL) {
+		init_arg = get_accl_init_sensor_config(card_id, cfg->num);
+		CHECK_NULL_ARG_WITH_RETURN(init_arg, SENSOR_INIT_UNSPECIFIED_ERROR);
+	} else {
+		init_arg = cfg->init_args;
+	}
+
+	if (init_arg->is_init != true) {
+		int ret = 0;
+		int bus = 0;
+		int retry = 5;
+		uint16_t calibration = 0;
+		I2C_MSG msg = { 0 };
+
+		bus = get_accl_bus(card_id, cfg->num);
+		if (bus < 0) {
+			return SENSOR_INIT_UNSPECIFIED_ERROR;
+		}
+
+		msg.bus = bus;
+		msg.target_addr = cfg->target_addr;
+		msg.tx_len = 3;
+		msg.data[0] = INA233_CALIBRATION_OFFSET;
+
+		// Calibration formula = (0.00512 / (current_lsb * r_shunt))
+		calibration = (uint16_t)(0.00512 / (init_arg->current_lsb * init_arg->r_shunt));
+		memcpy(&msg.data[1], &calibration, sizeof(uint16_t));
+
+		ret = i2c_master_write(&msg, retry);
+		if (ret != 0) {
+			LOG_ERR("i2c write fail ret: %d", ret);
+			return SENSOR_INIT_UNSPECIFIED_ERROR;
+		}
+		init_arg->is_init = true;
+	}
+
+	return SENSOR_INIT_SUCCESS;
+}

--- a/meta-facebook/at-cb/src/platform/plat_dev.h
+++ b/meta-facebook/at-cb/src/platform/plat_dev.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_DEV
+#define PLAT_DEV
+
+#include <stdint.h>
+#include "sensor.h"
+
+#define NVME_TEMP_OFFSET 0x00
+#define NVME_VOLTAGE_RAIL_1_OFFSET 0x75
+#define NVME_VOLTAGE_RAIL_2_OFFSET 0x77
+
+bool pal_sensor_drive_init(uint8_t card_id, sensor_cfg *cfg, uint8_t *init_status);
+bool pal_sensor_drive_read(uint8_t card_id, sensor_cfg *cfg, int *reading, uint8_t *sensor_status);
+uint8_t pal_nvme_init(uint8_t card_id, sensor_cfg *cfg);
+uint8_t pal_nvme_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
+uint8_t pal_ina233_init(uint8_t card_id, sensor_cfg *cfg);
+uint8_t pal_ina233_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
+
+#endif

--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -27,6 +27,7 @@
 #include "i2c-mux-tca9543a.h"
 #include "i2c-mux-pi4msd5v9542.h"
 #include "plat_sensor_table.h"
+#include "i2c-mux-pca954x.h"
 
 LOG_MODULE_REGISTER(plat_hook);
 
@@ -66,6 +67,57 @@ pex89000_init_arg pex_sensor_init_args[] = {
 	[1] = { .idx = 1, .is_init = false },
 };
 
+ina233_init_arg accl_ina233_init_args[] = {
+	// ACCL 1
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	// ACCL 2
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	// ACCL 3
+	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	// ACCL 4
+	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	// ACCL 5
+	[12] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[13] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[14] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	// ACCL 6
+	[15] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[16] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[17] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	// ACCL 7
+	[18] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[19] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[20] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	// ACCL 8
+	[21] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[22] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[23] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	// ACCL 9
+	[24] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[25] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[26] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	// ACCL 10
+	[27] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[28] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[29] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	// ACCL 11
+	[30] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[31] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[32] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	// ACCL 12
+	[33] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[34] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[35] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+};
+
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS
  **************************************************************************************************/
@@ -82,6 +134,28 @@ mux_config pi4msd5v9542_configs[] = {
 vr_page_cfg xdpe15284_page[] = {
 	[0] = { .vr_page = PMBUS_PAGE_0 },
 	[1] = { .vr_page = PMBUS_PAGE_1 },
+};
+
+mux_config pca9548_configs[] = {
+	[0] = { .bus = I2C_BUS7, .target_addr = 0x70, .channel = PCA9548A_CHANNEL_0 },
+	[1] = { .bus = I2C_BUS7, .target_addr = 0x70, .channel = PCA9548A_CHANNEL_1 },
+	[2] = { .bus = I2C_BUS7, .target_addr = 0x70, .channel = PCA9548A_CHANNEL_2 },
+	[3] = { .bus = I2C_BUS7, .target_addr = 0x70, .channel = PCA9548A_CHANNEL_3 },
+	[4] = { .bus = I2C_BUS7, .target_addr = 0x70, .channel = PCA9548A_CHANNEL_4 },
+	[5] = { .bus = I2C_BUS7, .target_addr = 0x70, .channel = PCA9548A_CHANNEL_5 },
+	[6] = { .bus = I2C_BUS8, .target_addr = 0x74, .channel = PCA9548A_CHANNEL_0 },
+	[7] = { .bus = I2C_BUS8, .target_addr = 0x74, .channel = PCA9548A_CHANNEL_1 },
+	[8] = { .bus = I2C_BUS8, .target_addr = 0x74, .channel = PCA9548A_CHANNEL_2 },
+	[9] = { .bus = I2C_BUS8, .target_addr = 0x74, .channel = PCA9548A_CHANNEL_3 },
+	[10] = { .bus = I2C_BUS8, .target_addr = 0x74, .channel = PCA9548A_CHANNEL_4 },
+	[11] = { .bus = I2C_BUS8, .target_addr = 0x74, .channel = PCA9548A_CHANNEL_5 },
+};
+
+mux_config pca9546_configs[] = {
+	[0] = { .target_addr = 0x72, .channel = PCA9546A_CHANNEL_0 },
+	[1] = { .target_addr = 0x72, .channel = PCA9546A_CHANNEL_1 },
+	[2] = { .target_addr = 0x72, .channel = PCA9546A_CHANNEL_2 },
+	[3] = { .target_addr = 0x72, .channel = PCA9546A_CHANNEL_3 },
 };
 
 /**************************************************************************************************
@@ -142,7 +216,7 @@ bool pre_xdpe15284_read(uint8_t sensor_num, void *args)
 	int retry = 3;
 	int mutex_status = 0;
 	I2C_MSG msg = { 0 };
-	vr_page_cfg *xdpe15284_page = (vr_page_cfg *)args;
+	vr_page_cfg *xdpe15284_vr_page = (vr_page_cfg *)args;
 
 	mutex_status = k_mutex_lock(&xdpe15284_mutex, K_MSEC(MUTEX_LOCK_INTERVAL_MS));
 	if (mutex_status != 0) {
@@ -154,7 +228,7 @@ bool pre_xdpe15284_read(uint8_t sensor_num, void *args)
 	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
 	msg.tx_len = 2;
 	msg.data[0] = PMBUS_PAGE;
-	msg.data[1] = xdpe15284_page->vr_page;
+	msg.data[1] = xdpe15284_vr_page->vr_page;
 
 	ret = i2c_master_write(&msg, retry);
 	if (ret != 0) {
@@ -238,6 +312,68 @@ bool post_pex89000_read(uint8_t sensor_num, void *args, int *reading)
 	uint8_t bus = sensor_config[sensor_config_index_map[sensor_num]].port;
 
 	struct k_mutex *mutex = get_i2c_mux_mutex(bus);
+	if (mutex->lock_count != 0) {
+		unlock_status = k_mutex_unlock(mutex);
+	}
+
+	if (unlock_status != 0) {
+		LOG_ERR("Mutex unlock fail, status: %d", unlock_status);
+		return false;
+	}
+
+	return true;
+}
+
+bool pre_accl_mux_switch(uint8_t card_id, uint8_t sensor_num)
+{
+	bool ret = false;
+	mux_config accl_mux = { 0 };
+	mux_config channel_mux = { 0 };
+
+	if (get_accl_mux_config(card_id, &accl_mux) != true) {
+		return false;
+	}
+
+	if (get_mux_channel_config(card_id, sensor_num, &channel_mux) != true) {
+		return false;
+	}
+
+	int mutex_status = 0;
+	struct k_mutex *mutex = get_i2c_mux_mutex(accl_mux.bus);
+
+	mutex_status = k_mutex_lock(mutex, K_MSEC(MUTEX_LOCK_INTERVAL_MS));
+	if (mutex_status != 0) {
+		LOG_ERR("Mutex lock fail, status: %d", mutex_status);
+		return false;
+	}
+
+	ret = set_mux_channel(accl_mux);
+	if (ret == false) {
+		LOG_ERR("ACCL switch mux fail");
+		k_mutex_unlock(mutex);
+		return false;
+	}
+
+	ret = set_mux_channel(channel_mux);
+	if (ret == false) {
+		LOG_ERR("ACCL switch mux fail");
+		k_mutex_unlock(mutex);
+		return false;
+	}
+
+	return true;
+}
+
+bool post_accl_mux_switch(uint8_t card_id, uint8_t sensor_num)
+{
+	mux_config accl_mux = { 0 };
+
+	if (get_accl_mux_config(card_id, &accl_mux) != true) {
+		return false;
+	}
+
+	int unlock_status = 0;
+	struct k_mutex *mutex = get_i2c_mux_mutex(accl_mux.bus);
 	if (mutex->lock_count != 0) {
 		unlock_status = k_mutex_unlock(mutex);
 	}

--- a/meta-facebook/at-cb/src/platform/plat_hook.h
+++ b/meta-facebook/at-cb/src/platform/plat_hook.h
@@ -28,6 +28,7 @@ extern adc_asd_init_arg adc_asd_init_args[];
 extern adm1272_init_arg adm1272_init_args[];
 extern ina233_init_arg ina233_init_args[];
 extern pex89000_init_arg pex_sensor_init_args[];
+extern ina233_init_arg accl_ina233_init_args[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS
@@ -35,6 +36,8 @@ extern pex89000_init_arg pex_sensor_init_args[];
 extern mux_config tca9543_configs[];
 extern mux_config pi4msd5v9542_configs[];
 extern vr_page_cfg xdpe15284_page[];
+extern mux_config pca9548_configs[];
+extern mux_config pca9546_configs[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK FUNC
@@ -45,5 +48,7 @@ bool pre_pex89000_read(uint8_t sensor_num, void *args);
 bool post_pex89000_read(uint8_t sensor_num, void *args, int *reading);
 bool pre_xdpe15284_read(uint8_t sensor_num, void *args);
 bool post_xdpe15284_read(uint8_t sensor_num, void *args, int *reading);
+bool pre_accl_mux_switch(uint8_t card_id, uint8_t sensor_num);
+bool post_accl_mux_switch(uint8_t card_id, uint8_t sensor_num);
 
 #endif

--- a/meta-facebook/at-cb/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-cb/src/platform/plat_sensor_table.c
@@ -29,12 +29,15 @@
 #include "plat_gpio.h"
 #include "plat_hook.h"
 #include "plat_class.h"
+#include "plat_dev.h"
 
 LOG_MODULE_REGISTER(plat_sensor_table);
 
 struct k_mutex i2c_2_tca9543_mutex;
 struct k_mutex i2c_3_tca9543_mutex;
 struct k_mutex i2c_4_pi4msd5v9542_mutex;
+struct k_mutex i2c_7_mutex;
+struct k_mutex i2c_8_mutex;
 
 sensor_cfg plat_sensor_config[] = {
 	/* number,                  type,       port,      address,      offset,
@@ -355,7 +358,78 @@ sensor_cfg plat_sensor_config[] = {
 	  post_ina233_read, &pi4msd5v9542_configs[1], &ina233_init_args[11] },
 };
 
+sensor_cfg plat_accl_sensor_config[] = {
+	/** Nvme Temperature **/
+	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, NONE, ACCL_FREYA_1_ADDR, NVME_TEMP_OFFSET,
+	  NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL, &pca9546_configs[0] },
+	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, NONE, ACCL_FREYA_2_ADDR, NVME_TEMP_OFFSET,
+	  NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL, &pca9546_configs[0] },
+
+	/** Nvme Voltage **/
+	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, NONE, ACCL_FREYA_1_ADDR,
+	  NVME_VOLTAGE_RAIL_1_OFFSET, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[0] },
+	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, NONE, ACCL_FREYA_1_ADDR,
+	  NVME_VOLTAGE_RAIL_2_OFFSET, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[0] },
+	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, NONE, ACCL_FREYA_2_ADDR,
+	  NVME_VOLTAGE_RAIL_1_OFFSET, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[0] },
+	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, NONE, ACCL_FREYA_2_ADDR,
+	  NVME_VOLTAGE_RAIL_2_OFFSET, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[0] },
+
+	/** INA233 Voltage **/
+	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, NONE, ACCL_12V_INA233_ADDR,
+	  PMBUS_READ_VOUT, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[3] },
+	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, NONE, ACCL_3V3_1_INA233_ADDR,
+	  PMBUS_READ_VOUT, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[3] },
+	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, NONE, ACCL_3V3_2_INA233_ADDR,
+	  PMBUS_READ_VOUT, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[3] },
+
+	/** INA233 Current **/
+	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, NONE, ACCL_12V_INA233_ADDR,
+	  PMBUS_READ_IOUT, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[3] },
+	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, NONE, ACCL_3V3_1_INA233_ADDR,
+	  PMBUS_READ_IOUT, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[3] },
+	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, NONE, ACCL_3V3_2_INA233_ADDR,
+	  PMBUS_READ_IOUT, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[3] },
+
+	/** INA233 Power **/
+	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, NONE, ACCL_12V_INA233_ADDR,
+	  PMBUS_READ_POUT, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[3] },
+	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, NONE, ACCL_3V3_1_INA233_ADDR,
+	  PMBUS_READ_POUT, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[3] },
+	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, NONE, ACCL_3V3_2_INA233_ADDR,
+	  PMBUS_READ_POUT, NULL, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &pca9546_configs[3] },
+};
+
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
+const int ACCL_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_accl_sensor_config);
 
 void load_sensor_config(void)
 {
@@ -392,6 +466,51 @@ bool is_dc_access(uint8_t sensor_num)
 	return is_mb_dc_on();
 }
 
+bool is_pcie_device_access(uint8_t card_id, uint8_t sensor_num)
+{
+	if (card_id >= ASIC_CARD_COUNT) {
+		LOG_ERR("Invalid card id: 0x%x", card_id);
+		return false;
+	}
+
+	bool ret = false;
+	uint8_t index = 0;
+	uint8_t device_status = 0;
+
+	ret = get_accl_sensor_config_index(sensor_num, &index);
+	if (ret != true) {
+		return ret;
+	}
+
+	sensor_cfg cfg = plat_accl_sensor_config[index];
+	if (asic_card_info[card_id].card_status == ASIC_CARD_PRESENT) {
+		switch (cfg.target_addr) {
+		case ACCL_FREYA_1_ADDR:
+			device_status = asic_card_info[card_id].asic_1_status;
+			break;
+		case ACCL_FREYA_2_ADDR:
+			device_status = asic_card_info[card_id].asic_2_status;
+			break;
+		case ACCL_12V_INA233_ADDR:
+		case ACCL_3V3_1_INA233_ADDR:
+		case ACCL_3V3_2_INA233_ADDR:
+			device_status = asic_card_info[card_id].card_status;
+			break;
+		default:
+			LOG_ERR("Invalid access address: 0x%x", cfg.target_addr);
+			return false;
+		}
+	} else {
+		return false;
+	}
+
+	if (device_status != ASIC_CARD_DEVICE_PRESENT) {
+		return false;
+	}
+
+	return true;
+}
+
 struct k_mutex *get_i2c_mux_mutex(uint8_t i2c_bus)
 {
 	struct k_mutex *mutex = NULL;
@@ -406,10 +525,162 @@ struct k_mutex *get_i2c_mux_mutex(uint8_t i2c_bus)
 	case I2C_BUS4:
 		mutex = &i2c_4_pi4msd5v9542_mutex;
 		break;
+	case I2C_BUS7:
+		mutex = &i2c_7_mutex;
+		break;
+	case I2C_BUS8:
+		mutex = &i2c_8_mutex;
+		break;
 	default:
 		LOG_ERR("No support for i2c bus %d mutex", i2c_bus);
 		break;
 	}
 
 	return mutex;
+}
+
+int get_accl_bus(uint8_t card_id, uint8_t sensor_number)
+{
+	if (card_id >= ASIC_CARD_COUNT) {
+		LOG_ERR("Invalid accl card id: 0x%x", card_id);
+		return -1;
+	}
+
+	return pca9548_configs[card_id].bus;
+}
+
+bool get_accl_sensor_config_index(uint8_t sensor_num, uint8_t *index)
+{
+	CHECK_NULL_ARG_WITH_RETURN(index, false);
+
+	uint8_t i = 0;
+	for (i = 0; i < ACCL_SENSOR_CONFIG_SIZE; ++i) {
+		if (sensor_num == plat_accl_sensor_config[i].num) {
+			*index = i;
+			return true;
+		}
+	}
+
+	LOG_ERR("Fail to find sensor num: 0x%x in ACCL sensor config", sensor_num);
+	return false;
+}
+
+bool get_accl_mux_config(uint8_t card_id, mux_config *accl_mux)
+{
+	CHECK_NULL_ARG_WITH_RETURN(accl_mux, false);
+
+	if (card_id >= ASIC_CARD_COUNT) {
+		LOG_ERR("Invalid accl card id: 0x%x", card_id);
+		return false;
+	}
+
+	*accl_mux = pca9548_configs[card_id];
+	return true;
+}
+
+bool get_mux_channel_config(uint8_t card_id, uint8_t sensor_number, mux_config *channel_mux)
+{
+	CHECK_NULL_ARG_WITH_RETURN(channel_mux, false);
+
+	if (card_id >= ASIC_CARD_COUNT) {
+		LOG_ERR("Invalid accl card id: 0x%x", card_id);
+		return false;
+	}
+
+	bool ret = false;
+	uint8_t index = 0;
+	uint8_t accl_bus = get_accl_bus(card_id, sensor_number);
+	mux_config *mux_cfg = NULL;
+
+	ret = get_accl_sensor_config_index(sensor_number, &index);
+	if (ret != true) {
+		return ret;
+	}
+
+	sensor_cfg cfg = plat_accl_sensor_config[index];
+	CHECK_NULL_ARG_WITH_RETURN(cfg.priv_data, false);
+
+	mux_cfg = cfg.priv_data;
+	mux_cfg->bus = accl_bus;
+	*channel_mux = *mux_cfg;
+	return true;
+}
+
+ina233_init_arg *get_accl_init_sensor_config(uint8_t card_id, uint8_t sensor_number)
+{
+	if (card_id >= ASIC_CARD_COUNT) {
+		LOG_ERR("Invalid accl card id: 0x%x", card_id);
+		return NULL;
+	}
+
+	bool ret = false;
+	uint8_t index = 0;
+	uint8_t offset = 3;
+
+	ret = get_accl_sensor_config_index(sensor_number, &index);
+	if (ret != true) {
+		return NULL;
+	}
+
+	sensor_cfg cfg = plat_accl_sensor_config[index];
+	switch (cfg.target_addr) {
+	case ACCL_12V_INA233_ADDR:
+		offset = (offset * card_id) + ACCL_12V_INA233_INIT_ARG_OFFSET;
+		break;
+	case ACCL_3V3_1_INA233_ADDR:
+		offset = (offset * card_id) + ACCL_3V3_1_INA233_INIT_ARG_OFFSET;
+		break;
+	case ACCL_3V3_2_INA233_ADDR:
+		offset = (offset * card_id) + ACCL_3V3_2_INA233_INIT_ARG_OFFSET;
+		break;
+	default:
+		LOG_ERR("Invalid accl ina233 address: 0x%x", cfg.target_addr);
+		return NULL;
+	}
+
+	return &accl_ina233_init_args[offset];
+}
+
+void pal_init_drive(sensor_cfg *cfg_table, uint8_t cfg_size, uint8_t card_id)
+{
+	CHECK_NULL_ARG(cfg_table);
+
+	bool ret = false;
+	uint8_t index = 0;
+	uint8_t sensor_num = 0;
+	uint8_t init_status = 0;
+	sensor_cfg *cfg = NULL;
+
+	for (index = 0; index < cfg_size; index++) {
+		cfg = &cfg_table[index];
+		sensor_num = cfg->num;
+
+		if (is_pcie_device_access(card_id, sensor_num) != true) {
+			continue;
+		}
+
+		ret = pre_accl_mux_switch(card_id, sensor_num);
+		if (ret != true) {
+			LOG_ERR("Pre switch mux fail, sensor num: 0x%x, card id: 0x%x", sensor_num,
+				card_id);
+			continue;
+		}
+
+		ret = pal_sensor_drive_init(card_id, cfg, &init_status);
+		if (ret == true) {
+			if (init_status != SENSOR_INIT_SUCCESS) {
+				LOG_ERR("Initial sensor drive fail, sensor num: 0x%x, card id: 0x%x",
+					sensor_num, card_id);
+			}
+		} else {
+			LOG_ERR("Map initial sensor function fail, sensor num: 0x%x, card id: 0x%x",
+				sensor_num, card_id);
+		}
+
+		ret = post_accl_mux_switch(card_id, sensor_num);
+		if (ret != true) {
+			LOG_ERR("Post switch mux fail, sensor num: 0x%x, card id: 0x%x", sensor_num,
+				card_id);
+		}
+	}
 }

--- a/meta-facebook/at-cb/src/platform/plat_sensor_table.h
+++ b/meta-facebook/at-cb/src/platform/plat_sensor_table.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include "sensor.h"
+#include "common_i2c_mux.h"
 
 #define PEX_MAX_NUMBER 2
 
@@ -131,9 +132,48 @@
 #define SENSOR_NUM_PWR_P12V_ACCL_11 0x51
 #define SENSOR_NUM_PWR_P12V_ACCL_12 0x52
 
+/** ACCL sensor config **/
+#define ACCL_FREYA_1_ADDR (0xD6 >> 1)
+#define ACCL_FREYA_2_ADDR (0xD0 >> 1)
+#define ACCL_12V_INA233_ADDR (0x80 >> 1)
+#define ACCL_3V3_1_INA233_ADDR (0x82 >> 1)
+#define ACCL_3V3_2_INA233_ADDR (0x84 >> 1)
+#define ACCL_12V_INA233_INIT_ARG_OFFSET 0
+#define ACCL_3V3_1_INA233_INIT_ARG_OFFSET 1
+#define ACCL_3V3_2_INA233_INIT_ARG_OFFSET 2
+
+/** ACCL sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_FREYA_1 0x01
+#define SENSOR_NUM_TEMP_ACCL_FREYA_2 0x02
+#define SENSOR_NUM_VOL_ACCL_P12V_EFUSE 0x03
+#define SENSOR_NUM_VOL_ACCL_P3V3_1 0x04
+#define SENSOR_NUM_VOL_ACCL_P3V3_2 0x05
+#define SENSOR_NUM_VOL_ACCL_FREYA_1_1 0x06
+#define SENSOR_NUM_VOL_ACCL_FREYA_1_2 0x07
+#define SENSOR_NUM_VOL_ACCL_FREYA_2_1 0x0B
+#define SENSOR_NUM_VOL_ACCL_FREYA_2_2 0x0C
+#define SENSOR_NUM_CUR_ACCL_P12V_EFUSE 0x08
+#define SENSOR_NUM_CUR_ACCL_P3V3_1 0x09
+#define SENSOR_NUM_CUR_ACCL_P3V3_2 0x0A
+#define SENSOR_NUM_PWR_ACCL_P12V_EFUSE 0x0D
+#define SENSOR_NUM_PWR_ACCL_P3V3_1 0x0E
+#define SENSOR_NUM_PWR_ACCL_P3V3_2 0x0F
+#define SENSOR_NUM_PWR_ACCL_FREYA_1 0x10
+#define SENSOR_NUM_PWR_ACCL_FREYA_2 0x11
+
+extern sensor_cfg plat_accl_sensor_config[];
+extern const int ACCL_SENSOR_CONFIG_SIZE;
+
 void load_sensor_config(void);
 bool is_mb_dc_on();
 bool is_dc_access(uint8_t sensor_num);
+bool is_pcie_device_access(uint8_t card_id, uint8_t sensor_num);
 struct k_mutex *get_i2c_mux_mutex(uint8_t i2c_bus);
+int get_accl_bus(uint8_t card_id, uint8_t sensor_number);
+bool get_accl_sensor_config_index(uint8_t sensor_num, uint8_t *index);
+bool get_accl_mux_config(uint8_t card_id, mux_config *accl_mux);
+bool get_mux_channel_config(uint8_t card_id, uint8_t sensor_number, mux_config *channel_mux);
+ina233_init_arg *get_accl_init_sensor_config(uint8_t card_id, uint8_t sensor_number);
+void pal_init_drive(sensor_cfg *cfg_table, uint8_t cfg_size, uint8_t card_id);
 
 #endif


### PR DESCRIPTION
Summary:
- Support to get ACCL device presence status via IPMI oem command.
- Support FAC sensor.
- Support IPMI command to get PCIE card sensor reading. (netfn: 0x38, cmd: 0x77).
- Add platform device initial and reading function to get sensor information from platform sensor config table.

Note:
- ACB IPMI command format
  - Request
    Byte 1:3 – MFG ID – 00A015h, LS byte first
    Byte 4 – FRU id (range: 0x12 ~ 0x1D)
           – FRU id is mapped to ACCL 1~12 card
    Byte 5 – Sensor number
  - Response
    Byte 1 – Completion Code
    Byte 2:4 – MFG ID – 00A015h, LS byte first
    Byte 5 – Device status
           – Bit 0: Present status bit
           – Bit 1: Power status bit
           – Bit 2: Device status bit
    Byte 6:7 – Integer bytes
    Byte 8:9 – Fraction bytes

Test Plan:
- Build code: Pass
- Get ACCL device presence status via raw command: Pass

Log:
root@bmc-oob:~# sensor-util acb_accl5 --threshold
acb_accl5:
ACB_ACCL5_Freya_1_Temp_C     (0x1) :   68.00 C     | (ok) | UCR: 98.00 | UNC: 85.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
ACB_ACCL5_Freya_2_Temp_C     (0x2) :   58.00 C     | (ok) | UCR: 98.00 | UNC: 85.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
ACB_ACCL5_P12V_EFUSE_VOL_V   (0x3) :   12.10 Volts | (ok) | UCR: 13.20 | UNC: 12.96 | UNR: 14.33 | LCR: 10.80 | LNC: 11.04 | LNR: 10.09
ACB_ACCL5_P3V3_1_VOL_V       (0x4) :    3.33 Volts | (ok) | UCR: 3.53 | UNC: 3.46 | UNR: 3.73 | LCR: 3.07 | LNC: 3.13 | LNR: 2.74
ACB_ACCL5_P3V3_2_VOL_V       (0x5) :    3.32 Volts | (ok) | UCR: 3.53 | UNC: 3.46 | UNR: 3.73 | LCR: 3.07 | LNC: 3.13 | LNR: 2.74
ACB_ACCL5_Freya_1_VOL_1_V    (0x6) :    4.10 Volts | (unr) | UCR: 3.53 | UNC: 3.46 | UNR: 3.73 | LCR: 3.07 | LNC: 3.13 | LNR: 2.74
ACB_ACCL5_Freya_1_VOL_2_V    (0x7) :    3.75 Volts | (unr) | UCR: 3.53 | UNC: 3.46 | UNR: 3.73 | LCR: 3.07 | LNC: 3.13 | LNR: 2.74
ACB_ACCL5_P12V_EFUSE_CUR_A   (0x8) :    3.01 Amps  | (ok) | UCR: 5.50 | UNC: NA | UNR: 7.20 | LCR: NA | LNC: NA | LNR: NA
ACB_ACCL5_P3V3_1_CUR_A       (0x9) :    4.96 Amps  | (ok) | UCR: 8.40 | UNC: NA | UNR: 11.50 | LCR: NA | LNC: NA | LNR: NA
ACB_ACCL5_P3V3_2_CUR_A       (0xA) :    5.45 Amps  | (ok) | UCR: 8.40 | UNC: NA | UNR: 11.50 | LCR: NA | LNC: NA | LNR: NA
ACB_ACCL5_Freya_2_VOL_1_V    (0xB) :    3.59 Volts | (ok) | UCR: 8.40 | UNC: NA | UNR: 11.50 | LCR: NA | LNC: NA | LNR: NA
ACB_ACCL5_Freya_2_VOL_2_V    (0xC) :    5.70 Volts | (ok) | UCR: 8.40 | UNC: NA | UNR: 11.50 | LCR: NA | LNC: NA | LNR: NA
ACB_ACCL5_P12V_EFUSE_PWR_W   (0xD) :   36.45 Watts | (ok) | UCR: 67.10 | UNC: NA | UNR: 87.80 | LCR: NA | LNC: NA | LNR: NA
ACB_ACCL5_P3V3_1_PWR_W       (0xE) :   16.50 Watts | (ok) | UCR: 27.72 | UNC: NA | UNR: 37.90 | LCR: NA | LNC: NA | LNR: NA
ACB_ACCL5_P3V3_2_PWR_W       (0xF) :   18.08 Watts | (ok) | UCR: 27.72 | UNC: NA | UNR: 37.90 | LCR: NA | LNC: NA | LNR: NA