### PR TITLE
fby35: cl: Support clear PMIC error

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.c
@@ -131,6 +131,8 @@ void ISR_DC_ON()
 	if (dc_status) {
 		k_work_schedule(&set_DC_on_5s_work, K_SECONDS(DC_ON_5_SECOND));
 
+		clear_pmic_error();
+
 	} else {
 		set_DC_on_delayed_status();
 
@@ -625,7 +627,6 @@ void ISR_CPU_VPP_INT()
 				}
 			}
 		}
-
 	}
 }
 

--- a/meta-facebook/yv35-cl/src/platform/plat_pmic.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_pmic.h
@@ -24,9 +24,15 @@
 
 #define MAX_COUNT_PMIC_ERROR_OFFSET 7
 #define MAX_COUNT_PMIC_ERROR_TYPE 17
+#define MAX_COUNT_PMIC_VENDER_ID 1
 
 #define CL_CPLD_BMC_CHANNEL_ADDR 0x1E // 8 bits
 #define PMIC_FAULT_STATUS_OFFSET 0x0B
+#define PMIC_VENDER_ID_OFFSET 0x3C
+#define PMIC_CLEAR_STATUS_BITS4_OFFSET 0x14
+#define PMIC_VENDOR_MEMORY_REGION_PASSWORD_UPPER_BYTE_OFFSET 0x37
+#define PMIC_VENDOR_MEMORY_REGION_PASSWORD_LOWER_BYTE_OFFSET 0x38
+#define PMIC_VENDOR_PASSWORD_CONTROL_OFFSET 0x39
 
 enum READ_PMIC_ERROR_PATH {
 	READ_PMIC_ERROR_VIA_ME,
@@ -42,5 +48,8 @@ int compare_pmic_error(uint8_t dimm_id, uint8_t *pmic_err_data, uint8_t pmic_err
 void add_pmic_error_sel(uint8_t dimm_id, uint8_t error_type);
 int get_pmic_fault_status();
 void read_pmic_error_when_dc_off();
+void clear_pmic_error();
+int write_read_pmic_via_me(uint8_t dimm_id, uint8_t offset, uint8_t read_len, uint8_t write_len,
+			   uint8_t *data, int *data_len);
 
 #endif


### PR DESCRIPTION
# Description
- Clear PMIC error when the host is DC on.

# Motivation
- BIC didn't clear the PMIC error after reading the PMIC error and sending SEL to BMC. It causes BIOS send the PMIC error again when next host on.

# Test Plan
1. Build CL BIC pass.
2. Inject PMIC error and check no duplicated PMIC error SEL.
- Before clear root@bmc-oob:~# dimm-util slot4 --pmic --dimm A7 --err_inj SWAout_UV Error inject successfully on DIMM A7
root@bmc-oob:~# power-util slot4 12V-cycle
12V Power cycling fru 4...
root@bmc-oob:~# power-util slot4 on
Powering fru 4 to ON state...
root@bmc-oob:~# log-util --print slot4
2023 May 19 02:31:46 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-19 02:31:59    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-19 02:31:59, Sensor: PMIC_ERR (0xB4), Event Data: (050600) DIMM A7 SWAout UV Assertion
4    slot4    2023-05-19 02:32:01    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-19 02:32:04    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-19 02:32:04, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-19 02:32:13    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-19 02:32:13, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) S0 power on failure Assertion
4    slot4    2023-05-19 02:33:00    power-util       SERVER_12V_CYCLE successful for FRU: 4
4    slot4    2023-05-19 02:33:20    power-util       SERVER_POWER_ON successful for FRU: 4
4    slot4    2023-05-19 02:33:21    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-19 02:33:39    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-19 02:33:39, Sensor: PMIC_ERR (0xB4), Event Data: (050600) DIMM A7 SWAout UV Assertion
4    slot4    2023-05-19 02:33:39    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: MEMORY_ECC_ERR(0x21), DIMM Slot Location: Sled 03/Socket 00, Channel 07, Slot 00, DIMM A7, DIMM Failure Event: Memory training failure, Major Code: 0x46, Minor Code: 0x04

- After clear root@bmc-oob:~# dimm-util slot4 --pmic --dimm A7 --err_inj SWAout_UV Error inject successfully on DIMM A7
root@bmc-oob:~# power-util slot4 12V-cycle
12V Power cycling fru 4...
root@bmc-oob:~# power-util slot4 on
Powering fru 4 to ON state...
root@bmc-oob:~# log-util --print slot4
2023 May 19 02:37:48 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-19 02:37:58    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-19 02:37:58, Sensor: PMIC_ERR (0xB4), Event Data: (050600) DIMM A7 SWAout UV Assertion
4    slot4    2023-05-19 02:38:00    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-19 02:38:03    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-19 02:38:03, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-19 02:38:12    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-19 02:38:12, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) S0 power on failure Assertion
4    slot4    2023-05-19 02:38:34    power-util       SERVER_12V_CYCLE successful for FRU: 4
4    slot4    2023-05-19 02:38:47    power-util       SERVER_POWER_ON successful for FRU: 4
4    slot4    2023-05-19 02:38:47    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-19 02:39:54    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15

