### PR TITLE
Artemis: mc: fix cxl fru mapping

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_fru.c
+++ b/meta-facebook/at-mc/src/platform/plat_fru.c
@@ -153,28 +153,28 @@ uint8_t pal_cxl_map_mux0_channel(uint8_t cxl_fru_id)
 
 	switch (pcie_card_id) {
 	case CARD_1_INDEX:
-		channel = PCA9548A_CHANNEL_6;
+		channel = PCA9548A_CHANNEL_0;
 		break;
 	case CARD_2_INDEX:
-		channel = PCA9548A_CHANNEL_7;
-		break;
-	case CARD_3_INDEX:
-		channel = PCA9548A_CHANNEL_4;
-		break;
-	case CARD_4_INDEX:
-		channel = PCA9548A_CHANNEL_5;
-		break;
-	case CARD_9_INDEX:
-		channel = PCA9548A_CHANNEL_3;
-		break;
-	case CARD_10_INDEX:
-		channel = PCA9548A_CHANNEL_2;
-		break;
-	case CARD_11_INDEX:
 		channel = PCA9548A_CHANNEL_1;
 		break;
+	case CARD_3_INDEX:
+		channel = PCA9548A_CHANNEL_2;
+		break;
+	case CARD_4_INDEX:
+		channel = PCA9548A_CHANNEL_3;
+		break;
+	case CARD_9_INDEX:
+		channel = PCA9548A_CHANNEL_4;
+		break;
+	case CARD_10_INDEX:
+		channel = PCA9548A_CHANNEL_5;
+		break;
+	case CARD_11_INDEX:
+		channel = PCA9548A_CHANNEL_6;
+		break;
 	case CARD_12_INDEX:
-		channel = PCA9548A_CHANNEL_0;
+		channel = PCA9548A_CHANNEL_7;
 		break;
 	default:
 		channel = PCA9548A_CHANNEL_DISABLE;


### PR DESCRIPTION
Description:
- The CXL fru mapping is wrong.

Motivation:
- Fix bmc show the correct cxl fru.

Test Plan:
- Build code : pass
- Get cxl fru : pass

LOG :
root@bmc-oob:~# for i in {1..8};
> do
> fruid-util mc_cxl${i}
> done

FRU Information           : MC CXL1
---------------           : ------------------
Board Mfg Date            : Mon Jan 10 12:34:00 2022
Board Mfg                 : Wiwynn
Board Product             : FAKE CXL1
Board Serial              : WT0720107TN01
Board Part Number         : B81.04G10.0007
Board FRU ID              : 1.0
Board Custom Data 1       : 09-001388
Board Custom Data 2       : PCB Supplier - TRI
Product Manufacturer      : Wiwynn
Product Name              : Great Lakes
Product Part Number       : B81.04G01.0020
Product Version           : EVT2
Product Serial            : WTT220400ZNSD
Product Asset Tag         : AX84682
Product FRU ID            : 1.0
Product Custom Data 1     : 01-005999
Product Custom Data 2     : Config A-7-MCC

FRU Information           : MC CXL2
---------------           : ------------------
Board Mfg Date            : Mon Jan 10 12:34:00 2022
Board Mfg                 : Wiwynn
Board Product             : FAKE CXL2
Board Serial              : WT0720107TN01
Board Part Number         : B81.04G10.0007
Board FRU ID              : 1.0
Board Custom Data 1       : 09-001388
Board Custom Data 2       : PCB Supplier - TRI
Product Manufacturer      : Wiwynn
Product Name              : Great Lakes
Product Part Number       : B81.04G01.0020
Product Version           : EVT2
Product Serial            : WTT220400ZNSD
Product Asset Tag         : AX84682
Product FRU ID            : 1.0
Product Custom Data 1     : 01-005999
Product Custom Data 2     : Config A-7-MCC

FRU Information           : MC CXL3
---------------           : ------------------
Board Mfg Date            : Mon Jan 10 12:34:00 2022
Board Mfg                 : Wiwynn
Board Product             : FAKE CXL3
Board Serial              : WT0720107TN01
Board Part Number         : B81.04G10.0007
Board FRU ID              : 1.0
Board Custom Data 1       : 09-001388
Board Custom Data 2       : PCB Supplier - TRI
Product Manufacturer      : Wiwynn
Product Name              : Great Lakes
Product Part Number       : B81.04G01.0020
Product Version           : EVT2
Product Serial            : WTT220400ZNSD
Product Asset Tag         : AX84682
Product FRU ID            : 1.0
Product Custom Data 1     : 01-005999
Product Custom Data 2     : Config A-7-MCC

FRU Information           : MC CXL4
---------------           : ------------------
Board Mfg Date            : Mon Jan 10 12:34:00 2022
Board Mfg                 : Wiwynn
Board Product             : FAKE CXL4
Board Serial              : WT0720107TN01
Board Part Number         : B81.04G10.0007
Board FRU ID              : 1.0
Board Custom Data 1       : 09-001388
Board Custom Data 2       : PCB Supplier - TRI
Product Manufacturer      : Wiwynn
Product Name              : Great Lakes
Product Part Number       : B81.04G01.0020
Product Version           : EVT2
Product Serial            : WTT220400ZNSD
Product Asset Tag         : AX84682
Product FRU ID            : 1.0
Product Custom Data 1     : 01-005999
Product Custom Data 2     : Config A-7-MCC

FRU Information           : MC CXL5
---------------           : ------------------
Board Mfg Date            : Mon Jan 10 12:34:00 2022
Board Mfg                 : Wiwynn
Board Product             : FAKE CXL5
Board Serial              : WT0720107TN01
Board Part Number         : B81.04G10.0007
Board FRU ID              : 1.0
Board Custom Data 1       : 09-001388
Board Custom Data 2       : PCB Supplier - TRI
Product Manufacturer      : Wiwynn
Product Name              : Great Lakes
Product Part Number       : B81.04G01.0020
Product Version           : EVT2
Product Serial            : WTT220400ZNSD
Product Asset Tag         : AX84682
Product FRU ID            : 1.0
Product Custom Data 1     : 01-005999
Product Custom Data 2     : Config A-7-MCC

FRU Information           : MC CXL6
---------------           : ------------------
Board Mfg Date            : Mon Jan 10 12:34:00 2022
Board Mfg                 : Wiwynn
Board Product             : FAKE CXL6
Board Serial              : WT0720107TN01
Board Part Number         : B81.04G10.0007
Board FRU ID              : 1.0
Board Custom Data 1       : 09-001388
Board Custom Data 2       : PCB Supplier - TRI
Product Manufacturer      : Wiwynn
Product Name              : Great Lakes
Product Part Number       : B81.04G01.0020
Product Version           : EVT2
Product Serial            : WTT220400ZNSD
Product Asset Tag         : AX84682
Product FRU ID            : 1.0
Product Custom Data 1     : 01-005999
Product Custom Data 2     : Config A-7-MCC

FRU Information           : MC CXL7
---------------           : ------------------
Board Mfg Date            : Mon Jan 10 12:34:00 2022
Board Mfg                 : Wiwynn
Board Product             : FAKE CXL7
Board Serial              : WT0720107TN01
Board Part Number         : B81.04G10.0007
Board FRU ID              : 1.0
Board Custom Data 1       : 09-001388
Board Custom Data 2       : PCB Supplier - TRI
Product Manufacturer      : Wiwynn
Product Name              : Great Lakes
Product Part Number       : B81.04G01.0020
Product Version           : EVT2
Product Serial            : WTT220400ZNSD
Product Asset Tag         : AX84682
Product FRU ID            : 1.0
Product Custom Data 1     : 01-005999
Product Custom Data 2     : Config A-7-MCC

FRU Information           : MC CXL8
---------------           : ------------------
Board Mfg Date            : Mon Jan 10 12:34:00 2022
Board Mfg                 : Wiwynn
Board Product             : FAKE CXL8
Board Serial              : WT0720107TN01
Board Part Number         : B81.04G10.0007
Board FRU ID              : 1.0
Board Custom Data 1       : 09-001388
Board Custom Data 2       : PCB Supplier - TRI
Product Manufacturer      : Wiwynn
Product Name              : Great Lakes
Product Part Number       : B81.04G01.0020
Product Version           : EVT2
Product Serial            : WTT220400ZNSD
Product Asset Tag         : AX84682
Product FRU ID            : 1.0
Product Custom Data 1     : 01-005999
Product Custom Data 2     : Config A-7-MCC