### PR TITLE
Artemis: mc: Correct card id mapping

### DIFF
--- a/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
@@ -241,7 +241,7 @@ int pal_get_pcie_card_sensor_reading(uint8_t read_type, uint8_t sensor_num, uint
 		}
 	}
 
-	ret = pal_sensor_drive_read(parameter, cfg, reading, &sensor_status);
+	ret = pal_sensor_drive_read(pcie_card_id, cfg, reading, &sensor_status);
 	if (ret != true) {
 		LOG_ERR("sensor: 0x%x read fail, card id: 0x%x", sensor_num, pcie_card_id);
 	}


### PR DESCRIPTION
Summary:
- Correct card id mapping.

Test Plan:
- Build code: Pass
- Get cxl sensor reading: Pass

Log:
root@bmc-oob:~# sensor-util meb_jcn1
meb_cxl8:
MEB_CXL8_CXL Inlet Temp_C    (0x1) :   24.00 C     | (ok)
MEB_CXL8_CXL CTRL Temp_C     (0x2) :   25.25 C     | (ok)
MEB_CXL8_P12V_STBY_4CP_VOL_V (0x3) :   12.10 Volts | (ok)
MEB_CXL8_P3V3_STBY_4CP_VOL_V (0x4) :    3.29 Volts | (ok)
MEB_CXL8_P5V_STBY_VOL_V      (0x5) :    5.10 Volts | (ok)
MEB_CXL8_P1V8_ASIC_VOL_V     (0x6) :    1.80 Volts | (ok)
MEB_CXL8_P12V_STBY_VOL_V     (0x7) :   12.11 Volts | (ok)
MEB_CXL8_P3V3_STBY_VOL_V     (0x8) :    3.29 Volts | (ok)
MEB_CXL8_PVPP_AB_VOL_V       (0x9) :    2.49 Volts | (ok)
MEB_CXL8_PVTT_AB_VOL_V       (0xA) :    0.59 Volts | (ok)
MEB_CXL8_PVPP_CD_VOL_V       (0xB) :    2.50 Volts | (ok)
MEB_CXL8_PVTT_CD_VOL_V       (0xC) :    0.60 Volts | (ok)
MEB_CXL8_P0V8_ASICA_VOL_V    (0xD) :    0.82 Volts | (ok)
MEB_CXL8_P0V9_ASICA_VOL_V    (0xE) :    0.95 Volts | (ok)
MEB_CXL8_P0V8_ASICD_VOL_V    (0xF) :    0.82 Volts | (ok)
MEB_CXL8_PVDDQ_AB_VOL_V      (0x10) :    1.20 Volts | (ok)
MEB_CXL8_PVDDQ_CD_VOL_V      (0x11) :    1.20 Volts | (ok)
MEB_CXL8_P12V_STBY_4CP_CUR_A (0x12) :    1.37 Amps  | (ok)
MEB_CXL8_P3V3_STBY_4CP_CUR_A (0x13) :    0.06 Amps  | (ok)
MEB_CXL8_P0V8_ASICA_CUR_A    (0x14) :    1.00 Amps  | (ok)
MEB_CXL8_P0V9_ASICA_CUR_A    (0x15) :    1.00 Amps  | (ok)
MEB_CXL8_P0V8_ASICD_CUR_A    (0x16) :    2.00 Amps  | (ok)
MEB_CXL8_PVDDQ_AB_CUR_A      (0x17) :    2.00 Amps  | (ok)
MEB_CXL8_PVDDQ_CD_CUR_A      (0x18) :    2.00 Amps  | (ok)
MEB_CXL8_P12V_STBY_4CP_PWR_W (0x19) :   16.75 Watts | (ok)
MEB_CXL8_P3V3_STBY_4CP_PWR_W (0x1A) :    0.20 Watts | (ok)
MEB_CXL8_P0V8_ASICA_PWR_W    (0x1B) :    1.00 Watts | (ok)
MEB_CXL8_P0V9_ASICA_PWR_W    (0x1C) :    1.00 Watts | (ok)
MEB_CXL8_P0V8_ASICD_PWR_W    (0x1D) :    2.00 Watts | (ok)
MEB_CXL8_PVDDQ_AB_PWR_W      (0x1E) :    2.00 Watts | (ok)
MEB_CXL8_PVDDQ_CD_PWR_W      (0x1F) :    3.00 Watts | (ok)
MEB_CXL8_DIMM_A_TEMP_C       (0x21) :   29.25 C     | (ok)
MEB_CXL8_DIMM_B_TEMP_C       (0x22) :   29.75 C     | (ok)
MEB_CXL8_DIMM_C_TEMP_C       (0x23) :   29.00 C     | (ok)
MEB_CXL8_DIMM_D_TEMP_C       (0x24) :   29.25 C     | (ok)

