### PR TITLE
fby35: nf: Support TMP461

### DIFF
--- a/common/dev/include/tmp461.h
+++ b/common/dev/include/tmp461.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TMP461_H
+#define TMP461_H
+
+enum TMP461_TEMP_RANGE {
+	TEMP_RANGE_M40_127 = 0, // -40~127°C
+	TEMP_RANGE_M64_191, // -64~191°C
+};
+
+enum TMP461_CHANNELS {
+	TMP461_LOCAL_TEMPERATRUE,
+	TMP461_REMOTE_TEMPERATRUE,
+};
+
+enum TMP461_REIGSTER_OFFSET {
+	OFFSET_LOCAL_TEMPERATURE_HIGH_BYTE = 0x00,
+	OFFSET_REMOTE_TEMPERATURE_HIGH_BYTE = 0x01,
+	OFFSET_CONFIGURATION = 0x03,
+	OFFSET_REMOTE_TEMPERATURE_LOW_BYTE = 0x10,
+	OFFSET_LOCAL_TEMPERATURE_LOW_BYTE = 0x15,
+};
+
+#endif

--- a/common/dev/mp2985.c
+++ b/common/dev/mp2985.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <logging/log.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "pmbus.h"
+
+LOG_MODULE_REGISTER(mp2985);
+
+uint8_t mp2985_read(uint8_t sensor_num, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+	if (sensor_num > SENSOR_NUM_MAX) {
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	sensor_cfg *cfg = &sensor_config[sensor_config_index_map[sensor_num]];
+	mp2985_init_arg *init_arg = (mp2985_init_arg *)cfg->init_args;
+	if (!init_arg->is_init) {
+		LOG_ERR("device isn't initialized");
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	uint8_t i2c_max_retry = 5;
+	float val = 0;
+	sensor_val *sval = (sensor_val *)reading;
+	I2C_MSG msg;
+	memset(sval, 0, sizeof(sensor_val));
+
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = cfg->offset;
+
+	if (i2c_master_read(&msg, i2c_max_retry)) {
+		/* read fail */
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	float pow2_n_iout = 0.0f;
+	int y_iout = 0;
+	switch (cfg->offset) {
+	case PMBUS_READ_TEMPERATURE_1:
+		/* TEMP[15:11] are reserved.
+		 * TEMP[10:0] are two’s complement integer.
+		 * BIC reports 0 degeee if the temperature is negative.
+		 */
+		if (GETBIT(msg.data[1], 2)) {
+			val = 0;
+		} else {
+			val = ((msg.data[1] & 0x3) << 8) | msg.data[0];
+		}
+		break;
+	case PMBUS_READ_VOUT:
+		/* The VOUT mode can be set into offset 20h.(VOUT_MODE)
+		 * VOUT mode is set as direct format and the resolution is 1mV/LSB in initialization stage.
+		 * VOUT[15:12] are reserved.
+		 * VOUT[11:0] are output voltage.
+		 */
+		val = ((msg.data[1] & 0x7) << 8) | msg.data[0];
+		val *= 0.001;
+		break;
+	case PMBUS_READ_IOUT:
+		/* The IOUT calculation format is linear-11.
+		 * Refer to PMBus spec 7.3, the linear-11 formula is
+		 * X = Y * (2 ^N)
+		 * Where, as described above:
+		 * X: real world value
+		 * Y: 11-bit(IOUT[10:0]), two’s complement integer
+		 * N: 5-bit(IOUT[15:11]), two’s complement integer
+		 */
+		if (GETBIT(msg.data[1], 7)) {
+			pow2_n_iout = 1 / (float)(1 << ((~(msg.data[1] >> 3) + 1) & 0x1F));
+		} else {
+			pow2_n_iout = 1 / (float)(1 << (msg.data[1] >> 3));
+		}
+
+		if (GETBIT(msg.data[1], 2)) {
+			y_iout = ~(((msg.data[1] & 0x7) << 8) | msg.data[0]) + 1;
+		} else {
+			y_iout = ((msg.data[1] & 0x7) << 8) | msg.data[0];
+		}
+
+		val = y_iout * pow2_n_iout;
+		break;
+	case PMBUS_READ_POUT:
+		/* Output power = POUT[10:0] * 0.25W/LSB */
+		val = ((msg.data[1] & 0x7) << 8) | msg.data[0];
+		val *= 0.25;
+		break;
+	default:
+		LOG_ERR("unsupported offset 0x%x reading", cfg->offset);
+		break;
+	}
+
+	sval->integer = (int32_t)val;
+	sval->fraction = (int32_t)(val * 1000) % 1000;
+
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t mp2985_init(uint8_t sensor_num)
+{
+	if (sensor_num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	if (!sensor_config[sensor_config_index_map[sensor_num]].init_args) {
+		LOG_ERR("%s init args are not provided!", __func__);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	mp2985_init_arg *init_args =
+		(mp2985_init_arg *)sensor_config[sensor_config_index_map[sensor_num]].init_args;
+	if (init_args->is_init)
+		goto skip_init;
+
+	uint8_t retry = 5;
+	I2C_MSG msg;
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
+	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
+
+	/* Set Page0 */
+	msg.tx_len = 2;
+	msg.data[0] = PMBUS_PAGE;
+	msg.data[1] = 0x0;
+	if (i2c_master_write(&msg, retry)) {
+		LOG_ERR("failed to set page0");
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	/* Set VOUT mode as direct format, 1mV/LSB
+	 * Offset 20h VOUT_MODE[7:0]:
+	 * 8'h40: direct format, 1mV/LSB
+	 * 8'h17: linear format, 1/512 V/LSB
+	 * 8'h21: VID format
+	 */
+	msg.tx_len = 2;
+	msg.data[0] = PMBUS_VOUT_MODE;
+	msg.data[1] = 0x40;
+	if (i2c_master_write(&msg, retry)) {
+		LOG_ERR("failed to vout mode");
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	init_args->is_init = true;
+
+skip_init:
+	sensor_config[sensor_config_index_map[sensor_num]].read = mp2985_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/dev/tmp461.c
+++ b/common/dev/tmp461.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <logging/log.h>
+#include "libutil.h"
+#include "sensor.h"
+#include "tmp461.h"
+
+LOG_MODULE_REGISTER(dev_tmp461);
+
+static uint8_t temperature_range = 0xFF;
+
+uint8_t tmp461_read(uint8_t sensor_num, int *reading)
+{
+	if (!reading || (sensor_num > SENSOR_NUM_MAX)) {
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	uint8_t retry = 5, temperature_high_byte = 0xFF, temperature_low_byte = 0xFF;
+	I2C_MSG msg = { 0 };
+
+	msg.bus = sensor_config[sensor_config_index_map[sensor_num]].port;
+	msg.target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 1;
+	uint8_t offset = sensor_config[sensor_config_index_map[sensor_num]].offset;
+
+	switch (offset) {
+	case TMP461_LOCAL_TEMPERATRUE:
+		msg.data[0] = OFFSET_LOCAL_TEMPERATURE_HIGH_BYTE;
+		if (i2c_master_read(&msg, retry)) {
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+		temperature_high_byte = msg.data[0];
+
+		msg.data[0] = OFFSET_LOCAL_TEMPERATURE_LOW_BYTE;
+		if (i2c_master_read(&msg, retry)) {
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+		temperature_low_byte = msg.data[0];
+		break;
+	case TMP461_REMOTE_TEMPERATRUE:
+		msg.data[0] = OFFSET_REMOTE_TEMPERATURE_HIGH_BYTE;
+		if (i2c_master_read(&msg, retry)) {
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+		temperature_high_byte = msg.data[0];
+
+		msg.data[0] = OFFSET_REMOTE_TEMPERATURE_LOW_BYTE;
+		if (i2c_master_read(&msg, retry)) {
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+		temperature_low_byte = msg.data[0];
+		break;
+	default:
+		LOG_ERR("Unknown register offset(%d)", offset);
+		break;
+	}
+
+	float val = 0;
+	switch (temperature_range) {
+	case TEMP_RANGE_M40_127:
+		// Negative numbers are represented in twos complement format
+		if (GETBIT(temperature_high_byte, 7)) {
+			temperature_high_byte = ~temperature_high_byte + 1;
+			val = -temperature_high_byte - ((temperature_low_byte >> 4) * 0.0625);
+		} else {
+			val = temperature_high_byte + ((temperature_low_byte >> 4) * 0.0625);
+		}
+		break;
+	case TEMP_RANGE_M64_191:
+		// All values are unsigned with a –64°C offset
+		val = (temperature_high_byte - 64) + ((temperature_low_byte >> 4) * 0.0625);
+		break;
+	default:
+		LOG_ERR("Unknown temperature range(%d)", temperature_range);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	sval->integer = (int32_t)val;
+	sval->fraction = (int32_t)(val * 1000) % 1000;
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t tmp461_init(uint8_t sensor_num)
+{
+	if (sensor_num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	uint8_t retry = 5;
+	I2C_MSG *i2c_msg = (I2C_MSG *)malloc(sizeof(I2C_MSG));
+
+	if (i2c_msg == NULL) {
+		LOG_ERR("Failed to allocate memory");
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	// Get the temperature range from chip
+	i2c_msg->bus = sensor_config[sensor_config_index_map[sensor_num]].port;
+	i2c_msg->target_addr = sensor_config[sensor_config_index_map[sensor_num]].target_addr;
+	i2c_msg->tx_len = 1;
+	i2c_msg->rx_len = 1;
+	i2c_msg->data[0] = OFFSET_CONFIGURATION;
+	if (i2c_master_read(i2c_msg, retry) != 0) {
+		LOG_ERR("Failed to read TMP461 register(0x%x)", OFFSET_CONFIGURATION);
+		goto exit;
+	}
+
+	temperature_range = GETBIT(i2c_msg->data[0], 2) ? TEMP_RANGE_M40_127 : TEMP_RANGE_M64_191;
+
+exit:
+	SAFE_FREE(i2c_msg);
+
+	sensor_config[sensor_config_index_map[sensor_num]].read = tmp461_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -109,6 +109,7 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(pt5161l)
 	sensor_name_to_num(lm75bd118)
 	sensor_name_to_num(tmp461)
+	sensor_name_to_num(mp2985)
 };
 // clang-format on
 
@@ -157,6 +158,7 @@ SENSOR_DRIVE_INIT_DECLARE(i3c_dimm);
 SENSOR_DRIVE_INIT_DECLARE(pt5161l);
 SENSOR_DRIVE_INIT_DECLARE(lm75bd118);
 SENSOR_DRIVE_INIT_DECLARE(tmp461);
+SENSOR_DRIVE_INIT_DECLARE(mp2985);
 
 struct sensor_drive_api {
 	enum SENSOR_DEV dev;
@@ -207,6 +209,7 @@ struct sensor_drive_api {
 	SENSOR_DRIVE_TYPE_INIT_MAP(pt5161l),
 	SENSOR_DRIVE_TYPE_INIT_MAP(lm75bd118),
 	SENSOR_DRIVE_TYPE_INIT_MAP(tmp461),
+	SENSOR_DRIVE_TYPE_INIT_MAP(mp2985),
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -107,7 +107,8 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(emc1412)
 	sensor_name_to_num(i3c_dimm)
 	sensor_name_to_num(pt5161l)
-  sensor_name_to_num(lm75bd118)
+	sensor_name_to_num(lm75bd118)
+	sensor_name_to_num(tmp461)
 };
 // clang-format on
 
@@ -155,6 +156,7 @@ SENSOR_DRIVE_INIT_DECLARE(emc1412);
 SENSOR_DRIVE_INIT_DECLARE(i3c_dimm);
 SENSOR_DRIVE_INIT_DECLARE(pt5161l);
 SENSOR_DRIVE_INIT_DECLARE(lm75bd118);
+SENSOR_DRIVE_INIT_DECLARE(tmp461);
 
 struct sensor_drive_api {
 	enum SENSOR_DEV dev;
@@ -204,6 +206,7 @@ struct sensor_drive_api {
 	SENSOR_DRIVE_TYPE_INIT_MAP(i3c_dimm),
 	SENSOR_DRIVE_TYPE_INIT_MAP(pt5161l),
 	SENSOR_DRIVE_TYPE_INIT_MAP(lm75bd118),
+	SENSOR_DRIVE_TYPE_INIT_MAP(tmp461),
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -143,6 +143,7 @@ enum SENSOR_DEV {
 	sensor_dev_pt5161l = 0x27,
 	sensor_dev_lm75bd118 = 0x28,
 	sensor_dev_tmp461 = 0x29,
+	sensor_dev_mp2985 = 0x2A,
 	sensor_dev_max
 };
 
@@ -580,6 +581,10 @@ typedef struct _pt5161l_init_arg_ {
 	uint8_t temp_cal_code_avg; // average temp calibration code
 	bool is_init;
 } pt5161l_init_arg;
+
+typedef struct _mp2985_init_arg {
+	bool is_init;
+} mp2985_init_arg;
 
 extern bool enable_sensor_poll_thread;
 extern sensor_cfg *sensor_config;

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -142,6 +142,7 @@ enum SENSOR_DEV {
 	sensor_dev_i3c_dimm = 0x26,
 	sensor_dev_pt5161l = 0x27,
 	sensor_dev_lm75bd118 = 0x28,
+	sensor_dev_tmp461 = 0x29,
 	sensor_dev_max
 };
 

--- a/meta-facebook/yv35-gl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_hook.c
@@ -50,6 +50,7 @@ mp5990_init_arg mp5990_init_args[] = { [0] = { .is_init = false,
 					       .iout_cal_gain = 0x021A,
 					       .iout_oc_fault_limit = 0x0054,
 					       .ocw_sc_ref = 0x0ADF } };
+mp2985_init_arg mp2985_init_args[] = { [0] = { .is_init = false } };
 
 struct tca9548 mux_conf_addr_0xe2[8] = {
 	[0] = { .addr = 0xe2, .chan = 0 }, [1] = { .addr = 0xe2, .chan = 1 },

--- a/meta-facebook/yv35-gl/src/platform/plat_hook.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_hook.h
@@ -32,6 +32,7 @@ typedef struct _dimm_pre_proc_arg {
 extern adc_asd_init_arg adc_asd_init_args[];
 extern adm1278_init_arg adm1278_init_args[];
 extern mp5990_init_arg mp5990_init_args[];
+extern mp2985_init_arg mp2985_init_args[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS

--- a/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
@@ -254,15 +254,18 @@ sensor_cfg mp5990_sensor_config_table[] = {
 	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &mp5990_init_args[0] },
-	{ SENSOR_NUM_MB_HSC_INPUT_VOLT_V, sensor_dev_mp5990, I2C_BUS2, HSC_MP5990_ADDR, PMBUS_READ_VIN,
-	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
-	{ SENSOR_NUM_MB_HSC_OUTPUT_CURR_A, sensor_dev_mp5990, I2C_BUS2, HSC_MP5990_ADDR, PMBUS_READ_IOUT,
-	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
-	{ SENSOR_NUM_MB_HSC_INPUT_PWR_W, sensor_dev_mp5990, I2C_BUS2, HSC_MP5990_ADDR, PMBUS_READ_PIN,
-	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
+	{ SENSOR_NUM_MB_HSC_INPUT_VOLT_V, sensor_dev_mp5990, I2C_BUS2, HSC_MP5990_ADDR,
+	  PMBUS_READ_VIN, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &mp5990_init_args[0] },
+	{ SENSOR_NUM_MB_HSC_OUTPUT_CURR_A, sensor_dev_mp5990, I2C_BUS2, HSC_MP5990_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &mp5990_init_args[0] },
+	{ SENSOR_NUM_MB_HSC_INPUT_PWR_W, sensor_dev_mp5990, I2C_BUS2, HSC_MP5990_ADDR,
+	  PMBUS_READ_PIN, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &mp5990_init_args[0] },
 };
 
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
@@ -284,6 +287,46 @@ uint8_t pal_get_extend_sensor_config()
 	}
 
 	return extend_sensor_config_size;
+}
+
+static void check_vr_type(uint8_t index)
+{
+	uint8_t retry = 5;
+	I2C_MSG msg;
+
+	xdpe15284_pre_read_arg *args = sensor_config[index].pre_sensor_read_args;
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = sensor_config[index].port;
+	msg.target_addr = sensor_config[index].target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = 0x00;
+	msg.data[1] = args->vr_page;
+	if (i2c_master_write(&msg, retry)) {
+		LOG_ERR("Failed to switch to VR page %d", args->vr_page);
+		return;
+	}
+
+	/* Get IC Device ID from VR chip */
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = sensor_config[index].port;
+	msg.target_addr = sensor_config[index].target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 7;
+	msg.data[0] = PMBUS_IC_DEVICE_ID;
+
+	if (i2c_master_read(&msg, retry)) {
+		LOG_ERR("Failed to read VR IC_DEVICE_ID: register(0x%x)", PMBUS_IC_DEVICE_ID);
+		return;
+	}
+
+	if ((msg.data[0] == 0x01) && (msg.data[1] == 0x85)) {
+		sensor_config[index].type = sensor_dev_mp2985;
+		sensor_config[index].init_args = &mp2985_init_args[0];
+	} else if ((msg.data[0] == 0x02) && (msg.data[2] == 0x8A)) {
+		sensor_config[index].type = sensor_dev_xdpe15284;
+	} else {
+		LOG_ERR("Unknown VR type");
+	}
 }
 
 void pal_extend_sensor_config()
@@ -317,5 +360,33 @@ void pal_extend_sensor_config()
 	default:
 		LOG_ERR("Unsupported HSC module, HSC module: 0x%x", hsc_module);
 		break;
+	}
+
+	/* Following the hardware design,
+	 * MPS and Renesas VR chips are used in EVT stage.
+	 * And the slave address is changed in EVT stage.
+	 * So, BIC revises VR slave address according to server board revision.
+	 * Besides, BIC judges VR chip type by getting device id
+	 * and then replace sensor config table before loading.
+	 */
+	uint8_t board_revision = get_board_revision();
+	sensor_count = ARRAY_SIZE(plat_sensor_config);
+	for (uint8_t index = 0; index < sensor_count; index++) {
+		if (sensor_config[index].type == sensor_dev_xdpe15284) {
+			if (board_revision == SYS_BOARD_EVT) {
+				switch (sensor_config[index].target_addr) {
+				case FIVRA_ADDR:
+					sensor_config[index].target_addr = EVT_FIVRA_ADDR;
+					break;
+				case PVCCD0_ADDR:
+					sensor_config[index].target_addr = EVT_PVCCD0_ADDR;
+					break;
+
+				default:
+					break;
+				};
+			};
+			check_vr_type(index);
+		}
 	}
 }

--- a/meta-facebook/yv35-gl/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_sensor_table.h
@@ -31,6 +31,8 @@
 #define INF_ADDR (0xDC >> 1)
 #define PVCCD0_ADDR (0xD4 >> 1)
 #define PVCCD1_ADDR (0xD4 >> 1)
+#define EVT_FIVRA_ADDR (0xC4 >> 1)
+#define EVT_PVCCD0_ADDR (0xE4 >> 1)
 #define CPU_PECI_ADDR 0x30
 #define SSD0_ADDR (0xD4 >> 1)
 #define SSD0_OFFSET 0x00

--- a/meta-facebook/yv35-nf/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-nf/src/platform/plat_sdr_table.c
@@ -102,7 +102,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -163,7 +163,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -224,7 +224,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -285,7 +285,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -346,7 +346,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -407,7 +407,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -468,7 +468,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -529,7 +529,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -590,7 +590,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -651,7 +651,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -712,7 +712,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_CURRENT, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -773,7 +773,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_CURRENT, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -834,7 +834,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_POWER_SUPPLY, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -895,7 +895,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_POWER_SUPPLY, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1200,7 +1200,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1261,7 +1261,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1322,7 +1322,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1383,7 +1383,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1444,7 +1444,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_POWER_SUPPLY, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1505,7 +1505,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_POWER_SUPPLY, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1566,7 +1566,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_POWER_SUPPLY, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1627,7 +1627,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_POWER_SUPPLY, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1688,7 +1688,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_CURRENT, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1749,7 +1749,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_CURRENT, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1810,7 +1810,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_CURRENT, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1871,7 +1871,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
 		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
 			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_SENSOR_TYPE_CURRENT, // sensor type
 		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
 		0x00, // assert event mask
 		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
@@ -1911,6 +1911,67 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // OEM
 		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
 		"NF_VR_PVDDQ_CD_CURR_A",
+	},
+	{
+		// TMP461 on board temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_CXL, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x54, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"NF_CXL_CNTR_TEMP_C",
 	},
 };
 

--- a/meta-facebook/yv35-nf/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-nf/src/platform/plat_sensor_table.c
@@ -18,6 +18,7 @@
 #include "sensor.h"
 #include "ast_adc.h"
 #include "pmbus.h"
+#include "tmp461.h"
 #include "plat_i2c.h"
 #include "plat_hook.h"
 #include "plat_sensor_table.h"
@@ -30,6 +31,9 @@ sensor_cfg plat_sensor_config[] = {
 	// Temperature =========================================================================
 	{ SENSOR_NUM_TEMP_TMP75, sensor_dev_tmp75, I2C_BUS3, TMP75_1OU_BOARD_ADDR,
 	  TMP75_TEMP_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_CXL, sensor_dev_tmp461, I2C_BUS2, TMP641_CXL_CNTR_ADDR,
+	  TMP461_REMOTE_TEMPERATRUE, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
 	// ADC =================================================================================


### PR DESCRIPTION
Summary:
- Support TMP461 sensor device layer.
- Add TMP461 sensor to NF sensor table.
- Correct NF SDR sensor type.

Note:
- Verify after receiving the NF 1OU board.

Test plan:
- Build code: Pass
- Check TMP461 is added to sensor table: Pass

Log:
1. Get sensor list on BIC console and check TMP461 is added to sensor table. uart:~$ platform sensor list_all
---------------------------------------------------------------------------------
[0x50] NF_1OU_BOARD_INLET_TEMP_C: tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    26.000
[0x51] NF_CXL_CNTR_TEMP_C       : tmp461     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.000
[0x57] NF_ADC_P1V2_STBY_VOLT_V  : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.324
[0x58] NF_ADC_P1V2_ASIC_VOLT_V  : adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x59] NF_ADC_P1V8_ASIC_VOLT_V  : adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5a] NF_ADC_PVPP_AB_VOLT_V    : adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5b] NF_ADC_PVPP_CD_VOLT_V    : adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5c] NF_ADC_PVTT_AB_VOLT_V    : adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5d] NF_ADC_PVTT_CD_VOLT_V    : adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5e] NF_ADC_P0V75_ASIC_VOLT_V : adc        | access[X] | poll[O] 1    sec | not_accesible             | na
[0x5f] NF_INA233_P12V_STBY_VOLT_V: ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.305
[0x60] NF_INA233_P3V3_STBY_VOLT_V: ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.316
[0x65] NF_INA233_P12V_STBY_CURR_A: ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.190
[0x66] NF_INA233_P3V3_STBY_CURR_A: ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.115
[0x6b] NF_INA233_P12V_STBY_PWR_W: ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.325
[0x6c] NF_INA233_P3V3_STBY_PWR_W: ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.375
[0x52] NF_VR_P0V85_ASIC_TEMP_C  : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x53] NF_VR_PVDDQ_AB_TEMP_C    : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x54] NF_VR_P0V8_ASIC_TEMP_C   : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x55] NF_VR_PVDDQ_CD_TEMP_C    : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x61] NF_VR_P0V85_ASIC_VOLT_V  : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x62] NF_VR_PVDDQ_AB_VOLT_V    : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x63] NF_VR_P0V8_ASIC_VOLT_V   : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x64] NF_VR_PVDDQ_CD_VOLT_V    : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x6d] NF_VR_P0V85_ASIC_PWR_W   : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x6e] NF_VR_PVDDQ_AB_PWR_W     : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x6f] NF_VR_P0V8_ASIC_PWR_W    : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x70] NF_VR_PVDDQ_CD_PWR_W     : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x67] NF_VR_P0V85_ASIC_CURR_A  : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x68] NF_VR_PVDDQ_AB_CURR_A    : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x69] NF_VR_P0V8_ASIC_CURR_A   : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
[0x6a] NF_VR_PVDDQ_CD_CURR_A    : xdpe12284c | access[X] | poll[O] 1    sec | not_accesible             | na
---------------------------------------------------------------------------------