### PR TITLE
YV3: dl: Add SRAM size in overlay

### DIFF
--- a/meta-facebook/yv3-dl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv3-dl/boards/ast1030_evb.overlay
@@ -238,5 +238,5 @@
 };
 
 &sram0 {
-	reg = <0 DT_SIZE_K(512)>, <0x80000 DT_SIZE_K(256)>;
+	reg = <0 DT_SIZE_K(576)>, <DT_SIZE_K(576) DT_SIZE_K(192)>;
 };


### PR DESCRIPTION
# Description
- Set the SRAM size in overlay file(SRAM NC 192 KB and SRAM 576 KB).

# Motivaion
- The size of SRAM is not enough.

# Test Plan
- Build code: Pass

Log:
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:       12704 B       192 KB      6.46%
           FLASH:          0 GB         0 GB
            SRAM:      523904 B       576 KB     88.82%
        IDT_LIST:          0 GB         2 KB      0.00%