2. Check all critical errors can be injected and have error SEL. root@bmc-oob:~# dimm-util slot4 --config --dimm A3 FRU: slot4
DIMM A3:
        Type: DDR5 SDRAM
        Size: 16384 MB
        Speed: 4800 MT/s
        Manufacturer: SK Hynix
        Manufacturing Date: 2022 Week19
        Part Number: HMCG78AEBRA168N
        Serial Number: 13F5A2BF
        Register Vendor: IDT
        PMIC Vendor: IDT

root@bmc-oob:~# dimm-util slot4 --pmic --dimm A3 --err_inj SWAout_OV Error inject successfully on DIMM A3
root@bmc-oob:~# power-util slot4 12V-cycle
12V Power cycling fru 4...
root@bmc-oob:~# power-util slot4 on
Powering fru 4 to ON state...
root@bmc-oob:~# log-util --print slot4
2023 May 22 23:08:47 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-22 23:08:58    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:08:58, Sensor: PMIC_ERR (0xB4), Event Data: (020000) DIMM A3 SWAout OV Assertion
4    slot4    2023-05-22 23:09:00    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-22 23:09:03    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:09:03, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-22 23:09:12    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:09:12, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) S0 power on failure Assertion
4    slot4    2023-05-22 23:09:22    power-util       SERVER_12V_CYCLE successful for FRU: 4
4    slot4    2023-05-22 23:09:29    power-util       SERVER_POWER_ON successful for FRU: 4
4    slot4    2023-05-22 23:09:36    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-22 23:10:36    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15

root@bmc-oob:~# dimm-util slot4 --pmic --dimm A3 --err_inj SWCout_OV Error inject successfully on DIMM A3
root@bmc-oob:~# power-util slot4 12V-cycle
12V Power cycling fru 4...
root@bmc-oob:~# power-util slot4 on
Powering fru 4 to ON state...
root@bmc-oob:~# log-util --print slot4
2023 May 22 23:13:49 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-22 23:14:00    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:14:00, Sensor: PMIC_ERR (0xB4), Event Data: (020200) DIMM A3 SWCout OV Assertion
4    slot4    2023-05-22 23:14:03    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-22 23:14:05    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:14:05, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-22 23:14:14    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:14:14, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) S0 power on failure Assertion
4    slot4    2023-05-22 23:14:26    power-util       SERVER_12V_CYCLE successful for FRU: 4
4    slot4    2023-05-22 23:14:37    power-util       SERVER_POWER_ON successful for FRU: 4
4    slot4    2023-05-22 23:14:37    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-22 23:15:44    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15

