### PR TITLE
Artemis: mc: Correct CXL card component id

### DIFF
--- a/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
@@ -35,6 +35,42 @@
 
 LOG_MODULE_REGISTER(plat_ipmi);
 
+int pal_cxl_component_id_map_jcn(uint8_t component_id, uint8_t *card_id)
+{
+	CHECK_NULL_ARG_WITH_RETURN(card_id, -1);
+
+	switch (component_id) {
+	case MC_COMPNT_CXL1:
+		*card_id = CXL_CARD_8;
+		break;
+	case MC_COMPNT_CXL2:
+		*card_id = CXL_CARD_7;
+		break;
+	case MC_COMPNT_CXL3:
+		*card_id = CXL_CARD_6;
+		break;
+	case MC_COMPNT_CXL4:
+		*card_id = CXL_CARD_5;
+		break;
+	case MC_COMPNT_CXL5:
+		*card_id = CXL_CARD_3;
+		break;
+	case MC_COMPNT_CXL6:
+		*card_id = CXL_CARD_4;
+		break;
+	case MC_COMPNT_CXL7:
+		*card_id = CXL_CARD_1;
+		break;
+	case MC_COMPNT_CXL8:
+		*card_id = CXL_CARD_2;
+		break;
+	default:
+		return -1;
+	}
+
+	return 0;
+}
+
 int pal_write_read_cxl_fru(uint8_t optional, uint8_t fru_id, EEPROM_ENTRY *fru_entry,
 			   uint8_t *status)
 {
@@ -254,7 +290,12 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 	case MC_COMPNT_CXL6:
 	case MC_COMPNT_CXL7:
 	case MC_COMPNT_CXL8:
-		cxl_id = component - MC_COMPNT_CXL1;
+		if (pal_cxl_component_id_map_jcn(component, &cxl_id) != 0) {
+			LOG_ERR("Invalid cxl component id: 0x%x", component);
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+			return;
+		}
+
 		if (pm8702_table[cxl_id].is_init != true) {
 			ret = pal_init_pm8702_info(cxl_id);
 			if (ret == false) {


### PR DESCRIPTION
Summary:
- Correct cxl card component id.

Test Plan:
- Build code: Pass
- Get cxl fw version: Pass

Log:
root@bmc-oob:~# fw-util meb --version cxl1
MEB CXL1 Version: 01.001.005.00
root@bmc-oob:~# fw-util meb --version cxl2
MEB CXL2 Version: 01.001.005.00
root@bmc-oob:~# fw-util meb --version cxl3
MEB CXL3 Version: 01.001.005.00
root@bmc-oob:~# fw-util meb --version cxl4
MEB CXL4 Version: 01.001.005.00
root@bmc-oob:~# fw-util meb --version cxl5
MEB CXL5 Version: 01.001.005.00
root@bmc-oob:~# fw-util meb --version cxl6
MEB CXL6 Version: 01.001.005.00
root@bmc-oob:~# fw-util meb --version cxl7
MEB CXL7 Version: 01.001.005.00
root@bmc-oob:~# fw-util meb --version cxl8
MEB CXL8 Version: 01.001.005.00