### PR TITLE
fby3.5: gl: Check DIMM presence status before read DIMM sensors

### DIFF
--- a/common/service/host/kcs.c
+++ b/common/service/host/kcs.c
@@ -136,6 +136,14 @@ static void kcs_read_task(void *arvg0, void *arvg1, void *arvg2)
 					LOG_ERR("Record bios fw version fail");
 				}
 			}
+			if ((req->netfn == NETFN_OEM_Q_REQ) &&
+			    (req->cmd == CMD_OEM_Q_SET_DIMM_INFO) &&
+			    (req->data[4] == CMD_DIMM_LOCATION)) {
+				int ret = pal_set_dimm_presence_status(ibuf);
+				if (!ret) {
+					LOG_ERR("Set dimm presence status fail");
+				}
+			}
 			bridge_msg.data_len = rc - 2; // exclude netfn, cmd
 			bridge_msg.seq_source = 0xff; // No seq for KCS
 			bridge_msg.InF_source = HOST_KCS_1 + kcs_inst->index;

--- a/common/service/host/kcs.h
+++ b/common/service/host/kcs.h
@@ -29,6 +29,7 @@
 #define KCS_MAX_CHANNEL_NUM 0x0F
 
 #define CMD_SYS_INFO_FW_VERSION 0x01
+#define CMD_DIMM_LOCATION 0x01
 #define KCS_TASK_NAME_LEN 32
 
 typedef struct _kcs_dev {

--- a/common/service/ipmi/include/ipmi.h
+++ b/common/service/ipmi/include/ipmi.h
@@ -70,6 +70,8 @@ static inline void pack_ipmi_resp(struct ipmi_response *resp, ipmi_msg *ipmi_res
 	}
 }
 
+// If command is from KCS, we need to check dimm presnece status
+bool pal_set_dimm_presence_status(uint8_t *buf);
 // If command is from KCS, we need to check whether BIC support this command.
 bool pal_request_msg_to_BIC_from_HOST(uint8_t netfn, uint8_t cmd);
 // If command is from KCS, we need to check whether BIC responds immediately.
@@ -197,6 +199,12 @@ enum {
 	CMD_OEM_GET_MB_INDEX = 0xF0,
 	CMD_OEM_SET_FAN_DUTY_MANUAL = 0xF1,
 	CMD_OEM_GET_SET_FAN_CTRL_MODE = 0xF2,
+};
+
+// OEM Q Command Codes (0x36)
+enum {
+	CMD_OEM_Q_SET_DIMM_INFO = 0x12,
+	CMD_OEM_Q_GET_DIMM_INFO = 0x13,
 };
 
 // OEM 1S Command Codes (0x38)

--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -158,6 +158,11 @@ static uint8_t send_msg_by_pldm(ipmi_msg_cfg *msg_cfg)
 	return 1;
 }
 
