### PR TITLE
GT: Modify SPI1 max frequency to 33.5 MHz

### DIFF
--- a/meta-facebook/gt-cc/boards/ast1030_evb.overlay
+++ b/meta-facebook/gt-cc/boards/ast1030_evb.overlay
@@ -149,7 +149,7 @@
 &spi1_cs0 {
 	status = "okay";
 	spi-max-buswidth = <1>;
-	spi-max-frequency = <33000000>;
+	spi-max-frequency = <33500000>;
 	re-init-support;
 };
 


### PR DESCRIPTION
Summary:
- Because ASPEED ast1030 SPI clock frequency setting close to 33 MHz are 40 MHz, 33.33 MHz and 28.57 MHz. The SPI max frequency setting to 33 MHz will be set to 28.57 MHz because 33.33 MHz is greater than 33 MHz, but we want the frequency to be close to 33 MHz as the EA team recommend.

Test Plan:
- Build code: Pass