### PR TITLE
fby35: CL: Modify ADC config

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -120,7 +120,7 @@ sensor_cfg plat_sensor_config[] = {
 	  &dimm_pre_proc_args[5], NULL, NULL, NULL },
 
 	// adc voltage
-	{ SENSOR_NUM_VOL_STBY12V, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE, stby_access, 667, 100,
+	{ SENSOR_NUM_VOL_STBY12V, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE, stby_access, 66, 10,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 	{ SENSOR_NUM_VOL_STBY3V, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE, stby_access, 2, 1,
@@ -135,7 +135,7 @@ sensor_cfg plat_sensor_config[] = {
 	{ SENSOR_NUM_VOL_STBY5V, sensor_dev_ast_adc, ADC_PORT9, NONE, NONE, stby_access, 711, 200,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
-	{ SENSOR_NUM_VOL_DIMM12V, sensor_dev_ast_adc, ADC_PORT11, NONE, NONE, dc_access, 667, 100,
+	{ SENSOR_NUM_VOL_DIMM12V, sensor_dev_ast_adc, ADC_PORT11, NONE, NONE, dc_access, 66, 10,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 	{ SENSOR_NUM_VOL_STBY1V2, sensor_dev_ast_adc, ADC_PORT13, NONE, NONE, stby_access, 1, 1,


### PR DESCRIPTION
Summary:
- Correct ADC0 and ADC11 config.

Test plan:
- Build code: Pass
- Get ADC reading: Pass

Log:
1. Get ADC0 and ADC11 reading. 
root@bmc-oob:~# sensor-util slot4 --force | grep MB_ADC_P12V_STBY_VOLT_V
MB_ADC_P12V_STBY_VOLT_V      (0x20) :   12.58 Volts  | (ok)

root@bmc-oob:~# sensor-util slot4 --force | grep MB_ADC_P12V_DIMM_VOLT_V
MB_ADC_P12V_DIMM_VOLT_V      (0x26) :   12.65 Volts  | (ok)