### PR TITLE
ol2: op: Support 2nd source pcie retimer m88rt51632

### DIFF
--- a/common/dev/include/ina233.h
+++ b/common/dev/include/ina233.h
@@ -19,6 +19,6 @@
 
 #include <stdint.h>
 
-extern uint8_t INA233_DEVICE_ID[4];
+extern uint8_t INA233_DEVICE_ID[3];
 
 #endif

--- a/common/dev/include/m88rt51632.h
+++ b/common/dev/include/m88rt51632.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,44 +14,26 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_CLASS_H
-#define PLAT_CLASS_H
+#ifndef M88RT51632_H
+#define M88RT51632_H
 
-#include <stdbool.h>
-#include <stdint.h>
+#include "hal_i2c.h"
 
-enum CARD_POSITION {
-	CARD_POSITION_1OU,
-	CARD_POSITION_2OU,
-	CARD_POSITION_3OU,
-	CARD_POSITION_4OU,
-	CARD_POSITION_UNKNOWN,
-};
+#define I2C_READ_CCODE_START 0x82
+#define I2C_READ_CCODE_END 0x81
+#define I2C_READ_BYTCNT 0x2
+#define I2C_WRITE_CCODE_START 0x87
+#define I2C_WRITE_BYTCNT 0x6
 
-enum CARD_TYPE {
-	CARD_TYPE_OPA,
-	CARD_TYPE_OPB,
-	CARD_TYPE_UNKNOWN,
-};
+#define RETIMER_VERSION 0x0104c
+#define RETIMER_ADDRPORT 0xfff0
+#define RETIMER_DATAPORT 0xfff4
 
-enum RETIMER_TYPE {
-	RETIMER_TYPE_PT5161L,
-	RETIMER_TYPE_M88RT51632,
-	RETIMER_TYPE_UNKNOWN,
-};
+#define M88RT51632_TEMP_OFFSET 0x00
 
-enum E1S_NUMBER {
-	E1S_0,
-	E1S_1,
-	E1S_2,
-	E1S_3,
-	E1S_4,
-};
+#define MAX_SENSORS 2
 
-int init_platform_config();
-uint8_t get_card_type();
-uint8_t get_card_position();
-int check_pcie_retimer_type(void);
-uint8_t get_pcie_retimer_type(void);
+bool m88rt51632_get_vendor_id(I2C_MSG *msg);
+bool m88rt51632_get_fw_version(I2C_MSG *msg, uint32_t *version);
 
 #endif

--- a/common/dev/include/pt5161l.h
+++ b/common/dev/include/pt5161l.h
@@ -64,6 +64,10 @@
 #define PT5161L_MUTEX_LOCK_MS 1000
 #define PCIE_RETIMER_UPDATE_MAX_OFFSET 0x40000
 
+#define PT5161L_VENDOR_ID_LENGTH 7
+extern uint8_t PT5161L_VENDOR_ID[7];
+
+bool pt5161l_get_vendor_id(I2C_MSG *msg);
 bool get_retimer_fw_version(I2C_MSG *msg, uint8_t *version);
 uint8_t pcie_retimer_fw_update(I2C_MSG *msg, uint32_t offset, uint16_t msg_len, uint8_t *msg_buf,
 			       uint8_t flag);

