### PR TITLE
fby3.5: cl: adjust HSC type ADC tolerance

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.c
@@ -176,25 +176,25 @@ void init_hsc_module(uint8_t board_revision)
 		case SYS_BOARD_PVT_HOTSWAP:
 		case SYS_BOARD_MP_HOTSWAP:
 			/* Follow the GPIO table, the HSC device type can be by ADC7(net name: HSC_TYPE_ADC)
-      * If the voltage of ADC-7 is 0.5V(+/- 15%), the hotswap model is ADM1278.
-      * If the voltage of ADC-7 is 1.0V(+/- 15%), the hotswap model is LTC4282.
-      * If the voltage of ADC-7 is 1.5V(+/- 15%), the hotswap model is LTC4286.
+      * If the voltage of ADC-7 is 0.5V(+/- 0.2V), the hotswap model is ADM1278.
+      * If the voltage of ADC-7 is 1.0V(+/- 0.2V), the hotswap model is LTC4282.
+      * If the voltage of ADC-7 is 1.5V(+/- 0.2V), the hotswap model is LTC4286.
       */
 			ret = get_adc_voltage(CHANNEL_7, &voltage_hsc_type_adc);
 			if (ret == false) {
 				LOG_ERR("Fail to get hsc type by adc");
 				break;
 			}
-			if ((voltage_hsc_type_adc > 0.5 - (0.5 * 0.15)) &&
-			    (voltage_hsc_type_adc < 0.5 + (0.5 * 0.15))) {
+			if ((voltage_hsc_type_adc > 0.5 - HSC_TYPE_ADC_TOLERANCE) &&
+			    (voltage_hsc_type_adc < 0.5 + HSC_TYPE_ADC_TOLERANCE)) {
 				hsc_module = HSC_MODULE_ADM1278;
 				break;
-			} else if ((voltage_hsc_type_adc > 1.0 - (1.0 * 0.15)) &&
-				   (voltage_hsc_type_adc < 1.0 + (1.0 * 0.15))) {
+			} else if ((voltage_hsc_type_adc > 1.0 - HSC_TYPE_ADC_TOLERANCE) &&
+				   (voltage_hsc_type_adc < 1.0 + HSC_TYPE_ADC_TOLERANCE)) {
 				hsc_module = HSC_MODULE_LTC4282;
 				break;
-			} else if ((voltage_hsc_type_adc > 1.5 - (1.5 * 0.15)) &&
-				   (voltage_hsc_type_adc < 1.5 + (1.5 * 0.15))) {
+			} else if ((voltage_hsc_type_adc > 1.5 - HSC_TYPE_ADC_TOLERANCE) &&
+				   (voltage_hsc_type_adc < 1.5 + HSC_TYPE_ADC_TOLERANCE)) {
 				hsc_module = HSC_MODULE_LTC4286;
 				break;
 			} else {

--- a/meta-facebook/yv35-cl/src/platform/plat_class.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -32,6 +32,7 @@
 #define I2C_DATA_SIZE 5
 #define NUMBER_OF_ADC_CHANNEL 16
 #define AST1030_ADC_BASE_ADDR 0x7e6e9000
+#define HSC_TYPE_ADC_TOLERANCE 0.2 // V
 
 #define MAX_1OU_M2_COUNT 4
 


### PR DESCRIPTION
# Description
Adjust HSC type ADC tolerance from 15% to 0.2V.

# Motivation
We've added the “HSC_TYPE_ADC” waveforms with about 1min timeframe, and the absolute peak voltages are within the range of +-0.2V for all three types of HSC.

# Test plan
Build and test pass on fby35 system.
1. HSC sensor reading root@bmc-oob:~# sensor-util slot1 | grep -i hsc
MB_HSC_TEMP_C                (0xE) :   25.94 C     | (ok)
MB_HSC_INPUT_VOLT_V          (0x29) :   12.53 Volts  | (ok)
MB_HSC_OUTPUT_CURR_A         (0x30) :    6.30 Amps  | (ok)
MB_HSC_INPUT_PWR_W           (0x39) :   77.85 Watts  | (ok)