### PR TITLE
fby3.5: gl: Revise sensor threshold following Great Lakes_BIC_GPIO_20…

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
@@ -74,8 +74,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x96, // UNRT
-		0x3C, // UCT
-		0x00, // UNCT
+		0x96, // UCT
+		0x3C, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -134,8 +134,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x96, // UNRT
-		0x50, // UCT
-		0x00, // UNCT
+		0x96, // UCT
+		0x50, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -193,9 +193,9 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x28, // UCT
-		0x00, // UNCT
+		0x96, // UNRT
+		0x96, // UCT
+		0x28, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -254,8 +254,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x69, // UCT
-		0x00, // UNCT
+		0x00, // UCT
+		0x5B, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -314,8 +314,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
-		0x00, // UNCT
+		0x00, // UCT
+		0x55, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -374,8 +374,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
-		0x00, // UNCT
+		0x00, // UCT
+		0x55, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -434,8 +434,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
-		0x00, // UNCT
+		0x00, // UCT
+		0x55, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -494,8 +494,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
-		0x00, // UNCT
+		0x00, // UCT
+		0x55, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -554,8 +554,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
-		0x00, // UNCT
+		0x00, // UCT
+		0x55, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -614,8 +614,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
-		0x00, // UNCT
+		0x00, // UCT
+		0x55, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -674,8 +674,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
-		0x00, // UNCT
+		0x00, // UCT
+		0x55, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -734,8 +734,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x55, // UCT
-		0x00, // UNCT
+		0x00, // UCT
+		0x55, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -793,9 +793,9 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x00, // UNRT
-		0x4B, // UCT
-		0x00, // UNCT
+		0x5D, // UNRT
+		0x5D, // UCT
+		0x4D, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -854,8 +854,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x64, // UCT
-		0x00, // UNCT
+		0x7D, // UCT
+		0x64, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -914,8 +914,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x64, // UCT
-		0x00, // UNCT
+		0x7D, // UCT
+		0x64, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -974,8 +974,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x64, // UCT
-		0x00, // UNCT
+		0x7D, // UCT
+		0x64, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1034,8 +1034,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x64, // UCT
-		0x00, // UNCT
+		0x7D, // UCT
+		0x64, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1094,8 +1094,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x64, // UCT
-		0x00, // UNCT
+		0x7D, // UCT
+		0x64, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1154,8 +1154,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x64, // UCT
-		0x00, // UNCT
+		0x7D, // UCT
+		0x64, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1206,16 +1206,16 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x7D, // UNRT
+		0x00, // UNRT
 		0x00, // UCT
-		0x00, // UNCT
+		0x01, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1273,8 +1273,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x7D, // UNRT
-		0x69, // UCT
+		0x00, // UNRT
+		0x00, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -2298,8 +2298,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0xBF, // UNRT
-		0xA5, // UCT
-		0x94, // UNCT
+		0xB5, // UCT
+		0xAD, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2358,8 +2358,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0xB3, // UNRT
-		0x99, // UCT
-		0x78, // UNCT
+		0x85, // UCT
+		0x7E, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2418,8 +2418,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0xFF, // UNRT
-		0xDE, // UCT
-		0xD3, // UNCT
+		0xE8, // UCT
+		0xDD, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2478,8 +2478,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0xF4, // UNRT
-		0xCB, // UCT
-		0xC4, // UNCT
+		0xE0, // UCT
+		0xDD, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2538,8 +2538,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0xC8, // UNRT
-		0x8C, // UCT
-		0x87, // UNCT
+		0x97, // UCT
+		0x90, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2598,8 +2598,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0xC8, // UNRT
-		0x8C, // UCT
-		0x87, // UNCT
+		0x97, // UCT
+		0x90, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2660,8 +2660,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0xC1, // UNRT
-		0xA3, // UCT
-		0x93, // UNCT
+		0xB4, // UCT
+		0xAC, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2720,8 +2720,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x19, // UNRT
-		0x16, // UCT
-		0x11, // UNCT
+		0x13, // UCT
+		0x12, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2767,21 +2767,21 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x30, // [7:0] M bits
+		0x31, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] acPWRacy , [3:2] acPWRacy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x1A, // UNRT
-		0x16, // UCT
-		0x15, // UNCT
+		0xFD, // UNRT
+		0xE6, // UCT
+		0xDC, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2840,8 +2840,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0xE9, // UNRT
-		0xC2, // UCT
-		0xBB, // UNCT
+		0xD6, // UCT
+		0xCD, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2900,8 +2900,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x1A, // UNRT
-		0x12, // UCT
-		0x11, // UNCT
+		0x14, // UCT
+		0x12, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2960,8 +2960,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x1A, // UNRT
-		0x12, // UCT
-		0x11, // UNCT
+		0x14, // UCT
+		0x12, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -3026,9 +3026,9 @@ SDR_Full_sensor hotswap_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x7D, // UNRT
-		0x50, // UCT
-		0x00, // UNCT
+		0xAF, // UNRT
+		0xAF, // UCT
+		0x50, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -3147,8 +3147,8 @@ SDR_Full_sensor hotswap_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0xFC, // UNRT
-		0xCD, // UCT
-		0xB9, // UNCT
+		0xE1, // UCT
+		0xD7, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -3207,8 +3207,8 @@ SDR_Full_sensor hotswap_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0xF3, // UNRT
-		0xC6, // UCT
-		0xB3, // UNCT
+		0xD9, // UCT
+		0xD0, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT


