### PR TITLE
fby35: cl: fix get post code IPMI command failed

### DIFF
--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -57,6 +57,12 @@
 #define MAX_CONTROL_SENSOR_POLLING_COUNT 10
 #define FOUR_BYTE_POST_CODE_PAGE_SIZE 60
 
+#ifdef ENABLE_PLDM
+#define POST_CODE_BUF_SIZE 240
+#else
+#define POST_CODE_BUF_SIZE SNOOP_MAX_LEN
+#endif
+
 LOG_MODULE_DECLARE(ipmi);
 
 __weak int pal_extend_msg_out_interface_handler(ipmi_msg *msg)
@@ -690,9 +696,9 @@ __weak void OEM_1S_GET_POST_CODE(ipmi_msg *msg)
 
 	if (postcode_num) {
 		uint8_t offset = 0;
-		if (snoop_read_num > SNOOP_MAX_LEN) {
-			postcode_num = SNOOP_MAX_LEN;
-			offset = snoop_read_num % SNOOP_MAX_LEN;
+		if (snoop_read_num > POST_CODE_BUF_SIZE) {
+			postcode_num = POST_CODE_BUF_SIZE;
+			offset = snoop_read_num % POST_CODE_BUF_SIZE;
 		}
 		copy_snoop_read_buffer(offset, postcode_num, msg->data, COPY_ALL_POSTCODE);
 	}

--- a/meta-facebook/yv35-cl/src/platform/plat_def.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_def.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -20,6 +20,7 @@
 #define ENABLE_ASD
 #define ENABLE_ISL69260
 #define ENABLE_FIX_SENSOR
+#define ENABLE_PLDM
 
 #define BMC_USB_PORT "CDC_ACM_0"
 


### PR DESCRIPTION
Summary:
PLDM over MCTP communication header is longer than IPMB. Current post code size 244 is too large and cause the payload size over MCTP max size 256. Revise the size to 240 for PLDM over MCTP.

Test plan:
Build and test pass on fby35 system.
1. Get post code IPMI [root@FBK8_221107 ~]# ipmitool raw 0x30 0x49
 7e bb bb bb 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 e3 e3 e3 aa 84 b1 b1 b0 af ad d9 ad b6 92 a0 92
 a0 a0 92 92 92 99 92 9c 9a 9d 98 97 92 92 92 92
 92 92 50 91 99 92 92 92 92 92 ef 96 95 94 94 94
 94 94 94 94 94 94 94 94 94 92 91 90 79 70 68 61
 60 33 4f 47 42 40 7f 7f 15 0d 0c 0b 06 04 00 50
 22 02 52 15 4d 4a 49 0e 48 7f 02 00 22 02 23 03
 ee ed af af af bf 7e c6 ce bc bc bc bc cc 7e dc
 ca ca b7 7e 70 7e d1 7e d1 7e d0 7e d0 7e d0 7e