root@bmc-oob:~# sensor-util meb_jcn2
meb_cxl7:
MEB_CXL7_CXL Inlet Temp_C    (0x1) :   24.00 C     | (ok)
MEB_CXL7_CXL CTRL Temp_C     (0x2) :   25.25 C     | (ok)
MEB_CXL7_P12V_STBY_4CP_VOL_V (0x3) :   12.11 Volts | (ok)
MEB_CXL7_P3V3_STBY_4CP_VOL_V (0x4) :    3.29 Volts | (ok)
MEB_CXL7_P5V_STBY_VOL_V      (0x5) :    5.08 Volts | (ok)
MEB_CXL7_P1V8_ASIC_VOL_V     (0x6) :    1.81 Volts | (ok)
MEB_CXL7_P12V_STBY_VOL_V     (0x7) :   12.08 Volts | (ok)
MEB_CXL7_P3V3_STBY_VOL_V     (0x8) :    3.30 Volts | (ok)
MEB_CXL7_PVPP_AB_VOL_V       (0x9) :    2.49 Volts | (ok)
MEB_CXL7_PVTT_AB_VOL_V       (0xA) :    0.60 Volts | (ok)
MEB_CXL7_PVPP_CD_VOL_V       (0xB) :    2.50 Volts | (ok)
MEB_CXL7_PVTT_CD_VOL_V       (0xC) :    0.60 Volts | (ok)
MEB_CXL7_P0V8_ASICA_VOL_V    (0xD) :    0.82 Volts | (ok)
MEB_CXL7_P0V9_ASICA_VOL_V    (0xE) :    0.95 Volts | (ok)
MEB_CXL7_P0V8_ASICD_VOL_V    (0xF) :    0.82 Volts | (ok)
MEB_CXL7_PVDDQ_AB_VOL_V      (0x10) :    1.20 Volts | (ok)
MEB_CXL7_PVDDQ_CD_VOL_V      (0x11) :    1.20 Volts | (ok)
MEB_CXL7_P12V_STBY_4CP_CUR_A (0x12) :    1.20 Amps  | (ok)
MEB_CXL7_P3V3_STBY_4CP_CUR_A (0x13) :    0.06 Amps  | (ok)
MEB_CXL7_P0V8_ASICA_CUR_A    (0x14) :    0.00 Amps  | (ok)
MEB_CXL7_P0V9_ASICA_CUR_A    (0x15) :    0.00 Amps  | (ok)
MEB_CXL7_P0V8_ASICD_CUR_A    (0x16) :    2.00 Amps  | (ok)
MEB_CXL7_PVDDQ_AB_CUR_A      (0x17) :    2.00 Amps  | (ok)
MEB_CXL7_PVDDQ_CD_CUR_A      (0x18) :    2.00 Amps  | (ok)
MEB_CXL7_P12V_STBY_4CP_PWR_W (0x19) :   14.55 Watts | (ok)
MEB_CXL7_P3V3_STBY_4CP_PWR_W (0x1A) :    0.20 Watts | (ok)
MEB_CXL7_P0V8_ASICA_PWR_W    (0x1B) :    0.00 Watts | (ok)
MEB_CXL7_P0V9_ASICA_PWR_W    (0x1C) :    0.00 Watts | (ok)
MEB_CXL7_P0V8_ASICD_PWR_W    (0x1D) :    1.00 Watts | (ok)
MEB_CXL7_PVDDQ_AB_PWR_W      (0x1E) :    3.00 Watts | (ok)
MEB_CXL7_PVDDQ_CD_PWR_W      (0x1F) :    3.00 Watts | (ok)
MEB_CXL7_DIMM_A_TEMP_C       (0x21) :   29.00 C     | (ok)
MEB_CXL7_DIMM_B_TEMP_C       (0x22) :   29.75 C     | (ok)
MEB_CXL7_DIMM_C_TEMP_C       (0x23) :   28.50 C     | (ok)
MEB_CXL7_DIMM_D_TEMP_C       (0x24) :   29.25 C     | (ok)

