### PR TITLE
fby35: gl: support 1OU expansion board

### DIFF
--- a/meta-facebook/yv35-gl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-gl/boards/ast1030_evb.overlay
@@ -83,6 +83,15 @@
 	pinctrl-0 = <&pinctrl_i2c7_default>;
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
+	ipmb7: ipmb@20 {
+		compatible = "aspeed,ipmb";
+		reg = <0x20>;
+		label = "IPMB_7";
+		size = <10>;
+#ifdef CONFIG_I2C_IPMB_SLAVE
+		status = "okay";
+#endif
+	};
 };
 
 &i2c8 {

--- a/meta-facebook/yv35-gl/src/platform/plat_ipmb.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_ipmb.c
@@ -27,12 +27,20 @@ IPMB_config pal_IPMB_config_table[] = {
 	// rx_thread_name, tx_thread_name
 	{ BMC_IPMB_IDX, I2C_IF, BMC_IPMB, IPMB_I2C_BMC, BMC_I2C_ADDRESS, ENABLE, SELF_I2C_ADDRESS,
 	  "RX_BMC_IPMB_TASK", "TX_BMC_IPMB_TASK" },
+	{ EXP1_IPMB_IDX, I2C_IF, EXP1_IPMB, IPMB_EXP1_BUS, BIC1_I2C_ADDRESS, DISABLE,
+	  SELF_I2C_ADDRESS, "RX_EPX1_IPMB_TASK", "TX_EXP1_IPMB_TASK" },
 	{ RESERVED_IDX, RESERVED_IF, RESERVED, RESERVED_BUS, RESERVED_ADDRESS, DISABLE,
 	  RESERVED_ADDRESS, "RESERVED_ATTR", "RESERVED_ATTR" },
 };
 
+
 bool pal_load_ipmb_config(void)
 {
+	CARD_STATUS _1ou_status = get_1ou_status();
+	if (_1ou_status.present) {
+		pal_IPMB_config_table[EXP1_IPMB_IDX].enable_status = ENABLE;
+	}
+
 	memcpy(&IPMB_config_table[0], &pal_IPMB_config_table[0], sizeof(pal_IPMB_config_table));
 	return true;
-};
+}

--- a/meta-facebook/yv35-gl/src/platform/plat_ipmb.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_ipmb.h
@@ -21,12 +21,16 @@
 #include "ipmb.h"
 
 #define IPMB_BMC_BUS I2C_BUS7
+#define IPMB_EXP1_BUS I2C_BUS8
 
 #define BMC_I2C_ADDRESS 0x10
 #define SELF_I2C_ADDRESS 0x20
-#define MAX_IPMB_IDX 2
+#define BIC1_I2C_ADDRESS 0x20
+#define MAX_IPMB_IDX 3
 
