### PR TITLE
fby3.5: rf: Modify CXL Update Process

### DIFF
--- a/meta-facebook/yv35-rf/src/lib/plat_spi.c
+++ b/meta-facebook/yv35-rf/src/lib/plat_spi.c
@@ -39,7 +39,7 @@ static bool switch_cxl_spi_mux(int gpio_status)
 
 	if (gpio_set(SPI_MASTER_SEL, gpio_status)) {
 		LOG_ERR("Fail to switch the flash to %s",
-		       (gpio_status == CXL_FLASH_TO_BIC) ? "BIC" : "PIONEER");
+			(gpio_status == CXL_FLASH_TO_BIC) ? "BIC" : "PIONEER");
 		return false;
 	}
 
@@ -81,7 +81,6 @@ static bool control_flash_power(int power_state)
 uint8_t fw_update_cxl(uint32_t offset, uint16_t msg_len, uint8_t *msg_buf, bool sector_end)
 {
 	uint8_t ret = FWUPDATE_UPDATE_FAIL;
-	set_CXL_update_status(POWER_ON);
 
 	if (offset > CXL_UPDATE_MAX_OFFSET) {
 		return FWUPDATE_OVER_LENGTH;
@@ -100,11 +99,7 @@ uint8_t fw_update_cxl(uint32_t offset, uint16_t msg_len, uint8_t *msg_buf, bool 
 
 	ret = fw_update(offset, msg_len, msg_buf, sector_end, DEVSPI_SPI1_CS0);
 
-	if (sector_end || ret != FWUPDATE_SUCCESS) {
-		control_flash_power(POWER_OFF);
-		switch_cxl_spi_mux(CXL_FLASH_TO_CXL);
-		set_CXL_update_status(POWER_OFF);
-	}
+	switch_cxl_spi_mux(CXL_FLASH_TO_CXL);
 
 	return ret;
 }

--- a/meta-facebook/yv35-rf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_power_seq.c
@@ -27,19 +27,8 @@
 #include <logging/log.h>
 
 LOG_MODULE_REGISTER(power_sequence);
-static bool cxl_update_stat = false;
 static uint8_t power_on_seq = DEFAULT_POWER_ON_SEQ;
 static uint8_t power_off_seq = DEFAULT_POWER_OFF_SEQ;
-
-void set_CXL_update_status(uint8_t set_status)
-{
-	cxl_update_stat = set_status;
-}
-
-bool get_CXL_update_status()
-{
-	return cxl_update_stat;
-}
 
 void set_MB_DC_status(uint8_t gpio_num)
 {
@@ -297,7 +286,6 @@ bool power_off_handler(uint8_t initial_stage)
 {
 	bool enable_power_off_handler = true;
 	int check_power_ret = -1;
-	int update_status = false;
 	uint8_t control_stage = initial_stage;
 	while (enable_power_off_handler == true) {
 		switch (control_stage) { // Disable VR power machine
@@ -314,20 +302,12 @@ bool power_off_handler(uint8_t initial_stage)
 			control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_06);
 			break;
 		case ASIC_POWER_OFF_STAGE1:
-			update_status = get_CXL_update_status();
-			if (update_status == false) {
-				control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_04);
-				break;
-			}
+			control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_04);
 			break;
 		case ASIC_POWER_OFF_STAGE2:
-			update_status = get_CXL_update_status();
-			if (update_status == false) {
-				control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_01);
-				control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_02);
-				control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_03);
-				break;
-			}
+			control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_01);
+			control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_02);
+			control_power_stage(DISABLE_POWER_MODE, CONTROL_POWER_SEQ_03);
 			break;
 		case BOARD_POWER_OFF_STAGE:
 			control_power_stage(DISABLE_POWER_MODE, CLK_100M_OSC_EN);
@@ -377,9 +357,7 @@ bool power_off_handler(uint8_t initial_stage)
 			control_stage = ASIC_POWER_OFF_STAGE1;
 			break;
 		case ASIC_POWER_OFF_STAGE1:
-			update_status = get_CXL_update_status();
-			if (update_status == false &&
-			    check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_04) != 0) {
+			if (check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_04) != 0) {
 				check_power_ret = -1;
 				break;
 			}
@@ -387,19 +365,15 @@ bool power_off_handler(uint8_t initial_stage)
 			control_stage = ASIC_POWER_OFF_STAGE2;
 			break;
 		case ASIC_POWER_OFF_STAGE2:
-			update_status = get_CXL_update_status();
-			if (update_status == false &&
-			    check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_03) != 0) {
+			if (check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_03) != 0) {
 				check_power_ret = -1;
 				break;
 			}
-			if (update_status == false &&
-			    check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_02) != 0) {
+			if (check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_02) != 0) {
 				check_power_ret = -1;
 				break;
 			}
-			if (update_status == false &&
-			    check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_01) != 0) {
+			if (check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_01) != 0) {
 				check_power_ret = -1;
 				break;
 			}

--- a/meta-facebook/yv35-rf/src/platform/plat_power_seq.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_power_seq.h
@@ -84,7 +84,5 @@ void control_power_stage(uint8_t control_mode, uint8_t control_seq);
 int check_power_stage(uint8_t check_mode, uint8_t check_seq);
 bool power_on_handler(uint8_t initial_stage);
 bool power_off_handler(uint8_t initial_stage);
-void set_CXL_update_status(uint8_t set_status);
-bool get_CXL_update_status();
 
 #endif


### PR DESCRIPTION
- Summary:

  Because BMC did not send an update end flag for BIC starting from version halfdome-v2023.08.1, the update processes have been modified in the following versions of BMC (expected as halfdome-v2023.12.1) and BIC (oby35-rf-2023.11.01).
  
  BMC part (expected as halfdome-v2023.12.1):
  -After updating the CXL, BMC will turn off the power for the CXL flash (P1V8_ASIC_EN_R)
  
  BIC  part (oby35-rf-2023.11.01):
  -The update flag has been deleted, and the SPI mux will be switched after updating a block.

- Test Plan:
Build code: PASS
