### PR TITLE
op2: revise E1.S device number

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_class.h
+++ b/meta-facebook/op2-op/src/platform/plat_class.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software

--- a/meta-facebook/op2-op/src/platform/plat_gpio.h
+++ b/meta-facebook/op2-op/src/platform/plat_gpio.h
@@ -27,29 +27,29 @@
 // clang-format off
 
 #define OPA_name_gpioA \
-	gpio_name_to_num(OPA_CLKBUF_E1S_0_OE_N) \
-	gpio_name_to_num(OPA_CLKBUF_E1S_1_OE_N) \
 	gpio_name_to_num(OPA_CLKBUF_E1S_2_OE_N) \
+	gpio_name_to_num(OPA_CLKBUF_E1S_1_OE_N) \
+	gpio_name_to_num(OPA_CLKBUF_E1S_0_OE_N) \
 	gpio_name_to_num(OPA_CLKBUF_RTM_OE_N) \
 	gpio_name_to_num(OPA_CLKBUF_RISER_OE_N) \
-	gpio_name_to_num(OPA_PWRGD_P12V_E1S_0_R) \
+	gpio_name_to_num(OPA_PWRGD_P12V_E1S_2_R) \
 	gpio_name_to_num(OPA_PWRGD_P12V_E1S_1_R) \
-	gpio_name_to_num(OPA_PWRGD_P12V_E1S_2_R)
+	gpio_name_to_num(OPA_PWRGD_P12V_E1S_0_R)
 
 #define OPA_name_gpioB \
 	gpio_name_to_num(OPA_PWRGD_EXP_PWR) \
 	gpio_name_to_num(OPA_RESERVE_GPIOB1) \
-	gpio_name_to_num(OPA_E1S_0_PRSNT_N) \
-	gpio_name_to_num(OPA_E1S_1_PRSNT_N) \
 	gpio_name_to_num(OPA_E1S_2_PRSNT_N) \
+	gpio_name_to_num(OPA_E1S_1_PRSNT_N) \
+	gpio_name_to_num(OPA_E1S_0_PRSNT_N) \
 	gpio_name_to_num(OPA_PWRGD_P3V3_STBY) \
 	gpio_name_to_num(OPA_PWRGD_P1V2_STBY ) \
 	gpio_name_to_num(OPA_SMB_TMP_SENSOR_ALT_N)
 
 #define OPA_name_gpioC \
-	gpio_name_to_num(OPA_PWRGD_P3V3_E1S_0_R) \
-	gpio_name_to_num(OPA_PWRGD_P3V3_E1S_1_R) \
 	gpio_name_to_num(OPA_PWRGD_P3V3_E1S_2_R) \
+	gpio_name_to_num(OPA_PWRGD_P3V3_E1S_1_R) \
+	gpio_name_to_num(OPA_PWRGD_P3V3_E1S_0_R) \
 	gpio_name_to_num(OPA_PWRGD_P1V8_VR) \
 	gpio_name_to_num(OPA_PWRGD_P0V9_VR) \
 	gpio_name_to_num(OPA_BOARD_REV_0) \
@@ -58,21 +58,21 @@
 
 #define OPA_name_gpioD \
 	gpio_name_to_num(OPA_PWRGD_P12V_MAIN) \
-	gpio_name_to_num(OPA_RST_SMBRST_BIC_E1S_0_N) \
-	gpio_name_to_num(OPA_RST_SMBRST_BIC_E1S_1_N) \
 	gpio_name_to_num(OPA_RST_SMBRST_BIC_E1S_2_N) \
+	gpio_name_to_num(OPA_RST_SMBRST_BIC_E1S_1_N) \
+	gpio_name_to_num(OPA_RST_SMBRST_BIC_E1S_0_N) \
 	gpio_name_to_num(OPA_RESET_BIC_RTM_N) \
 	gpio_name_to_num(OPA_RST_USB_HUB_N) \
 	gpio_name_to_num(OPA_PERST_BIC_RTM_N) \
 	gpio_name_to_num(OPA_RESERVE_GPIOD7)
 
 #define OPA_name_gpioE \
-	gpio_name_to_num(OPA_PERST_E1S_0_N) \
-	gpio_name_to_num(OPA_PERST_E1S_1_N) \
 	gpio_name_to_num(OPA_PERST_E1S_2_N) \
-	gpio_name_to_num(OPA_E1S_0_12V_POWER_EN) \
-	gpio_name_to_num(OPA_E1S_1_12V_POWER_EN) \
+	gpio_name_to_num(OPA_PERST_E1S_1_N) \
+	gpio_name_to_num(OPA_PERST_E1S_0_N) \
 	gpio_name_to_num(OPA_E1S_2_12V_POWER_EN) \
+	gpio_name_to_num(OPA_E1S_1_12V_POWER_EN) \
+	gpio_name_to_num(OPA_E1S_0_12V_POWER_EN) \
 	gpio_name_to_num(OPA_EN_P0V9_VR) \
 	gpio_name_to_num(OPA_RESERVE_GPIOE7)
 
@@ -80,21 +80,21 @@
 	gpio_name_to_num(OPA_SMB_PCIE_EXPB_ALERT_N) \
 	gpio_name_to_num(OPA_RST_PCIE_EXP_PERST0_N) \
 	gpio_name_to_num(OPA_CLKBUF_PWRDOWN_R_N) \
-	gpio_name_to_num(OPA_FM_PWRDIS_E1S_0) \
-	gpio_name_to_num(OPA_FM_PWRDIS_E1S_1) \
 	gpio_name_to_num(OPA_FM_PWRDIS_E1S_2) \
