### PR TITLE
Common: Modify PLDM firmware update related function

### DIFF
--- a/common/dev/include/isl69259.h
+++ b/common/dev/include/isl69259.h
@@ -21,7 +21,12 @@
 #define TWO_COMPLEMENT_NEGATIVE_BIT BIT(15)
 #define ADJUST_IOUT_RANGE 2
 
-bool isl69259_fwupdate(uint8_t bus, uint8_t addr, uint8_t *hex_buff);
+struct isl69259_config {
+	uint8_t *buff;
+	uint32_t len;
+};
+
+bool isl69259_fwupdate(uint8_t bus, uint8_t addr, uint8_t *img_buff, uint32_t img_size);
 bool isl69259_get_raa_hex_mode(uint8_t bus, uint8_t addr, uint8_t *mode);
 bool isl69259_get_raa_crc(uint8_t bus, uint8_t addr, uint8_t mode, uint32_t *crc);
 bool get_raa_remaining_wr(uint8_t bus, uint8_t addr, uint8_t mode, uint16_t *remain);

--- a/common/dev/include/mp2971.h
+++ b/common/dev/include/mp2971.h
@@ -18,7 +18,7 @@
 
 #include "stdint.h"
 
-bool mp2971_fwupdate(uint8_t bus, uint8_t addr, uint8_t *hex_buff);
+bool mp2971_fwupdate(uint8_t bus, uint8_t addr, uint8_t *img_buff, uint32_t img_size);
 bool mp2971_get_checksum(uint8_t bus, uint8_t addr, uint32_t *checksum);
 
 #endif

--- a/common/dev/include/xdpe12284c.h
+++ b/common/dev/include/xdpe12284c.h
@@ -19,7 +19,7 @@
 
 bool xdpe12284c_get_checksum(uint8_t bus, uint8_t target_addr, uint8_t *checksum);
 bool xdpe12284c_get_remaining_write(uint8_t bus, uint8_t target_addr, uint16_t *remain_write);
-bool xdpe12284c_fwupdate(uint8_t bus, uint8_t addr, uint8_t *hex_buff);
+bool xdpe12284c_fwupdate(uint8_t bus, uint8_t addr, uint8_t *img_buff, uint32_t img_size);
 
 enum INFINEON_PAGE {
 	INFINEON_STATUS_PAGE = 0x60,

--- a/common/service/pldm/pldm.h
+++ b/common/service/pldm/pldm.h
@@ -31,8 +31,11 @@ extern "C" {
 
 #define MONITOR_THREAD_STACK_SIZE 1024
 
-#define PLDM_MAX_DATA_SIZE 512
+#define PLDM_MAX_DATA_SIZE_DEFAULT 512
 
+#ifndef PLDM_MAX_DATA_SIZE
+#define PLDM_MAX_DATA_SIZE PLDM_MAX_DATA_SIZE_DEFAULT
+#endif
 typedef uint8_t (*pldm_cmd_proc_fn)(void *, uint8_t *, uint16_t, uint8_t, uint8_t *, uint16_t *,
 				    void *);
 

--- a/common/service/pldm/pldm_firmware_update.h
+++ b/common/service/pldm/pldm_firmware_update.h
@@ -26,11 +26,11 @@ extern "C" {
 #define MAX_FWUPDATE_RSP_BUF_SIZE 256
 #define MAX_IMAGE_MALLOC_SIZE (1024 * 64)
 
-#define KEYWORD_VR_ISL69259 "renesas_isl69259"
-#define KEYWORD_VR_XDPE12284C "infineon_xdpe12284c"
-#define KEYWORD_VR_MP2971 "mps_mp2971"
+#define KEYWORD_VR_ISL69259 "isl69259"
+#define KEYWORD_VR_XDPE12284C "xdpe12284c"
+#define KEYWORD_VR_MP2971 "mp2971"
 
-#define KEYWORD_CPLD_LATTICE "lattice"
+#define KEYWORD_CPLD_LATTICE "LCMXO3-9400C"
 
 static const char hex_to_ascii[] = { '0', '1', '2', '3', '4', '5', '6', '7',
 				     '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
@@ -266,6 +266,7 @@ typedef struct pldm_fw_update_info {
 	uint16_t activate_method;
 	pldm_act_func self_act_func;
 	pldm_get_fw_version_fn get_fw_version_fn;
+	uint8_t *pending_version_p;
 } pldm_fw_update_info_t;
 extern pldm_fw_update_info_t *comp_config;
 extern uint8_t comp_config_count;

--- a/meta-facebook/gt-cc/CMakeLists.txt
+++ b/meta-facebook/gt-cc/CMakeLists.txt
@@ -50,3 +50,4 @@ target_include_directories(app PRIVATE src/shell)
 target_compile_options(app PRIVATE -Werror)
 
 add_compile_definitions(PLDM_MONITOR_EVENT_QUEUE_MSG_NUM_MAX=30)
+add_compile_definitions(PLDM_MAX_DATA_SIZE=1024)

--- a/meta-facebook/gt-cc/src/platform/plat_isr.c
+++ b/meta-facebook/gt-cc/src/platform/plat_isr.c
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+#include <stdlib.h>
+#include <stdio.h>
 #include <logging/log.h>
 
 #include "libipmi.h"
@@ -33,6 +34,7 @@
 #include "plat_hook.h"
 #include "plat_pldm_monitor.h"
 #include "plat_led.h"
+#include "plat_pldm_fw_update.h"
 
 LOG_MODULE_REGISTER(plat_isr);
 
@@ -102,6 +104,8 @@ void ISR_DC_ON()
 	if (is_mb_dc_on()) {
 		k_work_schedule(&dc_on_send_cmd_to_dev_work, K_SECONDS(DC_ON_5_SECOND));
 		k_work_schedule(&dc_on_init_pex_work, K_SECONDS(DC_ON_5_SECOND));
+
+		clear_pending_version(COMP_ACT_DC_PWR_CYCLE);
 	}
 	pwr_led_check();
 }

--- a/meta-facebook/gt-cc/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/gt-cc/src/platform/plat_pldm_fw_update.c
@@ -529,3 +529,16 @@ post_hook_and_ret:
 
 	return ret;
 }
+
+void clear_pending_version(uint8_t activate_method)
+{
+	if (!comp_config || !comp_config_count) {
+		LOG_ERR("Component configuration is empty");
+		return;
+	}
+
+	for (uint8_t i = 0; i < comp_config_count; i++) {
+		if (comp_config[i].activate_method == activate_method)
+			SAFE_FREE(comp_config[i].pending_version_p);
+	}
+}

--- a/meta-facebook/gt-cc/src/platform/plat_pldm_fw_update.h
+++ b/meta-facebook/gt-cc/src/platform/plat_pldm_fw_update.h
@@ -22,5 +22,6 @@
 #include "pldm_firmware_update.h"
 
 void load_pldmupdate_comp_config(void);
+void clear_pending_version(uint8_t activate_method);
 
 #endif /* _PLAT_FWUPDATE_H_ */


### PR DESCRIPTION
Summary:
- Modify VR firmware update related function.(MP2971, ISL69269, and XDPE12284).
- Change the keyword pattern to a shorter chip name for each component.
- Define PLDM_MAX_DATA_SIZE by each platform code in CMakeLists.txt or use the default value if no define.
- Add pending version in GetFirmwareParameters after a component has been updated but is not active yet.

Test Plan:
- Build code: Pass