root@bmc-oob:~# sensor-util meb_jcn3
meb_cxl6:
MEB_CXL6_CXL Inlet Temp_C    (0x1) :   24.00 C     | (ok)
MEB_CXL6_CXL CTRL Temp_C     (0x2) :   24.38 C     | (ok)
MEB_CXL6_P12V_STBY_4CP_VOL_V (0x3) :   12.09 Volts | (ok)
MEB_CXL6_P3V3_STBY_4CP_VOL_V (0x4) :    3.29 Volts | (ok)
MEB_CXL6_P5V_STBY_VOL_V      (0x5) :    5.08 Volts | (ok)
MEB_CXL6_P1V8_ASIC_VOL_V     (0x6) :    1.80 Volts | (ok)
MEB_CXL6_P12V_STBY_VOL_V     (0x7) :   12.16 Volts | (ok)
MEB_CXL6_P3V3_STBY_VOL_V     (0x8) :    3.28 Volts | (ok)
MEB_CXL6_PVPP_AB_VOL_V       (0x9) :    2.52 Volts | (ok)
MEB_CXL6_PVTT_AB_VOL_V       (0xA) :    0.59 Volts | (ok)
MEB_CXL6_PVPP_CD_VOL_V       (0xB) :    2.52 Volts | (ok)
MEB_CXL6_PVTT_CD_VOL_V       (0xC) :    0.60 Volts | (ok)
MEB_CXL6_P0V8_ASICA_VOL_V    (0xD) :    0.82 Volts | (ok)
MEB_CXL6_P0V9_ASICA_VOL_V    (0xE) :    0.95 Volts | (ok)
MEB_CXL6_P0V8_ASICD_VOL_V    (0xF) :    0.82 Volts | (ok)
MEB_CXL6_PVDDQ_AB_VOL_V      (0x10) :    1.20 Volts | (ok)
MEB_CXL6_PVDDQ_CD_VOL_V      (0x11) :    1.20 Volts | (ok)
MEB_CXL6_P12V_STBY_4CP_CUR_A (0x12) :    1.21 Amps  | (ok)
MEB_CXL6_P3V3_STBY_4CP_CUR_A (0x13) :    0.06 Amps  | (ok)
MEB_CXL6_P0V8_ASICA_CUR_A    (0x14) :    0.00 Amps  | (ok)
MEB_CXL6_P0V9_ASICA_CUR_A    (0x15) :    0.00 Amps  | (ok)
MEB_CXL6_P0V8_ASICD_CUR_A    (0x16) :    2.00 Amps  | (ok)
MEB_CXL6_PVDDQ_AB_CUR_A      (0x17) :    3.00 Amps  | (ok)
MEB_CXL6_PVDDQ_CD_CUR_A      (0x18) :    3.00 Amps  | (ok)
MEB_CXL6_P12V_STBY_4CP_PWR_W (0x19) :   14.57 Watts | (ok)
MEB_CXL6_P3V3_STBY_4CP_PWR_W (0x1A) :    0.20 Watts | (ok)
MEB_CXL6_P0V8_ASICA_PWR_W    (0x1B) :    0.00 Watts | (ok)
MEB_CXL6_P0V9_ASICA_PWR_W    (0x1C) :    0.00 Watts | (ok)
MEB_CXL6_P0V8_ASICD_PWR_W    (0x1D) :    1.00 Watts | (ok)
MEB_CXL6_PVDDQ_AB_PWR_W      (0x1E) :    3.00 Watts | (ok)
MEB_CXL6_PVDDQ_CD_PWR_W      (0x1F) :    2.00 Watts | (ok)
MEB_CXL6_DIMM_A_TEMP_C       (0x21) :   28.25 C     | (ok)
MEB_CXL6_DIMM_B_TEMP_C       (0x22) :   29.00 C     | (ok)
MEB_CXL6_DIMM_C_TEMP_C       (0x23) :   29.00 C     | (ok)
MEB_CXL6_DIMM_D_TEMP_C       (0x24) :   29.25 C     | (ok)

