### PR TITLE
common: fru: Fix FRU read identification of out-of-range error

### DIFF
--- a/common/dev/fru.c
+++ b/common/dev/fru.c
@@ -84,7 +84,7 @@ uint8_t FRU_read(EEPROM_ENTRY *entry)
 		return FRU_INVALID_ID;
 	}
 
-	if ((entry->offset + entry->data_len) >=
+	if ((entry->offset + entry->data_len) >
 	    (FRU_START + FRU_SIZE)) { // Check data write out of range
 		LOG_ERR("FRU read out of range, type: %x, ID: %x", entry->config.dev_type,
 			entry->config.dev_id);


### PR DESCRIPTION
Summary:
- Revise the condition for identification of out-of-range error

Test Plan:
Build and test pass on fby35, fby3 and Artemis

Log:
(get fru area: 1024 bytes)
root@bmc-oob:~# bic-util slot4 0x28 0x10 0x0
00 04 00
(read 16 bytes from 0x3f0)
root@bmc-oob:~# bic-util slot4 0x28 0x11 0x0 0xf0 0x3 0x10 10 FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
FF