### PR TITLE
fby3.5: hd: Modify HSC temperature sensor setting

### DIFF
--- a/common/dev/g788p81u.c
+++ b/common/dev/g788p81u.c
@@ -124,6 +124,54 @@ uint8_t g788p81u_init(uint8_t sensor_num)
 		LOG_ERR("Failed to set alert mode, ret: %d", ret);
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = G788P81U_ALERT_MASK_OFFSET;
+	msg.data[1] = init_arg->alert_mask & 0xFF;
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Failed to set alert mask, ret: %d", ret);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = G788P81U_CONFIGURATION_OFFSET;
+	msg.data[1] = init_arg->configuration & 0xFF;
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Failed to set configuration, ret: %d", ret);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = G788P81U_REMOTE_TEMP_THERM_LIMIT_OFFSET;
+	msg.data[1] = init_arg->remote_temp_therm_limit & 0xFF;
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Failed to set remote temperature THERM limit, ret: %d", ret);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = G788P81U_LOCAL_TEMP_THERM_LIMIT_OFFSET;
+	msg.data[1] = init_arg->local_temp_therm_limit & 0xFF;
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Failed to set local temperature THERM limit, ret: %d", ret);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
 	init_arg->is_init = true;
 
 skip_init:

--- a/common/dev/nct7718w.c
+++ b/common/dev/nct7718w.c
@@ -119,6 +119,54 @@ uint8_t nct7718w_init(uint8_t sensor_num)
 		LOG_ERR("Failed to set RT filter and Alert mode, ret: %d", ret);
 		return SENSOR_INIT_UNSPECIFIED_ERROR;
 	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = NCT7718W_ALERT_MASK_OFFSET;
+	msg.data[1] = init_arg->alert_mask & 0xFF;
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Failed to set alert mask, ret: %d", ret);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = NCT7718W_CONFIGURATION_OFFSET;
+	msg.data[1] = init_arg->configuration & 0xFF;
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Failed to set configuration, ret: %d", ret);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = NCT7718W_RT1_CRITICAL_TEMP_OFFSET;
+	msg.data[1] = init_arg->rt1_critical_temperature & 0xFF;
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Failed to set RT1 critical temperature, ret: %d", ret);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = NCT7718W_LT_CRITICAL_TEMP_OFFSET;
+	msg.data[1] = init_arg->lt_critical_temperature & 0xFF;
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Failed to set local critical temperature, ret: %d", ret);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
 	init_arg->is_init = true;
 
 skip_init:

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -65,8 +65,12 @@ enum ADM1278_OFFSET {
 enum NCT7718W_OFFSET {
 	NCT7718W_LOCAL_TEMP_OFFSET = 0x00,
 	NCT7718W_REMOTE_TEMP_MSB_OFFSET = 0x01,
-	NCT7718W_RT1_HIGH_ALERT_TEMP_OFFSET = 0x07,
+	NCT7718W_CONFIGURATION_OFFSET = 0x03,
+	NCT7718W_RT1_HIGH_ALERT_TEMP_OFFSET = 0x0D,
 	NCT7718W_REMOTE_TEMP_LSB_OFFSET = 0x10,
+	NCT7718W_ALERT_MASK_OFFSET = 0x16,
+	NCT7718W_RT1_CRITICAL_TEMP_OFFSET = 0x19,
+	NCT7718W_LT_CRITICAL_TEMP_OFFSET = 0x20,
 	NCT7718W_RT_FILTER_ALERT_MODE_OFFSET = 0xBF,
 	NCT7718W_CHIP_ID_OFFSET = 0xFD,
 	NCT7718W_VENDOR_ID_OFFSET = 0xFE,
@@ -86,8 +90,12 @@ enum INA230_OFFSET {
 enum G788P81U_OFFSET {
 	G788P81U_LOCAL_TEMP_OFFSET = 0x00,
 	G788P81U_REMOTE_TEMP_OFFSET = 0x01,
-	G788P81U_REMOTE_THIGH_LIMIT_OFFSET = 0x07,
+	G788P81U_CONFIGURATION_OFFSET = 0x03,
+	G788P81U_REMOTE_THIGH_LIMIT_OFFSET = 0x0D,
 	G788P81U_REMOTE_TEMP_EXT_OFFSET = 0x10,
+	G788P81U_ALERT_MASK_OFFSET = 0x16,
+	G788P81U_REMOTE_TEMP_THERM_LIMIT_OFFSET = 0x19,
+	G788P81U_LOCAL_TEMP_THERM_LIMIT_OFFSET = 0x20,
 	G788P81U_ALERT_MODE_OFFSET = 0xBF,
 };
 
@@ -568,12 +576,20 @@ typedef struct _nct7718w_init_arg_ {
 	bool is_init;
 	uint8_t rt1_high_alert_temp;
 	uint8_t rt_filter_alert_mode;
+	uint8_t alert_mask;
+	uint8_t configuration;
+	uint8_t rt1_critical_temperature;
+	uint8_t lt_critical_temperature;
 } nct7718w_init_arg;
 
 typedef struct _g788p81u_init_arg_ {
 	bool is_init;
 	uint8_t remote_T_high_limit;
 	uint8_t alert_mode;
+	uint8_t alert_mask;
+	uint8_t configuration;
+	uint8_t remote_temp_therm_limit;
+	uint8_t local_temp_therm_limit;
 } g788p81u_init_arg;
 
 typedef struct _pt5161l_init_arg_ {

--- a/meta-facebook/yv35-hd/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_hook.c
@@ -58,12 +58,22 @@ mp5990_init_arg mp5990_init_args[] = {
 };
 
 nct7718w_init_arg nct7718w_init_args[] = {
-	[0] = { .is_init = false, .rt1_high_alert_temp = 0x50, .rt_filter_alert_mode = 0x01 },
+	[0] = { .is_init = false,
+		.rt1_high_alert_temp = 0x50,
+		.rt_filter_alert_mode = 0x01,
+		.alert_mask = 0x8B,
+		.configuration = 0x07,
+		.rt1_critical_temperature = 0x64,
+		.lt_critical_temperature = 0x64 },
 };
 
-g788p81u_init_arg g788p81u_init_args[] = {
-	[0] = { .is_init = false, .remote_T_high_limit = 0x50, .alert_mode = 0x01 }
-};
+g788p81u_init_arg g788p81u_init_args[] = { [0] = { .is_init = false,
+						   .remote_T_high_limit = 0x50,
+						   .alert_mode = 0x01,
+						   .alert_mask = 0x8B,
+						   .configuration = 0x07,
+						   .remote_temp_therm_limit = 0x64,
+						   .local_temp_therm_limit = 0x64 } };
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS


### PR DESCRIPTION
Summary:
- Add the configuration, alert mask, Local and remote critical temperature in initialization argument of nct7718w and g788p81u.
- Mask the alert except remote high temperature.
- Set the local and remote critical temperature to 100 degree C.

Test Plan:
- Build code: PASS
- Heat up HSC temperature to 80 degree and check alert pin: PASS