root@bmc-oob:~# sensor-util meb_jcn4
meb_cxl5:
MEB_CXL5_CXL Inlet Temp_C    (0x1) :   23.00 C     | (ok)
MEB_CXL5_CXL CTRL Temp_C     (0x2) :   25.38 C     | (ok)
MEB_CXL5_P12V_STBY_4CP_VOL_V (0x3) :   12.09 Volts | (ok)
MEB_CXL5_P3V3_STBY_4CP_VOL_V (0x4) :    3.29 Volts | (ok)
MEB_CXL5_P5V_STBY_VOL_V      (0x5) :    5.07 Volts | (ok)
MEB_CXL5_P1V8_ASIC_VOL_V     (0x6) :    1.80 Volts | (ok)
MEB_CXL5_P12V_STBY_VOL_V     (0x7) :   12.15 Volts | (ok)
MEB_CXL5_P3V3_STBY_VOL_V     (0x8) :    3.29 Volts | (ok)
MEB_CXL5_PVPP_AB_VOL_V       (0x9) :    2.51 Volts | (ok)
MEB_CXL5_PVTT_AB_VOL_V       (0xA) :    0.60 Volts | (ok)
MEB_CXL5_PVPP_CD_VOL_V       (0xB) :    2.51 Volts | (ok)
MEB_CXL5_PVTT_CD_VOL_V       (0xC) :    0.59 Volts | (ok)
MEB_CXL5_P0V8_ASICA_VOL_V    (0xD) :    0.82 Volts | (ok)
MEB_CXL5_P0V9_ASICA_VOL_V    (0xE) :    0.95 Volts | (ok)
MEB_CXL5_P0V8_ASICD_VOL_V    (0xF) :    0.82 Volts | (ok)
MEB_CXL5_PVDDQ_AB_VOL_V      (0x10) :    1.20 Volts | (ok)
MEB_CXL5_PVDDQ_CD_VOL_V      (0x11) :    1.20 Volts | (ok)
MEB_CXL5_P12V_STBY_4CP_CUR_A (0x12) :    1.66 Amps  | (ok)
MEB_CXL5_P3V3_STBY_4CP_CUR_A (0x13) :    0.06 Amps  | (ok)
MEB_CXL5_P0V8_ASICA_CUR_A    (0x14) :    2.00 Amps  | (ok)
MEB_CXL5_P0V9_ASICA_CUR_A    (0x15) :    2.00 Amps  | (ok)
MEB_CXL5_P0V8_ASICD_CUR_A    (0x16) :    3.00 Amps  | (ok)
MEB_CXL5_PVDDQ_AB_CUR_A      (0x17) :    3.00 Amps  | (ok)
MEB_CXL5_PVDDQ_CD_CUR_A      (0x18) :    3.00 Amps  | (ok)
MEB_CXL5_P12V_STBY_4CP_PWR_W (0x19) :   20.00 Watts | (ok)
MEB_CXL5_P3V3_STBY_4CP_PWR_W (0x1A) :    0.20 Watts | (ok)
MEB_CXL5_P0V8_ASICA_PWR_W    (0x1B) :    1.00 Watts | (ok)
MEB_CXL5_P0V9_ASICA_PWR_W    (0x1C) :    2.00 Watts | (ok)
MEB_CXL5_P0V8_ASICD_PWR_W    (0x1D) :    3.00 Watts | (ok)
MEB_CXL5_PVDDQ_AB_PWR_W      (0x1E) :    4.00 Watts | (ok)
MEB_CXL5_PVDDQ_CD_PWR_W      (0x1F) :    3.00 Watts | (ok)
MEB_CXL5_DIMM_A_TEMP_C       (0x21) :   29.00 C     | (ok)
MEB_CXL5_DIMM_B_TEMP_C       (0x22) :   29.50 C     | (ok)
MEB_CXL5_DIMM_C_TEMP_C       (0x23) :   29.00 C     | (ok)
MEB_CXL5_DIMM_D_TEMP_C       (0x24) :   29.75 C     | (ok)

