### PR TITLE
Common :Remove ESPI Config Setting of GUID CMD

### DIFF
--- a/common/service/ipmi/app_handler.c
+++ b/common/service/ipmi/app_handler.c
@@ -238,11 +238,9 @@ void IPMI_APP_handler(ipmi_msg *msg)
 	case CMD_APP_MASTER_WRITE_READ:
 		APP_MASTER_WRITE_READ(msg);
 		break;
-#ifdef CONFIG_ESPI
 	case CMD_APP_GET_SYSTEM_GUID:
 		APP_GET_SYSTEM_GUID(msg);
 		break;
-#endif
 	default:
 		LOG_ERR("Invalid APP msg netfn: %x, cmd: %x", msg->netfn, msg->cmd);
 		msg->data_len = 0;

--- a/common/service/ipmi/oem_handler.c
+++ b/common/service/ipmi/oem_handler.c
@@ -290,11 +290,11 @@ void IPMI_OEM_handler(ipmi_msg *msg)
 		LOG_DBG("Received NM Sensor Read command");
 		OEM_NM_SENSOR_READ(msg);
 		break;
+#endif
 	case CMD_OEM_SET_SYSTEM_GUID:
 		LOG_DBG("Received Set System GUID command");
 		OEM_SET_SYSTEM_GUID(msg);
 		break;
-#endif
 #ifdef ENABLE_FAN
 	case CMD_OEM_SET_FAN_DUTY_MANUAL:
 		LOG_DBG("Received Set Fan Duty (manual) command");


### PR DESCRIPTION
Summary:
- Remove the CONFIG_ESPI setting of the GUID OEM command.

Test Plan:
- Build code: Pass