### PR TITLE
fby3.5: cl: Fix mistakenly sending SEL of VPP power control

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_init.c
@@ -30,6 +30,7 @@
 #include "hal_i3c.h"
 #include "libutil.h"
 #include "mctp_ctrl.h"
+#include "plat_power.h"
 
 SCU_CFG scu_cfg[] = {
 	//register    value
@@ -59,6 +60,7 @@ void pal_device_init()
 
 	init_i3c_dimm();
 	start_monitor_pmic_error_thread();
+	init_vpp_power_status();
 }
 
 void pal_set_sys_status()

--- a/meta-facebook/yv35-cl/src/platform/plat_isr.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.h
@@ -27,7 +27,6 @@ enum GET_SET_M2_OPTION {
 };
 
 void send_gpio_interrupt(uint8_t gpio_num);
-int get_set_1ou_m2_power(ipmi_msg *msg, uint8_t device_id, uint8_t option);
 void ISR_PLTRST();
 void ISR_SLP3();
 void ISR_DC_ON();

--- a/meta-facebook/yv35-cl/src/platform/plat_power.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_power.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plat_power.h"
+#include <logging/log.h>
+#include "plat_class.h"
+#include "plat_i2c.h"
+#include "hal_i2c.h"
+#include "plat_mctp.h"
+#include "ipmi.h"
+#include "sensor.h"
+
+LOG_MODULE_REGISTER(plat_power);
+
+uint8_t _1ou_m2_mapping_table[4] = { 4, 3, 2, 1 };
+
+static uint8_t last_vpp_pwr_status;
+
+void init_vpp_power_status()
+{
+    I2C_MSG i2c_msg;
+    uint8_t retry = 3;
+
+    // Read VPP power status from SB CPLD
+    memset(&i2c_msg, 0, sizeof(I2C_MSG));
+    i2c_msg.bus = I2C_BUS1;
+    i2c_msg.target_addr = CPLD_ADDR;
+    i2c_msg.data[0] = CPLD_1OU_VPP_POWER_STATUS;
+    i2c_msg.tx_len = 1;
+    i2c_msg.rx_len = 1;
+    if (i2c_master_read(&i2c_msg, retry)) {
+        LOG_ERR("Failed to read CPU VPP status, bus0x%x addr0x%x offset0x%x",
+            i2c_msg.bus, i2c_msg.target_addr, i2c_msg.data[0]);
+        return;
+    }
+
+    last_vpp_pwr_status = i2c_msg.data[0];
+}
+
+uint8_t get_last_vpp_power_status()
+{
+    return last_vpp_pwr_status;
+}
+
+uint8_t get_updated_vpp_power_status()
+{
+    init_vpp_power_status();
+    return last_vpp_pwr_status;
+}
+
+int get_set_1ou_m2_power(ipmi_msg *msg, uint8_t device_id, uint8_t option)
+{
+    CHECK_NULL_ARG_WITH_RETURN(msg, -1);
+    uint32_t iana = IANA_ID;
+    ipmb_error status;
+
+    memset(msg, 0, sizeof(ipmi_msg));
+    msg->InF_source = SELF;
+    msg->InF_target = EXP1_IPMB;
+    msg->netfn = NETFN_OEM_1S_REQ;
+    msg->cmd = CMD_OEM_1S_GET_SET_M2;
+    msg->data_len = 5;
+    memcpy(&msg->data[0], (uint8_t *)&iana, 3);
+    msg->data[3] = _1ou_m2_mapping_table[device_id];
+    msg->data[4] = option;
+    status = ipmb_read(msg, IPMB_inf_index_map[msg->InF_target]);
+    if (status != IPMB_ERROR_SUCCESS) {
+        LOG_ERR("Failed to set get 1OU E1.S power: status 0x%x, id %d, option 0x%x", status,
+            device_id, option);
+        return -1;
+    }
+
+    return 0;
+}

--- a/meta-facebook/yv35-cl/src/platform/plat_power.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_power.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_POWER_H
+#define PLAT_POWER_H
+
+#include <stdint.h>
+#include "ipmi.h"
+
+void init_vpp_power_status();
+uint8_t get_last_vpp_power_status();
+uint8_t get_updated_vpp_power_status();
+int get_set_1ou_m2_power(ipmi_msg *msg, uint8_t device_id, uint8_t option);
+
+#endif


### PR DESCRIPTION
# Description
Init the power status of M.2 device by asking SB CPLD register. -> 1. Add plat_power.c and plat_power.h to maintain the power control related function. 2. Move power control related function in plat_isr.c to plat_power.c

# Motivation
Currently we will set power status of M.2 device with default value, which is incorrect. It may cause BIC to mistakenly send SEL to BMC if the device is not inserted.

# Test Plan
1. Build and test pass on YV3.5 system. pass

2. Check the SEL after setting M.2 device power off. (1) Before fix
2023 Apr 24 19:02:57 log-util: User cleared all logs 2 slot2 2023-04-24 19:03:10 power-util SERVER_POWER_OFF successful for FRU: 2 DEV: 1U-dev1 2 slot2 2023-04-24 19:03:10 ipmid SEL Entry: FRU: 2, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 84/Dev 03/Fun 00, 1OU/Num 1,TotalErrID1Cnt: 0x0000, ErrID2: 0x50(Received ERR_COR Message), ErrID1: 0x00(Receiver Error) 2 slot2 2023-04-24 19:03:10 ipmid SEL Entry: FRU: 2, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 84/Dev 03/Fun 00, 1OU/Num 1,TotalErrID1Cnt: 0x0000, ErrID2: 0x21(Surprise Down Error), ErrID1: 0x53(DPC triggered by uncorrectable error) 2 slot2 2023-04-24 19:03:10 ipmid SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2023-04-24 19:03:10, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B013A) 1OU/Num 0 VPP power control Triggered 2 slot2 2023-04-24 19:03:10 ipmid SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2023-04-24 19:03:10, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B013C) 1OU/Num 1 VPP power control Triggered

(2) After fix
root@bmc-oob:~# power-util slot1 1U-dev1 status
Power status for fru 1 dev 1U-dev1 : ON
root@bmc-oob:~# log-util all --clear
root@bmc-oob:~# power-util slot1 1U-dev1 off
Powering fru 1 dev 1U-dev1 to OFF...
root@bmc-oob:~# log-util all --print
2023 Apr 26 00:59:15 log-util: User cleared all logs
1    slot1    2023-04-26 00:59:18    power-util       SERVER_POWER_OFF successful for FRU: 1 DEV: 1U-dev1
1    slot1    2023-04-26 00:59:18    ipmid            SEL Entry: FRU: 1, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 84/Dev 03/Fun 00, 1OU/Num 1,TotalErrID1Cnt: 0x0000, ErrID2: 0x50(Received ERR_COR Message), ErrID1: 0x00(Receiver Error)
1    slot1    2023-04-26 00:59:18    ipmid            SEL Entry: FRU: 1, Record: Facebook Unified SEL (0xFB), GeneralInfo: x86/PCIeErr(0x20), Bus 84/Dev 03/Fun 00, 1OU/Num 1,TotalErrID1Cnt: 0x0000, ErrID2: 0x21(Surprise Down Error), ErrID1: 0x53(DPC triggered by uncorrectable error)
1    slot1    2023-04-26 00:59:19    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-04-26 00:59:19, Sensor: SYSTEM_STATUS (0x10), Event Data: (0B013C) 1OU/Num 1 VPP power control Triggered