### PR DESCRIPTION
…230505

# Description:
Revise sensor threshold following Great Lakes_BIC_GPIO_20230505

# Motivation:
Match Great Lakes_BIC_GPIO_20230505

# Test Plan:
- Check sensor name and threshold in sensor list : Pass

# Test Log:
root@bmc-oob:~# sensor-util slot3 --thres
slot3:
MB_INLET_TEMP_C              (0x1) :   26.00 C     | (ok) | UCR: 150.00 | UNC: 60.00 | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
MB_OUTLET_TEMP_C             (0x2) :   31.00 C     | (ok) | UCR: 150.00 | UNC: 80.00 | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
FIO_FRONT_TEMP_C             (0x3) :   26.00 C     | (ok) | UCR: 150.00 | UNC: 40.00 | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_CPU_TEMP_C            (0x4) :   38.00 C     | (ok) | UCR: NA | UNC: 91.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA_TEMP_C              (0x5) :  255.00 C     | (unc) | UCR: NA | UNC: 85.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMB_TEMP_C              (0x6) :  255.00 C     | (unc) | UCR: NA | UNC: 85.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMC_TEMP_C              (0x7) :  255.00 C     | (unc) | UCR: NA | UNC: 85.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMD_TEMP_C              (0x8) :  255.00 C     | (unc) | UCR: NA | UNC: 85.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMME_TEMP_C              (0x9) :   28.00 C     | (ok) | UCR: NA | UNC: 85.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMF_TEMP_C              (0xA) :  255.00 C     | (unc) | UCR: NA | UNC: 85.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMG_TEMP_C              (0xB) :  255.00 C     | (unc) | UCR: NA | UNC: 85.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMH_TEMP_C              (0xC) :  255.00 C     | (unc) | UCR: NA | UNC: 85.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SSD0_TEMP_C               (0xD) :   29.00 C     | (ok) | UCR: 93.00 | UNC: 77.00 | UNR: 93.00 | LCR: NA | LNC: NA | LNR: NA
MB_HSC_TEMP_C                (0xE) :   25.71 C     | (ok) | UCR: 175.00 | UNC: 80.00 | UNR: 175.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_TEMP_C           (0xF) :   41.00 C     | (ok) | UCR: 125.00 | UNC: 100.00 | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_TEMP_C             (0x10) :   41.00 C     | (ok) | UCR: 125.00 | UNC: 100.00 | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_TEMP_C           (0x11) :   38.00 C     | (ok) | UCR: 125.00 | UNC: 100.00 | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCINF_TEMP_C          (0x12) :   39.00 C     | (ok) | UCR: 125.00 | UNC: 100.00 | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD0_TEMP_C           (0x13) :   31.00 C     | (ok) | UCR: 125.00 | UNC: 100.00 | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD1_TEMP_C           (0x14) :   30.00 C     | (ok) | UCR: 125.00 | UNC: 100.00 | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_THERMAL_MARGIN_C      (0x15) :   67.00 C     | (unc) | UCR: NA | UNC: 0.00 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_TJMAX_C               (0x16) :  105.00 C     | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_ADC_P12V_STBY_VOLT_V      (0x17) :   12.55 Volts  | (ok) | UCR: 13.33 | UNC: 13.22 | UNR: 14.34 | LCR: 10.68 | LNC: 10.80 | LNR: 10.09
MB_ADC_P3V_BAT_VOLT_V        (0x18) :    3.19 Volts  | (ok) | UCR: 3.50 | UNC: 3.47 | UNR: NA | LCR: 2.76 | LNC: 2.80 | LNR: NA
MB_ADC_P3V3_STBY_VOLT_V      (0x19) :    3.35 Volts  | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.82 | LCR: 3.04 | LNC: 3.07 | LNR: 2.64
MB_ADC_P1V8_STBY_VOLT_V      (0x1A) :    1.81 Volts  | (ok) | UCR: 1.94 | UNC: 1.93 | UNR: 2.08 | LCR: 1.66 | LNC: 1.68 | LNR: 1.44
MB_ADC_P1V05_STBY_VOLT_V     (0x1B) :    1.06 Volts  | (ok) | UCR: 1.14 | UNC: 1.13 | UNR: NA | LCR: 0.97 | LNC: 1.00 | LNR: NA
MB_HSC_INPUT_VOLT_V          (0x1C) :   12.32 Volts  | (ok) | UCR: 13.33 | UNC: 13.22 | UNR: 14.34 | LCR: 10.68 | LNC: 10.80 | LNR: 10.09
MB_VR_VCCIN_VOLT_V           (0x1D) :    1.81 Volts  | (ok) | UCR: 1.93 | UNC: 1.91 | UNR: 2.27 | LCR: 1.46 | LNC: 1.48 | LNR: 1.43
MB_VR_VCCINF_VOLT_V          (0x1E) :    0.86 Volts  | (ok) | UCR: 1.04 | UNC: 1.03 | UNR: 1.40 | LCR: 0.52 | LNC: 0.53 | LNR: 0.36
MB_VR_FIVRA_VOLT_V           (0x1F) :    1.80 Volts  | (ok) | UCR: 1.95 | UNC: 1.93 | UNR: 2.29 | LCR: 1.67 | LNC: 1.68 | LNR: 1.39
MB_VR_VCCD0_VOLT_V           (0x20) :    1.11 Volts  | (ok) | UCR: 1.19 | UNC: 1.17 | UNR: 1.75 | LCR: 0.97 | LNC: 0.98 | LNR: 0.70
MB_VR_VCCD1_VOLT_V           (0x21) :    1.12 Volts  | (ok) | UCR: 1.19 | UNC: 1.17 | UNR: 1.75 | LCR: 0.97 | LNC: 0.98 | LNR: 0.70
MB_VR_EHV_VOLT_V             (0x22) :    1.80 Volts  | (ok) | UCR: 1.90 | UNC: 1.88 | UNR: 2.29 | LCR: 1.70 | LNC: 1.72 | LNR: 1.39
MB_ADC_VNN_VOLT_V            (0x23) :    1.00 Volts  | (ok) | UCR: 1.08 | UNC: 1.08 | UNR: 1.15 | LCR: 0.89 | LNC: 0.90 | LNR: 0.80
MB_ADC_P5V_STBY_VOLT_V       (0x24) :    4.98 Volts  | (ok) | UCR: 5.66 | UNC: 5.62 | UNR: 5.78 | LCR: 4.61 | LNC: 4.66 | LNR: 3.98
MB_ADC_P12V_DIMM_VOLT_V      (0x25) :   12.59 Volts  | (ok) | UCR: 14.24 | UNC: 14.05 | UNR: NA | LCR: 9.89 | LNC: 10.02 | LNR: NA
MB_ADC_P1V2_STBY_VOLT_V      (0x26) :    1.21 Volts  | (ok) | UCR: 1.30 | UNC: 1.29 | UNR: NA | LCR: 1.10 | LNC: 1.12 | LNR: NA
MB_ADC_P3V3_M2_VOLT_V        (0x27) :    3.33 Volts  | (ok) | UCR: 3.71 | UNC: 3.66 | UNR: NA | LCR: 2.91 | LNC: 2.94 | LNR: NA
MB_HSC_OUTPUT_CURR_A         (0x28) :    7.38 Amps  | (ok) | UCR: 60.75 | UNC: 58.05 | UNR: 68.04 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_CURR_A           (0x29) :   27.50 Amps  | (ok) | UCR: 289.60 | UNC: 276.80 | UNR: 305.60 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_CURR_A             (0x2A) :    0.88 Amps  | (ok) | UCR: 5.19 | UNC: 4.91 | UNR: 6.98 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_CURR_A           (0x2B) :    4.00 Amps  | (ok) | UCR: 62.64 | UNC: 59.67 | UNR: 68.85 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCINF_CURR_A          (0x2C) :   14.75 Amps  | (ok) | UCR: 60.48 | UNC: 59.67 | UNR: 65.88 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD0_CURR_A           (0x2D) :    0.50 Amps  | (ok) | UCR: 30.20 | UNC: 28.80 | UNR: 40.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD1_CURR_A           (0x2E) :    0.56 Amps  | (ok) | UCR: 30.20 | UNC: 28.80 | UNR: 40.00 | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_PWR_W           (0x2F) :   90.67 Watts  | (ok) | UCR: 759.50 | UNC: 728.00 | UNR: 850.50 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_PWR_W            (0x30) :   50.25 Watts  | (ok) | UCR: 522.00 | UNC: 498.80 | UNR: 559.70 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_PWR_W              (0x31) :    1.62 Watts  | (ok) | UCR: 9.31 | UNC: 8.82 | UNR: 12.25 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_PWR_W            (0x32) :    7.25 Watts  | (ok) | UCR: 112.70 | UNC: 107.80 | UNR: 123.97 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCINF_PWR_W           (0x33) :   12.88 Watts  | (ok) | UCR: 51.36 | UNC: 49.20 | UNR: 55.92 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD0_PWR_W            (0x34) :    0.62 Watts  | (ok) | UCR: 34.00 | UNC: 30.60 | UNR: 44.20 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD1_PWR_W            (0x35) :    0.62 Watts  | (ok) | UCR: 34.00 | UNC: 30.60 | UNR: 44.20 | LCR: NA | LNC: NA | LNR: NA