### PR TITLE
common: Add pldm instance id register/unregister functions

### DIFF
--- a/common/service/mctp/mctp.h
+++ b/common/service/mctp/mctp.h
@@ -182,6 +182,8 @@ typedef struct _mctp {
 
 	/* for pldm instance id */
 	uint8_t pldm_inst_id;
+	uint32_t pldm_inst_table; // 32 bits field for instant id
+
 	/* for cci_msg_tag */
 	uint8_t cci_msg_tag;
 } mctp;

--- a/common/service/mctp/mctp.h
+++ b/common/service/mctp/mctp.h
@@ -182,7 +182,7 @@ typedef struct _mctp {
 
 	/* for pldm instance id */
 	uint8_t pldm_inst_id;
-	uint32_t pldm_inst_table; // 32 bits field for instant id
+	uint32_t pldm_inst_table; // 32 bits field for instance id
 
 	/* for cci_msg_tag */
 	uint8_t cci_msg_tag;

--- a/common/service/pldm/pldm.c
+++ b/common/service/pldm/pldm.c
@@ -74,13 +74,13 @@ static bool unregister_instid(void *mctp_p, uint8_t inst_num)
 	CHECK_NULL_ARG_WITH_RETURN(mctp_p, false);
 
 	if (inst_num >= PLDM_MAX_INSTID_COUNT) {
-		LOG_ERR("Invalid instant number %d", inst_num);
+		LOG_ERR("Invalid instance number %d", inst_num);
 		return false;
 	}
 
 	mctp *mctp_inst = (mctp *)mctp_p;
 	if (!mctp_inst->pldm_inst_table) {
-		LOG_ERR("Instant table not init!");
+		LOG_ERR("Instance table not init!");
 		return false;
 	}
 	if (!(mctp_inst->pldm_inst_table & BIT(inst_num))) {


### PR DESCRIPTION
Summary:
- Add array of instance id for pldm in each mctp_inst.
- Prevent repeating use of same instant id.

Test Plan:
- Build code: Pass
- Get BIC(cl) fw version: Pass

Log:
root@bmc-oob:~# fw-util slot1 --version bic
SB Bridge-IC Version: oby35-cl-v2023.09.01