+	gpio_name_to_num(OPA_FM_PWRDIS_E1S_1) \
+	gpio_name_to_num(OPA_FM_PWRDIS_E1S_0) \
 	gpio_name_to_num(OPA_SMB_PCIE_EXP1_ALERT_N) \
 	gpio_name_to_num(OPA_RESERVE_GPIOF7)
 
 #define OPA_name_gpioG \
-	gpio_name_to_num(OPA_SMB_E1S_0_INA233_ALT_N) \
-	gpio_name_to_num(OPA_SMB_E1S_1_INA233_ALT_N) \
 	gpio_name_to_num(OPA_SMB_E1S_2_INA233_ALT_N) \
+	gpio_name_to_num(OPA_SMB_E1S_1_INA233_ALT_N) \
+	gpio_name_to_num(OPA_SMB_E1S_0_INA233_ALT_N) \
 	gpio_name_to_num(OPA_SMB_P12V_EDGE_INA233_ALT_N) \
 	gpio_name_to_num(OPA_RTM_IOEXP_INT_N) \
-	gpio_name_to_num(OPA_LED_E1S_0_ATTN_R) \
+	gpio_name_to_num(OPA_LED_E1S_2_ATTN_R) \
 	gpio_name_to_num(OPA_LED_E1S_1_ATTN_R) \
-	gpio_name_to_num(OPA_LED_E1S_2_ATTN_R)
+	gpio_name_to_num(OPA_LED_E1S_0_ATTN_R)
 
 #define OPA_name_gpioH \
 	gpio_name_to_num(OPA_RESERVE_GPIOH0) \
@@ -139,9 +139,9 @@
 #define OPA_name_gpioL \
 	gpio_name_to_num(OPA_RESERVE_GPIOL0) \
 	gpio_name_to_num(OPA_RESERVE_GPIOL1) \
-	gpio_name_to_num(OPA_E1S_0_3V3_POWER_EN) \
-	gpio_name_to_num(OPA_E1S_1_3V3_POWER_EN) \
 	gpio_name_to_num(OPA_E1S_2_3V3_POWER_EN) \
+	gpio_name_to_num(OPA_E1S_1_3V3_POWER_EN) \
+	gpio_name_to_num(OPA_E1S_0_3V3_POWER_EN) \
 	gpio_name_to_num(OPA_RESERVE_GPIOL5) \
 	gpio_name_to_num(OPA_RESERVE_GPIOL6) \
 	gpio_name_to_num(OPA_RESERVE_GPIOL7)
@@ -238,78 +238,78 @@
 
 // For OPB BIC GPIO name
 #define OPB_name_gpioA \
-	gpio_name_to_num(OPB_CLKBUF_E1S_0_OE_N) \
-	gpio_name_to_num(OPB_CLKBUF_E1S_1_OE_N) \
-	gpio_name_to_num(OPB_CLKBUF_E1S_2_OE_N) \
-	gpio_name_to_num(OPB_CLKBUF_E1S_3_OE_N) \
 	gpio_name_to_num(OPB_CLKBUF_E1S_4_OE_N) \
-	gpio_name_to_num(OPB_PWRGD_P12V_E1S_0_R) \
-	gpio_name_to_num(OPB_PWRGD_P12V_E1S_1_R) \
+	gpio_name_to_num(OPB_CLKBUF_E1S_3_OE_N) \
+	gpio_name_to_num(OPB_CLKBUF_E1S_2_OE_N) \
+	gpio_name_to_num(OPB_CLKBUF_E1S_1_OE_N) \
+	gpio_name_to_num(OPB_CLKBUF_E1S_0_OE_N) \
+	gpio_name_to_num(OPB_PWRGD_P12V_E1S_4_R) \
+	gpio_name_to_num(OPB_PWRGD_P12V_E1S_3_R) \
 	gpio_name_to_num(OPB_PWRGD_P12V_E1S_2_R)
 
 #define OPB_name_gpioB \
-	gpio_name_to_num(OPB_PWRGD_P12V_E1S_3_R) \
-	gpio_name_to_num(OPB_PWRGD_P12V_E1S_4_R) \
-	gpio_name_to_num(OPB_E1S_0_PRSNT_N) \
-	gpio_name_to_num(OPB_E1S_1_PRSNT_N) \
-	gpio_name_to_num(OPB_E1S_2_PRSNT_N) \
+	gpio_name_to_num(OPB_PWRGD_P12V_E1S_1_R) \
+	gpio_name_to_num(OPB_PWRGD_P12V_E1S_0_R) \
+	gpio_name_to_num(OPB_E1S_4_PRSNT_N) \
 	gpio_name_to_num(OPB_E1S_3_PRSNT_N) \
-	gpio_name_to_num(OPB_E1S_4_PRSNT_N ) \
+	gpio_name_to_num(OPB_E1S_2_PRSNT_N) \
+	gpio_name_to_num(OPB_E1S_1_PRSNT_N) \
+	gpio_name_to_num(OPB_E1S_0_PRSNT_N ) \
 	gpio_name_to_num(OPB_SMB_TEMP_SENSOR_ALT_N)
 
 #define OPB_name_gpioC \
-	gpio_name_to_num(OPB_PWRGD_P3V3_E1S_0_R) \
-	gpio_name_to_num(OPB_PWRGD_P3V3_E1S_1_R) \
-	gpio_name_to_num(OPB_PWRGD_P3V3_E1S_2_R) \
-	gpio_name_to_num(OPB_PWRGD_P3V3_E1S_3_R) \
 	gpio_name_to_num(OPB_PWRGD_P3V3_E1S_4_R) \
