### PR TITLE
at: mc: fix fru mapping

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_fru.c
+++ b/meta-facebook/at-mc/src/platform/plat_fru.c
@@ -20,6 +20,8 @@
 #include <string.h>
 #include "fru.h"
 #include "i2c-mux-pca954x.h"
+#include "plat_class.h"
+#include "plat_ipmi.h"
 
 const EEPROM_CFG plat_fru_config[] = {
 	{
@@ -147,29 +149,31 @@ uint8_t pal_cxl_map_mux0_channel(uint8_t cxl_fru_id)
 {
 	uint8_t channel = 0;
 
-	switch (cxl_fru_id) {
-	case CXL_FRU_ID1:
+	uint8_t pcie_card_id = cxl_fru_id - PCIE_CARD_ID_OFFSET;
+
+	switch (pcie_card_id) {
+	case CARD_1_INDEX:
 		channel = PCA9548A_CHANNEL_6;
 		break;
-	case CXL_FRU_ID2:
+	case CARD_2_INDEX:
 		channel = PCA9548A_CHANNEL_7;
 		break;
-	case CXL_FRU_ID3:
+	case CARD_3_INDEX:
 		channel = PCA9548A_CHANNEL_4;
 		break;
-	case CXL_FRU_ID4:
+	case CARD_4_INDEX:
 		channel = PCA9548A_CHANNEL_5;
 		break;
-	case CXL_FRU_ID5:
+	case CARD_9_INDEX:
 		channel = PCA9548A_CHANNEL_3;
 		break;
-	case CXL_FRU_ID6:
+	case CARD_10_INDEX:
 		channel = PCA9548A_CHANNEL_2;
 		break;
-	case CXL_FRU_ID7:
+	case CARD_11_INDEX:
 		channel = PCA9548A_CHANNEL_1;
 		break;
-	case CXL_FRU_ID8:
+	case CARD_12_INDEX:
 		channel = PCA9548A_CHANNEL_0;
 		break;
 	default:


### PR DESCRIPTION
Summary:
- The fru mapping is wrong. Solution:
- Change fru id to pcie card id and remapping for cxl.

Test Plan:
- Build Code : pass
- Get fru info: root@bmc-oob:~# fruid-util mc_cxl2

FRU Information           : MC CXL2
---------------           : ------------------
Board Mfg Date            : Mon Jan 10 12:34:00 2022
Board Mfg                 : Wiwynn
Board Product             : FAKE CXL8 FRU
Board Serial              : WT0720107TN01
Board Part Number         : B81.04G10.0007
Board FRU ID              : 1.0
Board Custom Data 1       : 09-001388
Board Custom Data 2       : PCB Supplier - TRI
Product Manufacturer      : Wiwynn
Product Name              : Great Lakes
Product Part Number       : B81.04G01.0020
Product Version           : EVT2
Product Serial            : WTT220400ZNSD
Product Asset Tag         : AX84682
Product FRU ID            : 1.0
Product Custom Data 1     : 01-005999
Product Custom Data 2     : Config A-7-MCC

plug out cxl3 and get the fru info
root@bmc-oob:~# fruid-util mc_cxl3
Cannot read FRUID for mc_cxl3
Usage: fruid-util [ all, mb, nic0, nic1, bmc, scm, vpdb, hpdb, fan_bp1, fan_bp2, fio, hsc, cb, mc, cb_accl1, cb_accl2, cb_accl3, cb_accl4, cb_accl5, cb_accl6, cb_accl7, cb_accl8, cb_accl9, cb_accl10, cb_accl11, cb_accl12, mc_cxl8, mc_cxl7, mc_cxl6, mc_cxl5, mc_cxl4, mc_cxl1, mc_cxl2 ] [--json]
Usage: fruid-util [ mb, nic0, nic1, bmc, scm, vpdb, hpdb, fan_bp1, fan_bp2, fio, hsc, cb, mc, cb_accl1, cb_accl2, cb_accl3, cb_accl4, cb_accl5, cb_accl6, cb_accl7, cb_accl8, cb_accl9, cb_accl10, cb_accl11, cb_accl12, mc_cxl8, mc_cxl7, mc_cxl6, mc_cxl5, mc_cxl4, mc_cxl1, mc_cxl2 ] [--dump | --write ] <file>
Usage: fruid-util [ mb, nic0, nic1, bmc, scm, vpdb, hpdb, fan_bp1, fan_bp2, fio, hsc, cb, mc, cb_accl1, cb_accl2, cb_accl3, cb_accl4, cb_accl5, cb_accl6, cb_accl7, cb_accl8, cb_accl9, cb_accl10, cb_accl11, cb_accl12, mc_cxl8, mc_cxl7, mc_cxl6, mc_cxl5, mc_cxl4, mc_cxl1, mc_cxl2 ] --modify <field> <data> <file>
       [field] : CPN  (Chassis Part Number)
                       e.g., fruid-util fru1 --modify --CPN "xxxxx" xxx.bin
                 CSN  (Chassis Serial Number)
                 CCD1 (Chassis Custom Data 1)
                 CCD2 (Chassis Custom Data 2)
                 CCD3 (Chassis Custom Data 3)
                 CCD4 (Chassis Custom Data 4)
                 CCD5 (Chassis Custom Data 5)
                 CCD6 (Chassis Custom Data 6)
                 BMD  (Board Mfg Date)
                       e.g., fruid-util fru1 --modify --BMD "$( date +%s -d "2018-01-01 17:00:00" )" xxx.bin
                 BM   (Board Manufacturer)
                 BP   (Board Product Number)
                 BSN  (Board Serial Number)
                 BPN  (Board Part Number)
                 BFI  (Board FRU ID)
                 BCD1 (Board Custom Data 1)
                 BCD2 (Board Custom Data 2)
                 BCD3 (Board Custom Data 3)
                 BCD4 (Board Custom Data 4)
                 BCD5 (Board Custom Data 5)
                 BCD6 (Board Custom Data 6)
                 PM   (Product Manufacturer)
                 PN   (Product Name)
                 PPN  (Product Part Number)
                 PV   (Product Version)
                 PSN  (Product Serial Number)
                 PAT  (Product Asset Tag)
                 PFI  (Product FRU ID)
                 PCD1 (Product Custom Data 1)
                 PCD2 (Product Custom Data 2)
                 PCD3 (Product Custom Data 3)
                 PCD4 (Product Custom Data 4)
                 PCD5 (Product Custom Data 5)
                 PCD6 (Product Custom Data 6)