### PR TITLE
fby35: CL: Modify LTC4286 adjustment

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.c
@@ -41,8 +41,8 @@ LOG_MODULE_REGISTER(plat_hook);
 
 #define ADJUST_ADM1278_POWER(x) (x * 0.98)
 #define ADJUST_ADM1278_CURRENT(x) ((x * 0.98) + 0.1)
-#define ADJUST_LTC4286_POWER(x) ((x * 0.97) - 8)
-#define ADJUST_LTC4286_CURRENT(x) ((x * 0.97) - 0.4)
+#define ADJUST_LTC4286_POWER(x) ((x * 0.99) + 1.5)
+#define ADJUST_LTC4286_CURRENT(x) ((x * 0.99) + 0.3)
 #define ADJUST_LTC4282_POWER(x) (x * 0.99)
 #define ADJUST_LTC4282_CURRENT(x) (x * 0.99)
 


### PR DESCRIPTION
Summary:
- Modify the correction formula of LTC4286 power and current.
- Power: Pin * 0.99 + 1.5 Current: Iout * 0.99 + 0.3.

Test plan:
- Build code: Pass
- Read power and current: Pass

Log:
1. Check LTC4286 reading.
DC load             BMC reporting    DM                              BMC reporting  DM                          BMC reporting  DM
Current loading(A)  Input power(W)   Input power(W)  Deviation(%)    current(A)     Current(A)  Deviation (%)   Voltage(V)     Voltage(V)  Deviation(%)
6                   78.32            79.4828288      -1.46%          6.44           6.368       1.13%           12.52          12.4816     0.31%
9                   115.65           116.8878711     -1.06%          9.42           9.373       0.50%           12.52          12.4707     0.40%
12                  152.77           154.871585      -1.36%          12.4           12.43       -0.24%          12.51          12.4595     0.41%
15                  190.09           192.203296      -1.10%          15.39          15.44       -0.32%          12.51          12.4484     0.49%
18                  227.32           229.715084      -1.04%          18.37          18.47       -0.54%          12.49          12.4372     0.42%
21                  264.44           268.155238      -1.39%          21.36          21.58       -1.02%          12.49          12.4261     0.51%
24                  301.37           305.774061      -1.44%          24.35          24.63       -1.14%          12.48          12.4147     0.53%
27                  338.49           339.74556       -0.37%          27.33          27.39       -0.22%          12.47          12.404      0.53%
30                  375.62           376.172544      -0.15%          30.32          30.36       -0.13%          12.46          12.3904     0.56%
33                  412.65           412.829645      -0.04%          33.31          33.35       -0.12%          12.46          12.3787     0.66%
36                  449.47           449.54045       -0.02%          36.3           36.35       -0.14%          12.45          12.367      0.67%