### PR TITLE
common: patch: Fix am problem for 0050 patch

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0050-i2c-aspeed-Support-mode-select-and-improve_byte_mode.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0050-i2c-aspeed-Support-mode-select-and-improve_byte_mode.patch
@@ -1,47 +1,21 @@
-From 2beebb916809899c3d6d0417baedcc1140d1f922 Mon Sep 17 00:00:00 2001
-From: Tommy Haung <tommy_huang@aspeedtech.com>
-Date: Wed, 24 May 2023 17:38:56 +0800
-Subject: [PATCH] drivers:i2c:update slave match behavior
-
-1.Update slave match behvior without recevice done condition.
-
-Signed-off-by: Tommy Haung <tommy_huang@aspeedtech.com>
-Change-Id: Ide50ef5232525dae3e1de16cb4281b086743b39f
-
-From ae90ea25a22f410b365c5a8f8240b3c107946e94 Mon Sep 17 00:00:00 2001
-From: Tommy Haung <tommy_huang@aspeedtech.com>
-Date: Wed, 24 May 2023 14:00:20 +0800
-Subject: [PATCH] drivers:i2c:handle nak/stop/address case
-
-1.Add handling nak/stop/address match case.
-
-Signed-off-by: Tommy Haung <tommy_huang@aspeedtech.com>
-Change-Id: I150f49c897a6f0923ea7addfba1b4445683e3fce
-
-From d364f1d04230ef914bfedb4726c63fe3ff1fde57 Mon Sep 17 00:00:00 2001
-From: Tommy Haung <tommy_huang@aspeedtech.com>
-Date: Tue, 23 May 2023 11:13:10 +0800
-Subject: [PATCH] drivers:i2c:add pending stop handle into byte mode
-
-1.Add interrupt pending condition for byte mode.
-
-Signed-off-by: Tommy Haung <tommy_huang@aspeedtech.com>
-Change-Id: I4ce4358d7cbe10cf324a157609771959d6e42a07
-
 From 35ec58db10e73bd3b102ec80eb3dacf6cfe83539 Mon Sep 17 00:00:00 2001
 From: Tommy Haung <tommy_huang@aspeedtech.com>
 Date: Thu, 25 May 2023 18:42:24 +0800
-Subject: [PATCH] drivers:i2c:add i2c transfer mode parameter
+Subject: [PATCH] drivers:i2c:support-mode-select-and-improve_byte_mode
 
-1.Add xfer-mode to idenify which one i2c transfer mode used.
-2.The "BYTE", "BUFF", "DMA" values could be assigned.
-3.The default mode is DMA.
+1.Update slave match behvior without recevice done condition.
+2.Add handling nak/stop/address match case.
+3.Add interrupt pending condition for byte mode.
+4.Add xfer-mode to idenify which one i2c transfer mode used.
+5.The "BYTE", "BUFF", "DMA" values could be assigned.
+6.The default mode is DMA.
+7.Add handle byte mode interrupt with stop and next address match
 
 Signed-off-by: Tommy Haung <tommy_huang@aspeedtech.com>
 Change-Id: Ida8485ecfd8adc7dd8e296e4ae6d8f9904a8217a
 
 diff --git a/drivers/i2c/i2c_aspeed.c b/drivers/i2c/i2c_aspeed.c
-index e5b3f3008c..8fb41a5d58 100644
+index e5b3f3008c..f5e99a7cc9 100644
 --- a/drivers/i2c/i2c_aspeed.c
 +++ b/drivers/i2c/i2c_aspeed.c
 @@ -255,11 +255,11 @@ LOG_MODULE_REGISTER(i2c_aspeed);
@@ -90,12 +64,13 @@ index e5b3f3008c..8fb41a5d58 100644
  		data->slave_addr_last = byte_data;
  		break;
  	case AST_I2CS_RX_DONE | AST_I2CS_Wait_RX_DMA:
-@@ -1682,16 +1705,29 @@ void aspeed_i2c_slave_byte_irq(const struct device *dev, uint32_t i2c_base, uint
+@@ -1682,16 +1705,32 @@ void aspeed_i2c_slave_byte_irq(const struct device *dev, uint32_t i2c_base, uint
  		sys_write32(byte_data, i2c_base + AST_I2CC_STS_AND_BUFF);
  		break;
  	case AST_I2CS_STOP:
 +	case AST_I2CS_STOP | AST_I2CS_TX_NAK:
 +	case AST_I2CS_SLAVE_MATCH |AST_I2CS_STOP | AST_I2CS_TX_NAK:
++	case AST_I2CS_SLAVE_MATCH | AST_I2CS_Wait_RX_DMA | AST_I2CS_STOP | AST_I2CS_TX_NAK:
 +		LOG_DBG("S : P\n");
  		if (slave_cb->stop) {
  			slave_cb->stop(data->slave_cfg);
@@ -110,14 +85,16 @@ index e5b3f3008c..8fb41a5d58 100644
 +			data->slave_addr_last = 0x0;
 +		}
 +
-+		if (sts == (AST_I2CS_SLAVE_MATCH |AST_I2CS_STOP | AST_I2CS_TX_NAK)) {
-+			LOG_WRN("0x92 occur!!");
-+		}
-+
 +		if(sts & AST_I2CS_SLAVE_MATCH) {
 +			/* Don't handle this match for current condition*/
 +			sts &= ~(AST_I2CS_SLAVE_MATCH);
 +		}
++
++		if (sts & AST_I2CS_Wait_RX_DMA) {
++			/* Don't handle this waiting for current condition*/
++			sts &= ~(AST_I2CS_Wait_RX_DMA);
++		}
++
  		break;
  	default:
 -		LOG_DBG("TODO no pkt_done intr ~~~ ***** sts %x\n", sts);
@@ -125,7 +102,7 @@ index e5b3f3008c..8fb41a5d58 100644
  		break;
  	}
  	sys_write32(cmd, i2c_base + AST_I2CS_CMD_STS);
-@@ -1798,9 +1834,6 @@ static int i2c_aspeed_init(const struct device *dev)
+@@ -1798,9 +1837,6 @@ static int i2c_aspeed_init(const struct device *dev)
  		config->clk_div_mode = 1;
  	}
  
@@ -135,7 +112,7 @@ index e5b3f3008c..8fb41a5d58 100644
  	/* buffer mode base and size */
  	config->buf_base = config->global_reg + i2c_base_offset;
  	config->buf_size = I2C_BUF_SIZE;
-@@ -1912,6 +1945,7 @@ static const struct i2c_driver_api i2c_aspeed_driver_api = {
+@@ -1912,6 +1948,7 @@ static const struct i2c_driver_api i2c_aspeed_driver_api = {
  		.base = DT_INST_REG_ADDR(n),					  \
  		.irq_config_func = i2c_aspeed_config_func_##n,			  \
  		.bitrate = DT_INST_PROP(n, clock_frequency),			  \


### PR DESCRIPTION
Summary:
- Update slave match behvior without recevice done condition.
- Add handling nak/stop/address match case.
- Add interrupt pending condition for byte mode.
- Add xfer-mode to idenify which one i2c transfer mode used.
- The "BYTE", "BUFF", "DMA" values could be assigned.
- The default mode is DMA.
- Add handle byte mode interrupt with stop and next address match

Test Plan:
- BuildCode: PASS
- git am: PASS
