### PR TITLE
fby35: cl: Update sensor threshold

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
@@ -77,7 +77,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x96, // UNRT
-		0x30, // UCT
+		0x34, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -138,7 +138,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x96, // UNRT
-		0x5D, // UCT
+		0x53, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -199,7 +199,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x28, // UCT
+		0x2B, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -321,7 +321,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x54, // UCT
+		0x4D, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -443,7 +443,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
+		0x50, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -504,7 +504,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
+		0x50, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -565,7 +565,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
+		0x50, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -626,7 +626,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
+		0x50, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -687,7 +687,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
+		0x50, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -748,7 +748,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
+		0x50, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -870,7 +870,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x4A, // UCT
+		0x4B, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -3130,7 +3130,7 @@ SDR_Full_sensor hotswap_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x56, // UCT
+		0x50, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT


### PR DESCRIPTION
Summary:
Update CL sensor threshold

Test Plan:
1. Build and test pass on yv3.5 system pass

2. Check the sensor threshold root@bmc-oob:~# sensor-util slot1 --thres
slot1:
MB_INLET_TEMP_C              (0x1) :   35.00 C     | (ok) | UCR: 52.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA MB_OUTLET_TEMP_C             (0x2) :   52.75 C     | (ok) | UCR: 83.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA FIO_FRONT_TEMP_C             (0x3) :   26.20 C     | (ok) | UCR: 43.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_PCH_TEMP_C                (0x4) :   56.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_SOC_CPU_TEMP_C            (0x5) :   51.00 C     | (ok) | UCR: 77.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_SOC_THERMAL_MARGIN_C      (0x14) :  -26.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA MB_SOC_TJMAX_C               (0x15) :   77.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA MB_DIMMA0_TEMP_C             (0x6) :   51.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_DIMMA2_TEMP_C             (0x7) :   51.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_DIMMA3_TEMP_C             (0x9) :   49.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_DIMMA4_TEMP_C             (0xA) :   51.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_DIMMA6_TEMP_C             (0xB) :   48.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_DIMMA7_TEMP_C             (0xC) :   45.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_SSD0_M2A_TEMP_C           (0xD) :   38.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_HSC_TEMP_C                (0xE) :   50.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA MB_VR_VCCIN_TEMP_C           (0xF) :   57.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA MB_VR_FIVRA_TEMP_C           (0x10) :   53.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA MB_VR_EHV_TEMP_C             (0x11) :   49.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA MB_VR_VCCD_TEMP_C            (0x12) :   47.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA MB_VR_FAON_TEMP_C            (0x13) :   50.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA MB_ADC_P12V_STBY_VOLT_V      (0x20) :   12.73 Volts  | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08 MB_ADC_P3V_BAT_VOLT_V        (0x21) :    3.11 Volts  | (ok) | UCR: 3.51 | UNC: 3.46 | UNR: NA | LCR: 2.76 | LNC: 2.79 | LNR: NA MB_ADC_P3V3_STBY_VOLT_V      (0x22) :    3.35 Volts  | (ok) | UCR: 3.56 | UNC: 3.53 | UNR: 4.00 | LCR: 3.04 | LNC: 3.08 | LNR: 2.30 MB_ADC_P1V8_STBY_VOLT_V      (0x23) :    1.80 Volts  | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.09 | LCR: 1.67 | LNC: 1.69 | LNR: 1.44 MB_ADC_P1V05_PCH_VOLT_V      (0x24) :    1.05 Volts  | (ok) | UCR: 1.12 | UNC: 1.10 | UNR: 1.22 | LCR: 0.97 | LNC: 0.98 | LNR: 0.84 MB_ADC_P5V_STBY_VOLT_V       (0x25) :    5.04 Volts  | (ok) | UCR: 5.40 | UNC: 5.35 | UNR: 5.80 | LCR: 4.59 | LNC: 4.64 | LNR: 4.00 MB_ADC_P12V_DIMM_VOLT_V      (0x26) :   12.65 Volts  | (ok) | UCR: 14.21 | UNC: 14.07 | UNR: NA | LCR: 9.87 | LNC: 10.01 | LNR: NA MB_ADC_P1V2_STBY_VOLT_V      (0x27) :    1.20 Volts  | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.39 | LCR: 1.10 | LNC: 1.12 | LNR: 0.96 MB_ADC_P3V3_M2_VOLT_V        (0x28) :    3.33 Volts  | (ok) | UCR: 3.71 | UNC: 3.67 | UNR: NA | LCR: 2.91 | LNC: 2.94 | LNR: NA MB_HSC_INPUT_VOLT_V          (0x29) :   12.52 Volts  | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08 MB_VR_VCCIN_VOLT_V           (0x2A) :    1.79 Volts  | (ok) | UCR: 1.93 | UNC: 1.91 | UNR: 2.20 | LCR: 1.46 | LNC: 1.48 | LNR: 0.40 MB_VR_FIVRA_VOLT_V           (0x2C) :    1.80 Volts  | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.20 | LCR: 1.69 | LNC: 1.71 | LNR: 0.40 MB_VR_EHV_VOLT_V             (0x2D) :    1.80 Volts  | (ok) | UCR: 1.90 | UNC: 1.88 | UNR: 2.20 | LCR: 1.70 | LNC: 1.72 | LNR: 0.40 MB_VR_VCCD_VOLT_V            (0x2E) :    1.14 Volts  | (ok) | UCR: 1.23 | UNC: 1.21 | UNR: 1.50 | LCR: 1.05 | LNC: 1.06 | LNR: 0.40 MB_VR_FAON_VOLT_V            (0x2F) :    1.06 Volts  | (ok) | UCR: 1.11 | UNC: 1.10 | UNR: 1.48 | LCR: 0.90 | LNC: 0.91 | LNR: 0.40 MB_HSC_OUTPUT_CURR_A         (0x30) :    6.44 Amps  | (ok) | UCR: 31.96 | UNC: 28.73 | UNR: 39.95 | LCR: NA | LNC: NA | LNR: NA MB_VR_VCCIN_CURR_A           (0x31) :    7.19 Amps  | (ok) | UCR: 141.18 | UNC: 119.34 | UNR: 180.18 | LCR: NA | LNC: NA | LNR: NA MB_VR_FIVRA_CURR_A           (0x32) :    2.69 Amps  | (ok) | UCR: 53.01 | UNC: 48.05 | UNR: 70.99 | LCR: NA | LNC: NA | LNR: NA MB_VR_EHV_CURR_A             (0x33) :    0.00 Amps  | (ok) | UCR: 6.24 | UNC: 5.04 | UNR: 18.00 | LCR: NA | LNC: NA | LNR: NA MB_VR_VCCD_CURR_A            (0x34) :    0.06 Amps  | (ok) | UCR: 30.02 | UNC: 26.98 | UNR: 42.94 | LCR: NA | LNC: NA | LNR: NA MB_VR_FAON_CURR_A            (0x35) :    6.69 Amps  | (ok) | UCR: 46.02 | UNC: 42.12 | UNR: 60.06 | LCR: NA | LNC: NA | LNR: NA MB_SOC_PACKAGE_PWR_W         (0x38) :   37.00 Watts  | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_HSC_INPUT_PWR_W           (0x39) :   69.78 Watts  | (ok) | UCR: 399.28 | UNC: 360.22 | UNR: 499.10 | LCR: NA | LNC: NA | LNR: NA MB_VR_VCCIN_PWR_W            (0x3A) :   11.88 Watts  | (ok) | UCR: 253.80 | UNC: 214.32 | UNR: 324.30 | LCR: NA | LNC: NA | LNR: NA MB_VR_FIVRA_PWR_W            (0x3C) :    4.62 Watts  | (ok) | UCR: 95.19 | UNC: 86.64 | UNR: 127.68 | LCR: NA | LNC: NA | LNR: NA MB_VR_EHV_PWR_W              (0x3D) :    0.00 Watts  | (ok) | UCR: 11.25 | UNC: 8.97 | UNR: 32.38 | LCR: NA | LNC: NA | LNR: NA MB_VR_VCCD_PWR_W             (0x3E) :    0.38 Watts  | (ok) | UCR: 34.32 | UNC: 31.02 | UNR: 49.28 | LCR: NA | LNC: NA | LNR: NA MB_VR_FAON_PWR_W             (0x3F) :    6.88 Watts  | (ok) | UCR: 49.28 | UNC: 45.08 | UNR: 64.12 | LCR: NA | LNC: NA | LNR: NA MB_VR_DIMMA0_PMIC_PWR_W      (0x1E) :    0.38 Watts  | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_VR_DIMMA2_PMIC_PWR_W      (0x1F) :    0.38 Watts  | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_VR_DIMMA3_PMIC_PWR_W      (0x36) :    0.12 Watts  | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_VR_DIMMA4_PMIC_PWR_W      (0x37) :    0.38 Watts  | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_VR_DIMMA6_PMIC_PWR_W      (0x42) :    0.50 Watts  | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA MB_VR_DIMMA7_PMIC_PWR_W      (0x47) :    0.25 Watts  | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA VF_E1S_OUTLET_TEMP_C         (0x50) :   33.00 C     | (ok) | UCR: 70.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA VF_E1S_P12V_AUX_VOLT_V       (0x51) :   12.51 Volts  | (ok) | UCR: 13.14 | UNC: NA | UNR: NA | LCR: 10.85 | LNC: NA | LNR: NA VF_E1S_P12V_EDGE_VOLT_V      (0x52) :   12.44 Volts  | (ok) | UCR: 13.14 | UNC: NA | UNR: NA | LCR: 10.85 | LNC: NA | LNR: NA VF_E1S_P3V3_AUX_VOLT_V       (0x53) :    3.32 Volts  | (ok) | UCR: 3.48 | UNC: NA | UNR: NA | LCR: 3.11 | LNC: NA | LNR: NA VF_E1S_P1V2_STBY_VOLT_V      (0x58) :    1.20 Volts  | (ok) | UCR: 1.26 | UNC: NA | UNR: NA | LCR: 1.14 | LNC: NA | LNR: NA VF_E1S_SSD0_PWR_WATT_W       (0x60) :    2.92 Watts  | (ok) | UCR: 15.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA VF_E1S_SSD0_VOLT_V           (0x61) :   12.52 Volts  | (ok) | UCR: 13.14 | UNC: NA | UNR: NA | LCR: 10.85 | LNC: NA | LNR: NA VF_E1S_SSD0_TEMP_C           (0x62) :   41.00 C     | (ok) | UCR: 76.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA VF_E1S_SSD0_3V3_ADC_VOLT_V   (0x64) :    3.32 Volts  | (ok) | UCR: 3.48 | UNC: NA | UNR: NA | LCR: 3.11 | LNC: NA | LNR: NA VF_E1S_SSD0_12V_ADC_VOLT_V   (0x63) :   12.56 Volts  | (ok) | UCR: 13.14 | UNC: NA | UNR: NA | LCR: 10.85 | LNC: NA | LNR: NA VF_E1S_SSD1_PWR_WATT_W       (0x68) :    2.90 Watts  | (ok) | UCR: 15.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA VF_E1S_SSD1_VOLT_V           (0x69) :   12.51 Volts  | (ok) | UCR: 13.14 | UNC: NA | UNR: NA | LCR: 10.85 | LNC: NA | LNR: NA VF_E1S_SSD1_TEMP_C           (0x6A) :   40.00 C     | (ok) | UCR: 76.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA VF_E1S_SSD1_3V3_ADC_VOLT_V   (0x6C) :    3.31 Volts  | (ok) | UCR: 3.48 | UNC: NA | UNR: NA | LCR: 3.11 | LNC: NA | LNR: NA VF_E1S_SSD1_12V_ADC_VOLT_V   (0x6B) :   12.64 Volts  | (ok) | UCR: 13.14 | UNC: NA | UNR: NA | LCR: 10.85 | LNC: NA | LNR: NA VF_E1S_SSD2_PWR_WATT_W       (0x70) : NA | (na)
VF_E1S_SSD2_VOLT_V           (0x71) : NA | (na)
VF_E1S_SSD2_TEMP_C           (0x72) : NA | (na)
VF_E1S_SSD2_3V3_ADC_VOLT_V   (0x74) : NA | (na)
VF_E1S_SSD2_12V_ADC_VOLT_V   (0x73) : NA | (na)
VF_E1S_SSD3_PWR_WATT_W       (0x78) :    2.88 Watts  | (ok) | UCR: 15.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA VF_E1S_SSD3_VOLT_V           (0x79) :   12.52 Volts  | (ok) | UCR: 13.14 | UNC: NA | UNR: NA | LCR: 10.85 | LNC: NA | LNR: NA VF_E1S_SSD3_TEMP_C           (0x7A) :   40.00 C     | (ok) | UCR: 76.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA VF_E1S_SSD3_3V3_ADC_VOLT_V   (0x7C) :    3.32 Volts  | (ok) | UCR: 3.48 | UNC: NA | UNR: NA | LCR: 3.11 | LNC: NA | LNR: NA VF_E1S_SSD3_12V_ADC_VOLT_V   (0x7B) :   12.56 Volts  | (ok) | UCR: 13.14 | UNC: NA | UNR: NA | LCR: 10.85 | LNC: NA | LNR: NA