root@bmc-oob:~# sensor-util meb_jcn9
meb_cxl3:
MEB_CXL3_CXL Inlet Temp_C    (0x1) :   24.00 C     | (ok)
MEB_CXL3_CXL CTRL Temp_C     (0x2) :   23.75 C     | (ok)
MEB_CXL3_P12V_STBY_4CP_VOL_V (0x3) :   12.11 Volts | (ok)
MEB_CXL3_P3V3_STBY_4CP_VOL_V (0x4) :    3.29 Volts | (ok)
MEB_CXL3_P5V_STBY_VOL_V      (0x5) :    5.07 Volts | (ok)
MEB_CXL3_P1V8_ASIC_VOL_V     (0x6) :    1.80 Volts | (ok)
MEB_CXL3_P12V_STBY_VOL_V     (0x7) :   12.00 Volts | (ok)
MEB_CXL3_P3V3_STBY_VOL_V     (0x8) :    3.31 Volts | (ok)
MEB_CXL3_PVPP_AB_VOL_V       (0x9) :    2.51 Volts | (ok)
MEB_CXL3_PVTT_AB_VOL_V       (0xA) :    0.60 Volts | (ok)
MEB_CXL3_PVPP_CD_VOL_V       (0xB) :    2.51 Volts | (ok)
MEB_CXL3_PVTT_CD_VOL_V       (0xC) :    0.60 Volts | (ok)
MEB_CXL3_P0V8_ASICA_VOL_V    (0xD) :    0.82 Volts | (ok)
MEB_CXL3_P0V9_ASICA_VOL_V    (0xE) :    0.95 Volts | (ok)
MEB_CXL3_P0V8_ASICD_VOL_V    (0xF) :    0.82 Volts | (ok)
MEB_CXL3_PVDDQ_AB_VOL_V      (0x10) :    1.20 Volts | (ok)
MEB_CXL3_PVDDQ_CD_VOL_V      (0x11) :    1.20 Volts | (ok)
MEB_CXL3_P12V_STBY_4CP_CUR_A (0x12) :    1.07 Amps  | (ok)
MEB_CXL3_P3V3_STBY_4CP_CUR_A (0x13) :    0.06 Amps  | (ok)
MEB_CXL3_P0V8_ASICA_CUR_A    (0x14) :    1.00 Amps  | (ok)
MEB_CXL3_P0V9_ASICA_CUR_A    (0x15) :    1.00 Amps  | (ok)
MEB_CXL3_P0V8_ASICD_CUR_A    (0x16) :    2.00 Amps  | (ok)
MEB_CXL3_PVDDQ_AB_CUR_A      (0x17) :    1.00 Amps  | (ok)
MEB_CXL3_PVDDQ_CD_CUR_A      (0x18) :    1.00 Amps  | (ok)
MEB_CXL3_P12V_STBY_4CP_PWR_W (0x19) :   12.85 Watts | (ok)
MEB_CXL3_P3V3_STBY_4CP_PWR_W (0x1A) :    0.20 Watts | (ok)
MEB_CXL3_P0V8_ASICA_PWR_W    (0x1B) :    1.00 Watts | (ok)
MEB_CXL3_P0V9_ASICA_PWR_W    (0x1C) :    1.00 Watts | (ok)
MEB_CXL3_P0V8_ASICD_PWR_W    (0x1D) :    2.00 Watts | (ok)
MEB_CXL3_PVDDQ_AB_PWR_W      (0x1E) :    1.00 Watts | (ok)
MEB_CXL3_PVDDQ_CD_PWR_W      (0x1F) :    1.00 Watts | (ok)
MEB_CXL3_DIMM_A_TEMP_C       (0x21) :   26.25 C     | (ok)
MEB_CXL3_DIMM_B_TEMP_C       (0x22) :   27.00 C     | (ok)
MEB_CXL3_DIMM_C_TEMP_C       (0x23) :   26.75 C     | (ok)
MEB_CXL3_DIMM_D_TEMP_C       (0x24) :   27.25 C     | (ok)

