### PR TITLE
fby3.5: cl: Fix abnormal message when send SEL

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_mctp.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_mctp.c
@@ -238,6 +238,7 @@ bool mctp_add_sel_to_ipmi(common_addsel_msg_t *sel_msg)
 	uint8_t resp_len = sizeof(struct mctp_to_ipmi_sel_resp);
 	uint8_t rbuf[resp_len];
 
+	memset(&rbuf, 0, resp_len);
 	if (!mctp_pldm_read(find_mctp_by_i3c(I3C_BUS_BMC), &msg, rbuf, resp_len)) {
 		LOG_ERR("mctp_pldm_read fail");
 		return false;

--- a/meta-facebook/yv35-cl/src/platform/plat_mctp.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_mctp.h
@@ -13,7 +13,6 @@ struct mctp_to_ipmi_header_req {
 
 struct mctp_to_ipmi_header_resp {
     uint8_t completion_code;
-    uint8_t iana[IANA_LEN];
     uint8_t netfn_lun;
     uint8_t ipmi_cmd;
     uint8_t ipmi_comp_code;


### PR DESCRIPTION
# Description
- PLDM response from add SEL didn't include IANA, however, the defined structure for response had IANA. It causes mapping wrong.
- Remove the IANA definition in the structure. And using memset function to clear the response buffer before getting the response.

# Motivation
- SB BIC console shows abnormal message when add SEL to BMC.

# Test Plan
- Build code: Pass
- Check no abnormal message: Pass
- Log:
1. Trigger GPIO to check no abnormal message when sending SEL to BMC.
- Before fix [BIC console]
uart:~$ gpio conf GPIO0_A_D 16 out
Configuring GPIO0_A_D pin 16
uart:~$ gpio set GPIO0_A_D 16 1
Writing to GPIO0_A_D pin 16
uart:~$ [01:03:52.905,000] <err> plat_mctp: Check reponse completion code fail 0 2 [01:03:52.905,000] <err> plat_isr: HSC OC addsel fail [01:03:52.911,000] <err> plat_mctp: Check reponse completion code fail 0 7 [01:03:52.911,000] <err> plat_isr: System Throttle addsel fail [01:03:52.905,000] <err> plat_mctp: Check reponse completion code fail 0 2 [01:03:52.905,000] <err> plat_isr: HSC OC addsel fail [01:03:52.911,000] <err> plat_mctp: Check reponse completion code fail 0 7 [01:03:52.911,000] <err> plat_isr: System Throttle addsel fail uart:~$ gpio conf GPIO0_A_D 16 in
Configuring GPIO0_A_D pin 16
uart:~$ [01:03:58.586,000] <err> plat_mctp: Check reponse completion code fail 0 7 [01:03:58.586,000] <err> plat_isr: System Throttle addsel fail [01:03:58.586,000] <err> plat_mctp: Check reponse completion code fail 0 7 [01:03:58.586,000] <err> plat_isr: System Throttle addsel fail uart:~$ Connection closed.

[BMC console]
root@bmc-oob:~# log-util --print slot2
2018 Mar 09 05:45:49 log-util: User cleared FRU: 2 logs
2    slot2    2018-03-09 05:46:10    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2018-03-09 05:46:10, Sensor: SYSTEM_STATUS (0x10), Event Data: (06FFFF) HSC_OC warning Deassertion
2    slot2    2018-03-09 05:46:10    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2018-03-09 05:46:10, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Assertion
2    slot2    2018-03-09 05:46:11    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2018-03-09 05:46:11, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Assertion
2    slot2    2018-03-09 05:46:16    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2018-03-09 05:46:16, Sensor: SYSTEM_STATUS (0x10), Event Data: (06FFFF) HSC_OC warning Assertion
2    slot2    2018-03-09 05:46:16    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2018-03-09 05:46:16, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Deassertion
2    slot2    2018-03-09 05:46:16    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2018-03-09 05:46:16, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Deassertion

- After fix [BIC console]
uart:~$ gpio conf GPIO0_A_D 16 out
Configuring GPIO0_A_D pin 16
uart:~$ gpio set GPIO0_A_D 16 1
Writing to GPIO0_A_D pin 16
uart:~$ gpio conf GPIO0_A_D 16 in
Configuring GPIO0_A_D pin 16

[BMC console]
root@bmc-oob:~# log-util slot4 --print
2023 May 09 02:34:14 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-09 02:34:27    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-09 02:34:27, Sensor: SYSTEM_STATUS (0x10), Event Data: (06FFFF) HSC_OC warning Deassertion
4    slot4    2023-05-09 02:34:27    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-09 02:34:27, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Assertion
4    slot4    2023-05-09 02:34:28    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-09 02:34:28, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Assertion
4    slot4    2023-05-09 02:34:35    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-09 02:34:35, Sensor: SYSTEM_STATUS (0x10), Event Data: (06FFFF) HSC_OC warning Assertion
4    slot4    2023-05-09 02:34:35    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-09 02:34:35, Sensor: SYSTEM_STATUS (0x10), Event Data: (02FFFF) SYS_Throttle throttle Deassertion
4    slot4    2023-05-09 02:34:35    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-09 02:34:35, Sensor: CPU0_THERM_STATUS (0x1C), Event Data: (01FFFF) PROCHOT# Deassertion