-enum { BMC_IPMB_IDX,
+enum {
+	BMC_IPMB_IDX,
+	EXP1_IPMB_IDX,
 };
 
 extern IPMB_config pal_IPMB_config_table[];


### PR DESCRIPTION
Summary:
- Support 1ou rainbow falls BIC

Test Plan:
- Update RBF BIC firmware
- Get RBF BIC sensors
- Access RBF BIC console

Log:
root@bmc-oob:~# fw-util slot3 --version 1ou_bic
1OU Bridge-IC Version: oby35-rf-v2023.08.01
root@bmc-oob:~# fw-util slot3 --force --update 1ou_bic /tmp/oby35-rf-2023.10.01.bin slot_id: 3, comp: 10, intf: 0, img: /tmp/oby35-rf-2023.10.01.bin, force: 1 file size = 234788 bytes, slot = 3, intf = 0x5
updating fw on slot 3:
updated bic: 100 %
Elapsed time:  20   sec.

get new SDR cache from BIC
Force upgrade of slot3 : 1ou_bic succeeded
root@bmc-oob:~# fw-util slot3 --version 1ou_bic
1OU Bridge-IC Version: oby35-rf-v2023.10.01
root@bmc-oob:~# sensor-util slot3 |grep RF
RF_MB_INLET_TEMP_C           (0x50) :   26.00 C     | (ok)
RF_CXL_CNTR_TEMP_C           (0x51) :   38.00 C     | (ok)
RF_CXL_TEMP_C                (0x52) :   27.00 C     | (ok)
RF_DIMM_A_TEMP_C             (0x53) :   30.25 C     | (ok)
RF_DIMM_B_TEMP_C             (0x54) :   30.50 C     | (ok)
RF_DIMM_C_TEMP_C             (0x55) :   29.50 C     | (ok)
RF_DIMM_D_TEMP_C             (0x57) :   29.25 C     | (ok)
RF_P0V9_A_TEMP_C             (0x58) :   35.00 C     | (ok)
RF_P0V8_A_TEMP_C             (0x59) :   34.00 C     | (ok)
RF_P0V8_D_TEMP_C             (0x5A) :   31.00 C     | (ok)
RF_PVDDQ_AB_TEMP_C           (0x5B) :   33.00 C     | (ok)
RF_PVDDQ_CD_TEMP_C           (0x5C) :   33.00 C     | (ok)
RF_P12V_STBY_VOLT_V          (0x5D) :   12.28 Volts  | (ok)
RF_P3V3_STBY_VOLT_V          (0x5E) :    3.34 Volts  | (ok)
RF_P5V_STBY_VOLT_V           (0x5F) :    5.03 Volts  | (ok)
RF_P1V2_STBY_VOLT_V          (0x60) :    1.21 Volts  | (ok)
RF_P1V8_ASIC_VOLT_V          (0x61) :    1.83 Volts  | (ok)
RF_P0V9_A_VOLT_V             (0x62) :    0.95 Volts  | (ok)
RF_P0V8_A_VOLT_V             (0x64) :    0.82 Volts  | (ok)
RF_P0V8_D_VOLT_V             (0x65) :    0.82 Volts  | (ok)
RF_PVDDQ_AB_VOLT_V           (0x66) :    1.20 Volts  | (ok)
RF_PVDDQ_CD_VOLT_V           (0x67) :    1.20 Volts  | (ok)
RF_PVPP_AB_VOLT_V            (0x68) :    2.47 Volts  | (ok)
RF_PVPP_CD_VOLT_V            (0x69) :    2.47 Volts  | (ok)
RF_PVTT_AB_VOLT_V            (0x6A) :    0.58 Volts  | (ok)
RF_PVTT_CD_VOLT_V            (0x6B) :    0.58 Volts  | (ok)
RF_P12V_STBY_CURR_A          (0x6C) :    1.25 Amps  | (ok)
RF_P3V3_STBY_CURR_A          (0x6D) :    0.33 Amps  | (ok)
RF_P0V9_A_CURR_A             (0x6E) :    2.70 Amps  | (ok)
RF_P0V8_A_CURR_A             (0x6F) :    3.30 Amps  | (ok)
RF_P0V8_D_CURR_A             (0x70) :    3.40 Amps  | (ok)
RF_PVDDQ_AB_CURR_A           (0x71) :    2.80 Amps  | (ok)
RF_PVDDQ_CD_CURR_A           (0x72) :    2.10 Amps  | (ok)
RF_P12V_STBY_PWR_W           (0x73) :   15.32 Watts  | (ok)
RF_P3V3_STBY_PWR_W           (0x74) :    1.10 Watts  | (ok)
RF_P0V9_A_PWR_W              (0x75) :    2.00 Watts  | (ok)
RF_P0V8_A_PWR_W              (0x76) :    2.00 Watts  | (ok)
RF_P0V8_D_PWR_W              (0x77) :    2.00 Watts  | (ok)
RF_PVDDQ_AB_PWR_W            (0x78) :    3.00 Watts  | (ok)
RF_PVDDQ_CD_PWR_W            (0x79) :    2.00 Watts  | (ok)
uart:~$ platform info
========================{SHELL COMMAND INFO}========================================
* NAME:          Platform command
* DESCRIPTION:   Commands that could be used to debug or validate.
* DATE/VERSION:  none
* CHIP/OS:       ast1030_evb - Zephyr
* Note:          none
------------------------------------------------------------------
* PLATFORM:      Yosemite 3.5-Rainbow Falls
* BOARD ID:      3
* STAGE:         2
* SYSTEM:        255
* FW VERSION:    35.5
* FW DATE:       2023.11.1
* FW IMAGE:      Y35BRF.bin
========================{SHELL COMMAND INFO}========================================
uart:~$