+__weak bool pal_set_dimm_presence_status(uint8_t *buf)
+{
+	return false;
+}
+
 __weak bool pal_request_msg_to_BIC_from_HOST(uint8_t netfn, uint8_t cmd)
 {
 	if (netfn == NETFN_OEM_1S_REQ) {

--- a/meta-facebook/yv35-gl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-gl/src/ipmi/plat_ipmi.c
@@ -24,8 +24,26 @@
 #include "plat_class.h"
 #include "plat_ipmb.h"
 #include <logging/log.h>
+#include "plat_dimm.h"
 
 LOG_MODULE_REGISTER(plat_ipmi);
+
+bool pal_set_dimm_presence_status(uint8_t *buf)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, -1);
+
+	uint8_t dimm_index = buf[DIMM_INDEX_BYTE];
+	uint8_t status = buf[DIMM_STATUS_BYTE];
+
+	if (dimm_index < DIMM_INDEX_MIN || dimm_index > DIMM_INDEX_MAX) {
+		LOG_ERR("DIMM index is out of range");
+		return false;
+	}
+
+	set_dimm_presence_status(dimm_index, status);
+
+	return true;
+}
 
 void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
 {

--- a/meta-facebook/yv35-gl/src/platform/plat_dimm.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_dimm.c
@@ -1,0 +1,106 @@
+#include "plat_dimm.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <zephyr.h>
+#include <logging/log.h>
+#include <errno.h>
+#include "plat_sensor_table.h"
+#include "ipmb.h"
+#include "ipmi.h"
+#include "kcs.h"
+
+LOG_MODULE_REGISTER(plat_dimm);
+
+bool dimm_presence[MAX_COUNT_DIMM];
+static bool dimm_inited = false;
+
+bool is_dimm_inited()
+{
+	return dimm_inited;
+}
+
+void init_dimm_status()
+{
+	int index;
+	for (index = DIMM_ID_A; index < MAX_COUNT_DIMM; index++) {
+		ipmi_msg msg = { 0 };
+
+		msg.InF_source = SELF;
+		msg.InF_target = BMC_IPMB;
+		msg.netfn = NETFN_OEM_Q_REQ;
+		msg.cmd = CMD_OEM_Q_GET_DIMM_INFO;
+		msg.data_len = 5;
+		msg.data[0] = IANA_ID & 0xFF;
+		msg.data[1] = (IANA_ID >> 8) & 0xFF;
+		msg.data[2] = (IANA_ID >> 16) & 0xFF;
+		msg.data[3] = (uint8_t)index;
+		msg.data[4] = CMD_DIMM_LOCATION;
+
+		ipmb_error ret = ipmb_read(&msg, IPMB_inf_index_map[msg.InF_target]);
+		if (ret != IPMB_ERROR_SUCCESS) {
+			LOG_ERR("Failed to get DIMM status, ret %d", ret);
+			return;
+		}
+
+		uint8_t status = msg.data[0];
+		if (status == DIMM_PRESENT) {
+			dimm_presence[index] = true;
+		} else {
+			dimm_presence[index] = false;
+		}
+	}
+
+	dimm_inited = true;
+}
+
+bool get_dimm_presence_status(uint8_t dimm_id)
+{
+	return dimm_presence[dimm_id];
+}
+
+void set_dimm_presence_status(uint8_t index, uint8_t status)
+{
+	if (status == DIMM_PRESENT) {
+		dimm_presence[index] = true;
+	} else {
+		dimm_presence[index] = false;
+	}
+}
+
+uint8_t sensor_num_map_dimm_id(uint8_t sensor_num)
+{
+	uint8_t dimm_id = DIMM_ID_UNKNOWN;
+
+	switch (sensor_num) {
+	case SENSOR_NUM_MB_DIMMA_TEMP_C:
+		dimm_id = DIMM_ID_A;
+		break;
+	case SENSOR_NUM_MB_DIMMB_TEMP_C:
+		dimm_id = DIMM_ID_B;
+		break;
+	case SENSOR_NUM_MB_DIMMC_TEMP_C:
+		dimm_id = DIMM_ID_C;
+		break;
+	case SENSOR_NUM_MB_DIMMD_TEMP_C:
+		dimm_id = DIMM_ID_D;
+		break;
+	case SENSOR_NUM_MB_DIMME_TEMP_C:
+		dimm_id = DIMM_ID_E;
+		break;
+	case SENSOR_NUM_MB_DIMMF_TEMP_C:
+		dimm_id = DIMM_ID_F;
+		break;
+	case SENSOR_NUM_MB_DIMMG_TEMP_C:
+		dimm_id = DIMM_ID_G;
+		break;
+	case SENSOR_NUM_MB_DIMMH_TEMP_C:
+		dimm_id = DIMM_ID_H;
+		break;
+	default:
+		dimm_id = DIMM_ID_UNKNOWN;
+		break;
+	}
+
+	return dimm_id;
+}

--- a/meta-facebook/yv35-gl/src/platform/plat_dimm.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_dimm.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_DIMM_H
+#define PLAT_DIMM_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define MAX_COUNT_DIMM 8
+#define DIMM_INDEX_BYTE 5
+#define DIMM_STATUS_BYTE 7
+#define DIMM_INDEX_MIN 0
+#define DIMM_INDEX_MAX 7
+#define DIMM_PRESENT 0x1
+
+enum DIMM_ID {
+	DIMM_ID_A = 0,
+	DIMM_ID_B,
+	DIMM_ID_C,
+	DIMM_ID_D,
+	DIMM_ID_E,
+	DIMM_ID_F,
+	DIMM_ID_G,
+	DIMM_ID_H,
+	DIMM_ID_UNKNOWN = 0xff,
+};
+
+bool is_dimm_inited();
+void init_dimm_status();
+bool get_dimm_presence_status(uint8_t dimm_id);
+void set_dimm_presence_status(uint8_t index, uint8_t status);
+uint8_t sensor_num_map_dimm_id(uint8_t sensor_num);
+
+#endif

--- a/meta-facebook/yv35-gl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_init.c
@@ -21,6 +21,7 @@
 #include "plat_class.h"
 #include "plat_gpio.h"
 #include "plat_kcs.h"
+#include "plat_dimm.h"
 
 /*
  * The operating voltage of GPIO input pins are lower than actual voltage because the chip 
@@ -67,6 +68,11 @@ void pal_set_sys_status()
 	set_CPU_power_status(PWRGD_CPU_LVC3);
 	set_post_thread();
 	set_sys_ready_pin(BIC_READY);
+}
+
+void pal_device_init()
+{
+	init_dimm_status();
 }
 
 #define DEF_PROJ_GPIO_PRIORITY 78


### PR DESCRIPTION
# Description:
Check DIMM presence status before read DIMM sensors

# Motivation:
BIC can avoid to read empty DIMM

# Test Plan:
1. Host power cycle and check sensor values and status before and after POST complete - pass
2. Host power reset and check sensor values and status before and after POST complete - pass
3. Host power graceful shutdown then on and check sensor values and status before and after POST complete - pass
4. BIC reset and check sensor values and status - pass
5. BIC FW update and check sensor values and status - pass

# Test Log:
1. Host power cycle Before POST complete:
root@bmc-oob:~# log-util slot1 --print
2018 Mar 09 04:39:11 log-util: User cleared FRU: 1 logs
1    slot1    2018-03-09 04:39:39    gpiod            FRU: 1, System powered OFF
1    slot1    2018-03-09 04:39:45    power-util       SERVER_POWER_CYCLE successful for FRU: 1
1    slot1    2018-03-09 04:39:49    gpiod            FRU: 1, System powered ON
root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   24.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   28.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   23.00 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) : NA | (na)
MB_DIMMA_TEMP_C              (0x5) : NA | (na)
MB_DIMMB_TEMP_C              (0x6) : NA | (na)
MB_DIMMC_TEMP_C              (0x7) : NA | (na)
MB_DIMMD_TEMP_C              (0x8) : NA | (na)
MB_DIMME_TEMP_C              (0x9) : NA | (na)
MB_DIMMF_TEMP_C              (0xA) : NA | (na)
MB_DIMMG_TEMP_C              (0xB) : NA | (na)
MB_DIMMH_TEMP_C              (0xC) : NA | (na)
After POST complete:
root@bmc-oob:~# log-util slot1 --print
2018 Mar 09 04:39:11 log-util: User cleared FRU: 1 logs
1    slot1    2018-03-09 04:41:05    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2018-03-09 04:41:05, Sensor: END_OF_POST (0x11), Event Data: (01FFFF) OEM System boot event Assertion
root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   24.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   29.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   23.00 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) :   34.00 C     | (ok)
MB_DIMMA_TEMP_C              (0x5) : NA | (na)
MB_DIMMB_TEMP_C              (0x6) : NA | (na)
MB_DIMMC_TEMP_C              (0x7) : NA | (na)
MB_DIMMD_TEMP_C              (0x8) :   27.00 C     | (ok)
MB_DIMME_TEMP_C              (0x9) : NA | (na)
MB_DIMMF_TEMP_C              (0xA) : NA | (na)
MB_DIMMG_TEMP_C              (0xB) : NA | (na)
MB_DIMMH_TEMP_C              (0xC) :   27.00 C     | (ok)

2. Host power reset Before POST complete:
root@bmc-oob:~# log-util slot1 --print
2018 Mar 09 05:05:59 log-util: User cleared FRU: 1 logs
1    slot1    2018-03-09 05:06:05    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2018-03-09 05:06:05, Sensor: END_OF_POST (0x11), Event Data: (01FFFF) OEM System boot event Deassertion
1    slot1    2018-03-09 05:06:06    power-util       SERVER_POWER_RESET successful for FRU: 1
root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   25.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   30.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   24.00 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) : NA | (na)
MB_DIMMA_TEMP_C              (0x5) : NA | (na)
MB_DIMMB_TEMP_C              (0x6) : NA | (na)
MB_DIMMC_TEMP_C              (0x7) : NA | (na)
MB_DIMMD_TEMP_C              (0x8) : NA | (na)
MB_DIMME_TEMP_C              (0x9) : NA | (na)
MB_DIMMF_TEMP_C              (0xA) : NA | (na)
MB_DIMMG_TEMP_C              (0xB) : NA | (na)
MB_DIMMH_TEMP_C              (0xC) : NA | (na)
After POST complete:
root@bmc-oob:~# log-util slot1 --print
1    slot1    2018-03-09 05:07:10    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2018-03-09 05:07:10, Sensor: END_OF_POST (0x11), Event Data: (01FFFF) OEM System boot event Assertion
root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   25.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   31.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   24.00 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) :   38.00 C     | (ok)
MB_DIMMA_TEMP_C              (0x5) : NA | (na)
MB_DIMMB_TEMP_C              (0x6) : NA | (na)
MB_DIMMC_TEMP_C              (0x7) : NA | (na)
MB_DIMMD_TEMP_C              (0x8) :   28.00 C     | (ok)
MB_DIMME_TEMP_C              (0x9) : NA | (na)
MB_DIMMF_TEMP_C              (0xA) : NA | (na)
MB_DIMMG_TEMP_C              (0xB) : NA | (na)
MB_DIMMH_TEMP_C              (0xC) :   28.00 C     | (ok)

3. Host power graceful shutdown then on Before POST complete:
root@bmc-oob:~# log-util slot1 --print
2018 Mar 09 05:10:02 log-util: User cleared FRU: 1 logs
1    slot1    2018-03-09 05:10:09    power-util       SERVER_GRACEFUL_SHUTDOWN successful for FRU: 1
1    slot1    2018-03-09 05:10:13    gpiod            FRU: 1, System powered OFF
1    slot1    2018-03-09 05:10:23    power-util       SERVER_POWER_ON successful for FRU: 1
1    slot1    2018-03-09 05:10:23    gpiod            FRU: 1, System powered ON
root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   25.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   30.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   24.00 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) : NA | (na)
MB_DIMMA_TEMP_C              (0x5) : NA | (na)
MB_DIMMB_TEMP_C              (0x6) : NA | (na)
MB_DIMMC_TEMP_C              (0x7) : NA | (na)
MB_DIMMD_TEMP_C              (0x8) : NA | (na)
MB_DIMME_TEMP_C              (0x9) : NA | (na)
MB_DIMMF_TEMP_C              (0xA) : NA | (na)
MB_DIMMG_TEMP_C              (0xB) : NA | (na)
MB_DIMMH_TEMP_C              (0xC) : NA | (na)
After POST complete:
root@bmc-oob:~# log-util slot1 --print
1    slot1    2018-03-09 05:11:29    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2018-03-09 05:11:29, Sensor: END_OF_POST (0x11), Event Data: (01FFFF) OEM System boot event Assertion
root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   25.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   31.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   24.00 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) :   38.00 C     | (ok)
MB_DIMMA_TEMP_C              (0x5) : NA | (na)
MB_DIMMB_TEMP_C              (0x6) : NA | (na)
MB_DIMMC_TEMP_C              (0x7) : NA | (na)
MB_DIMMD_TEMP_C              (0x8) :   28.00 C     | (ok)
MB_DIMME_TEMP_C              (0x9) : NA | (na)
MB_DIMMF_TEMP_C              (0xA) : NA | (na)
MB_DIMMG_TEMP_C              (0xB) : NA | (na)
MB_DIMMH_TEMP_C              (0xC) :   28.00 C     | (ok)

4. BIC reset root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   24.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   28.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   23.00 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) :   34.00 C     | (ok)
MB_DIMMA_TEMP_C              (0x5) : NA | (na)
MB_DIMMB_TEMP_C              (0x6) : NA | (na)
MB_DIMMC_TEMP_C              (0x7) : NA | (na)
MB_DIMMD_TEMP_C              (0x8) :   26.00 C     | (ok)
MB_DIMME_TEMP_C              (0x9) : NA | (na)
MB_DIMMF_TEMP_C              (0xA) : NA | (na)
MB_DIMMG_TEMP_C              (0xB) : NA | (na)
MB_DIMMH_TEMP_C              (0xC) :   26.00 C     | (ok)
root@bmc-oob:~# bic-util slot1 --reset
Performing BIC reset, status 0
root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   24.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   28.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   23.00 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) :   34.00 C     | (ok)
MB_DIMMA_TEMP_C              (0x5) : NA | (na)
MB_DIMMB_TEMP_C              (0x6) : NA | (na)
MB_DIMMC_TEMP_C              (0x7) : NA | (na)
MB_DIMMD_TEMP_C              (0x8) :   26.00 C     | (ok)
MB_DIMME_TEMP_C              (0x9) : NA | (na)
MB_DIMMF_TEMP_C              (0xA) : NA | (na)
MB_DIMMG_TEMP_C              (0xB) : NA | (na)
MB_DIMMH_TEMP_C              (0xC) :   26.00 C     | (ok)

5. BIC FW update root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   24.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   29.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   23.00 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) :   34.00 C     | (ok)
MB_DIMMA_TEMP_C              (0x5) : NA | (na)
MB_DIMMB_TEMP_C              (0x6) : NA | (na)
MB_DIMMC_TEMP_C              (0x7) : NA | (na)
MB_DIMMD_TEMP_C              (0x8) :   26.00 C     | (ok)
MB_DIMME_TEMP_C              (0x9) : NA | (na)
MB_DIMMF_TEMP_C              (0xA) : NA | (na)
MB_DIMMG_TEMP_C              (0xB) : NA | (na)
MB_DIMMH_TEMP_C              (0xC) :   26.00 C     | (ok)
root@bmc-oob:~# fw-util slot1 --force --update bic Y35BGL.bin
There is no valid platform signature in image.
slot_id: 1, comp: 2, intf: 0, img: Y35BGL.bin, force: 1
file size = 252852 bytes, slot = 1, intf = 0xff
updating fw on slot 1:
updated bic: 100 %
Elapsed time:  12   sec.

get new SDR cache from BIC
Force upgrade of slot1 : bic succeeded
root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   24.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   28.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   23.00 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) :   34.00 C     | (ok)
MB_DIMMA_TEMP_C              (0x5) : NA | (na)
MB_DIMMB_TEMP_C              (0x6) : NA | (na)
MB_DIMMC_TEMP_C              (0x7) : NA | (na)
MB_DIMMD_TEMP_C              (0x8) :   26.00 C     | (ok)
MB_DIMME_TEMP_C              (0x9) : NA | (na)
MB_DIMMF_TEMP_C              (0xA) : NA | (na)
MB_DIMMG_TEMP_C              (0xB) : NA | (na)
MB_DIMMH_TEMP_C              (0xC) :   26.00 C     | (ok)