root@bmc-oob:~# sensor-util meb_jcn10
meb_cxl4:
MEB_CXL4_CXL Inlet Temp_C    (0x1) :   24.00 C     | (ok)
MEB_CXL4_CXL CTRL Temp_C     (0x2) :   24.50 C     | (ok)
MEB_CXL4_P12V_STBY_4CP_VOL_V (0x3) :   12.09 Volts | (ok)
MEB_CXL4_P3V3_STBY_4CP_VOL_V (0x4) :    3.29 Volts | (ok)
MEB_CXL4_P5V_STBY_VOL_V      (0x5) :    5.07 Volts | (ok)
MEB_CXL4_P1V8_ASIC_VOL_V     (0x6) :    1.80 Volts | (ok)
MEB_CXL4_P12V_STBY_VOL_V     (0x7) :   12.00 Volts | (ok)
MEB_CXL4_P3V3_STBY_VOL_V     (0x8) :    3.31 Volts | (ok)
MEB_CXL4_PVPP_AB_VOL_V       (0x9) :    2.52 Volts | (ok)
MEB_CXL4_PVTT_AB_VOL_V       (0xA) :    0.60 Volts | (ok)
MEB_CXL4_PVPP_CD_VOL_V       (0xB) :    2.51 Volts | (ok)
MEB_CXL4_PVTT_CD_VOL_V       (0xC) :    0.60 Volts | (ok)
MEB_CXL4_P0V8_ASICA_VOL_V    (0xD) :    0.82 Volts | (ok)
MEB_CXL4_P0V9_ASICA_VOL_V    (0xE) :    0.95 Volts | (ok)
MEB_CXL4_P0V8_ASICD_VOL_V    (0xF) :    0.82 Volts | (ok)
MEB_CXL4_PVDDQ_AB_VOL_V      (0x10) :    1.20 Volts | (ok)
MEB_CXL4_PVDDQ_CD_VOL_V      (0x11) :    1.20 Volts | (ok)
MEB_CXL4_P12V_STBY_4CP_CUR_A (0x12) :    1.35 Amps  | (ok)
MEB_CXL4_P3V3_STBY_4CP_CUR_A (0x13) :    0.06 Amps  | (ok)
MEB_CXL4_P0V8_ASICA_CUR_A    (0x14) :    1.00 Amps  | (ok)
MEB_CXL4_P0V9_ASICA_CUR_A    (0x15) :    1.00 Amps  | (ok)
MEB_CXL4_P0V8_ASICD_CUR_A    (0x16) :    2.00 Amps  | (ok)
MEB_CXL4_PVDDQ_AB_CUR_A      (0x17) :    2.00 Amps  | (ok)
MEB_CXL4_PVDDQ_CD_CUR_A      (0x18) :    2.00 Amps  | (ok)
MEB_CXL4_P12V_STBY_4CP_PWR_W (0x19) :   16.48 Watts | (ok)
MEB_CXL4_P3V3_STBY_4CP_PWR_W (0x1A) :    0.20 Watts | (ok)
MEB_CXL4_P0V8_ASICA_PWR_W    (0x1B) :    1.00 Watts | (ok)
MEB_CXL4_P0V9_ASICA_PWR_W    (0x1C) :    1.00 Watts | (ok)
MEB_CXL4_P0V8_ASICD_PWR_W    (0x1D) :    2.00 Watts | (ok)
MEB_CXL4_PVDDQ_AB_PWR_W      (0x1E) :    3.00 Watts | (ok)
MEB_CXL4_PVDDQ_CD_PWR_W      (0x1F) :    3.00 Watts | (ok)
MEB_CXL4_DIMM_A_TEMP_C       (0x21) :   28.25 C     | (ok)
MEB_CXL4_DIMM_B_TEMP_C       (0x22) :   28.75 C     | (ok)
MEB_CXL4_DIMM_C_TEMP_C       (0x23) :   29.00 C     | (ok)
MEB_CXL4_DIMM_D_TEMP_C       (0x24) :   29.25 C     | (ok)

