### PR TITLE
oby35: rf: Remove CXL Temp Sensor

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_sdr_table.c
@@ -389,67 +389,6 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"RF_MB_INLET_TEMP_C",
 	},
 	{
-		// TMP75 on CXL temperature
-		0x00,
-		0x00, // record ID
-		IPMI_SDR_VER_15, // SDR ver
-		IPMI_SDR_FULL_SENSOR, // record type
-		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
-
-		SELF_I2C_ADDRESS << 1, // owner id
-		0x00, // owner lun
-		SENSOR_NUM_TEMP_CXL_CNTR, // sensor number
-
-		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
-		0x00, // entity instance
-		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
-			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
-			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
-			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
-		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
-			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
-		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
-		0x00, // assert event mask
-		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
-			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
-		0x00, // deassert event mask
-		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
-			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
-		0x00, // discrete reading mask/ settable
-		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
-			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
-		0x00, // modifier unit
-		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
-		0x00, // [7:0] B bits
-		0x00, // [9:8] B bits, tolerance
-		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
-		0x00, // analog characteristic
-		0x00, // nominal reading
-		0x00, // normal maximum
-		0x00, // normal minimum
-		0x00, // sensor maximum reading
-		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x54, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
-		0x00, // positive-going threshold
-		0x00, // negative-going threshold
-		0x00, // reserved
-		0x00, // reserved
-		0x00, // OEM
-		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
-		"RF_CXL_TEMP_C",
-	},
-	{
 		// P5V STBY ADC voltage
 		0x00,
 		0x00, // record ID

--- a/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
@@ -60,9 +60,6 @@ sensor_cfg plat_sensor_config[] = {
 	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_pm8702_read, NULL, post_pm8702_read, NULL,
 	  &pm8702_dimm_init_args[3] },
-	{ SENSOR_NUM_TEMP_CXL_CNTR, sensor_dev_tmp75, I2C_BUS2, TMP75_ASIC_ADDR, TMP75_TEMP_OFFSET,
-	  dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, pre_pm8702_read, NULL, post_pm8702_read, NULL, NULL },
 
 	// ADC
 	{ SENSOR_NUM_VOL_STBY5V, sensor_dev_ast_adc, ADC_PORT14, NONE, NONE, stby_access, 711, 200,

--- a/meta-facebook/yv35-rf/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_sensor_table.h
@@ -50,7 +50,6 @@
 /*  threshold sensor number, 1 based  */
 #define SENSOR_NUM_TEMP_TMP75 0x50
 #define SENSOR_NUM_TEMP_CXL 0x51
-#define SENSOR_NUM_TEMP_CXL_CNTR 0x52
 #define SENSOR_NUM_TEMP_DIMMA 0x53
 #define SENSOR_NUM_TEMP_DIMMB 0x54
 #define SENSOR_NUM_TEMP_DIMMC 0x55


### PR DESCRIPTION
- Summary:
Since the BIC can read the temperature of the CXL more stably through the MCTP CCI, we have removed the CXL thermal sensor from the PCB to avoid any confusion for users.

- Test Plan:
Build code: Pass

```
root@bmc-oob:~# sensor-util slot1 | grep RF
RF_MB_INLET_TEMP_C           (0x50) :   32.00 C     | (ok)
RF_CXL_CNTR_TEMP_C           (0x51) :   48.00 C     | (ok)
RF_DIMM_A_TEMP_C             (0x53) :   39.00 C     | (ok)
RF_DIMM_B_TEMP_C             (0x54) :   39.50 C     | (ok)
RF_DIMM_C_TEMP_C             (0x55) :   38.50 C     | (ok)
RF_DIMM_D_TEMP_C             (0x57) :   36.75 C     | (ok)
RF_P0V9_A_TEMP_C             (0x58) :   38.00 C     | (ok)
RF_P0V8_A_TEMP_C             (0x59) :   40.00 C     | (ok)
RF_P0V8_D_TEMP_C             (0x5A) :   38.00 C     | (ok)
RF_PVDDQ_AB_TEMP_C           (0x5B) :   38.00 C     | (ok)
RF_PVDDQ_CD_TEMP_C           (0x5C) :   37.00 C     | (ok)
```

