### PR TITLE
fby35: cl: Avoid CARD_TYPE_EXP floating when 1OU board isn't present

### DIFF
--- a/common/hal/hal_gpio.h
+++ b/common/hal/hal_gpio.h
@@ -58,6 +58,7 @@
 #define OPEN_DRAIN 0
 #define PUSH_PULL 1
 
+#define REG_ADC_BASE 0x7e6e9000
 #define REG_GPIO_BASE 0x7e780000
 #define REG_SCU 0x7E6E2000
 #define REG_DIRECTION_OFFSET 4

--- a/meta-facebook/yv35-cl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.c
@@ -359,6 +359,18 @@ void init_platform_config()
 				}
 			}
 		}
+	} else {
+		// If 1ou card not present, disable ADC6(CARD_TYPE_EXP) and set it to GPIO to avoid floating
+		uint32_t read_value = 0;
+		// Disable ADC channel 6: ADC000[22]
+		read_value = sys_read32(REG_ADC_BASE + 0x000);
+		read_value = CLEARBIT(read_value, 22);
+		sys_write32(read_value, REG_ADC_BASE + 0x000);
+
+		// Multi-function pin ctl #5: SCU430[30] is GPIT6
+		read_value = sys_read32(REG_SCU + 0x430);
+		read_value = SETBIT(read_value, 30);
+		sys_write32(read_value, REG_SCU + 0x430);
 	}
 
 	if (_2ou_status.present) {


### PR DESCRIPTION
# Description
- When 1OU board isn't present, set ADC6 (CARD_TYPE_EXP signal) to GPIO low and disable ADC chip monitoring ADC6 to avoid ADC6 signal floating.
- Set ADC6 to GPIO (Enable multi-function pin): SCU430[30] set 1.
- Disable ADC6 monitor: ADC000[22] set 0.

# Motivation
- ADC6 is floating when 1OU isn't present. It might cause the ADC to have wrong.

# Test Plan
1. Build code CL BIC pass.
2. Check register memory when 1OU not present.
- Before modify uart:~$ md 0x7e6e9000 1

[7e6e9000] 00ff010f

uart:~$ md 0x7E6E2430 1

[7e6e2430] 00060c00

- After modify uart:~$ md 0x7e6e9000 1

[7e6e9000] 00bf010f

uart:~$ md 0x7E6E2430 1

[7e6e2430] 40060c00