### PR TITLE
at: Correct MooseCreek PCIE card sensor initial settings and INA233 MFR ADC config

### DIFF
--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -513,6 +513,17 @@ typedef struct _sq52205_init_arg_ {
 	bool is_init;
 	float current_lsb;
 	float r_shunt;
+	union {
+		uint16_t value;
+		struct {
+			uint16_t operating_mode : 3;
+			uint16_t shunt_volt_time : 3;
+			uint16_t bus_volt_time : 3;
+			uint16_t aver_mode : 3;
+			uint16_t rsvd : 3; // bit[14:12] are reserved.
+			uint16_t reset_bit : 1;
+		};
+	} config;
 } sq52205_init_arg;
 
 typedef struct _ltc2991_init_arg_ {

--- a/meta-facebook/at-cb/src/platform/plat_dev.c
+++ b/meta-facebook/at-cb/src/platform/plat_dev.c
@@ -283,7 +283,8 @@ uint8_t pal_ina233_init(uint8_t card_id, sensor_cfg *cfg)
 		msg.data[0] = INA233_CALIBRATION_OFFSET;
 
 		// Calibration formula = (0.00512 / (current_lsb * r_shunt))
-		calibration = (uint16_t)(0.00512 / (init_arg->current_lsb * init_arg->r_shunt));
+		calibration =
+			(uint16_t)((0.00512 / (init_arg->current_lsb * init_arg->r_shunt)) + 0.5);
 		memcpy(&msg.data[1], &calibration, sizeof(uint16_t));
 
 		ret = i2c_master_write(&msg, retry);

--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -48,18 +48,114 @@ adm1272_init_arg adm1272_init_args[] = {
 };
 
 ina233_init_arg ina233_init_args[] = {
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 };
 
 pex89000_init_arg pex_sensor_init_args[] = {
@@ -69,58 +165,364 @@ pex89000_init_arg pex_sensor_init_args[] = {
 
 ina233_init_arg accl_ina233_init_args[] = {
 	// ACCL 1
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// ACCL 2
-	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// ACCL 3
-	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// ACCL 4
-	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// ACCL 5
-	[12] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[13] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[14] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[12] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[13] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[14] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// ACCL 6
-	[15] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[16] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[17] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[15] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[16] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[17] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// ACCL 7
-	[18] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[19] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[20] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[18] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[19] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[20] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// ACCL 8
-	[21] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[22] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[23] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[21] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[22] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[23] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// ACCL 9
-	[24] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[25] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[26] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[24] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[25] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[26] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// ACCL 10
-	[27] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[28] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[29] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[27] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[28] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[29] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// ACCL 11
-	[30] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[31] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[32] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[30] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[31] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[32] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// ACCL 12
-	[33] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[34] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[35] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[33] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[34] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[35] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 };
 
 sq52205_init_arg sq52205_init_args[] = {
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
 };
 
 /**************************************************************************************************

--- a/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
@@ -167,7 +167,7 @@ int pal_get_pcie_card_sensor_reading(uint8_t read_type, uint8_t sensor_num, uint
 			}
 		}
 
-		ret = pal_sensor_drive_read(cfg, reading, &sensor_status);
+		ret = pal_sensor_drive_read(pcie_card_id, cfg, reading, &sensor_status);
 		if (ret != true) {
 			LOG_ERR("sensor: 0x%x read fail", sensor_num);
 		}

--- a/meta-facebook/at-mc/src/platform/plat_dev.c
+++ b/meta-facebook/at-mc/src/platform/plat_dev.c
@@ -75,32 +75,32 @@ pm8702_dev_info pm8702_table[] = {
 	{ .is_init = false }, { .is_init = false }, { .is_init = false }, { .is_init = false },
 };
 
-bool pal_sensor_drive_init(sensor_cfg *cfg, uint8_t *init_status)
+bool pal_sensor_drive_init(uint8_t card_id, sensor_cfg *cfg, uint8_t *init_status)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(init_status, false);
 
 	switch (cfg->type) {
 	case sensor_dev_tmp75:
-		*init_status = pal_tmp75_init(cfg);
+		*init_status = pal_tmp75_init(card_id, cfg);
 		break;
 	case sensor_dev_emc1412:
-		*init_status = pal_emc1412_init(cfg);
+		*init_status = pal_emc1412_init(card_id, cfg);
 		break;
 	case sensor_dev_nvme:
-		*init_status = pal_nvme_init(cfg);
+		*init_status = pal_nvme_init(card_id, cfg);
 		break;
 	case sensor_dev_ina233:
-		*init_status = pal_ina233_init(cfg);
+		*init_status = pal_ina233_init(card_id, cfg);
 		break;
 	case sensor_dev_ltc2991:
-		*init_status = pal_ltc2991_init(cfg);
+		*init_status = pal_ltc2991_init(card_id, cfg);
 		break;
 	case sensor_dev_xdpe12284c:
-		*init_status = pal_xdpe12284c_init(cfg);
+		*init_status = pal_xdpe12284c_init(card_id, cfg);
 		break;
 	case sensor_dev_pm8702:
-		*init_status = pal_pm8702_init(cfg);
+		*init_status = pal_pm8702_init(card_id, cfg);
 		break;
 	default:
 		LOG_ERR("Invalid initial drive type: 0x%x", cfg->type);
@@ -110,7 +110,7 @@ bool pal_sensor_drive_init(sensor_cfg *cfg, uint8_t *init_status)
 	return true;
 }
 
-bool pal_sensor_drive_read(sensor_cfg *cfg, int *reading, uint8_t *sensor_status)
+bool pal_sensor_drive_read(uint8_t card_id, sensor_cfg *cfg, int *reading, uint8_t *sensor_status)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(reading, false);
@@ -118,25 +118,25 @@ bool pal_sensor_drive_read(sensor_cfg *cfg, int *reading, uint8_t *sensor_status
 
 	switch (cfg->type) {
 	case sensor_dev_tmp75:
-		*sensor_status = pal_tmp75_read(cfg, reading);
+		*sensor_status = pal_tmp75_read(card_id, cfg, reading);
 		break;
 	case sensor_dev_emc1412:
-		*sensor_status = pal_emc1412_read(cfg, reading);
+		*sensor_status = pal_emc1412_read(card_id, cfg, reading);
 		break;
 	case sensor_dev_nvme:
-		*sensor_status = pal_nvme_read(cfg, reading);
+		*sensor_status = pal_nvme_read(card_id, cfg, reading);
 		break;
 	case sensor_dev_ina233:
-		*sensor_status = pal_ina233_read(cfg, reading);
+		*sensor_status = pal_ina233_read(card_id, cfg, reading);
 		break;
 	case sensor_dev_ltc2991:
-		*sensor_status = pal_ltc2991_read(cfg, reading);
+		*sensor_status = pal_ltc2991_read(card_id, cfg, reading);
 		break;
 	case sensor_dev_xdpe12284c:
-		*sensor_status = pal_xdpe12284c_read(cfg, reading);
+		*sensor_status = pal_xdpe12284c_read(card_id, cfg, reading);
 		break;
 	case sensor_dev_pm8702:
-		*sensor_status = pal_pm8702_read(cfg, reading);
+		*sensor_status = pal_pm8702_read(card_id, cfg, reading);
 		break;
 	default:
 		LOG_ERR("Invalid reading drive type: 0x%x", cfg->type);
@@ -186,7 +186,7 @@ float pal_vid_to_float(int val, uint8_t vout_mode)
 	return 0;
 }
 
-uint8_t pal_tmp75_read(sensor_cfg *cfg, int *reading)
+uint8_t pal_tmp75_read(uint8_t card_id, sensor_cfg *cfg, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
@@ -218,7 +218,7 @@ uint8_t pal_tmp75_read(sensor_cfg *cfg, int *reading)
 	return SENSOR_READ_SUCCESS;
 }
 
-uint8_t pal_tmp75_init(sensor_cfg *cfg)
+uint8_t pal_tmp75_init(uint8_t card_id, sensor_cfg *cfg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
 
@@ -229,7 +229,7 @@ uint8_t pal_tmp75_init(sensor_cfg *cfg)
 	return SENSOR_INIT_SUCCESS;
 }
 
-uint8_t pal_emc1412_read(sensor_cfg *cfg, int *reading)
+uint8_t pal_emc1412_read(uint8_t card_id, sensor_cfg *cfg, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
@@ -288,7 +288,7 @@ uint8_t pal_emc1412_read(sensor_cfg *cfg, int *reading)
 	return SENSOR_READ_SUCCESS;
 }
 
-uint8_t pal_emc1412_init(sensor_cfg *cfg)
+uint8_t pal_emc1412_init(uint8_t card_id, sensor_cfg *cfg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
 
@@ -299,7 +299,7 @@ uint8_t pal_emc1412_init(sensor_cfg *cfg)
 	return SENSOR_INIT_SUCCESS;
 }
 
-uint8_t pal_nvme_read(sensor_cfg *cfg, int *reading)
+uint8_t pal_nvme_read(uint8_t card_id, sensor_cfg *cfg, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
@@ -352,7 +352,7 @@ uint8_t pal_nvme_read(sensor_cfg *cfg, int *reading)
 	return SENSOR_READ_SUCCESS;
 }
 
-uint8_t pal_nvme_init(sensor_cfg *cfg)
+uint8_t pal_nvme_init(uint8_t card_id, sensor_cfg *cfg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
 
@@ -363,7 +363,7 @@ uint8_t pal_nvme_init(sensor_cfg *cfg)
 	return SENSOR_INIT_SUCCESS;
 }
 
-uint8_t pal_ina233_read(sensor_cfg *cfg, int *reading)
+uint8_t pal_ina233_read(uint8_t card_id, sensor_cfg *cfg, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
@@ -373,10 +373,12 @@ uint8_t pal_ina233_read(sensor_cfg *cfg, int *reading)
 		return SENSOR_UNSPECIFIED_ERROR;
 	}
 
-	ina233_init_arg *init_arg = (ina233_init_arg *)cfg->init_args;
-	if (init_arg == NULL) {
-		LOG_ERR("input initial pointer is NULL");
-		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	ina233_init_arg *init_arg = NULL;
+	if (cfg->init_args == NULL) {
+		init_arg = get_pcie_init_sensor_config(card_id, cfg->num);
+		CHECK_NULL_ARG_WITH_RETURN(init_arg, SENSOR_UNSPECIFIED_ERROR);
+	} else {
+		init_arg = cfg->init_args;
 	}
 
 	if (init_arg->is_init != true) {
@@ -434,7 +436,7 @@ uint8_t pal_ina233_read(sensor_cfg *cfg, int *reading)
 	return SENSOR_READ_SUCCESS;
 }
 
-uint8_t pal_ina233_init(sensor_cfg *cfg)
+uint8_t pal_ina233_init(uint8_t card_id, sensor_cfg *cfg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
 
@@ -442,11 +444,14 @@ uint8_t pal_ina233_init(sensor_cfg *cfg)
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
 
-	ina233_init_arg *init_arg = (ina233_init_arg *)cfg->init_args;
-	if (init_arg == NULL) {
-		LOG_ERR("input initial pointer is NULL");
-		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	ina233_init_arg *init_arg = NULL;
+	if (cfg->init_args == NULL) {
+		init_arg = get_pcie_init_sensor_config(card_id, cfg->num);
+		CHECK_NULL_ARG_WITH_RETURN(init_arg, SENSOR_UNSPECIFIED_ERROR);
+	} else {
+		init_arg = cfg->init_args;
 	}
+
 	if (init_arg->is_init != true) {
 		int ret = 0, retry = 5;
 		uint16_t calibration = 0;
@@ -472,7 +477,7 @@ uint8_t pal_ina233_init(sensor_cfg *cfg)
 	return SENSOR_INIT_SUCCESS;
 }
 
-uint8_t pal_ltc2991_read(sensor_cfg *cfg, int *reading)
+uint8_t pal_ltc2991_read(uint8_t card_id, sensor_cfg *cfg, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
@@ -573,7 +578,7 @@ uint8_t pal_ltc2991_read(sensor_cfg *cfg, int *reading)
 	return SENSOR_READ_SUCCESS;
 }
 
-uint8_t pal_ltc2991_init(sensor_cfg *cfg)
+uint8_t pal_ltc2991_init(uint8_t card_id, sensor_cfg *cfg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
 
@@ -581,10 +586,12 @@ uint8_t pal_ltc2991_init(sensor_cfg *cfg)
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
 
-	ltc2991_init_arg *init_arg = (ltc2991_init_arg *)cfg->init_args;
-	if (init_arg == NULL) {
-		LOG_ERR("input initial pointer is NULL");
-		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	ltc2991_init_arg *init_arg = NULL;
+	if (cfg->init_args == NULL) {
+		init_arg = get_pcie_init_sensor_config(card_id, cfg->num);
+		CHECK_NULL_ARG_WITH_RETURN(init_arg, SENSOR_UNSPECIFIED_ERROR);
+	} else {
+		init_arg = cfg->init_args;
 	}
 
 	if (init_arg->is_init != true) {
@@ -661,7 +668,7 @@ uint8_t pal_ltc2991_init(sensor_cfg *cfg)
 	return SENSOR_INIT_SUCCESS;
 }
 
-uint8_t pal_xdpe12284c_read(sensor_cfg *cfg, int *reading)
+uint8_t pal_xdpe12284c_read(uint8_t card_id, sensor_cfg *cfg, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
@@ -722,7 +729,7 @@ uint8_t pal_xdpe12284c_read(sensor_cfg *cfg, int *reading)
 	return SENSOR_READ_SUCCESS;
 }
 
-uint8_t pal_xdpe12284c_init(sensor_cfg *cfg)
+uint8_t pal_xdpe12284c_init(uint8_t card_id, sensor_cfg *cfg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
 
@@ -976,7 +983,7 @@ int cxl_ioexp_init(uint8_t cxl_channel)
 	return 0;
 }
 
-uint8_t pal_pm8702_read(sensor_cfg *cfg, int *reading)
+uint8_t pal_pm8702_read(uint8_t card_id, sensor_cfg *cfg, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
@@ -1018,7 +1025,7 @@ uint8_t pal_pm8702_read(sensor_cfg *cfg, int *reading)
 	return SENSOR_READ_SUCCESS;
 }
 
-uint8_t pal_pm8702_init(sensor_cfg *cfg)
+uint8_t pal_pm8702_init(uint8_t card_id, sensor_cfg *cfg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
 

--- a/meta-facebook/at-mc/src/platform/plat_dev.c
+++ b/meta-facebook/at-mc/src/platform/plat_dev.c
@@ -463,7 +463,8 @@ uint8_t pal_ina233_init(uint8_t card_id, sensor_cfg *cfg)
 		msg.data[0] = INA233_CALIBRATION_OFFSET;
 
 		// Calibration formula = (0.00512 / (current_lsb * r_shunt))
-		calibration = (uint16_t)(0.00512 / (init_arg->current_lsb * init_arg->r_shunt));
+		calibration =
+			(uint16_t)((0.00512 / (init_arg->current_lsb * init_arg->r_shunt)) + 0.5);
 		memcpy(&msg.data[1], &calibration, sizeof(uint16_t));
 
 		ret = i2c_master_write(&msg, retry);

--- a/meta-facebook/at-mc/src/platform/plat_dev.h
+++ b/meta-facebook/at-mc/src/platform/plat_dev.h
@@ -28,24 +28,24 @@ typedef struct _pm8702_dev_info {
 
 extern pm8702_dev_info pm8702_table[];
 
-bool pal_sensor_drive_init(sensor_cfg *cfg, uint8_t *init_status);
-bool pal_sensor_drive_read(sensor_cfg *cfg, int *reading, uint8_t *sensor_status);
-uint8_t pal_tmp75_init(sensor_cfg *cfg);
-uint8_t pal_tmp75_read(sensor_cfg *cfg, int *reading);
-uint8_t pal_emc1412_init(sensor_cfg *cfg);
-uint8_t pal_emc1412_read(sensor_cfg *cfg, int *reading);
-uint8_t pal_nvme_init(sensor_cfg *cfg);
-uint8_t pal_nvme_read(sensor_cfg *cfg, int *reading);
-uint8_t pal_ina233_init(sensor_cfg *cfg);
-uint8_t pal_ina233_read(sensor_cfg *cfg, int *reading);
-uint8_t pal_ltc2991_init(sensor_cfg *cfg);
-uint8_t pal_ltc2991_read(sensor_cfg *cfg, int *reading);
-uint8_t pal_xdpe12284c_init(sensor_cfg *cfg);
-uint8_t pal_xdpe12284c_read(sensor_cfg *cfg, int *reading);
+bool pal_sensor_drive_init(uint8_t card_id, sensor_cfg *cfg, uint8_t *init_status);
+bool pal_sensor_drive_read(uint8_t card_id, sensor_cfg *cfg, int *reading, uint8_t *sensor_status);
+uint8_t pal_tmp75_init(uint8_t card_id, sensor_cfg *cfg);
+uint8_t pal_tmp75_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
+uint8_t pal_emc1412_init(uint8_t card_id, sensor_cfg *cfg);
+uint8_t pal_emc1412_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
+uint8_t pal_nvme_init(uint8_t card_id, sensor_cfg *cfg);
+uint8_t pal_nvme_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
+uint8_t pal_ina233_init(uint8_t card_id, sensor_cfg *cfg);
+uint8_t pal_ina233_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
+uint8_t pal_ltc2991_init(uint8_t card_id, sensor_cfg *cfg);
+uint8_t pal_ltc2991_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
+uint8_t pal_xdpe12284c_init(uint8_t card_id, sensor_cfg *cfg);
+uint8_t pal_xdpe12284c_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
 bool cxl_single_ioexp_init(uint8_t ioexp_name);
 int cxl_ioexp_init(uint8_t cxl_channel);
-uint8_t pal_pm8702_read(sensor_cfg *cfg, int *reading);
-uint8_t pal_pm8702_init(sensor_cfg *cfg);
+uint8_t pal_pm8702_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
+uint8_t pal_pm8702_init(uint8_t card_id, sensor_cfg *cfg);
 void cxl_mb_status_init(uint8_t cxl_id);
 bool pal_init_pm8702_info(uint8_t cxl_id);
 bool pal_pm8702_command_handler(uint8_t pcie_card_id, uint16_t opcode, uint8_t *data_buf,

--- a/meta-facebook/at-mc/src/platform/plat_hook.c
+++ b/meta-facebook/at-mc/src/platform/plat_hook.c
@@ -44,47 +44,301 @@ mp5990_init_arg mp5990_init_args[] = {
 adc_asd_init_arg adc_asd_init_args[] = { [0] = { .is_init = false } };
 
 sq52205_init_arg sq52205_init_args[] = {
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[12] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 },
-	[13] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001 }
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[12] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[13] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
 };
 
 ina233_init_arg ina233_init_args[] = {
 	// JCN1
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// JCN2
-	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// JCN3
-	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// JCN4
-	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// JCN9
-	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// JCN10
-	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// JCN11
-	[12] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[13] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[12] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[13] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 	// JCN12
-	[14] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
-	[15] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[14] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[15] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
 };
 
 ltc2991_init_arg ltc2991_init_args[] = {

--- a/meta-facebook/at-mc/src/platform/plat_hook.c
+++ b/meta-facebook/at-mc/src/platform/plat_hook.c
@@ -61,17 +61,89 @@ sq52205_init_arg sq52205_init_args[] = {
 };
 
 ina233_init_arg ina233_init_args[] = {
+	// JCN1
 	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
 	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	// JCN2
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	// JCN3
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	// JCN4
+	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	// JCN9
+	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	// JCN10
+	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	// JCN11
+	[12] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[13] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	// JCN12
+	[14] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
+	[15] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005 },
 };
 
 ltc2991_init_arg ltc2991_init_args[] = {
+	// JCN1
 	[0] = { .is_init = false,
-		.v1_v4_control_operation.value = LTC2991_KEEP_DEFAULT_SETTING,
-		.v5_v8_control_operation.value = LTC2991_KEEP_DEFAULT_SETTING },
+		.v1_v4_control_operation.value = 0,
+		.v5_v8_control_operation.value = 0 },
 	[1] = { .is_init = false,
-		.v1_v4_control_operation.value = LTC2991_KEEP_DEFAULT_SETTING,
-		.v5_v8_control_operation.value = LTC2991_KEEP_DEFAULT_SETTING },
+		.v1_v4_control_operation.value = 0,
+		.v5_v8_control_operation.value = 0 },
+	// JCN2
+	[2] = { .is_init = false,
+		.v1_v4_control_operation.value = 0,
+		.v5_v8_control_operation.value = 0 },
+	[3] = { .is_init = false,
+		.v1_v4_control_operation.value = 0,
+		.v5_v8_control_operation.value = 0 },
+	// JCN3
+	[4] = { .is_init = false,
+		.v1_v4_control_operation.value = 0,
+		.v5_v8_control_operation.value = 0 },
+	[5] = { .is_init = false,
+		.v1_v4_control_operation.value = 0,
+		.v5_v8_control_operation.value = 0 },
+	// JCN4
+	[6] = { .is_init = false,
+		.v1_v4_control_operation.value = 0,
+		.v5_v8_control_operation.value = 0 },
+	[7] = { .is_init = false,
+		.v1_v4_control_operation.value = 0,
+		.v5_v8_control_operation.value = 0 },
+	// JCN9
+	[8] = { .is_init = false,
+		.v1_v4_control_operation.value = 0,
+		.v5_v8_control_operation.value = 0 },
+	[9] = { .is_init = false,
+		.v1_v4_control_operation.value = 0,
+		.v5_v8_control_operation.value = 0 },
+	// JCN10
+	[10] = { .is_init = false,
+		 .v1_v4_control_operation.value = 0,
+		 .v5_v8_control_operation.value = 0 },
+	[11] = { .is_init = false,
+		 .v1_v4_control_operation.value = 0,
+		 .v5_v8_control_operation.value = 0 },
+	// JCN11
+	[12] = { .is_init = false,
+		 .v1_v4_control_operation.value = 0,
+		 .v5_v8_control_operation.value = 0 },
+	[13] = { .is_init = false,
+		 .v1_v4_control_operation.value = 0,
+		 .v5_v8_control_operation.value = 0 },
+	// JCN12
+	[14] = { .is_init = false,
+		 .v1_v4_control_operation.value = 0,
+		 .v5_v8_control_operation.value = 0 },
+	[15] = { .is_init = false,
+		 .v1_v4_control_operation.value = 0,
+		 .v5_v8_control_operation.value = 0 },
 };
 
 /**************************************************************************************************

--- a/meta-facebook/at-mc/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-mc/src/platform/plat_sensor_table.c
@@ -48,6 +48,8 @@ LOG_MODULE_REGISTER(plat_sensor_table);
 #define CARD_13_E1S_1_MUX_CFG_INDEX 5
 #define CARD_14_E1S_0_MUX_CFG_INDEX 6
 #define CARD_14_E1S_1_MUX_CFG_INDEX 7
+#define PCIE_CARD_INIT_CFG_OFFSET_0 0
+#define PCIE_CARD_INIT_CFG_OFFSET_1 1
 
 struct k_mutex i2c_2_pca9548a_mutex;
 struct k_mutex i2c_3_pca9546a_mutex;
@@ -351,62 +353,62 @@ sensor_cfg plat_cxl_sensor_config[] = {
 	/** INA233 **/
 	{ SENSOR_NUM_VOL_P12V_STBY_4CP, sensor_dev_ina233, I2C_BUS2, CXL_U6_INA233_ADDR,
 	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0], &cxl_mux_configs[1] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[1] },
 	{ SENSOR_NUM_VOL_P3V3_STBY_4CP, sensor_dev_ina233, I2C_BUS2, CXL_U7_INA233_ADDR,
 	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[1], &cxl_mux_configs[1] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[1] },
 	{ SENSOR_NUM_CUR_P12V_STBY_4CP, sensor_dev_ina233, I2C_BUS2, CXL_U6_INA233_ADDR,
 	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0], &cxl_mux_configs[1] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[1] },
 	{ SENSOR_NUM_CUR_P3V3_STBY_4CP, sensor_dev_ina233, I2C_BUS2, CXL_U7_INA233_ADDR,
 	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[1], &cxl_mux_configs[1] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[1] },
 	{ SENSOR_NUM_PWR_P12V_STBY_4CP, sensor_dev_ina233, I2C_BUS2, CXL_U6_INA233_ADDR,
 	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0], &cxl_mux_configs[1] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[1] },
 	{ SENSOR_NUM_PWR_P3V3_STBY_4CP, sensor_dev_ina233, I2C_BUS2, CXL_U7_INA233_ADDR,
 	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[1], &cxl_mux_configs[1] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[1] },
 
 	/** Voltage monitor **/
 	{ SENSOR_NUM_VOL_P5V_STBY, sensor_dev_ltc2991, I2C_BUS2, CXL_U8_LTC2991_ADDR,
 	  LTC2991_READ_V3_VOLTAGE, stby_access, 711, 200, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ltc2991_init_args[0], &cxl_mux_configs[5] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[5] },
 	{ SENSOR_NUM_VOL_P1V8_ASIC, sensor_dev_ltc2991, I2C_BUS2, CXL_U8_LTC2991_ADDR,
 	  LTC2991_READ_V5_VOLTAGE, stby_access, 1, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ltc2991_init_args[0], &cxl_mux_configs[5] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[5] },
 	{ SENSOR_NUM_VOL_P12V_STBY, sensor_dev_ltc2991, I2C_BUS2, CXL_U8_LTC2991_ADDR,
 	  LTC2991_READ_V1_VOLTAGE, stby_access, 66, 10, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ltc2991_init_args[0], &cxl_mux_configs[5] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[5] },
 	{ SENSOR_NUM_VOL_P3V3_STBY, sensor_dev_ltc2991, I2C_BUS2, CXL_U8_LTC2991_ADDR,
 	  LTC2991_READ_V2_VOLTAGE, stby_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ltc2991_init_args[0], &cxl_mux_configs[5] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[5] },
 	{ SENSOR_NUM_VOL_PVPP_AB, sensor_dev_ltc2991, I2C_BUS2, CXL_U9_LTC2991_ADDR,
 	  LTC2991_READ_V1_VOLTAGE, stby_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ltc2991_init_args[1], &cxl_mux_configs[5] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[5] },
 	{ SENSOR_NUM_VOL_PVTT_AB, sensor_dev_ltc2991, I2C_BUS2, CXL_U9_LTC2991_ADDR,
 	  LTC2991_READ_V3_VOLTAGE, stby_access, 1, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ltc2991_init_args[1], &cxl_mux_configs[5] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[5] },
 	{ SENSOR_NUM_VOL_PVPP_CD, sensor_dev_ltc2991, I2C_BUS2, CXL_U9_LTC2991_ADDR,
 	  LTC2991_READ_V2_VOLTAGE, stby_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ltc2991_init_args[1], &cxl_mux_configs[5] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[5] },
 	{ SENSOR_NUM_VOL_PVTT_CD, sensor_dev_ltc2991, I2C_BUS2, CXL_U9_LTC2991_ADDR,
 	  LTC2991_READ_V4_VOLTAGE, stby_access, 1, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ltc2991_init_args[1], &cxl_mux_configs[5] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL,
+	  &cxl_mux_configs[5] },
 
 	/** VR Voltage **/
 	{ SENSOR_NUM_VOL_P0V8_ASICA, sensor_dev_xdpe12284c, I2C_BUS2, CXL_VR_A0V8_ADDR,
@@ -749,7 +751,7 @@ void pal_init_drive(sensor_cfg *cfg_table, uint8_t cfg_size, uint8_t device_type
 			continue;
 		}
 
-		ret = pal_sensor_drive_init(cfg, &init_status);
+		ret = pal_sensor_drive_init(card_id, cfg, &init_status);
 		if (ret == true) {
 			if (init_status != SENSOR_INIT_SUCCESS) {
 				LOG_ERR("Initial sensor drive fail, sensor num: 0x%x, card id: 0x%x",
@@ -765,5 +767,46 @@ void pal_init_drive(sensor_cfg *cfg_table, uint8_t cfg_size, uint8_t device_type
 			LOG_ERR("Post switch mux fail, sensor num: 0x%x, card id: 0x%x", sensor_num,
 				card_id);
 		}
+	}
+}
+
+void *get_pcie_init_sensor_config(uint8_t card_id, uint8_t sensor_number)
+{
+	int ret = -1;
+	uint8_t cxl_id = 0;
+
+	ret = pcie_card_id_to_cxl_e1s_id(card_id, &cxl_id);
+	if (ret != 0) {
+		LOG_ERR("Invalid card id: 0x%x", card_id);
+		return NULL;
+	}
+
+	uint8_t index = 0;
+	uint8_t offset = 2;
+
+	if (get_cxl_sensor_config_index(sensor_number, &index) != true) {
+		LOG_ERR("Fail to find initial config, card: 0x%x, sensor num: 0x%x", card_id,
+			sensor_number);
+		return NULL;
+	}
+
+	sensor_cfg cfg = plat_cxl_sensor_config[index];
+	switch (cfg.target_addr) {
+	case CXL_U6_INA233_ADDR:
+		offset = (offset * cxl_id) + PCIE_CARD_INIT_CFG_OFFSET_0;
+		return &ina233_init_args[offset];
+	case CXL_U7_INA233_ADDR:
+		offset = (offset * cxl_id) + PCIE_CARD_INIT_CFG_OFFSET_1;
+		return &ina233_init_args[offset];
+	case CXL_U8_LTC2991_ADDR:
+		offset = (offset * cxl_id) + PCIE_CARD_INIT_CFG_OFFSET_0;
+		return &ltc2991_init_args[offset];
+	case CXL_U9_LTC2991_ADDR:
+		offset = (offset * cxl_id) + PCIE_CARD_INIT_CFG_OFFSET_1;
+		return &ltc2991_init_args[offset];
+		break;
+	default:
+		LOG_ERR("Invalid cxl address: 0x%x", cfg.target_addr);
+		return NULL;
 	}
 }

--- a/meta-facebook/at-mc/src/platform/plat_sensor_table.h
+++ b/meta-facebook/at-mc/src/platform/plat_sensor_table.h
@@ -178,5 +178,6 @@ bool get_cxl_sensor_config_index(uint8_t sensor_num, uint8_t *index);
 bool get_pcie_card_mux_config(uint8_t dev_type, uint8_t card_id, uint8_t sensor_num,
 			      mux_config *card_mux_cfg, mux_config *cxl_mux_cfg);
 void pal_init_drive(sensor_cfg *cfg_table, uint8_t cfg_size, uint8_t device_type, uint8_t card_id);
+void *get_pcie_init_sensor_config(uint8_t card_id, uint8_t sensor_number);
 
 #endif


### PR DESCRIPTION
Summary:
- Set ina233 MFR adc config to accurate sensor reading.
- Correct pcie card ina233 and ltc2991 sensor initial setting.

Test Plan:
- Build code: Pass
- Get correct sensor reading: Pass
- Get ina233 sensor reading: Pass

Log:
- ACB
root@bmc-oob:~# sensor-util acb
acb:
......
ACB_P12V_ACCL1_V             (0x23) :   12.16 Volts | (ok)
ACB_P12V_ACCL2_V             (0x24) :   12.16 Volts | (ok)
ACB_P12V_ACCL3_V             (0x25) :   12.16 Volts | (ok)
ACB_P12V_ACCL4_V             (0x26) :   12.15 Volts | (ok)
ACB_P12V_ACCL5_V             (0x27) :   12.15 Volts | (ok)
ACB_P12V_ACCL6_V             (0x28) :   12.15 Volts | (ok)
ACB_P12V_ACCL7_V             (0x29) :   12.15 Volts | (ok)
ACB_P12V_ACCL8_V             (0x2A) :   12.15 Volts | (ok)
ACB_P12V_ACCL9_V             (0x2C) :   12.15 Volts | (ok)
ACB_P12V_ACCL10_V            (0x2D) :   12.15 Volts | (ok)
ACB_P12V_ACCL11_V            (0x2E) :   12.15 Volts | (ok)
ACB_P12V_ACCL12_V            (0x2F) :   12.15 Volts | (ok)
ACB_P12V_ACCL1_A             (0x34) :    1.57 Amps  | (ok)
ACB_P12V_ACCL2_A             (0x35) :    1.76 Amps  | (ok)
ACB_P12V_ACCL3_A             (0x36) :    1.80 Amps  | (ok)
ACB_P12V_ACCL4_A             (0x37) :    1.79 Amps  | (ok)
ACB_P12V_ACCL5_A             (0x38) :    1.85 Amps  | (ok)
ACB_P12V_ACCL6_A             (0x39) :    1.88 Amps  | (ok)
ACB_P12V_ACCL7_A             (0x3A) :    1.62 Amps  | (ok)
ACB_P12V_ACCL8_A             (0x3C) :    1.78 Amps  | (ok)
ACB_P12V_ACCL9_A             (0x3D) :    1.78 Amps  | (ok)
ACB_P12V_ACCL10_A            (0x3E) :    1.81 Amps  | (ok)
ACB_P12V_ACCL11_A            (0x3F) :    1.77 Amps  | (ok)
ACB_P12V_ACCL12_A            (0x40) :    1.82 Amps  | (ok)
ACB_P12V_ACCL1_W             (0x45) :   19.08 Watts | (ok)
ACB_P12V_ACCL2_W             (0x46) :   21.38 Watts | (ok)
ACB_P12V_ACCL3_W             (0x47) :   21.83 Watts | (ok)
ACB_P12V_ACCL4_W             (0x48) :   21.75 Watts | (ok)
ACB_P12V_ACCL5_W             (0x49) :   22.48 Watts | (ok)
ACB_P12V_ACCL6_W             (0x4A) :   22.83 Watts | (ok)
ACB_P12V_ACCL7_W             (0x4B) :   19.73 Watts | (ok)
ACB_P12V_ACCL8_W             (0x4C) :   21.58 Watts | (ok)
ACB_P12V_ACCL9_W             (0x4D) :   21.58 Watts | (ok)
ACB_P12V_ACCL10_W            (0x50) :   21.92 Watts | (ok)
ACB_P12V_ACCL11_W            (0x51) :   21.50 Watts | (ok)
ACB_P12V_ACCL12_W            (0x52) :   22.08 Watts | (ok)
......

- ACB FAC
root@bmc-oob:~# sensor-util acb_accl1
acb_accl1:
......
ACB_ACCL1_P12V_EFUSE_VOL_V   (0x3) :   12.13 Volts | (ok)
ACB_ACCL1_P3V3_1_VOL_V       (0x4) :    3.31 Volts | (ok)
ACB_ACCL1_P3V3_2_VOL_V       (0x5) :    3.32 Volts | (ok)
ACB_ACCL1_P12V_EFUSE_CUR_A   (0x8) :    1.57 Amps  | (ok)
ACB_ACCL1_P3V3_1_CUR_A       (0x9) :    2.79 Amps  | (ok)
ACB_ACCL1_P3V3_2_CUR_A       (0xA) :    2.72 Amps  | (ok)
ACB_ACCL1_P12V_EFUSE_PWR_W   (0xD) :   19.00 Watts | (ok)
ACB_ACCL1_P3V3_1_PWR_W       (0xE) :    9.25 Watts | (ok)
ACB_ACCL1_P3V3_2_PWR_W       (0xF) :    9.00 Watts | (ok)
......

- MEB CXL
root@bmc-oob:~# sensor-util meb_jcn1
meb_cxl8:
......
MEB_CXL8_P12V_STBY_4CP_VOL_V (0x3) :   12.13 Volts | (ok)
MEB_CXL8_P3V3_STBY_4CP_VOL_V (0x4) :    3.29 Volts | (ok)
MEB_CXL8_P12V_STBY_4CP_CUR_A (0x12) :    1.18 Amps  | (ok)
MEB_CXL8_P3V3_STBY_4CP_CUR_A (0x13) :    0.06 Amps  | (ok)
MEB_CXL8_P12V_STBY_4CP_PWR_W (0x19) :   14.50 Watts | (ok)
MEB_CXL8_P3V3_STBY_4CP_PWR_W (0x1A) :    0.20 Watts | (ok)
......