### PR TITLE
common: Fix ball ID of hvi3c2

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0041-fix-ball-id-of-hvi3c2.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0041-fix-ball-id-of-hvi3c2.patch
@@ -1,0 +1,25 @@
+From d71ae11ae41090325b23a57702339b51f4e27b1f Mon Sep 17 00:00:00 2001
+From: Eli_Huang <Eli_Huang@wiwynn.com>
+Date: Tue, 14 Mar 2023 16:58:59 +0800
+Subject: [PATCH] fix ball id of hvi3c2
+
+---
+ soc/arm/aspeed/ast10x0/sig_def_list.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/soc/arm/aspeed/ast10x0/sig_def_list.h b/soc/arm/aspeed/ast10x0/sig_def_list.h
+index cd26d22c02..71af47370f 100644
+--- a/soc/arm/aspeed/ast10x0/sig_def_list.h
++++ b/soc/arm/aspeed/ast10x0/sig_def_list.h
+@@ -96,7 +96,7 @@ SIG_DEFINE(I3C2SCL, J14, SIG_DESC_SET(0x418, 18), SIG_DESC_CLEAR(0x4B8, 10))
+ SIG_DEFINE(I3C2SDA, H16, SIG_DESC_SET(0x418, 19), SIG_DESC_CLEAR(0x4B8, 11))
+ SIG_DEFINE(HVI3C2SCL, L14, SIG_DESC_SET(0x4B8, 10), SIG_DESC_CLEAR(0x418, 18),
+ 	   SIG_DESC_CLEAR(0x418, 10))
+-SIG_DEFINE(HVI3C2SDA, K15, SIG_DESC_SET(0x4B8, 11), SIG_DESC_CLEAR(0x418, 19),
++SIG_DEFINE(HVI3C2SDA, L15, SIG_DESC_SET(0x4B8, 11), SIG_DESC_CLEAR(0x418, 19),
+ 	   SIG_DESC_CLEAR(0x418, 11))
+ #endif
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Summary:
- Following the AST1030 spec, revise ball id of hvi3c2 to from K15 to L15

Test plan:
- Using hd and rf to test i3c communication

[hd]
uart:~$ i3c attach I3C_1 -a 0x9
Attach address 0x09 to I3C_1

uart:~$  i3c xfer I3C_1 -a 9 -w 1,2,3,4
Private transfer to address 0x09

[rf]
uart:~$ i3c smq I3C_SMQ_2 -r 5
00000000: 01 02 03 04 00                                   |.....            |

uart:~$ i3c smq I3C_SMQ_2 -r 5
00000000: 04 05 06 07 00                                   |.....            |