+	gpio_name_to_num(OPB_PWRGD_P3V3_E1S_3_R) \
+	gpio_name_to_num(OPB_PWRGD_P3V3_E1S_2_R) \
+	gpio_name_to_num(OPB_PWRGD_P3V3_E1S_1_R) \
+	gpio_name_to_num(OPB_PWRGD_P3V3_E1S_0_R) \
 	gpio_name_to_num(OPB_BOARD_REV_0) \
 	gpio_name_to_num(OPB_BOARD_REV_1) \
 	gpio_name_to_num(OPB_BOARD_REV_2)
 
 #define OPB_name_gpioD \
 	gpio_name_to_num(OPB_PWRGD_P12V_MAIN) \
-	gpio_name_to_num(OPB_RST_SMBRST_BIC_E1S_0) \
-	gpio_name_to_num(OPB_RST_SMBRST_BIC_E1S_1) \
-	gpio_name_to_num(OPB_RST_SMBRST_BIC_E1S_2) \
-	gpio_name_to_num(OPB_RST_SMBRST_BIC_E1S_3) \
 	gpio_name_to_num(OPB_RST_SMBRST_BIC_E1S_4) \
-	gpio_name_to_num(OPB_RST_E1S_3_PERST) \
-	gpio_name_to_num(OPB_RST_E1S_4_PERST)
+	gpio_name_to_num(OPB_RST_SMBRST_BIC_E1S_3) \
+	gpio_name_to_num(OPB_RST_SMBRST_BIC_E1S_2) \
+	gpio_name_to_num(OPB_RST_SMBRST_BIC_E1S_1) \
+	gpio_name_to_num(OPB_RST_SMBRST_BIC_E1S_0) \
+	gpio_name_to_num(OPB_RST_E1S_4_PERST) \
+	gpio_name_to_num(OPB_RST_E1S_3_PERST)
 
 #define OPB_name_gpioE \
-	gpio_name_to_num(OPB_RST_E1S_0_PERST) \
-	gpio_name_to_num(OPB_RST_E1S_1_PERST) \
 	gpio_name_to_num(OPB_RST_E1S_2_PERST) \
-	gpio_name_to_num(OPB_P12V_E1S_0_EN_R) \
-	gpio_name_to_num(OPB_P12V_E1S_1_EN_R) \
-	gpio_name_to_num(OPB_P12V_E1S_2_EN_R) \
+	gpio_name_to_num(OPB_RST_E1S_1_PERST) \
+	gpio_name_to_num(OPB_RST_E1S_0_PERST) \
+	gpio_name_to_num(OPB_P12V_E1S_4_EN_R) \
 	gpio_name_to_num(OPB_P12V_E1S_3_EN_R) \
-	gpio_name_to_num(OPB_P12V_E1S_4_EN_R)
+	gpio_name_to_num(OPB_P12V_E1S_2_EN_R) \
+	gpio_name_to_num(OPB_P12V_E1S_1_EN_R) \
+	gpio_name_to_num(OPB_P12V_E1S_0_EN_R)
 
 #define OPB_name_gpioF \
 	gpio_name_to_num(OPB_SMB_P12V_MAIN_INA233_ALT_N) \
 	gpio_name_to_num(OPB_PMB_P12V_MAIN_ALT_N) \
 	gpio_name_to_num(OPB_CLKBUF_PWRDOWN_R_N) \
-	gpio_name_to_num(OPB_FM_PWRDIS_E1S_0) \
-	gpio_name_to_num(OPB_FM_PWRDIS_E1S_1) \
-	gpio_name_to_num(OPB_FM_PWRDIS_E1S_2) \
+	gpio_name_to_num(OPB_FM_PWRDIS_E1S_4) \
 	gpio_name_to_num(OPB_FM_PWRDIS_E1S_3) \
-	gpio_name_to_num(OPB_FM_PWRDIS_E1S_4)
+	gpio_name_to_num(OPB_FM_PWRDIS_E1S_2) \
+	gpio_name_to_num(OPB_FM_PWRDIS_E1S_1) \
+	gpio_name_to_num(OPB_FM_PWRDIS_E1S_0)
 
 #define OPB_name_gpioG \
-	gpio_name_to_num(OPB_SMB_E1S_0_INA233_ALT_N) \
-	gpio_name_to_num(OPB_SMB_E1S_1_INA233_ALT_N) \
-	gpio_name_to_num(OPB_SMB_E1S_2_INA233_ALT_N) \
-	gpio_name_to_num(OPB_SMB_E1S_3_INA233_ALT_N) \
 	gpio_name_to_num(OPB_SMB_E1S_4_INA233_ALT_N) \
-	gpio_name_to_num(OPB_LED_E1S_0_ATTN_R) \
-	gpio_name_to_num(OPB_LED_E1S_1_ATTN_R) \
+	gpio_name_to_num(OPB_SMB_E1S_3_INA233_ALT_N) \
+	gpio_name_to_num(OPB_SMB_E1S_2_INA233_ALT_N) \
+	gpio_name_to_num(OPB_SMB_E1S_1_INA233_ALT_N) \
+	gpio_name_to_num(OPB_SMB_E1S_0_INA233_ALT_N) \
+	gpio_name_to_num(OPB_LED_E1S_4_ATTN_R) \
+	gpio_name_to_num(OPB_LED_E1S_3_ATTN_R) \
 	gpio_name_to_num(OPB_LED_E1S_2_ATTN_R)
 
 #define OPB_name_gpioH \
-	gpio_name_to_num(OPB_LED_E1S_3_ATTN_R) \
-	gpio_name_to_num(OPB_LED_E1S_4_ATTN_R) \
+	gpio_name_to_num(OPB_LED_E1S_1_ATTN_R) \
+	gpio_name_to_num(OPB_LED_E1S_0_ATTN_R) \
 	gpio_name_to_num(OPB_HUB1_MASTER_SELECT_R) \
 	gpio_name_to_num(OPB_SMB_IOEXP_ALT_N) \
 	gpio_name_to_num(OPB_RESERVE_GPIOH4) \
