### PR TITLE
fby35: gl: Modify VR VCCINF voltage threshold

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
@@ -1695,12 +1695,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x8E, // UNRT
-		0x5E, // UCT
-		0x5D, // UNCT
-		0x24, // LNRT
-		0x4F, // LCT
-		0x50, // LNCT
+		0x8F, // UNRT
+		0x6A, // UCT
+		0x69, // UNCT
+		0x25, // LNRT
+		0x35, // LCT
+		0x36, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
 		0x00, // reserved


### PR DESCRIPTION
Description
- Modify the voltage threshold of VR VCCINF, which refers to sensor table 20230517.

Motivation
- EE updated the new sensor table (20230517).

Test Plan
1. Build GL BIC is pass.
2. Read VCCINF voltage reading.
- Before modify root@bmc-oob:~# sensor-util slot1 --thre | grep VCCINF_VOL
MB_VR_VCCINF_VOLT_V          (0x1E) :    0.82 Volts  | (ok) | UCR: 0.92 | UNC: 0.91 | UNR: 1.39 | LCR: 0.77 | LNC: 0.78 | LNR: 0.35

- After modify root@bmc-oob:~# sensor-util slot3 --thre | grep VCCINF_VOL
MB_VR_VCCINF_VOLT_V          (0x1E) :    0.86 Volts  | (ok) | UCR: 1.04 | UNC: 1.03 | UNR: 1.40 | LCR: 0.52 | LNC: 0.53 | LNR: 0.36