### PR TITLE
ol2: op: Support second source power monitor SQ5220x

### DIFF
--- a/common/dev/ina233.c
+++ b/common/dev/ina233.c
@@ -21,11 +21,14 @@
 #include "sensor.h"
 #include "pmbus.h"
 #include "hal_i2c.h"
+#include "ina233.h"
 
 LOG_MODULE_REGISTER(dev_ina233);
 
 #define INA233_CALIBRATION_OFFSET 0xD4
 #define INA233_MFR_ADC_CONFIG 0xD0
+
+uint8_t INA233_DEVICE_ID[3] = { 0x02, 0x54, 0x49 };
 
 uint8_t ina233_read(uint8_t sensor_num, int *reading)
 {

--- a/common/dev/include/ina233.h
+++ b/common/dev/include/ina233.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __INA233__
+#define __INA233__
+
+#include <stdint.h>
+
+extern uint8_t INA233_DEVICE_ID[4];
+
+#endif

--- a/common/dev/sq52205.c
+++ b/common/dev/sq52205.c
@@ -108,7 +108,6 @@ uint8_t sq52205_init(uint8_t sensor_num)
 
 	if (init_arg->is_init != true) {
 		int ret = 0, retry = 5;
-		uint16_t shunt_unit = 0;
 		uint16_t calibration = 0;
 		I2C_MSG msg = { 0 };
 
@@ -127,16 +126,14 @@ uint8_t sq52205_init(uint8_t sensor_num)
 			return SENSOR_INIT_UNSPECIFIED_ERROR;
 		}
 
-		// Shunt unit = 1 ohm
-		shunt_unit = init_arg->r_shunt * 1000;
 		memset(&msg, 0, sizeof(I2C_MSG));
 		msg.bus = cfg.port;
 		msg.target_addr = cfg.target_addr;
 		msg.tx_len = 3;
 		msg.data[0] = SQ52205_CALIBRATION_OFFSET;
 
-		// Calibration formula = ((2048 * shunt_lsb) / (current_lsb * r_shunt)
-		calibration = (uint16_t)(((2048 * (shunt_unit * SQ52205_SHUNT_LSB)) /
+		// Calibration formula = ((2048 * shunt_lsb) / (current_lsb * r_shunt) round it up
+		calibration = (uint16_t)(((2048 * SQ52205_SHUNT_LSB) /
 					  (init_arg->current_lsb * init_arg->r_shunt)) +
 					 0.5);
 		msg.data[1] = (calibration >> 8) & 0xFF;

--- a/meta-facebook/op2-op/boards/ast1030_evb.overlay
+++ b/meta-facebook/op2-op/boards/ast1030_evb.overlay
@@ -144,3 +144,9 @@
 &wdt4 {
 	status = "okay";
 };
+
+
+&sram0 {
+	reg = <0 DT_SIZE_K(576)>, <0x90000 DT_SIZE_K(192)>;
+};
+

--- a/meta-facebook/op2-op/src/platform/plat_hook.c
+++ b/meta-facebook/op2-op/src/platform/plat_hook.c
@@ -44,6 +44,69 @@ ina233_init_arg ina233_init_args[] = {
 	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002 },
 };
 
+sq52205_init_arg sq52205_init_args[] = {
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.002,
+	.config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b000,
+		.reset_bit = 0b0,
+	},
+	},
+};
+
 i2c_proc_arg i2c_proc_args[] = {
 	[0] = { .bus = I2C_BUS2, .channel = I2C_HUB_CHANNEL_0 },
 	[1] = { .bus = I2C_BUS2, .channel = I2C_HUB_CHANNEL_1 },

--- a/meta-facebook/op2-op/src/platform/plat_hook.h
+++ b/meta-facebook/op2-op/src/platform/plat_hook.h
@@ -27,6 +27,7 @@ typedef struct _i2c_proc_arg {
 **************************************************************************************************/
 extern adc_asd_init_arg adc_asd_init_args[];
 extern ina233_init_arg ina233_init_args[];
+extern sq52205_init_arg sq52205_init_args[];
 extern i2c_proc_arg i2c_proc_args[];
 extern pt5161l_init_arg pt5161l_init_args[];
 extern struct k_mutex i2c_hub_mutex;

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.h
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.h
@@ -44,6 +44,10 @@
 #define INA233_CURR_OFFSET 0x8C
 #define INA233_PWR_OFFSET 0x96
 
+#define SQ5220X_VOL_OFFSET 0x02
+#define SQ5220X_PWR_OFFSET 0x03
+#define SQ5220X_CUR_OFFSET 0x04
+
 /* The difference between sensor number in each position is 0x30.
  * E.g. : SENSOR_NUM_1OU_TEMP is 0x40 and SENSOR_NUM_2OU_TEMP is 0x70.
  */
@@ -201,5 +205,12 @@ void pal_extend_sensor_config(void);
 void load_sensor_config(void);
 uint8_t pal_get_extend_sensor_config(void);
 void change_ina233_sensor_addr(void);
+void change_power_monitor_config_for_sq5220x(void);
+int check_pwr_monitor_type(void);
+
+enum POWER_MONITOR_TYPE {
+	PWR_INA233,
+	PWR_SQ5220X,
+};
 
 #endif

--- a/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_sensor_table.c
@@ -27,10 +27,9 @@
 #include "plat_mctp.h"
 #include "pm8702.h"
 #include <logging/log.h>
+#include "ina233.h"
 
 LOG_MODULE_REGISTER(plat_sensor_table);
-
-static uint8_t INA233_DEVICE_ID[4] = { 0x02, 0x54, 0x49, 0xe2 };
 
 sensor_cfg plat_sensor_config[] = {
 	/* number,                  type,       port,      address,      offset,


### PR DESCRIPTION
Summary:
- Fix the calibration according to spec for SQ5220x
- Modify the sensor config table according to the type of power monitor
- Set the sram size in overlay file(SRAM NC 192 KB and SRAM 576 KB) to prevent overflow. Test Plan:
- Build code : pass

3OU_BIC_TEMP_C               (0xA0) :   26.00 C     | (ok)
3OU_E1S_SSD0_P12V_VOLT_V     (0xA1) :   12.45 Volts  | (ok)
3OU_E1S_SSD1_P12V_VOLT_V     (0xA2) :   12.45 Volts  | (ok)
3OU_E1S_SSD2_P12V_VOLT_V     (0xA3) :   12.45 Volts  | (ok)
3OU_P12V_EDGE_VOLT_V         (0xA6) :   12.43 Volts  | (ok)
3OU_E1S_ADC_SSD0_P3V3_VOLT_V (0xA7) :    3.29 Volts  | (ok)
3OU_E1S_ADC_SSD1_P3V3_VOLT_V (0xA8) :    3.29 Volts  | (ok)
3OU_E1S_ADC_SSD2_P3V3_VOLT_V (0xA9) :    3.29 Volts  | (ok)
3OU_ADC_P3V3_STBY_VOLT_V     (0xAC) :    3.30 Volts  | (ok)
3OU_ADC_P1V8_VOLT_V          (0xAD) :    1.80 Volts  | (ok)
3OU_ADC_P0V9_VOLT_V          (0xAE) :    0.91 Volts  | (ok)
3OU_ADC_P1V2_VOLT_V          (0xAF) :    1.20 Volts  | (ok)
3OU_E1S_SSD0_P12V_CURR_A     (0xB0) :    0.66 Amps  | (ok)
3OU_E1S_SSD1_P12V_CURR_A     (0xB1) :    0.67 Amps  | (ok)
3OU_E1S_SSD2_P12V_CURR_A     (0xB2) :    0.67 Amps  | (ok)
3OU_E1S_P12V_EDGE_CURR_A     (0xB5) :    2.14 Amps  | (ok)
3OU_E1S_SSD0_P12V_PWR_W      (0xB6) :    8.18 Watts  | (ok)
3OU_E1S_SSD1_P12V_PWR_W      (0xB7) :    8.35 Watts  | (ok)
3OU_E1S_SSD2_P12V_PWR_W      (0xB8) :    8.38 Watts  | (ok)
3OU_E1S_P12V_EDGE_PWR_W      (0xBB) :   26.55 Watts  | (ok)
3OU_RETIMER_TEMP_C           (0xC1) : NA | (na)
3OU_E1S_SSD0_TEMP_C          (0xBC) :   33.00 C     | (ok)
3OU_E1S_SSD1_TEMP_C          (0xBD) :   33.00 C     | (ok)
3OU_E1S_SSD2_TEMP_C          (0xBE) :   33.00 C     | (ok)

root@bmc-oob:~# sensor-util slot1 |grep "2OU_E1S_SSD2" 2OU_E1S_SSD2_P12V_VOLT_V     (0x73) :   12.32 Volts  | (ok) 2OU_E1S_SSD2_P12V_CURR_A     (0x82) :    0.65 Amps  | (ok) 2OU_E1S_SSD2_P12V_PWR_W      (0x88) :    7.97 Watts  | (ok) 2OU_E1S_SSD2_TEMP_C          (0x8E) :   30.00 C     | (ok)