--- a/common/dev/m88rt51632.c
+++ b/common/dev/m88rt51632.c
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/crc.h>
+#include <logging/log.h>
+#include "libutil.h"
+#include "sensor.h"
+#include "m88rt51632.h"
+#include "hal_i2c.h"
+
+LOG_MODULE_REGISTER(dev_m88rt51632);
+
+static uint8_t cal_crc8_pec(uint8_t *crc_list, uint8_t len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(crc_list, 0);
+	return crc8(crc_list, len, 0x07, 0x00, false);
+}
+
+/* 
+ *@addr : address to read
+ *@data : return data
+ */
+static bool m88rt51632_smbus_read_byte(I2C_MSG *msg, uint16_t addr, uint32_t *data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+	uint8_t retry = 5;
+	uint8_t pec_crc, crc_reslut;
+	uint8_t crc_list[10];
+	int slave_addr = msg->target_addr << 1;
+	uint8_t addr_low = addr & 0xFF;
+	uint8_t addr_high = addr >> 8;
+
+	// read buffer is 3 + data bytes always
+	// First byte is num.bytes read
+	// Second and third bytes are address
+	// Bytes 4 onwards is data (4 bytes)
+	// 1 byte pec
+	uint8_t read_buf_len = 3 + 4 + 1;
+
+	msg->data[0] = I2C_READ_CCODE_START;
+	msg->data[1] = I2C_READ_BYTCNT;
+	msg->data[2] = addr_low;
+	msg->data[3] = addr_high;
+
+	crc_list[0] = slave_addr;
+	memcpy(&(crc_list[1]), msg->data, 4);
+
+	msg->data[4] = cal_crc8_pec(crc_list, 5);
+	msg->tx_len = 5;
+
+	if (i2c_master_write(msg, retry)) {
+		LOG_ERR("montage write reading address %x failed", addr);
+		return false;
+	}
+
+	memset(msg->data, 0, I2C_BUFF_SIZE);
+	msg->data[0] = I2C_READ_CCODE_END;
+	msg->tx_len = 1;
+	msg->rx_len = read_buf_len;
+	if (i2c_master_read(msg, retry)) {
+		LOG_ERR("montage write i2c read ccode end failed");
+		return false;
+	}
+
+	if (msg->data[0] != 6) {
+		LOG_ERR("Read error!, length: %d", msg->data[0]);
+		return false;
+	}
+
+	// PEC CRC
+	crc_list[0] = slave_addr;
+	crc_list[1] = I2C_READ_CCODE_END;
+	crc_list[2] = slave_addr + 1;
+	memcpy(&(crc_list[3]), msg->data, 7);
+
+	pec_crc = msg->data[7]; // pec value
+
+	crc_reslut = cal_crc8_pec(crc_list, 10);
+
+	if (pec_crc != crc_reslut) {
+		LOG_ERR("The read data pec_crc=0x%x is invalid, the right crc value=0x%x please check",
+			pec_crc, crc_reslut);
+		return -1;
+	}
+
+	uint32_t reverse_data;
+	convert_uint8_t_pointer_to_uint32_t(&reverse_data, &(msg->data[3]), 4, BIG_ENDIAN);
+	*data = uint32_t_byte_reverse(reverse_data);
+
+	return true;
+}
+
+static bool m88rt51632_smbus_write_byte(I2C_MSG *msg, uint16_t addr, uint32_t data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+	uint8_t retry = 3;
+	int slave_addr = msg->target_addr << 1;
+	uint8_t crc_list[9];
+	uint8_t addr_low = addr & 0xFF;
+	uint8_t addr_high = addr >> 8;
+	uint32_t reverse_data = uint32_t_byte_reverse(data);
+
+	/* Set buffer length based on number of bytes being written
+     * 1 bytes i2c write command code
+     * 2 bytes of address in calculation
+     * 1 extra byte for num bytes in buffer
+     * 4 bytes data
+     * 1 byte pec
+     */
+	int write_num_bytes = 9;
+
+	msg->data[0] = I2C_WRITE_CCODE_START;
+	msg->data[1] = I2C_WRITE_BYTCNT;
+	msg->data[2] = addr_low;
+	msg->data[3] = addr_high;
+	convert_uint32_t_to_uint8_t_pointer(reverse_data, &(msg->data[4]), 4, BIG_ENDIAN);
+
+	//cal pec
+	crc_list[0] = slave_addr;
+	memcpy(&(crc_list[1]), msg->data, 8);
+
+	msg->data[8] = cal_crc8_pec(crc_list, 9);
+	msg->tx_len = write_num_bytes;
+
+	if (i2c_master_write(msg, retry)) {
+		LOG_ERR("montage write address %x data %x %x %x %X pec %xfailed", addr,
+			msg->data[4], msg->data[5], msg->data[6], msg->data[7], msg->data[8]);
+		return false;
+	}
+
+	return true;
+}
+
+bool m88rt51632_get_vendor_id(I2C_MSG *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+	uint8_t retry = 5;
+
+	msg->tx_len = 4;
+	msg->data[0] = 0x02; //COMMAND CODE = 0x02 END=0, START=1, FUNC=3'b000, PEC=0
+	msg->data[1] = 0x02; //byte count
+	msg->data[2] = 0x04; //vendor id lower offset
+	msg->data[3] = 0x00; //vendor id upper offset
+
+	if (i2c_master_write(msg, retry)) {
+		LOG_ERR("Failed to set PCIE RETIMER vendor id offset");
+		return false;
+	}
+
+	memset(msg->data, 0, I2C_BUFF_SIZE);
+	msg->tx_len = 1;
+	msg->rx_len = 7;
+	msg->data[0] = 0x01; //COMMAND CODE = 0x01 END=1, START=0, FUNC=3'b000, PEC=0
+	if (i2c_master_read(msg, retry)) {
+		LOG_ERR("Failed to read PCIE RETIMER vendor id");
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * montage_retimer_read() - read retimer
+ * @addr: address to read
+ * @data: return data from retimer.
+ *
+ * Return: true on success, or false.
+ */
+bool montage_retimer_read(I2C_MSG *msg, uint32_t addr, uint32_t *data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+
+	if (!m88rt51632_smbus_write_byte(msg, RETIMER_ADDRPORT, addr)) {
+		LOG_ERR("montage reading set RETIMER_ADDRPORT with addr %x failed", addr);
+		return false;
+	}
+
+	if (!m88rt51632_smbus_read_byte(msg, RETIMER_DATAPORT, data)) {
+		LOG_ERR("montage reading RETIMER_DATAPORT failed");
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * montage_retimer_write() - write retimer
+ * @addr:       address to write
+ * @data:       data to write
+ *
+ * Return: true on success, or false.
+ */
+bool montage_retimer_write(I2C_MSG *msg, uint32_t addr, uint32_t data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+
+	if (!m88rt51632_smbus_write_byte(msg, RETIMER_ADDRPORT, addr)) {
+		LOG_ERR("montage write RETIMER_ADDRPORT with addr %x failed", addr);
+		return false;
+	}
+
+	if (!m88rt51632_smbus_write_byte(msg, RETIMER_DATAPORT, data)) {
+		LOG_ERR("montage write RETIMER_ADDRPORT with data %x failed", data);
+		return false;
+	}
+
+	return true;
+}
+
+bool m88rt51632_get_fw_version(I2C_MSG *msg, uint32_t *version)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+
+	if (!montage_retimer_read(msg, RETIMER_VERSION, version)) {
+		LOG_ERR("montage get pcie retimer version failed");
+		return false;
+	}
+
+	return true;
+}
+
+uint8_t m88rt51632_get_temperature(I2C_MSG *msg, float *temperature0, float *temperature1)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(temperature0, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(temperature1, SENSOR_UNSPECIFIED_ERROR);
+
+	uint32_t ts_ctl_add[2] = { 0xa10, 0xb10 };
+	uint32_t ts_sts_add[2] = { 0xa18, 0xb18 };
+
+	int i, j, timeout;
+	uint32_t ts_sts, flag, ODR, ts_ctl;
+	float res[2];
+
+	for (i = 0; i < MAX_SENSORS; i++) {
+		if (!montage_retimer_read(msg, ts_ctl_add[i], &ts_ctl)) {
+			LOG_ERR("montage get temperature read addr %x failed", ts_ctl_add[i]);
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+		ts_ctl = ts_ctl & 0xFFFFFFF8;
+
+		if (!montage_retimer_write(msg, ts_ctl_add[i], ts_ctl)) {
+			LOG_ERR("montage get temperature write ts_ctl %x failed", ts_ctl);
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+
+		if (!montage_retimer_write(msg, ts_ctl_add[i], ts_ctl | 0x4)) {
+			LOG_ERR("montage get temperature write ts_ctl | 0x4 %x failed",
+				ts_ctl | 0x4);
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+
+		if (!montage_retimer_write(msg, ts_ctl_add[i], ts_ctl | 0x5)) {
+			LOG_ERR("montage get temperature write ts_ctl | 0x5 %x failed",
+				ts_ctl | 0x5);
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+
+		timeout = 0;
+
+		for (j = 0; j < 100; j++) {
+			if (!montage_retimer_read(msg, ts_sts_add[i], &ts_sts)) {
+				LOG_ERR("montage get temperature read system status failed");
+				return SENSOR_UNSPECIFIED_ERROR;
+			}
+
+			if (GETBIT(ts_sts, 16)) {
+				break;
+			}
+
+			k_msleep(2);
+			if (j == 99) {
+				timeout = 1;
+			}
+		}
+
+		if (timeout == 1) {
+			LOG_ERR("read temperature timeout!");
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+
+		if (!montage_retimer_read(msg, ts_sts_add[i], &ts_sts)) {
+			LOG_ERR("montage get temperature read addr %x failed", ts_sts_add[i]);
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+
+		flag = (ts_sts >> 12) & 0x1;
+		ODR = ts_sts & 0xfff;
+
+		if (flag == 0) {
+			res[i] = +ODR / 16.000;
+		} else {
+			res[i] = -ODR / 16.000;
+		}
+	}
+
+	*temperature0 = res[0];
+	*temperature1 = res[1];
+
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t m88rt51632_read(uint8_t sensor_num, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+	if (sensor_num > SENSOR_NUM_MAX) {
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	float temperature[2] = { 0 };
+	float avg_temperature = 0;
+	I2C_MSG msg = { 0 };
+	uint8_t ret;
+
+	sensor_cfg *cfg = &sensor_config[sensor_config_index_map[sensor_num]];
+
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+
+	switch (cfg->offset) {
+	case M88RT51632_TEMP_OFFSET:
+		ret = m88rt51632_get_temperature(&msg, &(temperature[0]), &(temperature[1]));
+		if (ret != SENSOR_READ_SUCCESS) {
+			return ret;
+		}
+		avg_temperature = (temperature[0] + temperature[1]) / 2;
+		break;
+	default:
+		LOG_ERR("Invalid sensor 0x%x offset 0x%x", sensor_num, cfg->offset);
+		return SENSOR_NOT_FOUND;
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	memset(sval, 0, sizeof(*sval));
+
+	sval->integer = (int)avg_temperature & 0xFFFF;
+	sval->fraction = (avg_temperature - sval->integer) * 1000;
+
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t m88rt51632_init(uint8_t sensor_num)
+{
+	if (sensor_num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	if (sensor_config[sensor_config_index_map[sensor_num]].init_args != NULL) {
+		pt5161l_init_arg *init_args =
+			(pt5161l_init_arg *)sensor_config[sensor_config_index_map[sensor_num]]
+				.init_args;
+
+		if (init_args->is_init) {
+			goto exit;
+		}
+
+		init_args->is_init = true;
+	}
+
+exit:
+	sensor_config[sensor_config_index_map[sensor_num]].read = m88rt51632_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/lib/libutil.h
+++ b/common/lib/libutil.h
@@ -82,6 +82,11 @@ enum BIT_SETTING_READING_N {
 	BIT_CLEAR_N = 1,
 };
 
+enum BYTE_ENDIAN {
+	SMALL_ENDIAN = 0,
+	BIG_ENDIAN = 1,
+};
+
 ipmi_msg construct_ipmi_message(uint8_t seq_source, uint8_t netFn, uint8_t command,
 				uint8_t source_inft, uint8_t target_inft, uint16_t data_len,
 				uint8_t *data);
@@ -91,5 +96,10 @@ I2C_MSG construct_i2c_message(uint8_t bus_id, uint8_t address, uint8_t tx_len, u
 
 void reverse_array(uint8_t arr[], uint8_t size);
 int ascii_to_val(uint8_t ascii_byte);
+uint32_t uint32_t_byte_reverse(uint32_t data);
+void convert_uint32_t_to_uint8_t_pointer(uint32_t data_32, uint8_t *data_8, uint8_t len,
+					 uint8_t endian);
+void convert_uint8_t_pointer_to_uint32_t(uint32_t *data_32, uint8_t *data_8, uint8_t len,
+					 uint8_t endian);
 
 #endif

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -110,6 +110,7 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(lm75bd118)
 	sensor_name_to_num(tmp461)
 	sensor_name_to_num(mp2985)
+	sensor_name_to_num(m88rt51632)
 };
 // clang-format on
 
@@ -159,6 +160,7 @@ SENSOR_DRIVE_INIT_DECLARE(pt5161l);
 SENSOR_DRIVE_INIT_DECLARE(lm75bd118);
 SENSOR_DRIVE_INIT_DECLARE(tmp461);
 SENSOR_DRIVE_INIT_DECLARE(mp2985);
+SENSOR_DRIVE_INIT_DECLARE(m88rt51632);
 
 struct sensor_drive_api {
 	enum SENSOR_DEV dev;
@@ -210,6 +212,7 @@ struct sensor_drive_api {
 	SENSOR_DRIVE_TYPE_INIT_MAP(lm75bd118),
 	SENSOR_DRIVE_TYPE_INIT_MAP(tmp461),
 	SENSOR_DRIVE_TYPE_INIT_MAP(mp2985),
+	SENSOR_DRIVE_TYPE_INIT_MAP(m88rt51632),
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -144,6 +144,7 @@ enum SENSOR_DEV {
 	sensor_dev_lm75bd118 = 0x28,
 	sensor_dev_tmp461 = 0x29,
 	sensor_dev_mp2985 = 0x2A,
+	sensor_dev_m88rt51632 = 0x29,
 	sensor_dev_max
 };
 

--- a/meta-facebook/op2-op/src/platform/plat_power_seq.c
+++ b/meta-facebook/op2-op/src/platform/plat_power_seq.c
@@ -261,6 +261,11 @@ bool is_all_sequence_done(uint8_t status)
 	return all_sequence_done;
 }
 
+bool is_retimer_done(void)
+{
+	return is_retimer_sequence_done;
+}
+
 void control_power_stage(uint8_t control_mode, uint8_t control_seq)
 {
 	switch (control_mode) {

--- a/meta-facebook/op2-op/src/platform/plat_power_seq.h
+++ b/meta-facebook/op2-op/src/platform/plat_power_seq.h
@@ -71,10 +71,9 @@ enum CHECK_POWER_SEQ_NUM_MAPPING {
 };
 
 typedef enum {
-    E1S_POWER_SUCCESS = 0,
-    E1S_PERST_SUCCESS = 1,
+	E1S_POWER_SUCCESS = 0,
+	E1S_PERST_SUCCESS = 1,
 } E1S_POWER_ON_STATUS;
-
 
 typedef struct _e1s_power_control_gpio {
 	uint8_t present;
@@ -96,6 +95,7 @@ uint8_t get_e1s_pcie_reset_status(uint8_t index);
 void init_sequence_status();
 void set_sequence_status(uint8_t index, bool status);
 bool is_all_sequence_done(uint8_t status);
+bool is_retimer_done(void);
 void abort_e1s_power_thread(uint8_t index);
 void e1s_power_on_thread(uint8_t index, uint8_t initial_stage);
 void e1s_power_off_thread(uint8_t index);

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.c
@@ -31,6 +31,7 @@
 LOG_MODULE_REGISTER(plat_sensor);
 
 bool e1s_access(uint8_t sensor_num);
+bool retimer_access(uint8_t sensor_num);
 
 sensor_cfg plat_sensor_config[] = {
 	/*  number,
@@ -139,8 +140,9 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
-	{ SENSOR_NUM_1OU_RE_TIMER_TEMP_C, sensor_dev_pt5161l, I2C_BUS4, EXPA_RETIMER_ADDR,
-	  PT5161L_TEMP_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	//reconfig the retimer when the first read retimer temperature
+	{ SENSOR_NUM_1OU_RE_TIMER_TEMP_C, sensor_dev_max, I2C_BUS4, EXPA_RETIMER_ADDR,
+	  PT5161L_TEMP_OFFSET, retimer_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_retimer_read, NULL, NULL, NULL,
 	  &pt5161l_init_args[0] },
 
@@ -473,6 +475,10 @@ void pal_extend_sensor_config()
 		LOG_ERR("Unsupported card type, Card type: 0x%x", card_type);
 		break;
 	}
+}
+bool retimer_access(uint8_t sensor_num)
+{
+	return is_retimer_done();
 }
 
 bool e1s_access(uint8_t sensor_num)


### PR DESCRIPTION
Summary:
- Implement the function of m88rt51632  according to Montage retimer SDK. (retimer_sdk-oneflow_4.0.5)
- Distinguish the pcie retimer via vendor id.
- Reconfig the sensor table for retimer temperature when sensor polling.

Test Plan:
- Build code : pass

- Get fw version: root@bmc-oob:~# bic-util slot1 0xe0 0x2 0x15 0xa0 0x0 0x25 0xe0 0xb 0x15 0xa0 0x0 0x5 15 A0 00 25 39 0B 00 15 A0 00 08 58 63 00

- Get temperature:(1ou:main source, 3ou:second source) root@bmc-oob:~# sensor-util slot1| grep RETIMER
1OU_RETIMER_TEMP_C           (0x61) :   41.52 C     | (ok)
3OU_RETIMER_TEMP_C           (0xC1) :   41.41 C     | (ok)