root@bmc-oob:~# sensor-util meb_jcn11
meb_cxl1:
MEB_CXL1_CXL Inlet Temp_C    (0x1) :   24.00 C     | (ok)
MEB_CXL1_CXL CTRL Temp_C     (0x2) :   24.50 C     | (ok)
MEB_CXL1_P12V_STBY_4CP_VOL_V (0x3) :   12.09 Volts | (ok)
MEB_CXL1_P3V3_STBY_4CP_VOL_V (0x4) :    3.29 Volts | (ok)
MEB_CXL1_P5V_STBY_VOL_V      (0x5) :    5.08 Volts | (ok)
MEB_CXL1_P1V8_ASIC_VOL_V     (0x6) :    1.80 Volts | (ok)
MEB_CXL1_P12V_STBY_VOL_V     (0x7) :   12.12 Volts | (ok)
MEB_CXL1_P3V3_STBY_VOL_V     (0x8) :    3.30 Volts | (ok)
MEB_CXL1_PVPP_AB_VOL_V       (0x9) :    2.51 Volts | (ok)
MEB_CXL1_PVTT_AB_VOL_V       (0xA) :    0.60 Volts | (ok)
MEB_CXL1_PVPP_CD_VOL_V       (0xB) :    2.49 Volts | (ok)
MEB_CXL1_PVTT_CD_VOL_V       (0xC) :    0.59 Volts | (ok)
MEB_CXL1_P0V8_ASICA_VOL_V    (0xD) :    0.82 Volts | (ok)
MEB_CXL1_P0V9_ASICA_VOL_V    (0xE) :    0.95 Volts | (ok)
MEB_CXL1_P0V8_ASICD_VOL_V    (0xF) :    0.82 Volts | (ok)
MEB_CXL1_PVDDQ_AB_VOL_V      (0x10) :    1.20 Volts | (ok)
MEB_CXL1_PVDDQ_CD_VOL_V      (0x11) :    1.20 Volts | (ok)
MEB_CXL1_P12V_STBY_4CP_CUR_A (0x12) :    1.38 Amps  | (ok)
MEB_CXL1_P3V3_STBY_4CP_CUR_A (0x13) :    0.06 Amps  | (ok)
MEB_CXL1_P0V8_ASICA_CUR_A    (0x14) :    1.00 Amps  | (ok)
MEB_CXL1_P0V9_ASICA_CUR_A    (0x15) :    1.00 Amps  | (ok)
MEB_CXL1_P0V8_ASICD_CUR_A    (0x16) :    2.00 Amps  | (ok)
MEB_CXL1_PVDDQ_AB_CUR_A      (0x17) :    3.00 Amps  | (ok)
MEB_CXL1_PVDDQ_CD_CUR_A      (0x18) :    2.00 Amps  | (ok)
MEB_CXL1_P12V_STBY_4CP_PWR_W (0x19) :   16.48 Watts | (ok)
MEB_CXL1_P3V3_STBY_4CP_PWR_W (0x1A) :    0.20 Watts | (ok)
MEB_CXL1_P0V8_ASICA_PWR_W    (0x1B) :    1.00 Watts | (ok)
MEB_CXL1_P0V9_ASICA_PWR_W    (0x1C) :    1.00 Watts | (ok)
MEB_CXL1_P0V8_ASICD_PWR_W    (0x1D) :    1.00 Watts | (ok)
MEB_CXL1_PVDDQ_AB_PWR_W      (0x1E) :    4.00 Watts | (ok)
MEB_CXL1_PVDDQ_CD_PWR_W      (0x1F) :    4.00 Watts | (ok)
MEB_CXL1_DIMM_A_TEMP_C       (0x21) :   28.50 C     | (ok)
MEB_CXL1_DIMM_B_TEMP_C       (0x22) :   28.75 C     | (ok)
MEB_CXL1_DIMM_C_TEMP_C       (0x23) :   29.00 C     | (ok)
MEB_CXL1_DIMM_D_TEMP_C       (0x24) :   29.25 C     | (ok)

