### PR TITLE
fby3.5: hd: Disable ADC when setting as GPI

### DIFF
--- a/meta-facebook/yv35-hd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-hd/boards/ast1030_evb.overlay
@@ -5,6 +5,7 @@
 		&pinctrl_adc2_default &pinctrl_adc3_default
 		&pinctrl_adc4_default &pinctrl_adc5_default
 		&pinctrl_adc6_default>;
+	aspeed,adc-channels-used = <0x7f>;
 };
 
 &adc1 {
@@ -13,6 +14,7 @@
 		&pinctrl_adc10_default &pinctrl_adc11_default
 		&pinctrl_adc12_default &pinctrl_adc13_default
 		&pinctrl_adc14_default>;
+	aspeed,adc-channels-used = <0x7f>;
 };
 
 &jtag1{


### PR DESCRIPTION
Summary:
- Disable ADC when setting as GPI

Test Plan:
- Build code: PASS

0x7f means only ch 7 disabled

uart:~$ md 7e6e9000
[7e6e9000] 007f010f

uart:~$ md 7e6e9100
[7e6e9100] 007f010f