### PR TITLE
fby35: cl: Fix NMI event missing

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.c
@@ -676,7 +676,7 @@ void ISR_NMI()
 		sel_msg.event_data1 = IPMI_EVENT_CRITICAL_INT_FP_NMI;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;
-		if (!common_add_sel_evt_record(&sel_msg)) {
+		if (!mctp_add_sel_to_ipmi(&sel_msg)) {
 			LOG_ERR("addsel fail");
 		}
 	}


### PR DESCRIPTION
Summary:
- Change IPMB to PLDM to send NMI event to BMC.

Test plan:
- Build code: Pass
- Trigger and check SEL: Pass

Log:
1. Set GPIO to trigger event and check SEL. root@bmc-oob:~# bic-util slot4 --get_gpio |grep "42" 42 IRQ_PCH_CPU_NMI_EVENT_N: 1
root@bmc-oob:~# bic-util slot4 --set_gpio 42 0
slot 4: setting [42]IRQ_PCH_CPU_NMI_EVENT_N to 0
root@bmc-oob:~# bic-util slot4 --get_gpio |grep "42" 42 IRQ_PCH_CPU_NMI_EVENT_N: 0

root@bmc-oob:~# log-util --print slot4
4    slot4    2023-03-09 15:30:47    gpiointrd        FRU: 4, CPU presence
4    slot4    2023-03-09 18:30:22    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-03-09 18:30:22, Sensor: CRITICAL_IRQ (0xEA), Event Data: (00FFFF) NMI / Diagnostic Interrupt Assertion