### PR TITLE
fby3.5: cl: avoid ADC7 floating when not used

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.c
@@ -170,6 +170,21 @@ void init_hsc_module(uint8_t board_revision)
 		case SYS_BOARD_PVT_EFUSE:
 		case SYS_BOARD_MP_EFUSE:
 			hsc_module = HSC_MODULE_MP5990;
+			uint32_t read_value = 0;
+			// Disable ADC channel 7: ADC000[23]
+			read_value = sys_read32(REG_ADC_BASE + 0x000);
+			read_value = CLEARBIT(read_value, 23);
+			sys_write32(read_value, REG_ADC_BASE + 0x000);
+
+			// Multi-function pin ctl #5: SCU430[31] is GPIT7
+			read_value = sys_read32(REG_SCU + 0x430);
+			read_value = SETBIT(read_value, 31);
+			sys_write32(read_value, REG_SCU + 0x430);
+
+			// Enable internal PD
+			read_value = sys_read32(REG_SCU + 0x630);
+			read_value = CLEARBIT(read_value, 31);
+			sys_write32(read_value, REG_SCU + 0x630);
 			break;
 		case SYS_BOARD_EVT3_HOTSWAP:
 		case SYS_BOARD_DVT_HOTSWAP:


### PR DESCRIPTION
# Description
Disable ADC7 and internal pull down to avoid floating.

# Motivation
ADC7(HSC_TYPE_ADC) is not used on CL-B(efuse).

# Test plan
Build and test pass on fby35 system.
1. Get HSC sensor reading root@bmc-oob:~# sensor-util slot1 | grep -i hsc
MB_HSC_TEMP_C                (0xE) :   48.00 C     | (ok)
MB_HSC_INPUT_VOLT_V          (0x29) :   12.44 Volts  | (ok)
MB_HSC_OUTPUT_CURR_A         (0x30) :    6.00 Amps  | (ok)
MB_HSC_INPUT_PWR_W           (0x39) :   68.00 Watts  | (ok)

2. Read the registers md 0x7e6e9000

[7e6e9000] 007f010f 000000ff 00000000 00000008
[7e6e9010] 0003030c 01b202ad 00030015 024d02ca
[7e6e9020] 00000000 00000000 00000000 00000000
[7e6e9030] 00000000 00000000 00000000 00000000

uart:~$ md 0x7e6e2430

[7e6e2430] 80060c00 00ff0000 00003800 000000ff
[7e6e2440] 00000000 00000000 00000000 00000000
[7e6e2450] 0000a000 00000000 00000500 00000000
[7e6e2460] 00000000 00000000 00000000 00000000

uart:~$ md 0x7e6e2630

[7e6e2630] 7f000000 000000ff 000f0000 00000000
[7e6e2640] 00000000 00000000 00000000 00000000
[7e6e2650] 00000011 00000000 00000000 00000000
[7e6e2660] 00000000 00000000 00000000 00000000