### PR TITLE
Common: rf: Fix mctp_cci_read behavior

### DIFF
--- a/common/service/cci/cci.c
+++ b/common/service/cci/cci.c
@@ -238,7 +238,7 @@ uint16_t mctp_cci_read(void *mctp_p, mctp_cci_msg *msg, uint8_t *rbuf, uint16_t 
 			LOG_WRN("send msg failed!");
 			continue;
 		}
-		if (k_msgq_get(event_msgq_p, &event, K_MSEC(CCI_MSG_TIMEOUT_MS + 1000))) {
+		if (k_msgq_get(event_msgq_p, &event, K_FOREVER)) {
 			LOG_WRN("Failed to get status from msgq!");
 			continue;
 		}


### PR DESCRIPTION
Summary:

- The timeout callback function may attempt to use arguments already freed in the mctp_cci_read function, and it may cause undefined behavior and potentially lead to a firmware crash.
To avoid this potential risk, the waiting time of the event message queue is fixed as "wait forever,"  which ensures that the timeout callback function will not use any arguments freed in mctp_cci_read.


Test Plan:
- Build code: PASS
- Overnight stress test: PASS