@@ -350,11 +350,11 @@
 #define OPB_name_gpioL \
 	gpio_name_to_num(OPB_RESERVE_GPIOL0) \
 	gpio_name_to_num(OPB_RESERVE_GPIOL1) \
-	gpio_name_to_num(OPB_P3V3_E1S_0_EN_R) \
-	gpio_name_to_num(OPB_P3V3_E1S_1_EN_R) \
-	gpio_name_to_num(OPB_P3V3_E1S_2_EN_R) \
-	gpio_name_to_num(OPB_P3V3_E1S_3_EN_R) \
 	gpio_name_to_num(OPB_P3V3_E1S_4_EN_R) \
+	gpio_name_to_num(OPB_P3V3_E1S_3_EN_R) \
+	gpio_name_to_num(OPB_P3V3_E1S_2_EN_R) \
+	gpio_name_to_num(OPB_P3V3_E1S_1_EN_R) \
+	gpio_name_to_num(OPB_P3V3_E1S_0_EN_R) \
 	gpio_name_to_num(OPB_RESERVE_GPIOL7)
 
 #define OPB_name_gpioM \

--- a/meta-facebook/op2-op/src/platform/plat_hook.h
+++ b/meta-facebook/op2-op/src/platform/plat_hook.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -39,6 +39,12 @@ extern struct k_mutex i2c_hub_mutex;
 #define I2C_HUB_CHANNEL_3 0x08
 #define I2C_HUB_CHANNEL_4 0x10
 #define I2C_HUB_CHANNEL_5 0x20
+
+
+const static uint8_t e1s_mux_channel_opa[] = {I2C_HUB_CHANNEL_5, I2C_HUB_CHANNEL_1,
+	I2C_HUB_CHANNEL_0};
+const static uint8_t e1s_mux_channel_opb[] = {I2C_HUB_CHANNEL_4, I2C_HUB_CHANNEL_3,
+	I2C_HUB_CHANNEL_2, I2C_HUB_CHANNEL_1, I2C_HUB_CHANNEL_0};
 
 bool pre_i2c_bus_read(uint8_t sensor_num, void *args);
 bool post_i2c_bus_read(uint8_t sensor_num, void *args, int *reading);

--- a/meta-facebook/op2-op/src/platform/plat_led.c
+++ b/meta-facebook/op2-op/src/platform/plat_led.c
@@ -28,6 +28,10 @@ static uint8_t e1s_amber_led_pre_status[MAX_E1S_IDX] = { LED_STATUS_OFF, LED_STA
 							 LED_STATUS_OFF };
 static uint8_t e1s_amber_led_status[MAX_E1S_IDX] = { LED_STATUS_OFF, LED_STATUS_OFF, LED_STATUS_OFF,
 						     LED_STATUS_OFF, LED_STATUS_OFF };
+static uint8_t els_amber_led_gpio_opa[MAX_E1S_IDX] = { OPA_LED_E1S_0_ATTN_R, OPA_LED_E1S_1_ATTN_R,
+	OPA_LED_E1S_2_ATTN_R};
+static uint8_t els_amber_led_gpio_opb[MAX_E1S_IDX] = { OPB_LED_E1S_0_ATTN_R, OPB_LED_E1S_1_ATTN_R,
+	OPB_LED_E1S_2_ATTN_R, OPB_LED_E1S_3_ATTN_R, OPB_LED_E1S_4_ATTN_R};
 
 #define E1S_LED_BLINK_INIT(device)                                                                 \
 	void blink_handler_##device(struct k_timer *timer)                                         \
@@ -51,30 +55,11 @@ E1S_LED_BLINK_INIT(4);
 
 uint8_t get_e1s_led_gpio(uint8_t device_id)
 {
-	uint8_t gpio_num = UNKNOWN_LED_GPIO;
-
-	switch (device_id) {
-	case E1S_0:
-		gpio_num = OPA_LED_E1S_0_ATTN_R;
-		break;
-	case E1S_1:
-		gpio_num = OPA_LED_E1S_1_ATTN_R;
-		break;
-	case E1S_2:
-		gpio_num = OPA_LED_E1S_2_ATTN_R;
-		break;
-	case E1S_3:
-		gpio_num = OPB_LED_E1S_3_ATTN_R;
-		break;
-	case E1S_4:
-		gpio_num = OPB_LED_E1S_4_ATTN_R;
-		break;
-	default:
-		gpio_num = UNKNOWN_LED_GPIO;
-		break;
+	if (get_card_type() == CARD_TYPE_OPA) {
+		return els_amber_led_gpio_opa[device_id];
+	} else {
+		return els_amber_led_gpio_opb[device_id];
 	}
-
-	return gpio_num;
 }
 
 struct k_timer *get_e1s_led_timer(uint8_t device_id)

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.c
@@ -54,86 +54,40 @@ sensor_cfg plat_sensor_config[] = {
     */
 
 	//INA233 VOL
-	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
-	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
-
-	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
-	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[1] },
-
-	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
-	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[2] },
-
 	{ SENSOR_NUM_1OU_P12V_EDGE_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
 	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[5] },
 
 	//INA233 CURR
-	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
-	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
-
-	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
-	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[1] },
-
-	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
-	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[2] },
-
 	{ SENSOR_NUM_1OU_P12V_EDGE_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
 	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[5] },
 
 	//INA233 PWR
