### PR TITLE
ol2: op: Modify E1.S 3/4 P12V power threshold

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_sdr_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sdr_table.c
@@ -1954,21 +1954,21 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x0C, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFA, // UNRT
-		0xF7, // UCT
-		0xF5, // UNCT
+		0xD0, // UNRT
+		0xCE, // UCT
+		0xCC, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2015,21 +2015,21 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x0C, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0xFA, // UNRT
-		0xF7, // UCT
-		0xF5, // UNCT
+		0xD0, // UNRT
+		0xCE, // UCT
+		0xCC, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT


### PR DESCRIPTION
# Description
- Correct SSD E1.S 3 and E1.S 4 P12V power threshold.

# Motivation
- Currently, E1.S 3 and E1.S 4 P12V power threshold is wrong.

# Test Plan
1. Build OP BIC pass.

2. Read sensor to check threshold is correct.
- Before fix root@bmc-oob:~# sensor-util slot1 --thre | grep P12V_PWR_W
1OU_E1S_SSD0_P12V_PWR_W      (0x56) :    3.53 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
1OU_E1S_SSD1_P12V_PWR_W      (0x57) :    3.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
1OU_E1S_SSD2_P12V_PWR_W      (0x58) :    3.45 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD0_P12V_PWR_W      (0x86) :    1.35 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD1_P12V_PWR_W      (0x87) :    1.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD2_P12V_PWR_W      (0x88) :    1.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD3_P12V_PWR_W      (0x89) :    1.40 Watts  | (ok) | UCR: 24.70 | UNC: 24.50 | UNR: 25.00 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD4_P12V_PWR_W      (0x8A) :    1.40 Watts  | (ok) | UCR: 24.70 | UNC: 24.50 | UNR: 25.00 | LCR: NA | LNC: NA | LNR: NA
2OU_BIC_MAIN_P12V_PWR_W      (0x8B) :   11.27 Watts  | (ok) | UCR: 15.33 | UNC: 15.19 | UNR: 15.47 | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD0_P12V_PWR_W      (0xB6) :    1.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD1_P12V_PWR_W      (0xB7) :    1.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD2_P12V_PWR_W      (0xB8) :    1.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD0_P12V_PWR_W      (0xE6) :    1.42 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD1_P12V_PWR_W      (0xE7) :    1.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD2_P12V_PWR_W      (0xE8) :    1.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD3_P12V_PWR_W      (0xE9) :    1.35 Watts  | (ok) | UCR: 24.70 | UNC: 24.50 | UNR: 25.00 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD4_P12V_PWR_W      (0xEA) :    1.35 Watts  | (ok) | UCR: 24.70 | UNC: 24.50 | UNR: 25.00 | LCR: NA | LNC: NA | LNR: NA
4OU_BIC_MAIN_P12V_PWR_W      (0xEB) :   10.98 Watts  | (ok) | UCR: 15.33 | UNC: 15.19 | UNR: 15.47 | LCR: NA | LNC: NA | LNR: NA

- After fix root@bmc-oob:~# sensor-util slot1 --thre | grep P12V_PWR_W
1OU_E1S_SSD0_P12V_PWR_W      (0x56) :    3.58 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
1OU_E1S_SSD1_P12V_PWR_W      (0x57) :    3.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
1OU_E1S_SSD2_P12V_PWR_W      (0x58) :    3.47 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD0_P12V_PWR_W      (0x86) :    3.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD1_P12V_PWR_W      (0x87) :    3.47 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD2_P12V_PWR_W      (0x88) :    3.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD3_P12V_PWR_W      (0x89) :    3.47 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
2OU_E1S_SSD4_P12V_PWR_W      (0x8A) :    3.47 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
2OU_BIC_MAIN_P12V_PWR_W      (0x8B) :   27.77 Watts  | (ok) | UCR: 198.00 | UNC: 195.80 | UNR: 199.10 | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD0_P12V_PWR_W      (0xB6) :    1.35 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD1_P12V_PWR_W      (0xB7) :    1.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
3OU_E1S_SSD2_P12V_PWR_W      (0xB8) :    1.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD0_P12V_PWR_W      (0xE6) :    3.60 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD1_P12V_PWR_W      (0xE7) :    3.53 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD2_P12V_PWR_W      (0xE8) :    3.40 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD3_P12V_PWR_W      (0xE9) :    3.45 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
4OU_E1S_SSD4_P12V_PWR_W      (0xEA) :    3.47 Watts  | (ok) | UCR: 24.72 | UNC: 24.48 | UNR: 24.96 | LCR: NA | LNC: NA | LNR: NA
4OU_BIC_MAIN_P12V_PWR_W      (0xEB) :   28.50 Watts  | (ok) | UCR: 198.00 | UNC: 195.80 | UNR: 199.10 | LCR: NA | LNC: NA | LN