### PR TITLE
at: mc: remove mutex lock in interrupt handler and modify ioexp init

### DIFF
--- a/common/dev/common_i2c_mux.c
+++ b/common/dev/common_i2c_mux.c
@@ -22,7 +22,7 @@
 
 LOG_MODULE_REGISTER(common_i2c_mux);
 
-bool set_mux_channel(mux_config mux_cfg)
+bool set_mux_channel(mux_config mux_cfg, bool is_mutex)
 {
 	int status = 0;
 	int retry = 5;
@@ -34,11 +34,20 @@ bool set_mux_channel(mux_config mux_cfg)
 	mux_msg.tx_len = 1;
 	mux_msg.data[0] = mux_cfg.channel;
 
-	status = i2c_master_write(&mux_msg, retry);
-	if (status != 0) {
-		LOG_ERR("set channel fail, status: %d, bus: %d, addr: 0x%x", status, mux_cfg.bus,
-			mux_cfg.target_addr);
-		return false;
+	if (is_mutex) {
+		status = i2c_master_write(&mux_msg, retry);
+		if (status != 0) {
+			LOG_ERR("set channel fail, status: %d, bus: %d, addr: 0x%x", status,
+				mux_cfg.bus, mux_cfg.target_addr);
+			return false;
+		}
+	} else {
+		status = i2c_master_write_without_mutex(&mux_msg, retry);
+		if (status != 0) {
+			LOG_ERR("set channel fail without mutex, status: %d, bus: %d, addr: 0x%x",
+				status, mux_cfg.bus, mux_cfg.target_addr);
+			return false;
+		}
 	}
 
 	return true;

--- a/common/dev/include/common_i2c_mux.h
+++ b/common/dev/include/common_i2c_mux.h
@@ -26,6 +26,6 @@ typedef struct _mux_config {
 	uint8_t channel;
 } mux_config;
 
-bool set_mux_channel(mux_config mux_cfg);
+bool set_mux_channel(mux_config mux_cfg, bool is_mutex);
 
 #endif

--- a/common/hal/hal_i2c.h
+++ b/common/hal/hal_i2c.h
@@ -87,6 +87,8 @@
 #define DEV_I2C(n) DEV_I2C_##n
 
 #define I2C_BUFF_SIZE 256
+#define MUTEX_LOCK_ENABLE true
+#define MUTEX_LOCK_DISENABLE false
 
 enum I2C_TRANSFER_TYPE {
 	I2C_READ,
@@ -104,7 +106,9 @@ typedef struct _I2C_MSG_ {
 
 int i2c_freq_set(uint8_t i2c_bus, uint8_t i2c_speed_mode, uint8_t en_slave);
 int i2c_master_read(I2C_MSG *msg, uint8_t retry);
+int i2c_master_read_without_mutex(I2C_MSG *msg, uint8_t retry);
 int i2c_master_write(I2C_MSG *msg, uint8_t retry);
+int i2c_master_write_without_mutex(I2C_MSG *msg, uint8_t retry);
 void i2c_scan(uint8_t bus, uint8_t *target_addr, uint8_t *target_addr_len);
 void util_init_I2C(void);
 int check_i2c_bus_valid(uint8_t bus);

--- a/meta-facebook/at-cb/src/platform/plat_class.c
+++ b/meta-facebook/at-cb/src/platform/plat_class.c
@@ -296,7 +296,7 @@ void check_asic_card_status()
 			continue;
 		}
 
-		ret = set_mux_channel(i2c_mux);
+		ret = set_mux_channel(i2c_mux, MUTEX_LOCK_ENABLE);
 		if (ret != true) {
 			LOG_ERR("Switch ASIC%d mux fail", index);
 			k_mutex_unlock(mutex);

--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -585,7 +585,7 @@ bool pre_ina233_read(uint8_t sensor_num, void *args)
 		return false;
 	}
 
-	ret = set_mux_channel(*pre_args);
+	ret = set_mux_channel(*pre_args, MUTEX_LOCK_ENABLE);
 	if (ret == false) {
 		LOG_ERR("ina233 switch mux fail");
 		k_mutex_unlock(mutex);
@@ -685,7 +685,7 @@ bool pre_pex89000_read(uint8_t sensor_num, void *args)
 		return false;
 	}
 
-	ret = set_mux_channel(*pre_args);
+	ret = set_mux_channel(*pre_args, MUTEX_LOCK_ENABLE);
 	if (ret == false) {
 		LOG_ERR("pex switch mux fail");
 		k_mutex_unlock(mutex);
@@ -754,14 +754,14 @@ bool pre_accl_mux_switch(uint8_t card_id, uint8_t sensor_num)
 		return false;
 	}
 
-	ret = set_mux_channel(accl_mux);
+	ret = set_mux_channel(accl_mux, MUTEX_LOCK_ENABLE);
 	if (ret == false) {
 		LOG_ERR("ACCL switch mux fail");
 		k_mutex_unlock(mutex);
 		return false;
 	}
 
-	ret = set_mux_channel(channel_mux);
+	ret = set_mux_channel(channel_mux, MUTEX_LOCK_ENABLE);
 	if (ret == false) {
 		LOG_ERR("ACCL switch mux fail");
 		k_mutex_unlock(mutex);

--- a/meta-facebook/at-mc/src/platform/plat_dev.h
+++ b/meta-facebook/at-mc/src/platform/plat_dev.h
@@ -42,7 +42,7 @@ uint8_t pal_ltc2991_init(uint8_t card_id, sensor_cfg *cfg);
 uint8_t pal_ltc2991_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
 uint8_t pal_xdpe12284c_init(uint8_t card_id, sensor_cfg *cfg);
 uint8_t pal_xdpe12284c_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
-bool cxl_single_ioexp_init(uint8_t ioexp_name);
+bool cxl_single_ioexp_alert_reset(uint8_t ioexp_name, bool is_mutex);
 int cxl_ioexp_init(uint8_t cxl_channel);
 uint8_t pal_pm8702_read(uint8_t card_id, sensor_cfg *cfg, int *reading);
 uint8_t pal_pm8702_init(uint8_t card_id, sensor_cfg *cfg);

--- a/meta-facebook/at-mc/src/platform/plat_hook.c
+++ b/meta-facebook/at-mc/src/platform/plat_hook.c
@@ -480,7 +480,7 @@ bool pre_nvme_read(uint8_t sensor_num, void *args)
 		return false;
 	}
 
-	ret = set_mux_channel(*pre_args);
+	ret = set_mux_channel(*pre_args, MUTEX_LOCK_ENABLE);
 	return ret;
 }
 
@@ -522,7 +522,7 @@ bool pre_sq52205_read(uint8_t sensor_num, void *args)
 		return false;
 	}
 
-	ret = set_mux_channel(*pre_args);
+	ret = set_mux_channel(*pre_args, MUTEX_LOCK_ENABLE);
 	return ret;
 }
 
