### PR TITLE
ol2: op: Version commit for op-v2023.23.01

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_version.h
+++ b/meta-facebook/op2-op/src/platform/plat_version.h
@@ -32,7 +32,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x06
+#define FIRMWARE_REVISION_2 0x07
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -41,7 +41,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x23
-#define BIC_FW_WEEK 0x17
+#define BIC_FW_WEEK 0x23
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x6f // char: o
 #define BIC_FW_platform_1 0x70 // char: p


### PR DESCRIPTION
Summary:
- Version commit for op-v2023.23.01

Test Plan:
- Build code: Pass
- Get version: Pass

Log:
1. Get all expansion card fw version. root@bmc-oob:~# fw-util slot1 --version 1ou_bic
1OU Bridge-IC Version: oby35-op-v2023.23.01
root@bmc-oob:~# fw-util slot1 --version 2ou_bic
2OU Bridge-IC Version: oby35-op-v2023.23.01
root@bmc-oob:~# fw-util slot1 --version 3ou_bic
3OU Bridge-IC Version: oby35-op-v2023.23.01
root@bmc-oob:~# fw-util slot1 --version 4ou_bic
4OU Bridge-IC Version: oby35-op-v2023.23.01