root@bmc-oob:~# dimm-util slot4 --pmic --dimm A3 --err_inj SWDout_OV Error inject successfully on DIMM A3
root@bmc-oob:~# power-util slot4 12V-cycle
12V Power cycling fru 4...
root@bmc-oob:~# power-util slot4 on
Powering fru 4 to ON state...
root@bmc-oob:~# log-util --print slot4
2023 May 22 23:16:34 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-22 23:16:37    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:16:37, Sensor: PMIC_ERR (0xB4), Event Data: (020300) DIMM A3 SWDout OV Assertion
4    slot4    2023-05-22 23:16:39    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-22 23:16:42    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:16:42, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-22 23:16:51    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:16:51, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) S0 power on failure Assertion
4    slot4    2023-05-22 23:16:57    power-util       SERVER_12V_CYCLE successful for FRU: 4
4    slot4    2023-05-22 23:17:07    power-util       SERVER_POWER_ON successful for FRU: 4
4    slot4    2023-05-22 23:17:13    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-22 23:18:14    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15

root@bmc-oob:~# dimm-util slot4 --pmic --dimm A3 --err_inj VinB_OV Error inject successfully on DIMM A3
root@bmc-oob:~# power-util slot4 12V-cycle
12V Power cycling fru 4...
root@bmc-oob:~# power-util slot4 on
Powering fru 4 to ON state...
root@bmc-oob:~# log-util --print slot4
2023 May 22 23:16:34 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-22 23:22:12    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:22:12, Sensor: PMIC_ERR (0xB4), Event Data: (020400) DIMM A3 Vin Bulk OV Assertion
4    slot4    2023-05-22 23:22:14    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-22 23:22:17    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:22:17, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-22 23:22:26    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:22:26, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) S0 power on failure Assertion
4    slot4    2023-05-22 23:22:46    power-util       SERVER_12V_CYCLE successful for FRU: 4
4    slot4    2023-05-22 23:23:03    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-22 23:23:04    power-util       SERVER_POWER_ON successful for FRU: 4
4    slot4    2023-05-22 23:24:10    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15

root@bmc-oob:~# dimm-util slot4 --config --dimm A7 FRU: slot4
DIMM A7:
        Type: DDR5 SDRAM
        Size: 16384 MB
        Speed: 4800 MT/s
        Manufacturer: SK Hynix
        Manufacturing Date: 2022 Week19
        Part Number: HMCG78AEBRA107N
        Serial Number: 13F42010
        Register Vendor: Montage
        PMIC Vendor: MPS

root@bmc-oob:~# dimm-util slot4 --pmic --dimm A7 --err_inj SWAout_UV Error inject successfully on DIMM A7
root@bmc-oob:~# power-util slot4 12V-cycle
12V Power cycling fru 4...
root@bmc-oob:~# power-util slot4 on
Powering fru 4 to ON state...
root@bmc-oob:~# log-util slot4 --print
2023 May 22 23:28:16 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-22 23:29:51    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:29:51, Sensor: PMIC_ERR (0xB4), Event Data: (050600) DIMM A7 SWAout UV Assertion
4    slot4    2023-05-22 23:29:53    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-22 23:29:56    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:29:56, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-22 23:30:05    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:30:05, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) S0 power on failure Assertion
4    slot4    2023-05-22 23:31:24    power-util       SERVER_12V_CYCLE successful for FRU: 4
4    slot4    2023-05-22 23:32:27    power-util       SERVER_POWER_ON successful for FRU: 4
4    slot4    2023-05-22 23:32:28    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-22 23:33:34    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15

root@bmc-oob:~# dimm-util slot4 --pmic --dimm A7 --err_inj SWCout_UV Error inject successfully on DIMM A7
root@bmc-oob:~# power-util slot4 12V-cycle
12V Power cycling fru 4...
root@bmc-oob:~# power-util slot4 on
Powering fru 4 to ON state...
root@bmc-oob:~# log-util --print slot4
2023 May 22 23:34:14 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-22 23:34:31    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:34:31, Sensor: PMIC_ERR (0xB4), Event Data: (050800) DIMM A7 SWCout UV Assertion
4    slot4    2023-05-22 23:34:34    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-22 23:34:36    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:34:36, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-22 23:34:45    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:34:45, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) S0 power on failure Assertion
4    slot4    2023-05-22 23:34:52    power-util       SERVER_12V_CYCLE successful for FRU: 4
4    slot4    2023-05-22 23:35:01    power-util       SERVER_POWER_ON successful for FRU: 4
4    slot4    2023-05-22 23:35:08    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-22 23:36:08    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15

