### PR TITLE
at: mc : support 2nd power monitor and remove hsc for evt2

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_class.c
+++ b/meta-facebook/at-mc/src/platform/plat_class.c
@@ -21,6 +21,8 @@
 
 #include "libutil.h"
 #include "hal_i2c.h"
+#include "hal_gpio.h"
+#include "plat_gpio.h"
 #include "plat_i2c.h"
 #include "plat_class.h"
 #include "plat_sensor_table.h"
@@ -333,4 +335,9 @@ bool is_cxl_present()
 	}
 
 	return false;
+}
+
+uint8_t get_board_revision()
+{
+	return (gpio_get(REV_ID0) << 2) | (gpio_get(REV_ID1) << 1) | gpio_get(REV_ID2);
 }

--- a/meta-facebook/at-mc/src/platform/plat_class.h
+++ b/meta-facebook/at-mc/src/platform/plat_class.h
@@ -31,6 +31,14 @@
 #define CXL_PRESENT 0x0E
 #define NO_DEVICE_PRESENT 0x0F
 
+enum BOARD_REVERSION {
+	REV_EVT1,
+	REV_EVT2,
+	REV_DVT,
+	REV_PVT,
+	REV_MP,
+};
+
 enum CARD_INFO_INDEX {
 	CARD_1_INDEX,
 	CARD_2_INDEX,
@@ -85,5 +93,6 @@ int get_pcie_device_type(uint8_t card_id, uint8_t device_id, uint8_t *device_typ
 int pcie_card_id_to_cxl_id(uint8_t pcie_card_id, uint8_t *cxl_id);
 int cxl_id_to_pcie_card_id(uint8_t cxl_id, uint8_t *pcie_card_id);
 bool is_cxl_present();
+uint8_t get_board_revision();
 
 #endif

--- a/meta-facebook/at-mc/src/platform/plat_hook.c
+++ b/meta-facebook/at-mc/src/platform/plat_hook.c
@@ -186,6 +186,135 @@ sq52205_init_arg sq52205_init_args[] = {
 	},
 };
 
+ina233_init_arg mc_ina233_init_args[] = {
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[12] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+	[13] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	.mfr_config = {
+		.operating_mode =0b111,
+		.shunt_volt_time = 0b100,
+		.bus_volt_time = 0b100,
+		.aver_mode = 0b111, //set 1024 average times
+		.rsvd = 0b0100,
+	},
+	},
+};
+
 ina233_init_arg ina233_init_args[] = {
 	// JCN11
 	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.005, .mfr_config_init = true,

--- a/meta-facebook/at-mc/src/platform/plat_hook.h
+++ b/meta-facebook/at-mc/src/platform/plat_hook.h
@@ -25,6 +25,7 @@
 extern mp5990_init_arg mp5990_init_args[];
 extern adc_asd_init_arg adc_asd_init_args[];
 extern sq52205_init_arg sq52205_init_args[];
+extern ina233_init_arg mc_ina233_init_args[];
 extern ina233_init_arg ina233_init_args[];
 extern ltc2991_init_arg ltc2991_init_args[];
 

--- a/meta-facebook/at-mc/src/platform/plat_sdr_table.c
+++ b/meta-facebook/at-mc/src/platform/plat_sdr_table.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include "sdr.h"
 #include "sensor.h"
+#include "plat_class.h"
 #include "plat_ipmb.h"
 #include "plat_sensor_table.h"
 
@@ -329,251 +330,6 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // OEM
 		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
 		"E1S_3_TEMP",
-	},
-	// HSC SDR
-	{
-		// PU4 temperature
-		0x00,
-		0x00, // record ID
-		IPMI_SDR_VER_15, // SDR ver
-		IPMI_SDR_FULL_SENSOR, // record type
-		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
-
-		SELF_I2C_ADDRESS << 1, // owner id
-		0x00, // owner lun
-		SENSOR_NUM_TEMP_PU4, // sensor number
-
-		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
-		0x00, // entity instance
-		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
-			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
-			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
-			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
-		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
-			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
-		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
-		0x00, // assert event mask
-		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
-			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
-		0x00, // deassert event mask
-		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
-			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
-		0x00, // discrete reading mask/ settable
-		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
-			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
-		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
-		0x00, // modifier unit
-		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
-		0x00, // [7:0] B bits
-		0x00, // [9:8] B bits, tolerance
-		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
-		0x00, // analog characteristic
-		0x00, // nominal reading
-		0x00, // normal maximum
-		0x00, // normal minimum
-		0x00, // sensor maximum reading
-		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
-		0x00, // positive-going threshold
-		0x00, // negative-going threshold
-		0x00, // reserved
-		0x00, // reserved
-		0x00, // OEM
-		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
-		"PU4_TEMP",
-	},
-	{
-		// P12V_AUX voltage
-		0x00,
-		0x00, // record ID
-		IPMI_SDR_VER_15, // SDR ver
-		IPMI_SDR_FULL_SENSOR, // record type
-		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
-
-		SELF_I2C_ADDRESS << 1, // owner id
-		0x00, // owner lun
-		SENSOR_NUM_VOL_P12V_AUX, // sensor number
-
-		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
-		0x00, // entity instance
-		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
-			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
-			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
-			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
-		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
-			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
-		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
-		0x00, // assert event mask
-		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
-			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
-		0x00, // deassert event mask
-		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
-			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
-		0x00, // discrete reading mask/ settable
-		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
-			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x00, // sensor unit
-		IPMI_SENSOR_UNIT_VOL, // base unit
-		0x00, // modifier unit
-		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
-		0x00, // [7:0] B bits
-		0x00, // [9:8] B bits, tolerance
-		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
-		0x00, // analog characteristic
-		0x00, // nominal reading
-		0x00, // normal maximum
-		0x00, // normal minimum
-		0x00, // sensor maximum reading
-		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
-		0x00, // positive-going threshold
-		0x00, // negative-going threshold
-		0x00, // reserved
-		0x00, // reserved
-		0x00, // OEM
-		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
-		"P12V_AUX_VOL",
-	},
-	{
-		// P12V_AUX current
-		0x00,
-		0x00, // record ID
-		IPMI_SDR_VER_15, // SDR ver
-		IPMI_SDR_FULL_SENSOR, // record type
-		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
-
-		SELF_I2C_ADDRESS << 1, // owner id
-		0x00, // owner lun
-		SENSOR_NUM_CUR_P12V_AUX, // sensor number
-
-		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
-		0x00, // entity instance
-		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
-			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
-			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
-			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
-		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
-			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
-		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
-		0x00, // assert event mask
-		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
-			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
-		0x00, // deassert event mask
-		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
-			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
-		0x00, // discrete reading mask/ settable
-		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
-			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x00, // sensor unit
-		IPMI_SENSOR_UNIT_AMP, // base unit
-		0x00, // modifier unit
-		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
-		0x00, // [7:0] B bits
-		0x00, // [9:8] B bits, tolerance
-		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
-		0x00, // analog characteristic
-		0x00, // nominal reading
-		0x00, // normal maximum
-		0x00, // normal minimum
-		0x00, // sensor maximum reading
-		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
-		0x00, // positive-going threshold
-		0x00, // negative-going threshold
-		0x00, // reserved
-		0x00, // reserved
-		0x00, // OEM
-		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
-		"P12V_AUX_CUR",
-	},
-	{
-		// P12V_AUX power
-		0x00,
-		0x00, // record ID
-		IPMI_SDR_VER_15, // SDR ver
-		IPMI_SDR_FULL_SENSOR, // record type
-		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
-
-		SELF_I2C_ADDRESS << 1, // owner id
-		0x00, // owner lun
-		SENSOR_NUM_PWR_P12V_AUX, // sensor number
-
-		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
-		0x00, // entity instance
-		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
-			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
-			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
-			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
-		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
-			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
-		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
-		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
-		0x00, // assert event mask
-		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
-			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
-		0x00, // deassert event mask
-		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
-			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
-		0x00, // discrete reading mask/ settable
-		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
-			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x00, // sensor unit
-		IPMI_SENSOR_UNIT_WATT, // base unit
-		0x00, // modifier unit
-		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
-		0x00, // [9:8] M bits, tolerance
-		0x00, // [7:0] B bits
-		0x00, // [9:8] B bits, tolerance
-		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
-		0x00, // analog characteristic
-		0x00, // nominal reading
-		0x00, // normal maximum
-		0x00, // normal minimum
-		0x00, // sensor maximum reading
-		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x00, // UCT
-		0x00, // UNCT
-		0x00, // LNRT
-		0x00, // LCT
-		0x00, // LNCT
-		0x00, // positive-going threshold
-		0x00, // negative-going threshold
-		0x00, // reserved
-		0x00, // reserved
-		0x00, // OEM
-		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
-		"P12V_AUX_PWR",
 	},
 	// ADC SDR
 	{
@@ -3337,4 +3093,301 @@ SDR_Full_sensor plat_sdr_table[] = {
 	},
 };
 
