### PR TITLE
fby3.5: hd: Avoid CARD_TYPE_EXP floating when 1OU not present

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_class.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_class.c
@@ -270,9 +270,9 @@ void init_platform_config()
 					break;
 				case RANGE:
 					if ((voltage >
-					     typical_voltage - (typical_voltage * 0.05)) &&
+					     typical_voltage - (typical_voltage * 0.07)) &&
 					    (voltage <
-					     typical_voltage + (typical_voltage * 0.05))) {
+					     typical_voltage + (typical_voltage * 0.07))) {
 						_1ou_status.card_type =
 							_1ou_card_mapping_table[cnt].card_type;
 					}
@@ -303,6 +303,23 @@ void init_platform_config()
 					voltage);
 			}
 		}
+	} else {
+		// If 1ou card not present, disable ADC6(CARD_TYPE_EXP) and set it to GPIO to avoid floating
+		uint32_t read_value = 0;
+		// Disable ADC channel 6: ADC000[22]
+		read_value = sys_read32(REG_ADC_BASE + 0x000);
+		read_value = CLEARBIT(read_value, 22);
+		sys_write32(read_value, REG_ADC_BASE + 0x000);
+
+		// Multi-function pin ctl #5: SCU430[30] is GPIT6
+		read_value = sys_read32(REG_SCU + 0x430);
+		read_value = SETBIT(read_value, 30);
+		sys_write32(read_value, REG_SCU + 0x430);
+
+		// Enable internal PD
+		read_value = sys_read32(REG_SCU + 0x630);
+		read_value = CLEARBIT(read_value, 30);
+		sys_write32(read_value, REG_SCU + 0x630);
 	}
 
 	if (_2ou_status.present) {


### PR DESCRIPTION
Summary:
- Set to GPI for ADC6 when 1OU not present
- Disable ADC channel 6 when 1OU not present
- Enable internal PD for ADC6 when 1OU not present
- Change from 5% to 7% for CARD_TYPE voltage identity

Test Plan:
- Build code: PASS

Set to GPI for ADC6
md 7e6e2430
[7e6e2430] c0060c1f

Disable ADC channel 6
md 7e6e9000
[7e6e9000] 00bf010f

Enable internal PD for ADC6
md 7e6e2630
[7e6e2630] bf000000