root@bmc-oob:~# dimm-util slot4 --pmic --dimm A7 --err_inj SWDout_UV Error inject successfully on DIMM A7
root@bmc-oob:~# power-util slot4 12V-cycle
12V Power cycling fru 4...
root@bmc-oob:~# power-util slot4 on
Powering fru 4 to ON state...
root@bmc-oob:~# log-util slot4 --print
2023 May 22 23:34:14 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-22 23:43:06    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:43:05, Sensor: PMIC_ERR (0xB4), Event Data: (050900) DIMM A7 SWDout UV Assertion
4    slot4    2023-05-22 23:43:09    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-22 23:43:10    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:43:10, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-22 23:43:20    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:43:20, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) S0 power on failure Assertion
4    slot4    2023-05-22 23:43:26    power-util       SERVER_12V_CYCLE successful for FRU: 4
4    slot4    2023-05-22 23:43:43    power-util       SERVER_POWER_ON successful for FRU: 4
4    slot4    2023-05-22 23:43:44    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-22 23:44:50    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15

root@bmc-oob:~# dimm-util slot4 --pmic --dimm A7 --err_inj critical_temp_shutdown Error inject successfully on DIMM A7
root@bmc-oob:~# power-util slot4 12V-cycle
12V Power cycling fru 4...
root@bmc-oob:~# power-util slot4 on
Powering fru 4 to ON state...
root@bmc-oob:~# log-util --print slot4
2023 May 22 23:45:53 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-22 23:46:01    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:46:01, Sensor: PMIC_ERR (0xB4), Event Data: (051000) DIMM A7 Critical Temp Shutdown Assertion
4    slot4    2023-05-22 23:46:05    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-22 23:46:06    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:46:06, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-22 23:46:16    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:46:16, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) S0 power on failure Assertion
4    slot4    2023-05-22 23:46:23    power-util       SERVER_12V_CYCLE successful for FRU: 4
4    slot4    2023-05-22 23:46:32    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-22 23:46:32    power-util       SERVER_POWER_ON successful for FRU: 4
4    slot4    2023-05-22 23:47:39    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15

root@bmc-oob:~# dimm-util slot4 --pmic --dimm A7 --err_inj VinB_UV Error inject successfully on DIMM A7
root@bmc-oob:~# power-util slot4 12V-cycle
12V Power cycling fru 4...
root@bmc-oob:~# power-util slot4 on
Powering fru 4 to ON state...
root@bmc-oob:~# log-util --print slot4
2023 May 22 23:49:10 log-util: User cleared FRU: 4 logs
4    slot4    2023-05-22 23:49:17    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:49:17, Sensor: PMIC_ERR (0xB4), Event Data: (050A00) DIMM A7 Vin Bulk UV Assertion
4    slot4    2023-05-22 23:49:20    gpiod            FRU: 4, System powered OFF
4    slot4    2023-05-22 23:49:22    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:49:22, Sensor: ME_POWER_STATE (0x16), Event Data: (000000) RUNNING Assertion
4    slot4    2023-05-22 23:49:31    ipmid            SEL Entry: FRU: 4, Record: Standard (0x02), Time: 2023-05-22 23:49:31, Sensor: SYSTEM_STATUS (0x10), Event Data: (0AFFFF) S0 power on failure Assertion
4    slot4    2023-05-22 23:49:42    power-util       SERVER_12V_CYCLE successful for FRU: 4
4    slot4    2023-05-22 23:49:50    power-util       SERVER_POWER_ON successful for FRU: 4
4    slot4    2023-05-22 23:49:57    gpiod            FRU: 4, System powered ON
4    slot4    2023-05-22 23:50:57    ipmid            SEL Entry: FRU: 4, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15