### PR TITLE
fby35: cl: LTC4282 adjust

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.c
@@ -43,8 +43,8 @@ LOG_MODULE_REGISTER(plat_hook);
 #define ADJUST_ADM1278_CURRENT(x) ((x * 0.98) + 0.1)
 #define ADJUST_LTC4286_POWER(x) ((x * 0.97) - 8)
 #define ADJUST_LTC4286_CURRENT(x) ((x * 0.97) - 0.4)
-#define ADJUST_LTC4282_POWER(x) ((x * 0.98) - 0.2)
-#define ADJUST_LTC4282_CURRENT(x) ((x * 0.99) - 0.2)
+#define ADJUST_LTC4282_POWER(x) (x * 0.99)
+#define ADJUST_LTC4282_CURRENT(x) (x * 0.99)
 
 /**************************************************************************************************
  * INIT ARGS


### PR DESCRIPTION
Summary:
- Modify correction formula of LTC4282 power and current.
- Power: Iout * 0.99 Current: Pin * 0.99

Test plan:
- Build code: Pass
- Read LTC4282: Pass

Log:
1. Check LTC2482 power.
DC load             BMC reporting   DM
Current loading(A)  Input power(W)  Input power(W)  Deviation(%)
3                   40.02           40.69057356     -1.65%
6                   77.62           78.03926643     -0.54%
9                   115.15          115.2702079     -0.10%
12                  152.67          152.4426976     0.15%
15                  190.12          189.542928      0.30%
18                  227.52          226.544346      0.43%
21                  264.97          263.4788331     0.57%
24                  302.29          300.3348509     0.65%
27                  339.54          336.7668525     0.82%
30                  377.34          373.4173835     1.05%
33                  414.55          410.0301816     1.10%
36                  451.67          446.53524       1.15%

2. Check LTC4282 current.
DC load             BMC reporting  DM
Current loading(A)  current(A)     Current(A)  Deviation (%)
3                   3.24           3.2578      -0.55%
6                   6.26           6.2547      0.08%
9                   9.27           9.2484      0.23%
12                  12.29          12.244      0.38%
15                  15.3           15.24       0.39%
18                  18.32          18.235      0.47%
21                  21.34          21.231      0.51%
24                  24.36          24.227      0.55%
27                  27.37          27.197      0.64%
30                  30.4           30.191      0.69%
33                  33.41          33.189      0.67%
36                  36.44          36.186      0.70%

3. Check LTC4282 voltage.
DC load             BMC reporting  DM
Current loading(A)  Voltage(V)     Voltage(V)  Deviation(%)
3                   12.48          12.4902     -0.08%
6                   12.47          12.4769     -0.06%
9                   12.46          12.4638     -0.03%
12                  12.46          12.4504     0.08%
15                  12.45          12.4372     0.10%
18                  12.44          12.4236     0.13%
21                  12.44          12.4101     0.24%
24                  12.43          12.3967     0.27%
27                  12.42          12.3825     0.30%
30                  12.41          12.3685     0.34%
33                  12.41          12.3544     0.45%
36                  12.4           12.34       0.49%