### PR TITLE
Common: Clarify the application of ipmb_notify_client function

### DIFF
--- a/common/service/host/kcs.c
+++ b/common/service/host/kcs.c
@@ -103,7 +103,7 @@ static void kcs_read_task(void *arvg0, void *arvg1, void *arvg2)
 			LOG_DBG("KCS to ipmi netfn 0x%x, cmd 0x%x, length %d",
 				current_msg.buffer.netfn, current_msg.buffer.cmd,
 				current_msg.buffer.data_len);
-			ipmb_notify_client(&current_msg);
+			notify_ipmi_client(&current_msg);
 		} else { // default command for BMC, should add BIC firmware update, BMC reset, real time sensor read in future
 			if (pal_immediate_respond_from_HOST(req->netfn, req->cmd)) {
 				do { // break if malloc fail.

--- a/common/service/ipmb/ipmb.h
+++ b/common/service/ipmb/ipmb.h
@@ -198,7 +198,6 @@ ipmb_error ipmb_send_response(ipmi_msg *resp, uint8_t index);
 ipmb_error ipmb_read(ipmi_msg *msg, uint8_t bus);
 void ipmb_tx_suspend(uint8_t index);
 void ipmb_tx_resume(uint8_t index);
-ipmb_error ipmb_notify_client(ipmi_msg_cfg *msg_cfg);
 
 void pal_encode_response_bridge_cmd(ipmi_msg *bridge_msg, ipmi_msg_cfg *current_msg_rx,
 				    IPMB_config *ipmb_cfg, IPMB_config *IPMB_config_tables);

--- a/common/service/ipmi/include/ipmi.h
+++ b/common/service/ipmi/include/ipmi.h
@@ -284,4 +284,6 @@ enum {
 	INDEX_SLOT3 = 0x03,
 };
 
+ipmb_error notify_ipmi_client(ipmi_msg_cfg *msg_cfg);
+
 #endif

--- a/common/service/pldm/pldm_oem.c
+++ b/common/service/pldm/pldm_oem.c
@@ -137,7 +137,7 @@ static uint8_t ipmi_cmd(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t ins
 	/* store the pldm header in the buffer */
 	memcpy(msg.buffer.data + pldm_hdr_ofs, buf - sizeof(pldm_hdr), sizeof(pldm_hdr));
 
-	ipmb_notify_client(&msg);
+	notify_ipmi_client(&msg);
 
 	return PLDM_LATER_RESP;
 }

--- a/common/service/usb/usb.c
+++ b/common/service/usb/usb.c
@@ -43,7 +43,7 @@ static inline void try_ipmi_message(ipmi_msg_cfg *current_msg, int retry)
 	if (current_msg == NULL) {
 		return;
 	}
-	ipmb_notify_client(current_msg);
+	notify_ipmi_client(current_msg);
 }
 
 void handle_usb_data(uint8_t *rx_buff, int rx_len)
@@ -60,10 +60,9 @@ void handle_usb_data(uint8_t *rx_buff, int rx_len)
 
 	if (DEBUG_USB) {
 		LOG_DBG("USB: len %d, req: %x %x ID: %x %x %x target: %x offset: %x %x %x %x len: %x %x",
-		       rx_len,
-		       rx_buff[0], rx_buff[1], rx_buff[2], rx_buff[3],
-		       rx_buff[4], rx_buff[5], rx_buff[6], rx_buff[7],
-		       rx_buff[8], rx_buff[9], rx_buff[10], rx_buff[11]);
+			rx_len, rx_buff[0], rx_buff[1], rx_buff[2], rx_buff[3], rx_buff[4],
+			rx_buff[5], rx_buff[6], rx_buff[7], rx_buff[8], rx_buff[9], rx_buff[10],
+			rx_buff[11]);
 	}
 
 	// USB driver must receive 64 byte package from bmc
@@ -76,7 +75,7 @@ void handle_usb_data(uint8_t *rx_buff, int rx_len)
 	if (fwupdate_keep_data) {
 		if ((keep_data_len + rx_len) > IPMI_DATA_MAX_LENGTH) {
 			LOG_ERR("USB FW update recv data over ipmi buff size %d, keep %d, recv %d",
-			       IPMI_DATA_MAX_LENGTH, keep_data_len, rx_len);
+				IPMI_DATA_MAX_LENGTH, keep_data_len, rx_len);
 			keep_data_len = 0;
 			fwupdate_keep_data = false;
 			return;

--- a/common/shell/commands/ipmi_shell.c
+++ b/common/shell/commands/ipmi_shell.c
@@ -41,7 +41,7 @@ void cmd_ipmi_raw(const struct shell *shell, size_t argc, char **argv)
 	for (int i = 0; i < data_len; i++) {
 		msg.buffer.data[i] = strtol(argv[3 + i], NULL, 16);
 	}
-	ipmb_notify_client(&msg);
+	notify_ipmi_client(&msg);
 
 	if (k_msgq_get(&self_ipmi_msgq, &msg, K_MSEC(1000))) {
 		shell_error(shell, "Failed to get ipmi msgq in time");
@@ -89,7 +89,7 @@ void cmd_ipmi_list(const struct shell *shell, size_t argc, char **argv)
 			msg.buffer.data_len = ARRAY_SIZE(dummy_msg);
 			memcpy(msg.buffer.data, dummy_msg, ARRAY_SIZE(dummy_msg));
 
-			if (ipmb_notify_client(&msg)) {
+			if (notify_ipmi_client(&msg)) {
 				shell_error(shell, "Failed to send req netfn:0x%x cmd:0x%x...",
 					    netfn_idx, cmd_idx);
 				continue;


### PR DESCRIPTION
# Description
- Clarify the application of ipmb_notify_client function.
  - The application of ipmb_notify_client function is to process the IPMI message through the IPMI handler instead of transmitting the message through IPMB, so this function should be defined in IPMI.
  - After modification, the issue that Artemis ACB/MEB and GT BIC can't build the image can be fixed.

# Motivation
- When analyzing the issue of ACB/MEB BIC fail to build image, we found that the root cause is ACB/MEB BIC doesn't use IPMB, so the image can't be build where the common layer uses IPMB related functions. Clarify the application of IPMB related functions to normally execute protocols such as IPMB/PLDM.

# Test Plan
- Build code: Pass [YV3, YV35, OP, GT, WC]
- Get firmware version in YV3.5 system: Pass
- Get firmware version/update firmware in Artemis system: Pass

# Log
- ACB BIC firmware update and get version root@bmc-oob:~# fw-util cb --version bic
CB BIC Version: cb2023.20.e2
root@bmc-oob:~# fw-util cb --force --update bic ATCB_2023_20_E1_ipmb.bin Raw image detected.
updating fw on bus 3
updated: 100 %
Elapsed time:  12   sec.
Force upgrade of cb : bic succeeded
root@bmc-oob:~# fw-util cb --version bic
CB BIC Version: cb2023.20.e1

- MEB BIC firmware update and get version root@bmc-oob:~# fw-util mc --version bic
MC BIC Version: mc2023.17.01
root@bmc-oob:~# fw-util mc --force --update bic ATMC.bin Raw image detected.
updating fw on bus 9
updated: 100 %
Elapsed time:  12   sec.
Force upgrade of mc : bic succeeded
root@bmc-oob:~# fw-util mc --version bic
MC BIC Version: mc2023.20.01