### PR TITLE
ol2: op: Support montage pcie retimer update

### DIFF
--- a/common/dev/include/m88rt51632.h
+++ b/common/dev/include/m88rt51632.h
@@ -30,10 +30,17 @@
 #define RETIMER_DATAPORT 0xfff4
 
 #define M88RT51632_TEMP_OFFSET 0x00
+#define M88RT51632_EEPROM_BASE_OFFSET 0x800000
 
 #define MAX_SENSORS 2
 
+#define IMAGE_PACKAGE_SIZE 0x40
+
+#define M88RT51632_MUTEX_LOCK_MS 1000
+
 bool m88rt51632_get_vendor_id(I2C_MSG *msg);
 bool m88rt51632_get_fw_version(I2C_MSG *msg, uint32_t *version);
+uint8_t m88rt51632_fw_update(I2C_MSG *msg, uint32_t offset, uint16_t msg_len, uint8_t *msg_buf,
+			     uint8_t flag);
 
 #endif


### PR DESCRIPTION
# Description
Support montage pcie retimer update

# Motivation
Support montage pcie retimer update.

# Test plan
Build code : pass

# Log:
Update montage retimer:
root@bmc-oob:~# fw-util slot1 --update 3ou_retimer 08586300.bin Checking if the server is ready...
slot_id: 1, comp: 3a, intf: 0, img: 08586300.bin, force: 0 updated retimer: 100 %
Elapsed time:  302   sec.

Power-cycling the server...
Upgrade of slot1 : 3ou_retimer succeeded

Update asteralab retimer:
root@bmc-oob:~# fw-util slot1 --update 1ou_retimer pt516_x2x2x2x2x2x2x2x2_normal_HOT_P                                                                                             LUG-X2_v1_31_0.bin
Checking if the server is ready...
slot_id: 1, comp: 39, intf: 0, img: pt516_x2x2x2x2x2x2x2x2_normal_HOT_PLUG-X2_v1_31_0.                                                                                             bin, force: 0
updated retimer: 100 %
Elapsed time:  73   sec.

Power-cycling the server...
Upgrade of slot1 : 1ou_retimer succeeded