@@ -565,7 +565,7 @@ bool pre_cxl_switch_mux(uint8_t sensor_num, uint8_t pcie_card_id)
 	}
 
 	// Switch card mux
-	ret = set_mux_channel(card_mux);
+	ret = set_mux_channel(card_mux, MUTEX_LOCK_ENABLE);
 	if (ret != true) {
 		LOG_ERR("Switch card mux fail");
 		k_mutex_unlock(mutex);
@@ -573,7 +573,7 @@ bool pre_cxl_switch_mux(uint8_t sensor_num, uint8_t pcie_card_id)
 	}
 
 	// Switch cxl mux
-	ret = set_mux_channel(cxl_mux);
+	ret = set_mux_channel(cxl_mux, MUTEX_LOCK_ENABLE);
 	if (ret != true) {
 		LOG_ERR("Switch cxl mux fail");
 		k_mutex_unlock(mutex);

--- a/meta-facebook/at-mc/src/platform/plat_isr.h
+++ b/meta-facebook/at-mc/src/platform/plat_isr.h
@@ -44,17 +44,17 @@ enum IOEXP_NAME {
 };
 
 typedef struct _cxl_work_info {
-    bool is_init;
-    uint8_t cxl_card_id;
-    uint8_t cxl_channel;
-    bool is_device_reset;
-    bool is_pe_reset;
-    struct k_work_delayable device_reset_work;
-    struct k_work_delayable set_eid_work;
-    
+	bool is_init;
+	uint8_t cxl_card_id;
+	uint8_t cxl_channel;
+	bool is_device_reset;
+	bool is_pe_reset;
+	struct k_work_delayable device_reset_work;
+	struct k_work_delayable set_eid_work;
 } cxl_work_info;
 
 extern cxl_work_info cxl_work_item[];
+extern bool is_interrupt_ongoing;
 
 void ISR_NORMAL_PWRGD();
 void ISR_CXL_IOEXP_ALERT0();
@@ -67,8 +67,8 @@ void ISR_CXL_IOEXP_ALERT6();
 void ISR_CXL_IOEXP_ALERT7();
 
 void init_cxl_work();
-int check_cxl_power_status();
-int set_cxl_device_reset_pin(uint8_t val);
+int check_cxl_power_status(bool is_mutex);
+int set_cxl_device_reset_pin(uint8_t val, bool is_mutex);
 void cxl_ioexp_alert_handler(struct k_work *work_item);
 
 #endif


### PR DESCRIPTION
Summary
- If the interrupt handler can not lock the mutex, the handler will return false.
- Therefore,BIC will not set the PERST for cxl.
- Remove mutex lock for interrupt to prevent cpu context switch and return error without control.
- BIC should set output value of ioexp before modify the gpio direction of the ioexp.

Test Plan:
- Build code : pass
- AC and DC cycle that OS have all of the cxl pcie link.
- Checking the AC cycle waveform.