### PR TITLE
common:patch:driver:adc Support deglitch feature

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0046-adc-aspeed-Add-the-property-to-control-the-enable-of-channels.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0046-adc-aspeed-Add-the-property-to-control-the-enable-of-channels.patch
@@ -1,0 +1,77 @@
+From a860097980578bde78cbde79681b4c8e346bfc7f Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Tue, 14 Feb 2023 18:10:20 +0800
+Subject: [PATCH] adc: aspeed: Add the property to control the enable of
+ channels.
+
+Add the 'aspeed,adc-channels-used' DTS property to enable channels using a
+bitmask instead of enabling all channels by default.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I32d9a8653e1184e0dc025e02cf2dec75cd61b351
+---
+ drivers/adc/aspeed/adc_aspeed.c  | 8 ++++++--
+ dts/bindings/adc/aspeed,adc.yaml | 4 ++++
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/adc/aspeed/adc_aspeed.c b/drivers/adc/aspeed/adc_aspeed.c
+index ac67e09133..59aa490d60 100644
+--- a/drivers/adc/aspeed/adc_aspeed.c
++++ b/drivers/adc/aspeed/adc_aspeed.c
+@@ -50,6 +50,7 @@ struct aspeed_adc_trim_locate {
+ struct adc_aspeed_cfg {
+ 	struct adc_register_s *base;
+ 	uint32_t scu_base;
++	uint32_t channels_used;
+ 	bool trim_valid;
+ 	struct aspeed_adc_trim_locate trim_locate;
+ 	const struct device *clock_dev;
+@@ -256,13 +257,15 @@ static int adc_aspeed_start_read(const struct device *dev,
+ 				 const struct adc_sequence *sequence)
+ {
+ 	struct adc_aspeed_data *priv = DEV_DATA(dev);
++	const struct adc_aspeed_cfg *config = DEV_CFG(dev);
+ 
+ 	if (sequence->resolution != 10) {
+ 		LOG_ERR("unsupported resolution %d", sequence->resolution);
+ 		return -ENOTSUP;
+ 	}
+ 
+-	if (find_msb_set(sequence->channels) > ASPEED_ADC_CH_NUMBER + 1) {
++	if (find_msb_set(sequence->channels) > ASPEED_ADC_CH_NUMBER + 1 ||
++	    !(sequence->channels & config->channels_used)) {
+ 		LOG_ERR("unsupported channels in mask: 0x%08x",
+ 			sequence->channels);
+ 		return -ENOTSUP;
+@@ -416,7 +419,7 @@ static int aspeed_adc_engine_init(const struct device *dev,
+ 		return ret;
+ 	}
+ 
+-	engine_ctrl.fields.channel_enable = 0xff;
++	engine_ctrl.fields.channel_enable = config->channels_used;
+ 	adc_register->engine_ctrl.value = engine_ctrl.value;
+ 
+ 	return 0;
+@@ -485,6 +488,7 @@ static struct adc_driver_api adc_aspeed_api = {
+ 		.base = (struct adc_register_s *)DT_INST_REG_ADDR(n),		       \
+ 		.scu_base = DT_REG_ADDR_BY_IDX(DT_INST_PHANDLE(n, aspeed_scu), 0),     \
+ 		.trim_valid = DT_INST_PROP_OR(n, aspeed_trim_data_valid, false),       \
++		.channels_used = DT_INST_PROP_OR(n, aspeed_adc_channels_used, 0xff),   \
+ 		.trim_locate = { DT_INST_PROP_BY_IDX(n, aspeed_trim_data_locate, 0),   \
+ 				 DT_INST_PROP_BY_IDX(n, aspeed_trim_data_locate, 1) }, \
+ 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		       \
+diff --git a/dts/bindings/adc/aspeed,adc.yaml b/dts/bindings/adc/aspeed,adc.yaml
+index ceb5e80890..2a8d960f70 100644
+--- a/dts/bindings/adc/aspeed,adc.yaml
++++ b/dts/bindings/adc/aspeed,adc.yaml
+@@ -20,6 +20,10 @@ properties:
+       required: true
+       description: phandle to SCU device tree node
+ 
++    aspeed,adc-channels-used:
++      type: int
++      description: Bitmask of the channels muxed and enabled for this device
++
+     aspeed,trim-data-valid:
+       type: boolean
+       description: |

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0047-adc-aspeed-Change-the-paremeter-meaning-of-the-adc-set-rate.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0047-adc-aspeed-Change-the-paremeter-meaning-of-the-adc-set-rate.patch
@@ -1,0 +1,104 @@
+From 64d4d3c9b336e4793c64011028d131d82a7f49ac Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Thu, 23 Mar 2023 17:07:13 +0800
+Subject: [PATCH] adc: aspeed: Change the paremeter meaning of the adc set
+ rate.
+
+The rate of sampling one channel has been used instead of the rate of the
+ADC operation clock. Additionally, the formula for obtaining the sampling
+period has been fixed.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I2794b8d2312e686e952d3468be03808321a337e4
+---
+ drivers/adc/aspeed/adc_aspeed.c | 24 ++++++++++++++++--------
+ drivers/adc/aspeed/adc_aspeed.h |  2 +-
+ 2 files changed, 17 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/adc/aspeed/adc_aspeed.c b/drivers/adc/aspeed/adc_aspeed.c
+index 59aa490d60..d8e6c1d52f 100644
+--- a/drivers/adc/aspeed/adc_aspeed.c
++++ b/drivers/adc/aspeed/adc_aspeed.c
+@@ -13,6 +13,7 @@
+ #include <kernel.h>
+ #include <init.h>
+ #include <soc.h>
++#include <aspeed_util.h>
+ 
+ #define ADC_CONTEXT_USES_KERNEL_TIMER
+ #include "../adc_context.h"
+@@ -30,7 +31,7 @@ struct adc_aspeed_data {
+ 	const struct device *dev;
+ 	uint32_t channels;
+ 	uint32_t clk_rate;
+-	uint32_t sampling_rate;
++	uint32_t sampling_period_us;
+ 	bool battery_sensing_enable;
+ 	uint16_t *buffer;
+ 	uint16_t *repeat_buffer;
+@@ -115,22 +116,29 @@ static int adc_aspeed_set_rate(const struct device *dev, uint32_t rate)
+ 	struct adc_aspeed_data *priv = DEV_DATA(dev);
+ 	struct adc_register_s *adc_register = config->base;
+ 	uint32_t clk_src, divisor;
++	uint32_t adc_clk;
+ 	union adc_clock_control_s adc_clk_ctrl;
+ 
++	if (rate > KHZ(500) || rate < KHZ(10)) {
++		LOG_ERR("sampling rate %d out of hw limitation\n", rate);
++		return -ERANGE;
++	}
++	adc_clk = rate * 12;
+ 	/*
+ 	 * Formula of adc clock:
+ 	 * ADC clock = ADC src clock / (divisor_of_adc_clock + 1)
+ 	 * ADC sampling rate = ADC clock / 12
++	 * ADC sampling period us = (1000000 * 12 * (divisor_of_adc_clock + 1)) / ADC src clock
+ 	 */
+ 	clock_control_get_rate(config->clock_dev, NULL, &clk_src);
+-	divisor = (clk_src / rate) - 1;
++	divisor = DIV_ROUND_UP(clk_src, adc_clk) - 1;
+ 	if (divisor >= BIT(16)) {
+-		LOG_ERR("clock freq %d out of range\n", rate);
++		LOG_ERR("Divisor %d out of register range", divisor);
+ 		return -ERANGE;
+ 	}
+-	priv->sampling_rate = ((divisor + 1) * ASPEED_CLOCKS_PER_SAMPLE) *
+-			      (clk_src / USEC_PER_SEC);
+-	LOG_DBG("sampling rate = %dus\n", priv->sampling_rate);
++	priv->sampling_period_us =
++		DIV_ROUND_UP(((divisor + 1) * ASPEED_CLOCKS_PER_SAMPLE * USEC_PER_SEC), clk_src);
++	LOG_DBG("sampling period per channel = %dus\n", priv->sampling_period_us);
+ 	adc_clk_ctrl.value = adc_register->adc_clk_ctrl.value;
+ 	adc_clk_ctrl.fields.divisor_of_adc_clock = divisor;
+ 	adc_register->adc_clk_ctrl.value = adc_clk_ctrl.value;
+@@ -184,7 +192,7 @@ static void aspeed_adc_calibration(const struct device *dev)
+ 	/* After enable compensating sensing need to wait 1ms for adc stable */
+ 	k_msleep(1);
+ 	for (index = 0; index < ASPEED_CV_SAMPLE_TIMES; index++) {
+-		k_usleep(priv->sampling_rate);
++		k_usleep(priv->sampling_period_us);
+ 		raw_data += adc_register->adc_data[0].fields.data_odd;
+ 	}
+ 	raw_data /= ASPEED_CV_SAMPLE_TIMES;
+@@ -445,7 +453,7 @@ static int adc_aspeed_init(const struct device *dev)
+ 		return ret;
+ 	}
+ 
+-	ret = adc_aspeed_set_rate(dev, ASPEED_CLOCK_FREQ_DEFAULT);
++	ret = adc_aspeed_set_rate(dev, ASPEED_SAMPLING_RATE_DEFAULT);
+ 	if (ret) {
+ 		return ret;
+ 	}
+diff --git a/drivers/adc/aspeed/adc_aspeed.h b/drivers/adc/aspeed/adc_aspeed.h
+index bba3a9ae68..3d05942b01 100644
+--- a/drivers/adc/aspeed/adc_aspeed.h
++++ b/drivers/adc/aspeed/adc_aspeed.h
+@@ -162,7 +162,7 @@ struct adc_register_s {
+ /**********************************************************
+  * Software setting
+  *********************************************************/
+-#define ASPEED_CLOCK_FREQ_DEFAULT       3000000
++#define ASPEED_SAMPLING_RATE_DEFAULT    KHZ(250)
+ #define ASPEED_ADC_INIT_TIMEOUT         500000
+ #define ASPEED_CV_SAMPLE_TIMES          10
+ 

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0048-adc-aspeed-Fix-the-channel-number-of-each-ADC-controller.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0048-adc-aspeed-Fix-the-channel-number-of-each-ADC-controller.patch
@@ -1,0 +1,58 @@
+From e886e9c1d18827321ee8c593472d2140cb8daba8 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Mon, 15 May 2023 09:42:37 +0800
+Subject: [PATCH] adc: aspeed: Fix the channel number of each ADC controller.
+
+The number of channels per ADC controller is 8, not 7.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I280c76f36fb1aece719f3b2d0ddcc01a1a189c2f
+---
+ drivers/adc/aspeed/adc_aspeed.c | 6 +++---
+ drivers/adc/aspeed/adc_aspeed.h | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/adc/aspeed/adc_aspeed.c b/drivers/adc/aspeed/adc_aspeed.c
+index d8e6c1d52f..a7919ed39f 100644
+--- a/drivers/adc/aspeed/adc_aspeed.c
++++ b/drivers/adc/aspeed/adc_aspeed.c
+@@ -272,7 +272,7 @@ static int adc_aspeed_start_read(const struct device *dev,
+ 		return -ENOTSUP;
+ 	}
+ 
+-	if (find_msb_set(sequence->channels) > ASPEED_ADC_CH_NUMBER + 1 ||
++	if (find_msb_set(sequence->channels) > ASPEED_ADC_CH_NUMBER ||
+ 	    !(sequence->channels & config->channels_used)) {
+ 		LOG_ERR("unsupported channels in mask: 0x%08x",
+ 			sequence->channels);
+@@ -313,7 +313,7 @@ static int adc_aspeed_channel_setup(const struct device *dev,
+ 	const struct adc_aspeed_cfg *config = DEV_CFG(dev);
+ 	uint8_t channel_id = channel_cfg->channel_id;
+ 
+-	if (channel_id > ASPEED_ADC_CH_NUMBER) {
++	if (channel_id > ASPEED_ADC_CH_NUMBER - 1) {
+ 		LOG_ERR("Channel %d is not valid", channel_id);
+ 		return -EINVAL;
+ 	}
+@@ -334,7 +334,7 @@ static int adc_aspeed_channel_setup(const struct device *dev,
+ 	}
+ 
+ 	/* The last channel have gain feature for battery sensing */
+-	if (channel_id == ASPEED_ADC_CH_NUMBER) {
++	if (channel_id == ASPEED_ADC_CH_NUMBER - 1) {
+ 		if (channel_cfg->gain != ADC_GAIN_1) {
+ 			if ((config->ref_voltage_mv < 1550 &&
+ 			     channel_cfg->gain != ADC_GAIN_1_3) ||
+diff --git a/drivers/adc/aspeed/adc_aspeed.h b/drivers/adc/aspeed/adc_aspeed.h
+index 3d05942b01..7e348e7511 100644
+--- a/drivers/adc/aspeed/adc_aspeed.h
++++ b/drivers/adc/aspeed/adc_aspeed.h
+@@ -133,7 +133,7 @@ struct adc_register_s {
+ /**********************************************************
+  * ADC feature define
+  *********************************************************/
+-#define ASPEED_ADC_CH_NUMBER            7
++#define ASPEED_ADC_CH_NUMBER            8
+ #define ASPEED_RESOLUTION_BITS          10
+ #define ASPEED_CLOCKS_PER_SAMPLE        12
+ 

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0049-adc-aspeed-Support-deglitch-feature.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0049-adc-aspeed-Support-deglitch-feature.patch
@@ -1,0 +1,99 @@
+From e3ddcfa4e520ff5ae925c1095f73d89cc34c83e3 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Mon, 15 May 2023 09:57:04 +0800
+Subject: [PATCH] adc: aspeed: Support deglitch feature.
+
+Add the parameters upper_bound, lower_bound, and deglitch_en for ADC
+channel configuration. When deglitch_en is set to true, the driver will
+use the upper_bound and lower_bound as threshold values. If the ADC value
+falls outside this threshold, the driver will wait for the ADC sampling
+period and perform an additional read once to achieve the deglitching
+purpose.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: Id96e29f6851bd937caed3ee09c49cb31e88dcaf8
+---
+ drivers/adc/aspeed/adc_aspeed.c | 33 +++++++++++++++++++++++++++++++++
+ include/drivers/adc.h           |  6 ++++++
+ 2 files changed, 39 insertions(+)
+
+diff --git a/drivers/adc/aspeed/adc_aspeed.c b/drivers/adc/aspeed/adc_aspeed.c
+index a7919ed39f..01ab881495 100644
+--- a/drivers/adc/aspeed/adc_aspeed.c
++++ b/drivers/adc/aspeed/adc_aspeed.c
+@@ -36,6 +36,9 @@ struct adc_aspeed_data {
+ 	uint16_t *buffer;
+ 	uint16_t *repeat_buffer;
+ 	bool calibrate;
++	uint16_t upper_bound[ASPEED_ADC_CH_NUMBER];
++	uint16_t lower_bound[ASPEED_ADC_CH_NUMBER];
++	bool deglitch_en[ASPEED_ADC_CH_NUMBER];
+ 	int cv;
+ 	struct k_thread thread;
+ 	struct k_sem acq_sem;
+@@ -101,11 +104,20 @@ static int adc_aspeed_read_channel(const struct device *dev, uint8_t channel,
+ 				   int32_t *result)
+ {
+ 	struct adc_aspeed_data *priv = DEV_DATA(dev);
++	const struct adc_aspeed_cfg *config = DEV_CFG(dev);
+ 
+ 	if (priv->battery_sensing_enable && channel == 7) {
+ 		*result = aspeed_adc_battery_read(dev, channel);
+ 	} else {
+ 		*result = aspeed_adc_read_raw(dev, channel);
++		if (priv->deglitch_en[channel]) {
++			if (*result >= priv->upper_bound[channel] ||
++			    *result <= priv->lower_bound[channel]) {
++				k_busy_wait(priv->sampling_period_us *
++					    popcount(config->channels_used));
++				*result = aspeed_adc_read_raw(dev, channel);
++			}
++		}
+ 	}
+ 	return 0;
+ }
+@@ -333,6 +345,27 @@ static int adc_aspeed_channel_setup(const struct device *dev,
+ 		return -ENOTSUP;
+ 	}
+ 
++	if (channel_cfg->deglitch_en) {
++		if (channel_cfg->upper_bound == 0 ||
++		    channel_cfg->upper_bound >= BIT(ASPEED_RESOLUTION_BITS)) {
++			LOG_ERR("Unsupported upper bound %d", channel_cfg->upper_bound);
++			return -ENOTSUP;
++		}
++
++		if (channel_cfg->lower_bound >= channel_cfg->upper_bound) {
++			LOG_ERR("Unsupported lower bound %d >= upper bound %d",
++				channel_cfg->lower_bound, channel_cfg->upper_bound);
++			return -ENOTSUP;
++		}
++		priv->upper_bound[channel_id] = channel_cfg->upper_bound;
++		priv->lower_bound[channel_id] = channel_cfg->lower_bound;
++		priv->deglitch_en[channel_id] = channel_cfg->deglitch_en;
++	}
++
++	LOG_DBG("channel %d, upper_bound:%d, lower_bound: %d, deglitch_en %d\n", channel_id,
++		priv->upper_bound[channel_id], priv->lower_bound[channel_id],
++		priv->deglitch_en[channel_id]);
++
+ 	/* The last channel have gain feature for battery sensing */
+ 	if (channel_id == ASPEED_ADC_CH_NUMBER - 1) {
+ 		if (channel_cfg->gain != ADC_GAIN_1) {
+diff --git a/include/drivers/adc.h b/include/drivers/adc.h
+index 1ce5cd21fd..5346b6e0dd 100644
+--- a/include/drivers/adc.h
++++ b/include/drivers/adc.h
+@@ -139,6 +139,12 @@ struct adc_channel_cfg {
+ 	 */
+ 	uint8_t input_negative;
+ #endif /* CONFIG_ADC_CONFIGURABLE_INPUTS */
++
++#ifdef CONFIG_ADC_ASPEED
++	uint16_t upper_bound;
++	uint16_t lower_bound;
++	bool deglitch_en;
++#endif
+ };
+ 
+ /**


### PR DESCRIPTION
Summary:
- Add the property to control the enable of channels.
- Change the paremeter meaning of the adc set rate.
- Fix the channel number of each ADC controller.
- Support deglitch feature.

Test Plan:
- Build code: Pass