### PR TITLE
Common: Fix util_worker time print issue

### DIFF
--- a/common/lib/util_worker.c
+++ b/common/lib/util_worker.c
@@ -61,11 +61,13 @@ static void work_handler(struct k_work *item)
 		fn_start_time = k_uptime_get();
 		work_job->fn(work_job->ptr_arg, work_job->ui32_arg);
 		fn_finish_time = k_uptime_get();
+		uint64_t duration = fn_finish_time - fn_start_time;
 
 		/* Processing time too long, print warning message */
-		if ((fn_finish_time - fn_start_time) > WARN_WORK_PROC_TIME_MS) {
-			LOG_ERR("WARN: work %s Processing time too long, %llu ms",
-				log_strdup(work_job->name), (fn_finish_time - fn_start_time));
+		if (duration > WARN_WORK_PROC_TIME_MS) {
+			LOG_ERR("WARN: work %s Processing time too long, 0x%08x_%08x ms",
+				log_strdup(work_job->name), (uint32_t)(duration >> 32),
+				(uint32_t)duration);
 		}
 	}
 	if (k_mutex_lock(&mutex_use_count, K_MSEC(1000))) {


### PR DESCRIPTION
Summary:
- Change the get time function to 32 bits, because the LOG function not support print 64 bit argument.

Test Plan:
- Build code: PASS

Log:
```
before:
[00:00:07.217,000] <err> util_worker: WARN: work  Processing time too long, 359630496596968 ms
after:
[00:00:07.217,000] <err> util_worker: WARN: work  Processing time too long, 2004 ms
```