### PR TITLE
Common: Using a structure that includes IANA to get PLDM response

### DIFF
--- a/common/service/pldm/pldm.c
+++ b/common/service/pldm/pldm.c
@@ -645,7 +645,7 @@ int pldm_send_ipmi_request(ipmi_msg *msg)
 		return false;
 	}
 
-	struct _pldm_ipmi_cmd_resp *resp = (struct _pldm_ipmi_cmd_resp *)rbuf;
+	struct _ipmi_cmd_resp  *resp = (struct _ipmi_cmd_resp  *)rbuf;
 
 	if ((resp->completion_code != MCTP_SUCCESS)) {
 		resp->ipmi_comp_code = CC_UNSPECIFIED_ERROR;
@@ -654,10 +654,10 @@ int pldm_send_ipmi_request(ipmi_msg *msg)
 	msg->completion_code = resp->ipmi_comp_code;
 	msg->netfn = resp->netfn_lun >> 2;
 	msg->cmd = resp->cmd;
-	// MCTP CC, Netfn, cmd, ipmi CC
-	if (res_len > 4) {
-		msg->data_len = res_len - 4;
-		memcpy(msg->data, &rbuf[4], msg->data_len);
+	// MCTP CC, IANA, Netfn, cmd, ipmi CC
+	if (res_len > 7) {
+		msg->data_len = res_len - 7;
+		memcpy(msg->data, &rbuf[7], msg->data_len);
 	} else {
 		msg->data_len = 0;
 	}


### PR DESCRIPTION
# Description
- Using a structure that includes IANA to get BMC response.

# Motivation
- The response from BMC is including IANA, but the current use structure doesn't include it. It causes BIC response mapping is wrong.

# Test Plan
1. Build and test pass.

2. Do host power cycle to check response from BMC is correct. root@bmc-oob:~# power-util slot4 cycle
Power cycling fru 4...
root@bmc-oob:~# power-util slot4 status
Power status for fru 4 : ON
root@bmc-oob:~#
root@bmc-oob:~# sol-util slot4

------------------TERMINAL MULTIPLEXER---------------------
  CTRL-l ?   : Display help message.
  CTRL-l x : Terminate the connection.
  /var/log/mTerm_slot4.log : Log location
  CTRL-l + b : Send Break

-----------------------------------------------------------

[root@FBK8_221107 ~]#
[root@FBK8_221107 ~]# Connection closed.

root@bmc-oob:~# log-util --print slot4
2023 May 16 22:24:34 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-16 22:24:47    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-16 22:24:49    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-16 22:24:49, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-16 22:24:52    power-util       SERVER_POWER_CYCLE successful for FRU: 4
4    slot4    2023-05-16 22:24:55    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-16 22:26:02    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15

3. Add SEL to BMC to check response from BMC is correct. [BIC console]
uart:~$ gpio conf GPIO0_A_D 16 out
Configuring GPIO0_A_D pin 16
uart:~$ gpio set GPIO0_A_D 16 1
Writing to GPIO0_A_D pin 16
uart:~$ gpio conf GPIO0_A_D 16 in
Configuring GPIO0_A_D pin 16

[BMC console]
root@bmc-oob:~# log-util --print slot4
2023 May 16 22:24:34 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-16 23:11:57    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-16 23:11:57, Sensor: SYSTEM_STATUS (0x10), Event Data: (06FFFF) HSC_OC warning Deassertion
4    slot4    2023-05-16 23:11:57    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-16 23:11:57, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Assertion
4    slot4    2023-05-16 23:11:57    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-16 23:11:57, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Assertion
4    slot4    2023-05-16 23:12:01    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-16 23:12:01, Sensor: SYSTEM_STATUS (0x10), Event Data: (06FFFF) HSC_OC warning Assertion
4    slot4    2023-05-16 23:12:01    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-16 23:12:01, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Deassertion
4    slot4    2023-05-16 23:12:01    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-16 23:12:01, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Deassertion