### PR TITLE
fby35: cl: lock IFX XDPE15284 register when idle

### DIFF
--- a/common/dev/include/xdpe15284.h
+++ b/common/dev/include/xdpe15284.h
@@ -18,5 +18,7 @@
 #define XDPE15284_H
 
 bool xdpe15284_get_checksum(uint8_t bus, uint8_t addr, uint8_t *checksum);
+bool xdpe15284_lock_reg(uint8_t bus, uint8_t addr);
+bool xdpe15284_unlock_reg(uint8_t bus, uint8_t addr);
 
 #endif

--- a/meta-facebook/yv35-cl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_init.c
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -57,7 +57,6 @@ void pal_post_init()
 void pal_device_init()
 {
 	init_me_firmware();
-
 	init_i3c_dimm();
 	start_monitor_pmic_error_thread();
 	init_vpp_power_status();

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -34,6 +34,7 @@
 #include "pmbus.h"
 #include "tmp431.h"
 #include "libutil.h"
+#include "xdpe15284.h"
 
 #include <logging/log.h>
 
@@ -397,6 +398,22 @@ uint8_t pal_get_extend_sensor_config()
 	return extend_sensor_config_size;
 }
 
+int set_vr_page(uint8_t bus, uint8_t addr, uint8_t page) {
+	I2C_MSG msg;
+	uint8_t retry = 5;
+
+	msg.bus = bus;
+	msg.target_addr = addr;
+	msg.tx_len = 2;
+	msg.data[0] = 0x00;
+	msg.data[1] = page;
+	if (i2c_master_write(&msg, retry)) {
+		LOG_ERR("pre_isl69259_read, set page fail");
+		return -1;
+	}
+	return 0;
+}
+
 void check_vr_type(uint8_t index)
 {
 	uint8_t retry = 5;
@@ -444,6 +461,12 @@ void check_vr_type(uint8_t index)
 		sensor_config[index].type = sensor_dev_tps53689;
 	} else if ((msg.data[0] == 0x02) && (msg.data[2] == 0x8A)) {
 		sensor_config[index].type = sensor_dev_xdpe15284;
+		if (sensor_config[index].offset == VR_VOL_CMD) {
+			set_vr_page(sensor_config[index].port, sensor_config[index].target_addr, 0);
+			xdpe15284_lock_reg(sensor_config[index].port, sensor_config[index].target_addr);
+			set_vr_page(sensor_config[index].port, sensor_config[index].target_addr, 1);
+			xdpe15284_lock_reg(sensor_config[index].port, sensor_config[index].target_addr);
+		}
 	} else if ((msg.data[0] == 0x04) && (msg.data[1] == 0x00) && (msg.data[2] == 0x81) &&
 		   (msg.data[3] == 0xD2) && (msg.data[4] == 0x49)) {
 	} else {


### PR DESCRIPTION
# Description
Lock Infineon XDPE15284 VR reigster when system idle.

# Motivation
Prevent unexpected write of VR register, which is suggested by VR vendor.

# Test plan
Build and test pass on fby35 system.
1. Get VR firmware version root@bmc-oob:~# fw-util slot1 --version
1OU Bridge-IC Version: oby35-vf-v2023.12.01
SB Bridge-IC Version: oby35-cl-v2023.18.01
BIOS Version: Y35CLP06T
BIOS Version after activation: Y35CLP06T
SB CPLD Version: 00010A03
SB CPLD Version after activation: 00010A03
ME Version: 6.0.4.70
VCCIN/VCCFA_EHV_FIVRA Version: Infineon 0E9E7384, Remaining Writes: 19 VCCIN/VCCFA_EHV_FIVRA Version after activation: Infineon 0E9E7384, Remaining Writes: 19 VCCD Version: Infineon 4271C0B3, Remaining Writes: 18 VCCD Version after activation: Infineon 4271C0B3, Remaining Writes: 18 VCCINFAON/VCCFA_EHV Version: Infineon 845F5A23, Remaining Writes: 20 VCCINFAON/VCCFA_EHV Version after activation: Infineon 845F5A23, Remaining Writes: 20