-	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
-	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[0] },
-
-	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
-	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[1] },
-
-	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
-	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &ina233_init_args[2] },
-
 	{ SENSOR_NUM_1OU_P12V_EDGE_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
 	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[5] },
+};
+sensor_cfg plat_expansion_A_sensor_config[] = {
 
 	//E1S Temp
 	{ SENSOR_NUM_1OU_E1S_SSD0_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
 	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[0], post_i2c_bus_read,
-	  &i2c_proc_args[0], NULL },
+	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[5], post_i2c_bus_read,
+	  &i2c_proc_args[5], NULL },
 
 	{ SENSOR_NUM_1OU_E1S_SSD1_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
 	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[1], post_i2c_bus_read,
 	  &i2c_proc_args[1], NULL },
-};
-sensor_cfg plat_expansion_A_sensor_config[] = {
 
-	//E1S Temp
 	{ SENSOR_NUM_1OU_E1S_SSD2_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
 	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[5], post_i2c_bus_read,
-	  &i2c_proc_args[5], NULL },
+	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[0], post_i2c_bus_read,
+	  &i2c_proc_args[0], NULL },
 
 	//Temp
 	{ SENSOR_NUM_1OU_TEMP, sensor_dev_tmp75, I2C_BUS4, TMP75_EXPA_TEMP_ADDR, TMP75_TEMP_OFFSET,
@@ -151,7 +105,7 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 	  2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE,
+	{ SENSOR_NUM_1OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
@@ -159,7 +113,7 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_E1S_SSD2_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE,
+	{ SENSOR_NUM_1OU_E1S_SSD2_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
@@ -174,11 +128,70 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 	{ SENSOR_NUM_1OU_P1V2_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT8, NONE, NONE, dc_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+
+	//INA233 VOL
+	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
+	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[0] },
+
+	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
+	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[1] },
+
+	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
+	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[2] },
+
+	//INA233 CURR
+	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
+	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[0] },
+
+	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
+	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[1] },
+
+	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
+	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[2] },
+
+	//INA233 PWR
+	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
+	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[0] },
+
+	{ SENSOR_NUM_1OU_E1S_SSD1_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_1_ADDR,
+	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[1] },
+
+	{ SENSOR_NUM_1OU_E1S_SSD2_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_2_ADDR,
+	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[2] },
+
 };
 
 sensor_cfg plat_expansion_B_sensor_config[] = {
 
 	//E1S Temp
+	{ SENSOR_NUM_2OU_E1S_SSD0_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
+	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[4], post_i2c_bus_read,
+	  &i2c_proc_args[4], NULL },
+
+	{ SENSOR_NUM_2OU_E1S_SSD1_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
+	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[3], post_i2c_bus_read,
+	  &i2c_proc_args[3], NULL },
+
 	{ SENSOR_NUM_2OU_E1S_SSD2_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
 	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[2], post_i2c_bus_read,
@@ -186,13 +199,13 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 
 	{ SENSOR_NUM_2OU_E1S_SSD3_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
 	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[3], post_i2c_bus_read,
-	  &i2c_proc_args[3], NULL },
+	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[1], post_i2c_bus_read,
+	  &i2c_proc_args[1], NULL },
 
 	{ SENSOR_NUM_2OU_E1S_SSD4_TEMP_C, sensor_dev_nvme, I2C_BUS2, NVME_ADDR, NVME_TEMP_OFFSET,
 	  e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[4], post_i2c_bus_read,
-	  &i2c_proc_args[4], NULL },
+	  SENSOR_INIT_STATUS, pre_i2c_bus_read, &i2c_proc_args[0], post_i2c_bus_read,
+	  &i2c_proc_args[0], NULL },
 
 	//Temp
 	{ SENSOR_NUM_2OU_TEMP, sensor_dev_tmp75, I2C_BUS4, TMP75_EXPB_TEMP_ADDR, TMP75_TEMP_OFFSET,
@@ -200,11 +213,11 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
 	//adc
-	{ SENSOR_NUM_2OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE,
+	{ SENSOR_NUM_2OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT4, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_2OU_E1S_SSD1_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE,
+	{ SENSOR_NUM_2OU_E1S_SSD1_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT3, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
@@ -212,11 +225,11 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_2OU_E1S_SSD3_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT3, NONE, NONE,
+	{ SENSOR_NUM_2OU_E1S_SSD3_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	{ SENSOR_NUM_2OU_E1S_SSD4_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT4, NONE, NONE,
+	{ SENSOR_NUM_2OU_E1S_SSD4_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
@@ -233,6 +246,21 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
 	//INA233 VOL
+	{ SENSOR_NUM_2OU_E1S_SSD0_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_0_ADDR,
+	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[0] },
+
+	{ SENSOR_NUM_2OU_E1S_SSD1_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_1_ADDR,
+	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[1] },
+
+	{ SENSOR_NUM_2OU_E1S_SSD2_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_2_ADDR,
+	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[2] },
+
 	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
 	  INA233_VOLT_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
@@ -244,6 +272,21 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 	  &ina233_init_args[4] },
 
 	//INA233 CURR
+	{ SENSOR_NUM_2OU_E1S_SSD0_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_0_ADDR,
+	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[0] },
+
+	{ SENSOR_NUM_2OU_E1S_SSD1_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_1_ADDR,
+	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[1] },
+
+	{ SENSOR_NUM_2OU_E1S_SSD2_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_2_ADDR,
+	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[2] },
+
 	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
 	  INA233_CURR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
@@ -255,6 +298,21 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 	  &ina233_init_args[4] },
 
 	//INA233 PWR
+	{ SENSOR_NUM_2OU_E1S_SSD0_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_0_ADDR,
+	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[0] },
+
+	{ SENSOR_NUM_2OU_E1S_SSD1_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_1_ADDR,
+	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[1] },
+
+	{ SENSOR_NUM_2OU_E1S_SSD2_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_2_ADDR,
+	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &ina233_init_args[2] },
+
 	{ SENSOR_NUM_2OU_E1S_SSD3_P12V_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_3_ADDR,
 	  INA233_PWR_OFFSET, e1s_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
@@ -267,6 +325,13 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 };
 
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
+const static uint8_t ina233_addr_opa[] = {INA233_EXPA_E1S_0_ADDR, INA233_EXPA_E1S_1_ADDR,
+	INA233_EXPA_E1S_2_ADDR};
+const static uint8_t ina233_addr_opb[] = {INA233_EXPB_E1S_0_ADDR, INA233_EXPB_E1S_1_ADDR,
+	INA233_EXPB_E1S_2_ADDR, INA233_EXPB_E1S_3_ADDR, INA233_EXPB_E1S_4_ADDR};
+const static uint8_t e1s_adc_channel_opa[] = {ADC_PORT2, ADC_PORT1, ADC_PORT0};
+const static uint8_t e1s_adc_channel_opb[] = {ADC_PORT4, ADC_PORT3, ADC_PORT2,
+	ADC_PORT1, ADC_PORT0};
 
 void load_sensor_config(void)
 {
@@ -487,39 +552,25 @@ bool e1s_access(uint8_t sensor_num)
 	uint8_t e1s_index = 0xff;
 	uint8_t card_type = get_card_type();
 	i2c_proc_arg *nvme_i2c_mux = NULL;
+	int i = 0;
 
 	switch (sensor_cfgs->type) {
 	case sensor_dev_ina233:
 	case sensor_dev_sq52205:
-		switch (sensor_cfgs->target_addr) {
-		case INA233_EXPA_E1S_0_ADDR:
-		case INA233_EXPB_E1S_0_ADDR:
-			e1s_index = 0;
-			break;
-		case INA233_EXPA_E1S_1_ADDR:
-			//check the card type because address is the same as INA233_EXPB_E1S_2_ADDR
-			if (card_type == CARD_TYPE_OPA) {
-				e1s_index = 1;
-			} else {
-				e1s_index = 2;
+		if (card_type == CARD_TYPE_OPA) {
+			for (i = 0; i < sizeof(ina233_addr_opa); i++) {
+				if (ina233_addr_opa[i] == sensor_cfgs->target_addr) {
+					e1s_index = i;
+					break;
+				}
 			}
-			break;
-		case INA233_EXPA_E1S_2_ADDR:
-			//check the card type because address is the same as INA233_EXPB_E1S_4_ADDR
-			if (card_type == CARD_TYPE_OPA) {
-				e1s_index = 2;
-			} else {
-				e1s_index = 4;
+		} else {
+			for (i = 0; i < sizeof(ina233_addr_opb); i++) {
+				if (ina233_addr_opb[i] == sensor_cfgs->target_addr) {
+					e1s_index = i;
+					break;
+				}
 			}
-			break;
-		case INA233_EXPB_E1S_1_ADDR:
-			e1s_index = 1;
-			break;
-		case INA233_EXPB_E1S_3_ADDR:
-			e1s_index = 3;
-			break;
-		default:
-			break;
 		}
 		break;
 	case sensor_dev_nvme:
@@ -527,40 +578,42 @@ bool e1s_access(uint8_t sensor_num)
 		/* For OPA expansion, the I3C HUB connect slave port-0/1/5.
 		 * For OPB expansion, the I3C HUB connect slave port-0/1/2/3/4.
 		 */
-		switch (nvme_i2c_mux->channel) {
-		case I2C_HUB_CHANNEL_0:
-			// i2c hub channel 0 connect to E1S 0
-			e1s_index = 0;
-			break;
-		case I2C_HUB_CHANNEL_1:
-			// i2c hub channel 1 connect to E1S 1
-			e1s_index = 1;
-			break;
-		case I2C_HUB_CHANNEL_2:
-		case I2C_HUB_CHANNEL_5:
-			// i2c hub channel 5 connect to E1S 2 on opa
-			// i2c hub channel 2 connect to E1S 2 on opb
-			e1s_index = 2;
-			break;
-		case I2C_HUB_CHANNEL_3:
-			// i2c hub channel 3 connect to E1S 3
-			e1s_index = 3;
-			break;
-		case I2C_HUB_CHANNEL_4:
-			// i2c hub channel 4 connect to E1S 4
-			e1s_index = 4;
-			break;
-		default:
-			break;
+		if (card_type == CARD_TYPE_OPA) {
+			for (i = 0; i < sizeof(e1s_mux_channel_opa); i++) {
+				if (e1s_mux_channel_opa[i] == nvme_i2c_mux->channel) {
+					e1s_index = i;
+					break;
+				}
+			}
+		} else {
+			for (i = 0; i < sizeof(e1s_mux_channel_opb); i++) {
+				if (e1s_mux_channel_opb[i] == nvme_i2c_mux->channel) {
+					e1s_index = i;
+					break;
+				}
+			}
 		}
 		break;
 	case sensor_dev_ast_adc:
-		e1s_index = sensor_cfgs->port;
+		if (card_type == CARD_TYPE_OPA) {
+			for (i = 0; i < sizeof(e1s_adc_channel_opa); i++) {
+				if (e1s_adc_channel_opa[i] == sensor_cfgs->port) {
+					e1s_index = i;
+					break;
+				}
+			}
+		} else {
+			for (i = 0; i < sizeof(e1s_adc_channel_opb); i++) {
+				if (e1s_adc_channel_opb[i] == sensor_cfgs->port) {
+					e1s_index = i;
+					break;
+				}
+			}
+		}
 		break;
 	default:
 		LOG_ERR("Unsupported sensor device for e1s checking.");
 		break;
 	}
-
 	return get_e1s_present(e1s_index) && get_DC_on_delayed_status();
 }

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.h
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -26,15 +26,15 @@
 #define EXPA_RETIMER_ADDR (0x46 >> 1)
 #define TMP75_EXPA_TEMP_ADDR (0x94 >> 1)
 #define TMP75_EXPB_TEMP_ADDR (0x9A >> 1)
-#define INA233_EXPA_E1S_0_ADDR (0x8C >> 1)
+#define INA233_EXPA_E1S_0_ADDR (0x98 >> 1)
 #define INA233_EXPA_E1S_1_ADDR (0x88 >> 1)
-#define INA233_EXPA_E1S_2_ADDR (0x98 >> 1)
+#define INA233_EXPA_E1S_2_ADDR (0x8C >> 1)
 #define INA233_EXPA_MAIN_ADDR (0x9A >> 1)
-#define INA233_EXPB_E1S_0_ADDR (0x8A >> 1)
-#define INA233_EXPB_E1S_1_ADDR (0x82 >> 1)
+#define INA233_EXPB_E1S_0_ADDR (0x98 >> 1)
+#define INA233_EXPB_E1S_1_ADDR (0x92 >> 1)
 #define INA233_EXPB_E1S_2_ADDR (0x88 >> 1)
-#define INA233_EXPB_E1S_3_ADDR (0x92 >> 1)
-#define INA233_EXPB_E1S_4_ADDR (0x98 >> 1)
+#define INA233_EXPB_E1S_3_ADDR (0x82 >> 1)
+#define INA233_EXPB_E1S_4_ADDR (0x8A >> 1)
 #define INA233_EXPB_MAIN_ADDR (0x90 >> 1)
 #define NVME_ADDR (0xD4 >> 1)
 


### PR DESCRIPTION
# Description
Revise E1.S device number and block invalid device.

# Motivation
To match the mechanical label.

# Test plan
Build and test pass on Olympic 2.0 system.
1. Power control and check power LED for each E1.S
2. LED control and check power LED for each E1.S
3. Sensor monitor works normal root@bmc-oob:~# sensor-util slot1 | grep -i ssd
MB_SSD0_M2A_TEMP_C           (0xD) :   25.00 C     | (ok)
1OU_E1S_SSD0_P12V_VOLT_V     (0x41) :   12.48 Volts  | (ok)
1OU_E1S_SSD1_P12V_VOLT_V     (0x42) :   12.48 Volts  | (ok)
1OU_E1S_SSD2_P12V_VOLT_V     (0x43) :   12.51 Volts  | (ok)
1OU_E1S_ADC_SSD0_P3V3_VOLT_V (0x47) :    3.34 Volts  | (ok)
1OU_E1S_ADC_SSD1_P3V3_VOLT_V (0x48) :    3.32 Volts  | (ok)
1OU_E1S_ADC_SSD2_P3V3_VOLT_V (0x49) :    3.33 Volts  | (ok)
1OU_E1S_SSD0_P12V_CURR_A     (0x50) :    0.28 Amps  | (ok)
1OU_E1S_SSD1_P12V_CURR_A     (0x51) :    0.28 Amps  | (ok)
1OU_E1S_SSD2_P12V_CURR_A     (0x52) :    0.29 Amps  | (ok)
1OU_E1S_SSD0_P12V_PWR_W      (0x56) :    3.45 Watts  | (ok)
1OU_E1S_SSD1_P12V_PWR_W      (0x57) :    3.40 Watts  | (ok)
1OU_E1S_SSD2_P12V_PWR_W      (0x58) :    3.60 Watts  | (ok)
1OU_E1S_SSD0_TEMP_C          (0x5C) :   30.00 C     | (ok)
1OU_E1S_SSD1_TEMP_C          (0x5D) :   30.00 C     | (ok)
1OU_E1S_SSD2_TEMP_C          (0x5E) :   29.00 C     | (ok)
2OU_E1S_SSD0_P12V_VOLT_V     (0x71) :   12.49 Volts  | (ok)
2OU_E1S_SSD1_P12V_VOLT_V     (0x72) :   12.53 Volts  | (ok)
2OU_E1S_SSD2_P12V_VOLT_V     (0x73) :   12.50 Volts  | (ok)
2OU_E1S_SSD3_P12V_VOLT_V     (0x74) :   12.51 Volts  | (ok)
2OU_E1S_SSD4_P12V_VOLT_V     (0x75) :   12.48 Volts  | (ok)
2OU_E1S_ADC_SSD0_P3V3_VOLT_V (0x77) :    3.28 Volts  | (ok)
2OU_E1S_ADC_SSD1_P3V3_VOLT_V (0x78) :    3.28 Volts  | (ok)
2OU_E1S_ADC_SSD2_P3V3_VOLT_V (0x79) :    3.28 Volts  | (ok)
2OU_E1S_ADC_SSD3_P3V3_VOLT_V (0x7A) :    3.28 Volts  | (ok)
2OU_E1S_ADC_SSD4_P3V3_VOLT_V (0x7B) :    3.27 Volts  | (ok)
2OU_E1S_SSD0_P12V_CURR_A     (0x80) :    0.27 Amps  | (ok)
2OU_E1S_SSD1_P12V_CURR_A     (0x81) :    0.28 Amps  | (ok)
2OU_E1S_SSD2_P12V_CURR_A     (0x82) :    0.27 Amps  | (ok)
2OU_E1S_SSD3_P12V_CURR_A     (0x83) :    0.28 Amps  | (ok)
2OU_E1S_SSD4_P12V_CURR_A     (0x84) :    0.27 Amps  | (ok)
2OU_E1S_SSD0_P12V_PWR_W      (0x86) :    3.40 Watts  | (ok)
2OU_E1S_SSD1_P12V_PWR_W      (0x87) :    3.58 Watts  | (ok)
2OU_E1S_SSD2_P12V_PWR_W      (0x88) :    3.40 Watts  | (ok)
2OU_E1S_SSD3_P12V_PWR_W      (0x89) :    3.47 Watts  | (ok)
2OU_E1S_SSD4_P12V_PWR_W      (0x8A) :    3.35 Watts  | (ok)
2OU_E1S_SSD0_TEMP_C          (0x8C) :   30.00 C     | (ok)
2OU_E1S_SSD1_TEMP_C          (0x8D) :   30.00 C     | (ok)
2OU_E1S_SSD2_TEMP_C          (0x8E) :   30.00 C     | (ok)
2OU_E1S_SSD3_TEMP_C          (0x8F) :   29.00 C     | (ok)
2OU_E1S_SSD4_TEMP_C          (0x90) :   29.00 C     | (ok)
3OU_E1S_SSD0_P12V_VOLT_V     (0xA1) :   12.50 Volts  | (ok)
3OU_E1S_SSD1_P12V_VOLT_V     (0xA2) :   12.48 Volts  | (ok)
3OU_E1S_SSD2_P12V_VOLT_V     (0xA3) :   12.48 Volts  | (ok)
3OU_E1S_ADC_SSD0_P3V3_VOLT_V (0xA7) :    3.34 Volts  | (ok)
3OU_E1S_ADC_SSD1_P3V3_VOLT_V (0xA8) :    3.33 Volts  | (ok)
3OU_E1S_ADC_SSD2_P3V3_VOLT_V (0xA9) :    3.33 Volts  | (ok)
3OU_E1S_SSD0_P12V_CURR_A     (0xB0) :    0.28 Amps  | (ok)
3OU_E1S_SSD1_P12V_CURR_A     (0xB1) :    0.28 Amps  | (ok)
3OU_E1S_SSD2_P12V_CURR_A     (0xB2) :    0.27 Amps  | (ok)
3OU_E1S_SSD0_P12V_PWR_W      (0xB6) :    3.45 Watts  | (ok)
3OU_E1S_SSD1_P12V_PWR_W      (0xB7) :    3.47 Watts  | (ok)
3OU_E1S_SSD2_P12V_PWR_W      (0xB8) :    3.35 Watts  | (ok)
3OU_E1S_SSD0_TEMP_C          (0xBC) :   30.00 C     | (ok)
3OU_E1S_SSD1_TEMP_C          (0xBD) :   30.00 C     | (ok)
3OU_E1S_SSD2_TEMP_C          (0xBE) :   30.00 C     | (ok)
4OU_E1S_SSD0_P12V_VOLT_V     (0xD1) :   12.52 Volts  | (ok)
4OU_E1S_SSD1_P12V_VOLT_V     (0xD2) :   12.52 Volts  | (ok)
4OU_E1S_SSD2_P12V_VOLT_V     (0xD3) :   12.49 Volts  | (ok)
4OU_E1S_SSD3_P12V_VOLT_V     (0xD4) :   12.50 Volts  | (ok)
4OU_E1S_SSD4_P12V_VOLT_V     (0xD5) :   12.53 Volts  | (ok)
4OU_E1S_ADC_SSD0_P3V3_VOLT_V (0xD7) :    3.32 Volts  | (ok)
4OU_E1S_ADC_SSD1_P3V3_VOLT_V (0xD8) :    3.33 Volts  | (ok)
4OU_E1S_ADC_SSD2_P3V3_VOLT_V (0xD9) :    3.33 Volts  | (ok)
4OU_E1S_ADC_SSD3_P3V3_VOLT_V (0xDA) :    3.33 Volts  | (ok)
4OU_E1S_ADC_SSD4_P3V3_VOLT_V (0xDB) :    3.32 Volts  | (ok)
4OU_E1S_SSD0_P12V_CURR_A     (0xE0) :    0.32 Amps  | (ok)
4OU_E1S_SSD1_P12V_CURR_A     (0xE1) :    0.26 Amps  | (ok)
4OU_E1S_SSD2_P12V_CURR_A     (0xE2) :    0.27 Amps  | (ok)
4OU_E1S_SSD3_P12V_CURR_A     (0xE3) :    0.33 Amps  | (ok)
4OU_E1S_SSD4_P12V_CURR_A     (0xE4) :    0.28 Amps  | (ok)
4OU_E1S_SSD0_P12V_PWR_W      (0xE6) :    4.03 Watts  | (ok)
4OU_E1S_SSD1_P12V_PWR_W      (0xE7) :    3.35 Watts  | (ok)
4OU_E1S_SSD2_P12V_PWR_W      (0xE8) :    3.40 Watts  | (ok)
4OU_E1S_SSD3_P12V_PWR_W      (0xE9) :    3.92 Watts  | (ok)
4OU_E1S_SSD4_P12V_PWR_W      (0xEA) :    3.58 Watts  | (ok)
4OU_E1S_SSD0_TEMP_C          (0xEC) :   30.00 C     | (ok)
4OU_E1S_SSD1_TEMP_C          (0xED) :   30.00 C     | (ok)
4OU_E1S_SSD2_TEMP_C          (0xEE) :   30.00 C     | (ok)
4OU_E1S_SSD3_TEMP_C          (0xEF) :   28.00 C     | (ok)
4OU_E1S_SSD4_TEMP_C          (0xF0) :   30.00 C     | (ok)