### PR TITLE
ol2: op: Fix m88rt51632 device number conflict

### DIFF
--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -144,7 +144,7 @@ enum SENSOR_DEV {
 	sensor_dev_lm75bd118 = 0x28,
 	sensor_dev_tmp461 = 0x29,
 	sensor_dev_mp2985 = 0x2A,
-	sensor_dev_m88rt51632 = 0x29,
+	sensor_dev_m88rt51632 = 0x2B,
 	sensor_dev_max
 };
 


### PR DESCRIPTION
Summary:
- As title.

Test Plan:
- Build code : pass

- Get sensor reading from BMC root@bmc-oob:~# sensor-util slot1 | grep 1OU_RETIMER_TEMP_C
1OU_RETIMER_TEMP_C           (0x61) :   46.25 C     | (ok)