### PR TITLE
yv35: cl: remove I3C static address of I3C bus to BIC

### DIFF
--- a/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
@@ -122,7 +122,6 @@
 
 &i3c0 {
 	status = "okay";
-	assigned-address = <0x9>;
 	pinctrl-0 = <&pinctrl_hvi3c0_default>;
 	i3c-scl-hz = <8000000>;
 	secondary;


### PR DESCRIPTION
Summary:
1. Remove I3C static address of I3C bus to BIC since we use ENTDAA to assign address in CL.

Test plan:
1. Build and test pass on yv35 system.

2. I3C communication works normally. root@bmc-oob:~# bic-util slot2 0x18 0x1
00 80 31 04 02 BF 15 A0 00 00 00 00 00 00 00