### PR TITLE
Artemis: mc: Add outlet temperature sensor for EVT2

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_sdr_table.c
+++ b/meta-facebook/at-mc/src/platform/plat_sdr_table.c
@@ -3341,8 +3341,73 @@ SDR_Full_sensor plat_hsc_sdr_table[] = {
 	},
 };
 
+SDR_Full_sensor evt2_extand_sdr_table[] = {
+	{
+		// TMP75 on board temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_TMP75_OUT, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"Outlet_TEMP",
+	},
+};
+
 const int SDR_TABLE_SIZE = ARRAY_SIZE(plat_sdr_table);
 const int HSC_SDR_TABLE_SIZE = ARRAY_SIZE(plat_hsc_sdr_table);
+const int EVT2_EXTAND_SDR_TABLE_SIZE = ARRAY_SIZE(evt2_extand_sdr_table);
 
 uint8_t pal_get_extend_sdr()
 {
@@ -3356,6 +3421,7 @@ uint8_t pal_get_extend_sdr()
 	case REV_DVT:
 	case REV_PVT:
 	case REV_MP:
+		extend_sdr_table_size += EVT2_EXTAND_SDR_TABLE_SIZE;
 		break;
 	default:
 		break;
@@ -3377,6 +3443,9 @@ void pal_extend_full_sdr_table()
 	case REV_DVT:
 	case REV_PVT:
 	case REV_MP:
+		for (int index = 0; index < EVT2_EXTAND_SDR_TABLE_SIZE; index++) {
+			add_full_sdr_table(evt2_extand_sdr_table[index]);
+		}
 		break;
 	default:
 		break;

--- a/meta-facebook/at-mc/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-mc/src/platform/plat_sensor_table.c
@@ -680,12 +680,19 @@ sensor_cfg plat_cxl_sensor_config[] = {
 	  post_cxl_xdpe12284c_read, NULL, NULL, &cxl_mux_configs[3] },
 };
 
+sensor_cfg evt2_extend_sensor_config[] = {
+	{ SENSOR_NUM_TEMP_TMP75_OUT, sensor_dev_tmp75, I2C_BUS1, TMP75_OUT_ADDR, TMP75_TEMP_OFFSET,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+};
+
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
 const int MC_SQ52205_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_mc_sq52205_sensor_config);
 const int MC_INA233_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_mc_ina233_sensor_config);
 const int E1S_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_e1s_1_12_sensor_config);
 const int CXL_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_cxl_sensor_config);
 const int HSC_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_hsc_mp5990_sensor_config);
+const int EVT2_EXTEND_SENSOR_CONFIG_SIZE = ARRAY_SIZE(evt2_extend_sensor_config);
 
 void pal_extend_sensor_config()
 {
@@ -702,6 +709,9 @@ void pal_extend_sensor_config()
 	case REV_DVT:
 	case REV_PVT:
 	case REV_MP:
+		for (int index = 0; index < EVT2_EXTEND_SENSOR_CONFIG_SIZE; index++) {
+			add_sensor_config(evt2_extend_sensor_config[index]);
+		}
 		break;
 	default:
 		LOG_ERR("Unknown board revision %x", board_revision);
@@ -744,6 +754,7 @@ uint8_t pal_get_extend_sensor_config()
 	case REV_DVT:
 	case REV_PVT:
 	case REV_MP:
+		extend_sensor_config_size += EVT2_EXTEND_SENSOR_CONFIG_SIZE;
 		break;
 	default:
 		LOG_ERR("Unknown board revision %x", board_revision);


### PR DESCRIPTION
Description:
- Add outlet temperature sensor for EVT2.

Motivation:
- The hardware adds an outlet temperature sensor on EVT2.

Test Plan:
- Build code: Pass
- Get outlet temperature sensor: Pass

Log:
root@bmc-oob:~# sensor-util mc | grep "MC_Outlet"
MC_Outlet Temp_C             (0x2) :   25.00 C     | (ok)