### PR TITLE
Artemis: mc: Improve implementation of IOexp interrupt

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_dev.c
+++ b/meta-facebook/at-mc/src/platform/plat_dev.c
@@ -36,6 +36,7 @@
 #include "plat_mctp.h"
 #include "plat_hook.h"
 #include "plat_class.h"
+#include "hal_gpio.h"
 
 LOG_MODULE_REGISTER(plat_dev);
 
@@ -57,7 +58,7 @@ LOG_MODULE_REGISTER(plat_dev);
 #define CXL_IOEXP_U14_CONFIG_1_REG_VAL 0xFF
 #define CXL_IOEXP_U15_CONFIG_0_REG_VAL 0x21
 #define CXL_IOEXP_U15_CONFIG_1_REG_VAL 0xFE
-#define CXL_IOEXP_U16_CONFIG_0_REG_VAL 0x84
+#define CXL_IOEXP_U16_CONFIG_0_REG_VAL 0x00
 #define CXL_IOEXP_U16_CONFIG_1_REG_VAL 0x00
 #define CXL_IOEXP_U17_CONFIG_0_REG_VAL 0xFF
 #define CXL_IOEXP_U17_CONFIG_1_REG_VAL 0xFF
@@ -969,6 +970,10 @@ int cxl_ioexp_init(uint8_t cxl_channel)
 	cxl_single_ioexp_config_init(IOEXP_U15);
 	cxl_single_ioexp_config_init(IOEXP_U16);
 	cxl_single_ioexp_config_init(IOEXP_U17);
+
+	if (check_cxl_power_status() == CXL_NOT_ALL_POWER_GOOD) {
+		set_cxl_device_reset_pin(HIGH_INACTIVE);
+	}
 
 	/** mutex unlock bus **/
 	k_mutex_unlock(meb_mutex);

--- a/meta-facebook/at-mc/src/platform/plat_init.c
+++ b/meta-facebook/at-mc/src/platform/plat_init.c
@@ -119,7 +119,7 @@ void pal_pre_init()
 				continue;
 			}
 
-			init_cxl_set_eid_work();
+			init_cxl_work();
 		}
 
 		if (I2C_TARGET_ENABLE_TABLE[index])

--- a/meta-facebook/at-mc/src/platform/plat_isr.h
+++ b/meta-facebook/at-mc/src/platform/plat_isr.h
@@ -29,10 +29,12 @@
 #define CXL_IOEXP_ASIC_PERESET_BIT BIT(6)
 #define CXL_IOEXP_CONTROLLER_PWRGD_VAL 0x7F
 #define CXL_IOEXP_DIMM_PWRGD_VAL 0x07
-#define CXL_IOEXP_BUTTON_PRESS_DELAY_MS 1
+#define CXL_NOT_ALL_POWER_GOOD 0
+#define CXL_ALL_POWER_GOOD 1
 
 #define CXL_CONTROLLER_MUX_CHANNEL 0x01
-#define CXL_DRIVE_READY_DELAY_MS 3000
+#define CXL_DRIVE_READY_DELAY_MS 1000
+#define CXL_POWER_GOOD_DELAY_MS 12
 
 enum IOEXP_NAME {
 	IOEXP_U14,
@@ -51,6 +53,9 @@ void ISR_CXL_IOEXP_ALERT5();
 void ISR_CXL_IOEXP_ALERT6();
 void ISR_CXL_IOEXP_ALERT7();
 
-void init_cxl_set_eid_work();
+void init_cxl_work();
+int check_cxl_power_status();
+int set_cxl_device_reset_pin(uint8_t val);
+void cxl_ioexp_alert_handler(struct k_work *work_item);
 
 #endif

--- a/meta-facebook/at-mc/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-mc/src/platform/plat_sensor_table.c
@@ -455,7 +455,7 @@ sensor_cfg plat_cxl_sensor_config[] = {
 	/** VR Power **/
 	{ SENSOR_NUM_PWR_P0V8_ASICA, sensor_dev_xdpe12284c, I2C_BUS2, CXL_VR_A0V8_ADDR,
 	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_cxl_vr_read, &vr_page_select[0],
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_cxl_vr_read, &vr_page_select[1],
 	  post_cxl_xdpe12284c_read, NULL, NULL, &cxl_mux_configs[3] },
 	{ SENSOR_NUM_PWR_P0V9_ASICA, sensor_dev_xdpe12284c, I2C_BUS2, CXL_VR_A0V9_ADDR,
 	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
@@ -467,7 +467,7 @@ sensor_cfg plat_cxl_sensor_config[] = {
 	  post_cxl_xdpe12284c_read, NULL, NULL, &cxl_mux_configs[3] },
 	{ SENSOR_NUM_PWR_PVDDQ_AB, sensor_dev_xdpe12284c, I2C_BUS2, CXL_VR_VDDQAB_ADDR,
 	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_cxl_vr_read, &vr_page_select[0],
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_cxl_vr_read, &vr_page_select[1],
 	  post_cxl_xdpe12284c_read, NULL, NULL, &cxl_mux_configs[3] },
 	{ SENSOR_NUM_PWR_PVDDQ_CD, sensor_dev_xdpe12284c, I2C_BUS2, CXL_VR_VDDQCD_ADDR,
 	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,


### PR DESCRIPTION
Summary:
- Improve implementation of IOexp interrupt
  - Add flag to the respective CXL to confirm whether to reset device and pe-reset.
  - Push the work of checking IOexp status to system workq when the interrupt was triggered.
  - Set cxl device reset pin keep low until all power good.
  - Add debug message in device reset/pe-reset function.
- Correct CXL VR page setting.

Test Plan:
- Build code: Pass
- Check BIC will pull device reset when cxl power good: Pass
- Host can detect PM8702 device: Pass

Log:
- Host can detect PM8702 device when 4 CXL with 4 DIMM present. [root@system7_slot1 ~]# lspci | grep 8702
74:00.0 CXL: PMC-Sierra Inc. Device 8702
8f:00.0 CXL: PMC-Sierra Inc. Device 8702
a7:00.0 CXL: PMC-Sierra Inc. Device 8702
be:00.0 CXL: PMC-Sierra Inc. Device 8702