### PR TITLE
fby3.5: cl: Fix add sel from exp board

### DIFF
--- a/common/service/ipmi/storage_handler.c
+++ b/common/service/ipmi/storage_handler.c
@@ -18,6 +18,7 @@
 #include "storage_handler.h"
 #include "plat_fru.h"
 #include "plat_ipmb.h"
+#include "pldm.h"
 #include "fru.h"
 #include "sdr.h"
 #include <logging/log.h>
@@ -284,18 +285,25 @@ __weak void STORAGE_ADD_SEL(ipmi_msg *msg)
 	add_sel_msg->data_len = msg->data_len;
 	memcpy(add_sel_msg->data, msg->data, add_sel_msg->data_len);
 
-	status = ipmb_read(add_sel_msg, IPMB_inf_index_map[add_sel_msg->InF_target]);
-	free(add_sel_msg);
+	// Check BMC communication interface if use IPMB or not
+	if (pal_is_interface_use_ipmb(IPMB_inf_index_map[get_add_sel_target_interface()])) {
+		status = ipmb_read(add_sel_msg, IPMB_inf_index_map[add_sel_msg->InF_target]);
+		free(add_sel_msg);
 
-	msg->data_len = 0;
-	if (status == IPMB_ERROR_FAILURE) {
-		msg->completion_code = CC_UNSPECIFIED_ERROR;
-		LOG_ERR("Fail to post msg to txqueue for addsel");
-		return;
-	} else if (status == IPMB_ERROR_GET_MESSAGE_QUEUE) {
-		msg->completion_code = CC_UNSPECIFIED_ERROR;
-		LOG_ERR("No response from bmc for addsel");
-		return;
+		msg->data_len = 0;
+		if (status == IPMB_ERROR_FAILURE) {
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+			LOG_ERR("Fail to post msg to txqueue for addsel");
+			return;
+		} else if (status == IPMB_ERROR_GET_MESSAGE_QUEUE) {
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+			LOG_ERR("No response from bmc for addsel");
+			return;
+		}
+	} else {
+		status = pldm_send_ipmi_request(add_sel_msg);
+		free(add_sel_msg);
+		msg->data_len = 0;
 	}
 
 	msg->completion_code = CC_SUCCESS;


### PR DESCRIPTION
Summary:
- Due to IPMB change to PLDM_MCTP_I3C, we shouldn't still use ipmb_read

Test Plan:
- Build code: Pass
- Add event sel from VF

1    slot1    2023-02-20 23:22:48    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-02-20 23:22:48, Sensor: Unknown (0x10), Event Data: (800701) Unknown Deassertion