### PR TITLE
Artemis: mc: Add delay between cci command

### DIFF
--- a/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
@@ -112,6 +112,7 @@ uint8_t fw_update_pm8702(uint8_t cxl_id, uint8_t pcie_card_id, uint8_t next_acti
 	uint8_t resp_len = 0;
 	pm8702_hbo_status_resp hbo_status = { 0 };
 
+	k_msleep(PM8702_TRANSFER_DELAY_MS);
 	if (pal_get_pm8702_hbo_status(pcie_card_id, (uint8_t *)&hbo_status, &resp_len) != true) {
 		LOG_ERR("Fail to get HBO status");
 		return FWUPDATE_UPDATE_FAIL;


### PR DESCRIPTION
Summary:
- Add a 20ms delay between sending consecutive cci commands according to the vendor suggestion.

Test Plan:
- Build code: Pass
- CXL firmware update: Pass

Log:
root@bmc-oob:~# ./fw-util meb --update cxl8 Artemis_mcrk_pioneer_test_1230-0x6F.bin updating fw on bus 9
updated: 100 %
Update success, sleep 10 secs and active cxl8

Elapsed time:  841   sec.
Upgrade of meb : cxl8 succeeded