+SDR_Full_sensor plat_hsc_sdr_table[] = {
+	// HSC SDR
+	{
+		// PU4 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_PU4, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"PU4_TEMP",
+	},
+	{
+		// P12V_AUX voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_P12V_AUX, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"P12V_AUX_VOL",
+	},
+	{
+		// P12V_AUX current
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_CUR_P12V_AUX, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"P12V_AUX_CUR",
+	},
+	{
+		// P12V_AUX power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_PWR_P12V_AUX, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"P12V_AUX_PWR",
+	},
+};
+
 const int SDR_TABLE_SIZE = ARRAY_SIZE(plat_sdr_table);
+const int HSC_SDR_TABLE_SIZE = ARRAY_SIZE(plat_hsc_sdr_table);
+
+uint8_t pal_get_extend_sdr()
+{
+	uint8_t extend_sdr_table_size = 0;
+	uint8_t board_revision = get_board_revision();
+	switch (board_revision) {
+	case REV_EVT1:
+		extend_sdr_table_size += HSC_SDR_TABLE_SIZE;
+		break;
+	case REV_EVT2:
+	case REV_DVT:
+	case REV_PVT:
+	case REV_MP:
+		break;
+	default:
+		break;
+	}
+
+	return extend_sdr_table_size;
+}
+
+void pal_extend_full_sdr_table()
+{
+	uint8_t board_revision = get_board_revision();
+	switch (board_revision) {
+	case REV_EVT1:
+		for (int index = 0; index < HSC_SDR_TABLE_SIZE; index++) {
+			add_full_sdr_table(plat_hsc_sdr_table[index]);
+		}
+		break;
+	case REV_EVT2:
+	case REV_DVT:
+	case REV_PVT:
+	case REV_MP:
+		break;
+	default:
+		break;
+	}
+}
+
+void load_sdr_table(void)
+{
+	memcpy(full_sdr_table, plat_sdr_table, sizeof(plat_sdr_table));
+	sdr_count = ARRAY_SIZE(plat_sdr_table);
+
+	// Fix SDR table in different system/config
+	pal_extend_full_sdr_table();
+}

