### PR TITLE
fby35: gl: Support for signing BIC image

### DIFF
--- a/scripts/signing/sign_bic_image.py
+++ b/scripts/signing/sign_bic_image.py
@@ -37,7 +37,7 @@ valid_projects = {
     "gt": {"cc", },
     "wc": {"mb", },
     "yv3": {"dl", "vf", },
-    "yv35": {"cl", "bb", "rf", "hd", "op", "nf", "hda1"},
+    "yv35": {"cl", "bb", "rf", "hd", "op", "gl", "nf", "hda1"},
 }
 
 # Numeric encoding of boards.
@@ -58,6 +58,7 @@ board_map = {
     "rf": "00011",
     "hd": "00100",
     "op": "00101",
+    "gl": "01000",
     "nf": "01001",
     "hda1": "01010",
 }


### PR DESCRIPTION
Description:
1. Add "gl" component in yv35 project list.
2. Add "gl: 01000" component in board map. gl's board ID is defined 8(The binary is 1000).

Motivation:
Support for signing GreatLakes BIC image

Test Plan:
1. Sign image: \#python3 scripts/signing/sign_bic_image.py -p yv35 -b gl -v 2023.20.01 -s poc -i build/zephyr/Y35BGL.bin -o oby35-gl-2023.20.01.bin

2. Update signed image: root@bmc-oob:~# fw-util slot1 --version bic SB Bridge-IC Version: oby35-gl-v2023.18.01 root@bmc-oob:~# fw-util slot1 --update bic oby35-gl-2023.20.01.bin slot_id: 1, comp: 2, intf: 0, img: oby35-gl-2023.20.01.bin, force: 0 file size = 252580 bytes, slot = 1, intf = 0xff updating fw on slot 1: updated bic: 100 %
    Elapsed time:  12   sec.

    get new SDR cache from BIC
    Upgrade of slot1 : bic succeeded
    root@bmc-oob:~# fw-util slot1 --version bic
    SB Bridge-IC Version: oby35-gl-v2023.20.01