### PR TITLE
GT: Change i2c base clock for tBuf issues with BMC

### DIFF
--- a/meta-facebook/gt-cc/boards/ast1030_evb.overlay
+++ b/meta-facebook/gt-cc/boards/ast1030_evb.overlay
@@ -29,6 +29,9 @@
   clock-frequency = <I2C_BITRATE_FAST>;
 };
 
+&i2c_gr {
+    clk-divider = <0x62220E02>;
+};
 &i2c1 {
 	pinctrl-0 = <&pinctrl_i2c1_default>;
 	status = "okay";


### PR DESCRIPTION
Summary:
- Change the base clock for tBuf to match BMC to avoid abnormal stops on I2C sometimes on the BMC side.
- Change i2c 400 KHz base clock to 6.25 MHz with 0.16 us every tick and tBuf is 2.56 us (0.16 * 16).
- Change i2c 1 MHz base clock to 25 MHz with 0.04 us every tick and tBuf is 0.64 us (0.04 * 16).

Test Plan:
- Build code: Pass