--- a/meta-facebook/at-mc/src/platform/plat_sdr_table.h
+++ b/meta-facebook/at-mc/src/platform/plat_sdr_table.h
@@ -21,4 +21,9 @@
 
 #define MAX_SENSOR_SIZE 60
 
+uint8_t plat_get_sdr_size();
+void load_sdr_table(void);
+void pal_extend_full_sdr_table();
+uint8_t pal_get_extend_sdr();
+
 #endif

--- a/meta-facebook/at-mc/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-mc/src/platform/plat_sensor_table.c
@@ -38,6 +38,7 @@
 #include "plat_dev.h"
 #include "cci.h"
 #include "plat_mctp.h"
+#include "plat_class.h"
 
 LOG_MODULE_REGISTER(plat_sensor_table);
 
@@ -80,21 +81,6 @@ sensor_cfg plat_sensor_config[] = {
 	  0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  pre_nvme_read, &bus_4_pca9548_configs[3], post_nvme_read, NULL, NULL },
 
-	/** HSC **/
-	{ SENSOR_NUM_TEMP_PU4, sensor_dev_mp5990, I2C_BUS6, MPS_MP5990_ADDR,
-	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &mp5990_init_args[0] },
-	{ SENSOR_NUM_VOL_P12V_AUX, sensor_dev_mp5990, I2C_BUS6, MPS_MP5990_ADDR, PMBUS_READ_VOUT,
-	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
-	{ SENSOR_NUM_CUR_P12V_AUX, sensor_dev_mp5990, I2C_BUS6, MPS_MP5990_ADDR, PMBUS_READ_IOUT,
-	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
-	{ SENSOR_NUM_PWR_P12V_AUX, sensor_dev_mp5990, I2C_BUS6, MPS_MP5990_ADDR, PMBUS_READ_PIN,
-	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
-
 	/** ADC **/
 	{ SENSOR_NUM_VOL_P3V3_AUX, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE, stby_access, 2, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
@@ -105,7 +91,9 @@ sensor_cfg plat_sensor_config[] = {
 	{ SENSOR_NUM_VOL_P3V3, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE, stby_access, 2, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+};
 
+sensor_cfg plat_mc_sq52205_sensor_config[] = {
 	/** SQ52205_01 **/
 	{ SENSOR_NUM_VOL_P12V_AUX_CARD01, sensor_dev_sq52205, I2C_BUS3, SQ52205_1_ADDR,
 	  SQ52205_READ_VOL_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
@@ -303,6 +291,221 @@ sensor_cfg plat_sensor_config[] = {
 	  post_sq52205_read, NULL, &sq52205_init_args[13] },
 };
 
+sensor_cfg plat_mc_ina233_sensor_config[] = {
+	/** INA233_01 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD01, sensor_dev_ina233, I2C_BUS3, SQ52205_1_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[0] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD01, sensor_dev_ina233, I2C_BUS3, SQ52205_1_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[0] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD01, sensor_dev_ina233, I2C_BUS3, SQ52205_1_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[0] },
+
+	/** INA233_02 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD02, sensor_dev_ina233, I2C_BUS3, SQ52205_2_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[1] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD02, sensor_dev_ina233, I2C_BUS3, SQ52205_2_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[1] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD02, sensor_dev_ina233, I2C_BUS3, SQ52205_2_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[1] },
+
+	/** INA233_03 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD03, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[2] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD03, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[2] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD03, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[2] },
+
+	/** INA233_04 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD04, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[3] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD04, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[3] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD04, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[0],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[3] },
+
+	/** INA233_05 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD05, sensor_dev_ina233, I2C_BUS3, SQ52205_1_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[4] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD05, sensor_dev_ina233, I2C_BUS3, SQ52205_1_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[4] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD05, sensor_dev_ina233, I2C_BUS3, SQ52205_1_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[4] },
+
+	/** INA233_06 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD06, sensor_dev_ina233, I2C_BUS3, SQ52205_2_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[5] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD06, sensor_dev_ina233, I2C_BUS3, SQ52205_2_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[5] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD06, sensor_dev_ina233, I2C_BUS3, SQ52205_2_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[5] },
+
+	/** INA233_07 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD07, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[6] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD07, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[6] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD07, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[6] },
+
+	/** INA233_08 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD08, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[7] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD08, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[7] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD08, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[1],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[7] },
+
+	/** INA233_09 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD09, sensor_dev_ina233, I2C_BUS3, SQ52205_1_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[8] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD09, sensor_dev_ina233, I2C_BUS3, SQ52205_1_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[8] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD09, sensor_dev_ina233, I2C_BUS3, SQ52205_1_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[8] },
+
+	/** INA233_10 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD10, sensor_dev_ina233, I2C_BUS3, SQ52205_2_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[9] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD10, sensor_dev_ina233, I2C_BUS3, SQ52205_2_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[9] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD10, sensor_dev_ina233, I2C_BUS3, SQ52205_2_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[9] },
+
+	/** INA233_11 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD11, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[10] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD11, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[10] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD11, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[10] },
+
+	/** INA233_12 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD12, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[11] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD12, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[11] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD12, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[2],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[11] },
+
+	/** INA233_13 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD13, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[3],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[12] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD13, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[3],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[12] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD13, sensor_dev_ina233, I2C_BUS3, SQ52205_3_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[3],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[12] },
+
+	/** INA233_14 **/
+	{ SENSOR_NUM_VOL_P12V_AUX_CARD14, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[3],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[13] },
+	{ SENSOR_NUM_CUR_P12V_AUX_CARD14, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[3],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[13] },
+	{ SENSOR_NUM_PWR_P12V_AUX_CARD14, sensor_dev_ina233, I2C_BUS3, SQ52205_4_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_sq52205_read, &bus_3_pca9546_configs[3],
+	  post_sq52205_read, NULL, &mc_ina233_init_args[13] },
+};
+
+sensor_cfg plat_hsc_mp5990_sensor_config[] = {
+	/** HSC **/
+	{ SENSOR_NUM_TEMP_PU4, sensor_dev_mp5990, I2C_BUS6, MPS_MP5990_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &mp5990_init_args[0] },
+	{ SENSOR_NUM_VOL_P12V_AUX, sensor_dev_mp5990, I2C_BUS6, MPS_MP5990_ADDR, PMBUS_READ_VOUT,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
+	{ SENSOR_NUM_CUR_P12V_AUX, sensor_dev_mp5990, I2C_BUS6, MPS_MP5990_ADDR, PMBUS_READ_IOUT,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
+	{ SENSOR_NUM_PWR_P12V_AUX, sensor_dev_mp5990, I2C_BUS6, MPS_MP5990_ADDR, PMBUS_READ_PIN,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
+};
+
 sensor_cfg plat_e1s_1_12_sensor_config[] = {
 	{ SENSOR_NUM_TEMP_JCN_E1S_0, sensor_dev_nvme, I2C_BUS8, E1S_ADDR, E1S_OFFSET, stby_access,
 	  0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
@@ -478,8 +681,45 @@ sensor_cfg plat_cxl_sensor_config[] = {
 };
 
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
+const int MC_SQ52205_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_mc_sq52205_sensor_config);
+const int MC_INA233_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_mc_ina233_sensor_config);
 const int E1S_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_e1s_1_12_sensor_config);
 const int CXL_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_cxl_sensor_config);
+const int HSC_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_hsc_mp5990_sensor_config);
+
+void pal_extend_sensor_config()
+{
+	uint8_t board_revision = get_board_revision();
+
+	switch (board_revision) {
+	case REV_EVT1:
+		LOG_ERR("add mp5990 config");
+		for (int index = 0; index < HSC_SENSOR_CONFIG_SIZE; index++) {
+			add_sensor_config(plat_hsc_mp5990_sensor_config[index]);
+		}
+		break;
+	case REV_EVT2:
+	case REV_DVT:
+	case REV_PVT:
+	case REV_MP:
+		break;
+	default:
+		LOG_ERR("Unknown board revision %x", board_revision);
+		break;
+	}
+
+	if (gpio_get(BOARD_ID1) == GPIO_LOW) {
+		LOG_ERR("add sq52205 config");
+		for (int index = 0; index < MC_SQ52205_SENSOR_CONFIG_SIZE; index++) {
+			add_sensor_config(plat_mc_sq52205_sensor_config[index]);
+		}
+	} else {
+		LOG_ERR("add ina233 config");
+		for (int index = 0; index < MC_INA233_SENSOR_CONFIG_SIZE; index++) {
+			add_sensor_config(plat_mc_ina233_sensor_config[index]);
+		}
+	}
+}
 
 void load_sensor_config(void)
 {
@@ -488,6 +728,31 @@ void load_sensor_config(void)
 
 	// Fix config table in different system/config
 	pal_extend_sensor_config();
+}
+
+uint8_t pal_get_extend_sensor_config()
+{
+	uint8_t extend_sensor_config_size = 0;
+
+	uint8_t board_revision = get_board_revision();
+
+	switch (board_revision) {
+	case REV_EVT1:
+		extend_sensor_config_size += HSC_SENSOR_CONFIG_SIZE;
+		break;
+	case REV_EVT2:
+	case REV_DVT:
+	case REV_PVT:
+	case REV_MP:
+		break;
+	default:
+		LOG_ERR("Unknown board revision %x", board_revision);
+		break;
+	}
+
+	extend_sensor_config_size += MC_SQ52205_SENSOR_CONFIG_SIZE;
+
+	return extend_sensor_config_size;
 }
 
 bool is_dc_access(uint8_t sensor_num)
@@ -585,8 +850,8 @@ bool get_cxl_sensor_config_index(uint8_t sensor_num, uint8_t *index)
 	return false;
 }
 
-bool get_pcie_card_mux_config(uint8_t card_id, uint8_t sensor_num,
-			      mux_config *card_mux_cfg, mux_config *cxl_mux_cfg)
+bool get_pcie_card_mux_config(uint8_t card_id, uint8_t sensor_num, mux_config *card_mux_cfg,
+			      mux_config *cxl_mux_cfg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(card_mux_cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(cxl_mux_cfg, false);
@@ -609,8 +874,7 @@ bool get_pcie_card_mux_config(uint8_t card_id, uint8_t sensor_num,
 	*card_mux_cfg = bus_2_pca9548_configs[cxl_id];
 	card_mux_cfg->bus = MEB_CXL_BUS;
 
-	tmp_mux_config =
-		(mux_config *)plat_cxl_sensor_config[sensor_config_index].priv_data;
+	tmp_mux_config = (mux_config *)plat_cxl_sensor_config[sensor_config_index].priv_data;
 	CHECK_NULL_ARG_WITH_RETURN(tmp_mux_config, false);
 
 	*cxl_mux_cfg = *tmp_mux_config;


### PR DESCRIPTION
Summary:
- Support power monitor ina233 for evt2.
- Remove HSC mp5990 for evt2

Test Plan:
- Build code : pass
- log with evt1 board root@bmc-oob:~# sensor-util mc
mc:
MC_Inlet Temp_C              (0x1) :   23.00 C     | (ok)
MC_Outlet Temp_C             (0x2) : NA | (na)
MC_PU4 Temp_C                (0x3) :   26.00 C     | (ok)
MC_P12V_AUX_VOL_V            (0x4) :   12.06 Volts | (ok)
MC_P3V3_AUX_VOL_V            (0x5) :    3.29 Volts | (ok)
MC_P1V2_AUX_VOL_V            (0x6) :    1.19 Volts | (ok)
MC_P3V3_VOL_V                (0x7) :    3.29 Volts | (ok)
MC_P12V_AUX_CARD1_VOL_V      (0x8) :   12.15 Volts | (ok)
MC_P12V_AUX_CARD2_VOL_V      (0x9) :   12.15 Volts | (ok)
MC_P12V_AUX_CARD3_VOL_V      (0xA) :   12.15 Volts | (ok)
MC_P12V_AUX_CARD4_VOL_V      (0xB) :   12.15 Volts | (ok)
MC_P12V_AUX_CARD5_VOL_V      (0xC) :   12.16 Volts | (ok)
MC_P12V_AUX_CARD6_VOL_V      (0xD) :   12.16 Volts | (ok)
MC_P12V_AUX_CARD7_VOL_V      (0xE) :   12.15 Volts | (ok)
MC_P12V_AUX_CARD8_VOL_V      (0xF) :   12.15 Volts | (ok)
MC_P12V_AUX_CARD9_VOL_V      (0x10) :   12.15 Volts | (ok)
MC_P12V_AUX_CARD10_VOL_V     (0x11) :   12.15 Volts | (ok)
MC_P12V_AUX_CARD11_VOL_V     (0x12) :   12.15 Volts | (ok)
MC_P12V_AUX_CARD12_VOL_V     (0x13) :   12.15 Volts | (ok)
MC_P12V_AUX_CARD13_VOL_V     (0x14) :   12.15 Volts | (ok)
MC_P12V_AUX_CARD14_VOL_V     (0x15) :   12.16 Volts | (ok)
MC_P12V_AUX_CUR_A            (0x16) :    9.00 Amps  | (ok)
MC_P12V_AUX_CARD1_CUR_A      (0x17) :    0.40 Amps  | (ok)
MC_P12V_AUX_CARD2_CUR_A      (0x18) :    1.32 Amps  | (ok)
MC_P12V_AUX_CARD3_CUR_A      (0x19) :    1.31 Amps  | (ok)
MC_P12V_AUX_CARD4_CUR_A      (0x1A) :    1.56 Amps  | (ok)
MC_P12V_AUX_CARD5_CUR_A      (0x1B) :    0.22 Amps  | (ok)
MC_P12V_AUX_CARD6_CUR_A      (0x1C) :    0.21 Amps  | (ok)
MC_P12V_AUX_CARD7_CUR_A      (0x1D) :    0.22 Amps  | (ok)
MC_P12V_AUX_CARD8_CUR_A      (0x1E) :    0.22 Amps  | (ok)
MC_P12V_AUX_CARD9_CUR_A      (0x1F) :    0.00 Amps  | (ok)
MC_P12V_AUX_CARD10_CUR_A     (0x20) :    1.29 Amps  | (ok)
MC_P12V_AUX_CARD11_CUR_A     (0x21) :    1.31 Amps  | (ok)
MC_P12V_AUX_CARD12_CUR_A     (0x22) :    1.30 Amps  | (ok)
MC_P12V_AUX_CARD13_CUR_A     (0x23) :    0.00 Amps  | (ok)
MC_P12V_AUX_CARD14_CUR_A     (0x24) :    0.00 Amps  | (ok)
MC_P12V_AUX_PWR_W            (0x25) :  109.00 Watts | (ok)
MC_P12V_AUX_CARD1_PWR_W      (0x26) :    4.80 Watts | (ok)
MC_P12V_AUX_CARD2_PWR_W      (0x27) :   15.98 Watts | (ok)
MC_P12V_AUX_CARD3_PWR_W      (0x28) :   15.85 Watts | (ok)
MC_P12V_AUX_CARD4_PWR_W      (0x29) :   18.92 Watts | (ok)
MC_P12V_AUX_CARD5_PWR_W      (0x2A) :    2.72 Watts | (ok)
MC_P12V_AUX_CARD6_PWR_W      (0x2B) :    2.55 Watts | (ok)
MC_P12V_AUX_CARD7_PWR_W      (0x2C) :    2.70 Watts | (ok)
MC_P12V_AUX_CARD8_PWR_W      (0x2D) :    2.67 Watts | (ok)
MC_P12V_AUX_CARD9_PWR_W      (0x2E) :    0.03 Watts | (ok)
MC_P12V_AUX_CARD10_PWR_W     (0x2F) :   15.65 Watts | (ok)
MC_P12V_AUX_CARD11_PWR_W     (0x30) :   15.95 Watts | (ok)
MC_P12V_AUX_CARD12_PWR_W     (0x31) :   15.77 Watts | (ok)
MC_P12V_AUX_CARD13_PWR_W     (0x32) :    0.03 Watts | (ok)
MC_P12V_AUX_CARD14_PWR_W     (0x33) :    0.05 Watts | (ok)
MC_E1S_0_TEMP_C              (0x34) :   22.00 C     | (ok)
MC_E1S_1_TEMP_C              (0x35) :   22.00 C     | (ok)
MC_E1S_2_TEMP_C              (0x36) :   22.00 C     | (ok)
MC_E1S_3_TEMP_C              (0x37) :   22.00 C     | (ok)