### PR TITLE
Artemis: mc: Fix invalid debug message when BIC set EID fail

### DIFF
--- a/common/service/mctp/mctp_ctrl.h
+++ b/common/service/mctp/mctp_ctrl.h
@@ -37,6 +37,12 @@ typedef struct _mctp_ctrl_cmd_handler {
 #define MCTP_CTRL_CMD_SET_ENDPOINT_ID 0x01
 #define MCTP_CTRL_CMD_GET_ENDPOINT_ID 0x02
 
+#define MCTP_CTRL_CMD_GET_ENDPOINT_ID_REQ_LEN 0x00
+
+#define MCTP_CTRL_READ_STATUS_SUCCESS 0x00
+#define MCTP_CTRL_READ_STATUS_CC_ERROR 0x01
+#define MCTP_CTRL_READ_STATUS_TIMEOUT 0x02
+
 /*
  * MCTP Control Completion Codes
  * See DSP0236 v1.3.0 Table 13.
@@ -112,9 +118,17 @@ typedef struct {
 	void *timeout_cb_fn_args;
 } mctp_ctrl_msg;
 
+typedef struct _mctp_ctrl_resp_arg {
+	struct k_msgq *msgq;
+	uint8_t *read_buf;
+	uint16_t read_len;
+	uint16_t return_len;
+} mctp_ctrl_resp_arg;
+
 uint8_t mctp_ctrl_cmd_handler(void *mctp_p, uint8_t *buf, uint32_t len, mctp_ext_params ext_params);
 
 uint8_t mctp_ctrl_send_msg(void *mctp_p, mctp_ctrl_msg *msg);
+uint8_t mctp_ctrl_read(void *mctp_p, mctp_ctrl_msg *msg, uint8_t *read_buf, uint16_t read_len);
 
 #ifdef __cplusplus
 }

--- a/meta-facebook/at-mc/src/platform/plat_dev.c
+++ b/meta-facebook/at-mc/src/platform/plat_dev.c
@@ -869,7 +869,7 @@ void cxl_mb_status_init(uint8_t cxl_id)
 			return;
 		}
 
-		set_cxl_endpoint(MCTP_EID_CXL, cxl_id);
+		get_set_cxl_endpoint(cxl_id, MCTP_EID_CXL);
 	}
 
 	k_mutex_unlock(meb_mutex);

--- a/meta-facebook/at-mc/src/platform/plat_isr.c
+++ b/meta-facebook/at-mc/src/platform/plat_isr.c
@@ -131,7 +131,7 @@ void cxl_set_eid_work_handler(struct k_work *work_item)
 	}
 
 	/** Set endpoint id **/
-	set_cxl_endpoint(MCTP_EID_CXL, work_info->cxl_card_id);
+	get_set_cxl_endpoint(work_info->cxl_card_id, MCTP_EID_CXL);
 
 	/** mutex unlock bus **/
 	k_mutex_unlock(meb_mutex);

--- a/meta-facebook/at-mc/src/platform/plat_mctp.h
+++ b/meta-facebook/at-mc/src/platform/plat_mctp.h
@@ -46,7 +46,7 @@
 #define CLEAR_EID_FLAG false
 
 void plat_mctp_init(void);
-void set_cxl_endpoint(uint8_t eid, uint8_t cxl_card_id);
+void get_set_cxl_endpoint(uint8_t cxl_card_id, uint8_t eid);
 bool get_cxl_eid_flag(uint8_t cxl_card_id);
 void set_cxl_eid_flag(uint8_t cxl_card_id, bool value);
 int pal_pldm_send_ipmi_request(ipmi_msg *msg, uint8_t eid);


### PR DESCRIPTION
Description:
- Fix invalid debug message when BIC set EID fail
  - Add MCTP control message reading function to get device message response.
  - Modify the behavior of setting EID - BIC will get EID first, if the got EID doesn't match the setting EID, than set the EID.
  - Print correct debug messasge after BIC gets the response from PM8702.

Motivation:
  - After sending the setting EID command, BIC ends the function without waiting for the response from PM8702. So when the PM8702 response timeout, it gets invalid parameters and prints an invalid debug message. BIC needs to get the correct debug message to confirm which CXL fails to set eid.

Test Plan:
- Build code: Pass
- Get correct debug message if BIC set EID fail: Pass

Log:
- Before [00:00:00.466,000] <err> plat_mctp: Endpoint 0x7 set endpoint fail, addr: 0x2f [00:00:00.466,000] <err> plat_mctp: Endpoint 0x7 set endpoint fail, addr: 0x2f [00:00:00.468,000] <err> plat_mctp: Endpoint 0x7 set endpoint fail, addr: 0x2f [00:00:00.468,000] <err> plat_mctp: Endpoint 0x7 set endpoint fail, addr: 0x2f [00:00:00.469,000] <err> plat_mctp: Endpoint 0x7 set endpoint fail, addr: 0x2f

- After [00:02:28.803,000] <err> plat_mctp: Fail to get eid, card id: 0x4 [00:02:28.807,000] <err> plat_mctp: Fail to get eid, card id: 0x5 [00:02:28.812,000] <err> plat_mctp: Fail to get eid, card id: 0x1 [00:02:28.816,000] <err> plat_mctp: Fail to get eid, card id: 0x0 [00:02:28.821,000] <err> plat_mctp: Fail to get eid, card id: 0x3 [00:02:28.828,000] <err> plat_mctp: Fail to get eid, card id: 0x2