### PR TITLE
fby35: gl: support mp5990 sensor reading

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -691,6 +691,8 @@ __weak void load_sensor_config(void)
 {
 	memcpy(sensor_config, plat_sensor_config, sizeof(sensor_cfg) * SENSOR_CONFIG_SIZE);
 	sensor_config_count = SENSOR_CONFIG_SIZE;
+
+	pal_extend_sensor_config();
 }
 
 void control_sensor_polling(uint8_t sensor_num, uint8_t optional, uint8_t cache_status)

--- a/meta-facebook/yv35-gl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_hook.c
@@ -42,6 +42,14 @@ adc_asd_init_arg adc_asd_init_args[] = { [0] = { .is_init = false } };
 adm1278_init_arg adm1278_init_args[] = {
 	[0] = { .is_init = false, .config = { 0x3F1C }, .r_sense = 0.25 }
 };
+mp5990_init_arg mp5990_init_args[] = { [0] = { .is_init = false,
+					       .iout_cal_gain = 0x01B3,
+					       .iout_oc_fault_limit = 0x0044,
+					       .ocw_sc_ref = 0x0AE0 },
+				       [1] = { .is_init = false,
+					       .iout_cal_gain = 0x021A,
+					       .iout_oc_fault_limit = 0x0054,
+					       .ocw_sc_ref = 0x0ADF } };
 
 struct tca9548 mux_conf_addr_0xe2[8] = {
 	[0] = { .addr = 0xe2, .chan = 0 }, [1] = { .addr = 0xe2, .chan = 1 },

--- a/meta-facebook/yv35-gl/src/platform/plat_hook.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_hook.h
@@ -31,6 +31,7 @@ typedef struct _dimm_pre_proc_arg {
 **************************************************************************************************/
 extern adc_asd_init_arg adc_asd_init_args[];
 extern adm1278_init_arg adm1278_init_args[];
+extern mp5990_init_arg mp5990_init_args[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS

--- a/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
@@ -22,6 +22,10 @@
 #include "plat_sensor_table.h"
 #include "plat_ipmb.h"
 
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(plat_sdr_table);
+
 SDR_Full_sensor plat_sdr_table[] = {
 	{
 		0x00,
@@ -802,66 +806,6 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // OEM
 		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
 		"MB_SSD0_TEMP_C",
-	},
-	{
-		0x00,
-		0x00, // record ID
-		IPMI_SDR_VER_15, // SDR ver
-		IPMI_SDR_FULL_SENSOR, // record type
-		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
-
-		SELF_I2C_ADDRESS << 1, // owner id
-		0x00, // owner lun
-		SENSOR_NUM_MB_HSC_TEMP_C, // sensor number
-
-		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
-		0x00, // entity instance
-		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
-			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
-			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
-			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
-		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
-			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
-		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
-		0x00, // assert event mask
-		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
-			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
-		0x00, // deassert event mask
-		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
-			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
-		0x00, // discrete reading mask/ settable
-		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
-			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
-		0x00, // modifier unit
-		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
-		0x00, // [7:0] B bits
-		0x00, // [9:8] B bits, tolerance
-		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
-		0x00, // analog characteristic
-		0x00, // nominal reading
-		0x00, // normal maximum
-		0x00, // normal minimum
-		0x00, // sensor maximum reading
-		0x00, // sensor minimum reading
-		0x7D, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
-		0x00, // positive-going threshold
-		0x00, // negative-going threshold
-		0x00, // reserved
-		0x00, // reserved
-		0x00, // OEM
-		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
-		"MB_HSC_TEMP_C",
 	},
 	{
 		0x00,
@@ -1654,66 +1598,6 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_MB_HSC_INPUT_VOLT_V, // sensor number
-
-		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
-		0x00, // entity instance
-		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
-			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
-			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
-			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
-		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
-			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
-		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
-		0x00, // assert event mask
-		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
-			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
-		0x00, // deassert event mask
-		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
-			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
-		0x00, // discrete reading mask/ settable
-		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
-			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
-		0x00, // modifier unit
-		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x3B, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
-		0x00, // [7:0] B bits
-		0x00, // [9:8] B bits, tolerance
-		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xD0, // Rexp, Bexp
-		0x00, // analog characteristic
-		0x00, // nominal reading
-		0x00, // normal maximum
-		0x00, // normal minimum
-		0x00, // sensor maximum reading
-		0x00, // sensor minimum reading
-		0xF3, // UNRT
-		0xE2, // UCT
-		0xE0, // UNCT
-		0xAB, // LNRT
-		0xB5, // LCT
-		0xB7, // LNCT
-		0x00, // positive-going threshold
-		0x00, // negative-going threshold
-		0x00, // reserved
-		0x00, // reserved
-		0x00, // OEM
-		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
-		"MB_HSC_INPUT_VOLT_V",
-	},
-	{
-		0x00,
-		0x00, // record ID
-		IPMI_SDR_VER_15, // SDR ver
-		IPMI_SDR_FULL_SENSOR, // record type
-		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
-
-		SELF_I2C_ADDRESS << 1, // owner id
-		0x00, // owner lun
 		SENSOR_NUM_MB_VR_VCCIN_VOLT_V, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
@@ -2376,66 +2260,6 @@ SDR_Full_sensor plat_sdr_table[] = {
 
 		SELF_I2C_ADDRESS << 1, // owner id
 		0x00, // owner lun
-		SENSOR_NUM_MB_HSC_OUTPUT_CURR_A, // sensor number
-
-		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
-		0x00, // entity instance
-		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
-			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
-			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
-			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
-		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
-			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_CURRENT, // sensor type
-		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
-		0x00, // assert event mask
-		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
-			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
-		0x00, // deassert event mask
-		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
-			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
-		0x00, // discrete reading mask/ settable
-		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
-			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_AMP, // base unit
-		0x00, // modifier unit
-		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x1B, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
-		0x00, // [7:0] B bits
-		0x00, // [9:8] B bits, tolerance
-		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xE0, // Rexp, Bexp
-		0x00, // analog characteristic
-		0x00, // nominal reading
-		0x00, // normal maximum
-		0x00, // normal minimum
-		0x00, // sensor maximum reading
-		0x00, // sensor minimum reading
-		0xFC, // UNRT
-		0xCD, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
-		0x00, // positive-going threshold
-		0x00, // negative-going threshold
-		0x00, // reserved
-		0x00, // reserved
-		0x00, // OEM
-		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
-		"MB_HSC_OUTPUT_CURR_A",
-	},
-	{
-		0x00,
-		0x00, // record ID
-		IPMI_SDR_VER_15, // SDR ver
-		IPMI_SDR_FULL_SENSOR, // record type
-		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
-
-		SELF_I2C_ADDRESS << 1, // owner id
-		0x00, // owner lun
 		SENSOR_NUM_MB_VR_VCCIN_CURR_A, // sensor number
 
 		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
@@ -2789,66 +2613,6 @@ SDR_Full_sensor plat_sdr_table[] = {
 	},
 
 	//Power
-	{
-		0x00,
-		0x00, // record ID
-		IPMI_SDR_VER_15, // SDR ver
-		IPMI_SDR_FULL_SENSOR, // record type
-		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
-
-		SELF_I2C_ADDRESS << 1, // owner id
-		0x00, // owner lun
-		SENSOR_NUM_MB_HSC_INPUT_PWR_W, // sensor number
-
-		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
-		0x00, // entity instance
-		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
-			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
-			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
-			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
-		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
-			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_POWER_SUPPLY, // sensor type
-		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
-		0x00, // assert event mask
-		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
-			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
-		0x00, // deassert event mask
-		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
-			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
-		0x00, // discrete reading mask/ settable
-		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
-			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_WATT, // base unit
-		0x00, // modifier unit
-		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x23, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
-		0x00, // [7:0] B bits
-		0x00, // [9:8] B bits, tolerance
-		0x00, // [7:4] acPWRacy , [3:2] acPWRacy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
-		0x00, // analog characteristic
-		0x00, // nominal reading
-		0x00, // normal maximum
-		0x00, // normal minimum
-		0x00, // sensor maximum reading
-		0x00, // sensor minimum reading
-		0xF3, // UNRT
-		0xC6, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
-		0x00, // positive-going threshold
-		0x00, // negative-going threshold
-		0x00, // reserved
-		0x00, // reserved
-		0x00, // OEM
-		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
-		"MB_HSC_INPUT_PWR_W",
-	},
 	{
 		0x00,
 		0x00, // record ID
@@ -3215,6 +2979,249 @@ SDR_Full_sensor plat_sdr_table[] = {
 	 */
 };
 
+SDR_Full_sensor hotswap_sdr_table[] = {
+	{
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_HSC_TEMP_C, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x7D, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_HSC_TEMP_C",
+	},
+	{
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_HSC_INPUT_VOLT_V, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x3B, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xD0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0xF3, // UNRT
+		0xE2, // UCT
+		0xE0, // UNCT
+		0xAB, // LNRT
+		0xB5, // LCT
+		0xB7, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_HSC_INPUT_VOLT_V",
+	},
+	{
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_HSC_OUTPUT_CURR_A, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_CURRENT, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x1B, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xE0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0xFC, // UNRT
+		0xCD, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_HSC_OUTPUT_CURR_A",
+	},
+	{
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_HSC_INPUT_PWR_W, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_POWER_SUPPLY, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x23, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] acPWRacy , [3:2] acPWRacy exp, [1:0] sensor direction
+		0xF0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0xF3, // UNRT
+		0xC6, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_HSC_INPUT_PWR_W",
+	},
+};
+
 uint8_t fix_2ou_sdr_table[][10] = {
 	// sensor_num , UNR , UCR , UNC , LNR , LCR , LNC , ( M_tolerance >> 6 ) || M , ( B_accuracy >> 6 ) || B , R
 	{ SENSOR_NUM_MB_HSC_OUTPUT_CURR_A, 0xB2, 0x91, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x00, 0xF0 },
@@ -3232,9 +3239,40 @@ void load_sdr_table(void)
 	pal_extend_full_sdr_table();
 }
 
+uint8_t pal_get_extend_sdr()
+{
+	uint8_t extend_sdr_size = 0;
+	uint8_t hsc_module = get_hsc_module();
+	switch (hsc_module) {
+	case HSC_MODULE_ADM1278:
+	case HSC_MODULE_MP5990:
+		extend_sdr_size += ARRAY_SIZE(hotswap_sdr_table);
+		break;
+	default:
+		LOG_ERR("Unsupported HSC module, HSC module: 0x%x", hsc_module);
+		break;
+	}
+
+	return extend_sdr_size;
+}
+
 void pal_extend_full_sdr_table()
 {
 	uint8_t extend_array_num = 0;
+
+	uint8_t hsc_module = get_hsc_module();
+	switch (hsc_module) {
+	case HSC_MODULE_ADM1278:
+	case HSC_MODULE_MP5990:
+		extend_array_num = ARRAY_SIZE(hotswap_sdr_table);
+		for (int index = 0; index < extend_array_num; index++) {
+			add_full_sdr_table(hotswap_sdr_table[index]);
+		}
+		break;
+	default:
+		LOG_ERR("Unsupported HSC module, HSC module: 0x%x", hsc_module);
+		break;
+	}
 
 	// Fix sdr table if 2ou card is present
 	CARD_STATUS _2ou_status = get_2ou_status();

--- a/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
@@ -19,11 +19,17 @@
 #include "sensor.h"
 #include "pmbus.h"
 #include "intel_peci.h"
+#include "hal_gpio.h"
 
 #include "plat_class.h"
+#include "plat_gpio.h"
 #include "plat_i2c.h"
 #include "plat_sensor_table.h"
 #include "plat_hook.h"
+
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(plat_sensor_table);
 
 sensor_cfg plat_sensor_config[] = {
 	/*  number,
@@ -97,11 +103,6 @@ sensor_cfg plat_sensor_config[] = {
 	  0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_nvme_read, &mux_conf_addr_0xe2[1], NULL, NULL, NULL },
 
-	{ SENSOR_NUM_MB_HSC_TEMP_C, sensor_dev_adm1278, I2C_BUS2, HSC_ADM1278_ADDR,
-	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &adm1278_init_args[0] },
-
 	{ SENSOR_NUM_MB_VR_VCCIN_TEMP_C, sensor_dev_xdpe15284, I2C_BUS5, PVCCIN_ADDR,
 	  VR_TEMP_OFFSET, vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read,
@@ -165,11 +166,6 @@ sensor_cfg plat_sensor_config[] = {
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	//Voltage
-	{ SENSOR_NUM_MB_HSC_INPUT_VOLT_V, sensor_dev_adm1278, I2C_BUS2, HSC_ADM1278_ADDR,
-	  PMBUS_READ_VIN, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &adm1278_init_args[0] },
-
 	{ SENSOR_NUM_MB_VR_VCCIN_VOLT_V, sensor_dev_xdpe15284, I2C_BUS5, PVCCIN_ADDR, VR_VOL_OFFSET,
 	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_pre_read_args[0], NULL, NULL, NULL },
@@ -190,11 +186,6 @@ sensor_cfg plat_sensor_config[] = {
 	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_pre_read_args[1], NULL, NULL, NULL },
 
 	//Current
-	{ SENSOR_NUM_MB_HSC_OUTPUT_CURR_A, sensor_dev_adm1278, I2C_BUS2, HSC_ADM1278_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &adm1278_init_args[0] },
-
 	{ SENSOR_NUM_MB_VR_VCCIN_CURR_A, sensor_dev_xdpe15284, I2C_BUS5, PVCCIN_ADDR, VR_CUR_OFFSET,
 	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_pre_read_args[0], NULL, NULL, NULL },
@@ -215,11 +206,6 @@ sensor_cfg plat_sensor_config[] = {
 	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_pre_read_args[1], NULL, NULL, NULL },
 
 	//Power
-	{ SENSOR_NUM_MB_HSC_INPUT_PWR_W, sensor_dev_adm1278, I2C_BUS2, HSC_ADM1278_ADDR,
-	  PMBUS_READ_PIN, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &adm1278_init_args[0] },
-
 	{ SENSOR_NUM_MB_VR_VCCIN_PWR_W, sensor_dev_xdpe15284, I2C_BUS5, PVCCIN_ADDR, VR_PWR_OFFSET,
 	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_pre_read_args[0], NULL, NULL, NULL },
@@ -244,4 +230,92 @@ sensor_cfg plat_sensor_config[] = {
 	 */
 };
 
+sensor_cfg adm1278_sensor_config_table[] = {
+	{ SENSOR_NUM_MB_HSC_TEMP_C, sensor_dev_adm1278, I2C_BUS2, HSC_ADM1278_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &adm1278_init_args[0] },
+	{ SENSOR_NUM_MB_HSC_INPUT_VOLT_V, sensor_dev_adm1278, I2C_BUS2, HSC_ADM1278_ADDR,
+	  PMBUS_READ_VIN, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &adm1278_init_args[0] },
+	{ SENSOR_NUM_MB_HSC_OUTPUT_CURR_A, sensor_dev_adm1278, I2C_BUS2, HSC_ADM1278_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &adm1278_init_args[0] },
+	{ SENSOR_NUM_MB_HSC_INPUT_PWR_W, sensor_dev_adm1278, I2C_BUS2, HSC_ADM1278_ADDR,
+	  PMBUS_READ_PIN, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &adm1278_init_args[0] },
+};
+
+sensor_cfg mp5990_sensor_config_table[] = {
+	{ SENSOR_NUM_MB_HSC_TEMP_C, sensor_dev_mp5990, I2C_BUS2, HSC_MP5990_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &mp5990_init_args[0] },
+	{ SENSOR_NUM_MB_HSC_INPUT_VOLT_V, sensor_dev_mp5990, I2C_BUS2, HSC_MP5990_ADDR, PMBUS_READ_VIN,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
+	{ SENSOR_NUM_MB_HSC_OUTPUT_CURR_A, sensor_dev_mp5990, I2C_BUS2, HSC_MP5990_ADDR, PMBUS_READ_IOUT,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
+	{ SENSOR_NUM_MB_HSC_INPUT_PWR_W, sensor_dev_mp5990, I2C_BUS2, HSC_MP5990_ADDR, PMBUS_READ_PIN,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
+};
+
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
+
+uint8_t pal_get_extend_sensor_config()
+{
+	uint8_t extend_sensor_config_size = 0;
+	uint8_t hsc_module = get_hsc_module();
+	switch (hsc_module) {
+	case HSC_MODULE_ADM1278:
+		extend_sensor_config_size += ARRAY_SIZE(adm1278_sensor_config_table);
+		break;
+	case HSC_MODULE_MP5990:
+		extend_sensor_config_size += ARRAY_SIZE(mp5990_sensor_config_table);
+		break;
+	default:
+		LOG_ERR("Unsupported HSC module, HSC module: 0x%x", hsc_module);
+		break;
+	}
+
+	return extend_sensor_config_size;
+}
+
+void pal_extend_sensor_config()
+{
+	/* Follow the hardware design,
+	 * the GPIOA7(HSC_SET_EN_R) should be set to "H"
+	 * and the 2OU configuration is set if the 2OU is present.
+	 */
+	CARD_STATUS _2ou_status = get_2ou_status();
+
+	int arg_index = (_2ou_status.present) ? 1 : 0;
+	int gpio_state = (_2ou_status.present) ? GPIO_HIGH : GPIO_LOW;
+	gpio_set(HSC_SET_EN_R, gpio_state);
+
+	uint8_t sensor_count = 0;
+	uint8_t hsc_module = get_hsc_module();
+	switch (hsc_module) {
+	case HSC_MODULE_ADM1278:
+		sensor_count = ARRAY_SIZE(adm1278_sensor_config_table);
+		for (int index = 0; index < sensor_count; index++) {
+			add_sensor_config(adm1278_sensor_config_table[index]);
+		}
+		break;
+	case HSC_MODULE_MP5990:
+		sensor_count = ARRAY_SIZE(mp5990_sensor_config_table);
+		for (int index = 0; index < sensor_count; index++) {
+			mp5990_sensor_config_table[index].init_args = &mp5990_init_args[arg_index];
+			add_sensor_config(mp5990_sensor_config_table[index]);
+		}
+		break;
+	default:
+		LOG_ERR("Unsupported HSC module, HSC module: 0x%x", hsc_module);
+		break;
+	}
+}


### PR DESCRIPTION
Summary:
- Support mp5990 HSC sensor monitoring

Test Plan:
- Check sensor reading with hsc adm1278 server board
- Check sensor reading with hsc mp5990 server board

Log:
[00:00:00.086,000] <inf> plat_class: BIC class type(class-1), 1ou present status(0), 2ou present status(1), board revision(0x0)

uart:~$ i2c read I2C_1 0xb 0x46 2
00000000: 54 00                                            |T.               |
uart:~$ i2c read I2C_1 0xb 0x38 2
00000000: 1a 02                                            |..               |
uart:~$ i2c read I2C_1 0xb 0xc5 2
00000000: df 0a                                            |..               |

uart:~$ platform sensor list_all
[0xe ] MB_HSC_TEMP_C            : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    27.000
[0x1c] MB_HSC_INPUT_VOLT_V      : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.250
[0x28] MB_HSC_OUTPUT_CURR_A     : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.500
[0x2f] MB_HSC_INPUT_PWR_W       : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.000

uart:~$ platform gpio get 7
[7  ] HSC_SET_EN_R                       : PP  | output(O) | 1(1)

root@bmc-oob:~# sensor-util slot1 |grep HSC
MB_HSC_TEMP_C                (0xE) :   27.00 C     | (ok)
MB_HSC_INPUT_VOLT_V          (0x1C) :   12.25 Volts  | (ok)
MB_HSC_OUTPUT_CURR_A         (0x28) :    0.25 Amps  | (ok)
MB_HSC_INPUT_PWR_W           (0x2F) :    0.00 Watts  | (ok)

[00:00:00.086,000] <inf> plat_class: BIC class type(class-1), 1ou present status(0), 2ou present status(0), board revision(0x0)

uart:~$ i2c read I2C_1 0xb 0x46 2
00000000: 44 00                                            |D.               |
uart:~$ i2c read I2C_1 0xb 0x38 2
00000000: b3 01                                            |..               |
uart:~$ i2c read I2C_1 0xb 0xc5 2
00000000: e0 0a                                            |..               |
uart:~$

uart:~$ platform sensor list_all
[0xe ] MB_HSC_TEMP_C            : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.000
[0x1c] MB_HSC_INPUT_VOLT_V      : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.218
[0x28] MB_HSC_OUTPUT_CURR_A     : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.250
[0x2f] MB_HSC_INPUT_PWR_W       : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.000

uart:~$ platform gpio get 7
[7  ] HSC_SET_EN_R                       : PP  | output(O) | 0(0)

.
root@bmc-oob:~# sensor-util slot1 |grep HSC
MB_HSC_TEMP_C                (0xE) :   28.00 C     | (ok)
MB_HSC_INPUT_VOLT_V          (0x1C) :   12.25 Volts  | (ok)
MB_HSC_OUTPUT_CURR_A         (0x28) :    0.25 Amps  | (ok)
MB_HSC_INPUT_PWR_W           (0x2F) :    0.00 Watts  | (ok)

[00:00:00.085,000] <inf> plat_class: BIC class type(class-1), 1ou present status(1), 2ou present status(1), board revision(0x0)

uart:~$ platform sensor list_all
[0xe ] MB_HSC_TEMP_C            : hsc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    22.380
[0x1c] MB_HSC_INPUT_VOLT_V      : hsc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.316
[0x28] MB_HSC_OUTPUT_CURR_A     : hsc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.875
[0x2f] MB_HSC_INPUT_PWR_W       : hsc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    10.713

uart:~$ platform gpio get 7
[7  ] HSC_SET_EN_R                       : PP  | output(O) | 1(1)

root@bmc-oob:~# sensor-util slot1 |grep HSC
MB_HSC_TEMP_C                (0xE) :   22.14 C     | (ok)
MB_HSC_INPUT_VOLT_V          (0x1C) :   12.32 Volts  | (ok)
MB_HSC_OUTPUT_CURR_A         (0x28) :    0.82 Amps  | (ok)
MB_HSC_INPUT_PWR_W           (0x2F) :   10.84 Watts  | (ok)

[00:00:00.086,000] <inf> plat_class: BIC class type(class-1), 1ou present status(1), 2ou present status(0), board revision(0x0)

uart:~$ platform sensor list_all
[0xe ] MB_HSC_TEMP_C            : hsc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    23.571
[0x1c] MB_HSC_INPUT_VOLT_V      : hsc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.316
[0x28] MB_HSC_OUTPUT_CURR_A     : hsc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.825
[0x2f] MB_HSC_INPUT_PWR_W       : hsc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    10.125

uart:~$ platform gpio get 7
[7  ] HSC_SET_EN_R                       : PP  | output(O) | 0(0)

root@bmc-oob:~# sensor-util slot1 |grep HSC
MB_HSC_TEMP_C                (0xE) :   23.57 C     | (ok)
MB_HSC_INPUT_VOLT_V          (0x1C) :   12.32 Volts  | (ok)
MB_HSC_OUTPUT_CURR_A         (0x28) :    0.88 Amps  | (ok)
MB_HSC_INPUT_PWR_W           (0x2F) :   10.65 Watts  | (ok)