### PR TITLE
fby3.5: hd&dl: Decrease worker stack size

### DIFF
--- a/common/lib/util_worker.c
+++ b/common/lib/util_worker.c
@@ -21,12 +21,16 @@
 #include "util_worker.h"
 #include "cmsis_os2.h"
 #include "libutil.h"
+#include "plat_def.h"
 
 #include <logging/log.h>
 
 LOG_MODULE_REGISTER(util_worker);
 
+#ifndef WORKER_STACK_SIZE
 #define WORKER_STACK_SIZE 10000
+#endif
+
 #define WORKER_PRIORITY CONFIG_MAIN_THREAD_PRIORITY
 
 #define MAX_WORK_COUNT 32

--- a/meta-facebook/yv3-dl/src/platform/plat_def.h
+++ b/meta-facebook/yv3-dl/src/platform/plat_def.h
@@ -22,4 +22,6 @@
 
 #define BMC_USB_PORT "CDC_ACM_0"
 
+#define WORKER_STACK_SIZE 4096
+
 #endif

--- a/meta-facebook/yv35-hd/src/platform/plat_def.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_def.h
@@ -23,4 +23,6 @@
 
 #define ENABLE_APML
 
+#define WORKER_STACK_SIZE 4096
+
 #endif


### PR DESCRIPTION
Summary:
- Decrease worker stack size

Test Plan:
- Build code: Pass

HD:
0x5e908 plat_worker (real size 4096):   unused 3828     usage 268 / 4096 (6 %)

DL:
0x5f4d8 plat_worker (real size 4096):   unused 3828     usage 268 / 4096 (6 %)

CL:
0x66b50 plat_worker (real size 10000):  unused 9732     usage 268 / 10000 (2 %)