root@bmc-oob:~# sensor-util meb_jcn12
meb_cxl2:
MEB_CXL2_CXL Inlet Temp_C    (0x1) :   24.00 C     | (ok)
MEB_CXL2_CXL CTRL Temp_C     (0x2) :   24.62 C     | (ok)
MEB_CXL2_P12V_STBY_4CP_VOL_V (0x3) :   12.11 Volts | (ok)
MEB_CXL2_P3V3_STBY_4CP_VOL_V (0x4) :    3.29 Volts | (ok)
MEB_CXL2_P5V_STBY_VOL_V      (0x5) :    5.05 Volts | (ok)
MEB_CXL2_P1V8_ASIC_VOL_V     (0x6) :    1.80 Volts | (ok)
MEB_CXL2_P12V_STBY_VOL_V     (0x7) :   12.09 Volts | (ok)
MEB_CXL2_P3V3_STBY_VOL_V     (0x8) :    3.31 Volts | (ok)
MEB_CXL2_PVPP_AB_VOL_V       (0x9) :    2.50 Volts | (ok)
MEB_CXL2_PVTT_AB_VOL_V       (0xA) :    0.59 Volts | (ok)
MEB_CXL2_PVPP_CD_VOL_V       (0xB) :    2.51 Volts | (ok)
MEB_CXL2_PVTT_CD_VOL_V       (0xC) :    0.60 Volts | (ok)
MEB_CXL2_P0V8_ASICA_VOL_V    (0xD) :    0.82 Volts | (ok)
MEB_CXL2_P0V9_ASICA_VOL_V    (0xE) :    0.95 Volts | (ok)
MEB_CXL2_P0V8_ASICD_VOL_V    (0xF) :    0.82 Volts | (ok)
MEB_CXL2_PVDDQ_AB_VOL_V      (0x10) :    1.20 Volts | (ok)
MEB_CXL2_PVDDQ_CD_VOL_V      (0x11) :    1.20 Volts | (ok)
MEB_CXL2_P12V_STBY_4CP_CUR_A (0x12) :    1.36 Amps  | (ok)
MEB_CXL2_P3V3_STBY_4CP_CUR_A (0x13) :    0.06 Amps  | (ok)
MEB_CXL2_P0V8_ASICA_CUR_A    (0x14) :    1.00 Amps  | (ok)
MEB_CXL2_P0V9_ASICA_CUR_A    (0x15) :    1.00 Amps  | (ok)
MEB_CXL2_P0V8_ASICD_CUR_A    (0x16) :    2.00 Amps  | (ok)
MEB_CXL2_PVDDQ_AB_CUR_A      (0x17) :    2.00 Amps  | (ok)
MEB_CXL2_PVDDQ_CD_CUR_A      (0x18) :    3.00 Amps  | (ok)
MEB_CXL2_P12V_STBY_4CP_PWR_W (0x19) :   16.60 Watts | (ok)
MEB_CXL2_P3V3_STBY_4CP_PWR_W (0x1A) :    0.20 Watts | (ok)
MEB_CXL2_P0V8_ASICA_PWR_W    (0x1B) :    1.00 Watts | (ok)
MEB_CXL2_P0V9_ASICA_PWR_W    (0x1C) :    1.00 Watts | (ok)
MEB_CXL2_P0V8_ASICD_PWR_W    (0x1D) :    2.00 Watts | (ok)
MEB_CXL2_PVDDQ_AB_PWR_W      (0x1E) :    3.00 Watts | (ok)
MEB_CXL2_PVDDQ_CD_PWR_W      (0x1F) :    2.00 Watts | (ok)
MEB_CXL2_DIMM_A_TEMP_C       (0x21) :   28.25 C     | (ok)
MEB_CXL2_DIMM_B_TEMP_C       (0x22) :   28.75 C     | (ok)
MEB_CXL2_DIMM_C_TEMP_C       (0x23) :   29.00 C     | (ok)
MEB_CXL2_DIMM_D_TEMP_C       (0x24) :   29.00 C     | (ok)