### PR TITLE
Artemis: mc: Version commit for obat-mc-2023.12.01

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_version.h
+++ b/meta-facebook/at-mc/src/platform/plat_version.h
@@ -33,7 +33,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x03
+#define FIRMWARE_REVISION_2 0x04
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -42,7 +42,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x23
-#define BIC_FW_WEEK 0x08
+#define BIC_FW_WEEK 0x12
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x6d // char: m
 #define BIC_FW_platform_1 0x63 // char: c


### PR DESCRIPTION
Summary:
- Version commit for MooseCreek BIC obat-mc-2023.12.01

Test Plan:
- Build code: Pass
- Get version: Pass

Log:
root@bmc-oob:~# fw-util meb --version bic
MEB BIC Version: 2023.12.01