### PR TITLE
fby3: vf: enable PD for unused adc

### DIFF
--- a/meta-facebook/yv3-vf/src/platform/plat_init.c
+++ b/meta-facebook/yv3-vf/src/platform/plat_init.c
@@ -39,6 +39,7 @@ SCU_CFG scu_cfg[] = {
 	//register    value
 	{ 0x7e6e2610, 0x0E000100 },
 	{ 0x7e6e2614, 0x00006000 },
+	{ 0x7e6e2634, 0x0000008F },
 };
 
 extern uint8_t ina230_init(uint8_t sensor_num);


### PR DESCRIPTION
Summary:
- enable PD for unused adc

Test plan:
- Build code : Pass

E1S P12V_AUX                 (0x51) :   11.90 Volts  | (ok)
E1S P12V_EDGE                (0x52) :   11.90 Volts  | (ok)
E1S P3V3_AUX                 (0x53) :    3.26 Volts  | (ok)
E1S DEV0 Voltage             (0x61) :   11.90 Volts  | (ok)
E1S 3V3_ADC_DEV0             (0x64) :    3.28 Volts  | (ok)
E1S 12V_ADC_DEV0             (0x63) :   11.97 Volts  | (ok)
E1S DEV1 Voltage             (0x69) :   11.90 Volts  | (ok)
E1S 3V3_ADC_DEV1             (0x6C) :    3.26 Volts  | (ok)
E1S 12V_ADC_DEV1             (0x6B) :   11.97 Volts  | (ok)
E1S DEV2 Voltage             (0x71) :   11.90 Volts  | (ok)
E1S 3V3_ADC_DEV2             (0x74) :    3.28 Volts  | (ok)
E1S 12V_ADC_DEV2             (0x73) :   11.97 Volts  | (ok)
E1S DEV3 Voltage             (0x79) :   11.97 Volts  | (ok)
E1S 3V3_ADC_DEV3             (0x7C) :    3.26 Volts  | (ok)
E1S 12V_ADC_DEV3             (0x7B) :   12.03 Volts  | (ok)