### PR TITLE
fby3.5: hda1: Support fru & guid

### DIFF
--- a/meta-facebook/yv35-hda1/src/platform/plat_fru.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_fru.c
@@ -22,9 +22,104 @@
 
 LOG_MODULE_REGISTER(plat_fru);
 
-const EEPROM_CFG plat_fru_config[] = {};
+const EEPROM_CFG plat_fru_config[] = {
+	{
+		NV_ATMEL_24C128,
+		MB_FRU_ID,
+		MB_FRU_PORT,
+		MB_FRU_ADDR,
+		FRU_DEV_ACCESS_BYTE,
+		FRU_START,
+		FRU_SIZE,
+	},
+	{
+		NV_ATMEL_24C128,
+		DPV2_FRU_ID,
+		DPV2_FRU_PORT,
+		DPV2_FRU_ADDR,
+		FRU_DEV_ACCESS_BYTE,
+		FRU_START,
+		FRU_SIZE,
+	},
+};
+
+// BIOS version is stored in MB EEPROM, but the location of EEPROM is different from fru information
+const EEPROM_CFG plat_bios_version_area_config = {
+	NV_ATMEL_24C128,
+	MB_FRU_ID,
+	MB_FRU_PORT,
+	MB_FRU_ADDR,
+	FRU_DEV_ACCESS_BYTE,
+	BIOS_FW_VERSION_START,
+	BIOS_FW_VERSION_MAX_SIZE,
+};
+
+/* PSB error information */
+const EEPROM_CFG plat_psb_error_area_config = {
+	NV_ATMEL_24C128,     MB_FRU_ID,       MB_FRU_PORT,	MB_CPU_EEPROM_ADDR,
+	FRU_DEV_ACCESS_BYTE, PSB_ERROR_START, PSB_ERROR_MAX_SIZE,
+};
 
 void pal_load_fru_config(void)
 {
 	memcpy(fru_config, plat_fru_config, sizeof(plat_fru_config));
+}
+
+bool write_psb_inform(EEPROM_ENTRY *entry)
+{
+	CHECK_NULL_ARG_WITH_RETURN(entry, false);
+
+	bool ret = false;
+	entry->config = plat_psb_error_area_config;
+	ret = eeprom_write(entry);
+	if (ret == false) {
+		LOG_ERR("eeprom_write fail");
+		return ret;
+	}
+
+	return ret;
+}
+
+int set_bios_version(EEPROM_ENTRY *entry, uint8_t block_index)
+{
+	CHECK_NULL_ARG_WITH_RETURN(entry, -1);
+
+	if (block_index >= BIOS_FW_VERSION_BLOCK_NUM)
+		return -1;
+
+	bool ret = false;
+	entry->config = plat_bios_version_area_config;
+	if (block_index == 1)
+		entry->config.start_offset += BIOS_FW_VERSION_SECOND_BLOCK_OFFSET;
+	entry->data_len = BIOS_FW_VERSION_BLOCK_MAX_SIZE;
+
+	ret = eeprom_write(entry);
+	if (ret == false) {
+		LOG_ERR("eeprom_write fail");
+		return -1;
+	}
+
+	return 0;
+}
+
+int get_bios_version(EEPROM_ENTRY *entry, uint8_t block_index)
+{
+	CHECK_NULL_ARG_WITH_RETURN(entry, -1);
+
+	if (block_index >= BIOS_FW_VERSION_BLOCK_NUM)
+		return -1;
+
+	bool ret = false;
+	entry->config = plat_bios_version_area_config;
+	if (block_index == 1)
+		entry->config.start_offset += BIOS_FW_VERSION_SECOND_BLOCK_OFFSET;
+	entry->data_len = BIOS_FW_VERSION_BLOCK_MAX_SIZE;
+
+	ret = eeprom_read(entry);
+	if (ret == false) {
+		LOG_ERR("eeprom_read fail");
+		return -1;
+	}
+
+	return 0;
 }

--- a/meta-facebook/yv35-hda1/src/platform/plat_fru.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_fru.c
@@ -56,8 +56,13 @@ const EEPROM_CFG plat_bios_version_area_config = {
 
 /* PSB error information */
 const EEPROM_CFG plat_psb_error_area_config = {
-	NV_ATMEL_24C128,     MB_FRU_ID,       MB_FRU_PORT,	MB_CPU_EEPROM_ADDR,
-	FRU_DEV_ACCESS_BYTE, PSB_ERROR_START, PSB_ERROR_MAX_SIZE,
+	NV_ATMEL_24C128,
+	MB_FRU_ID,
+	MB_FRU_PORT,
+	MB_CPU_EEPROM_ADDR,
+	FRU_DEV_ACCESS_BYTE,
+	PSB_ERROR_START,
+	PSB_ERROR_MAX_SIZE,
 };
 
 void pal_load_fru_config(void)

--- a/meta-facebook/yv35-hda1/src/platform/plat_fru.h
+++ b/meta-facebook/yv35-hda1/src/platform/plat_fru.h
@@ -22,9 +22,9 @@
 
 enum {
 	MB_FRU_ID,
-    DPV2_FRU_ID,
-    // OTHER_FRU_ID,
-    MAX_FRU_ID,
+	DPV2_FRU_ID,
+	// OTHER_FRU_ID,
+	MAX_FRU_ID,
 };
 
 #define FRU_CFG_NUM MAX_FRU_ID

--- a/meta-facebook/yv35-hda1/src/platform/plat_fru.h
+++ b/meta-facebook/yv35-hda1/src/platform/plat_fru.h
@@ -21,10 +21,32 @@
 #include "fru.h"
 
 enum {
-	// OTHER_FRU_ID,
-	MAX_FRU_ID,
+	MB_FRU_ID,
+    DPV2_FRU_ID,
+    // OTHER_FRU_ID,
+    MAX_FRU_ID,
 };
 
 #define FRU_CFG_NUM MAX_FRU_ID
+
+#define MB_FRU_PORT 0x01
+#define MB_FRU_ADDR 0x54
+#define MB_CPU_EEPROM_ADDR 0x50
+
+#define DPV2_FRU_PORT 0x08
+#define DPV2_FRU_ADDR 0x51
+
+#define BIOS_FW_VERSION_START 0x0A00
+#define BIOS_FW_VERSION_MAX_SIZE 34
+#define BIOS_FW_VERSION_BLOCK_NUM 2
+#define BIOS_FW_VERSION_SECOND_BLOCK_OFFSET 17
+#define BIOS_FW_VERSION_BLOCK_MAX_SIZE 17
+
+#define PSB_ERROR_START 0x0002
+#define PSB_ERROR_MAX_SIZE 9
+
+bool get_bios_version_area_config(EEPROM_CFG *config);
+int set_bios_version(EEPROM_ENTRY *entry, uint8_t block_index);
+int get_bios_version(EEPROM_ENTRY *entry, uint8_t block_index);
 
 #endif

--- a/meta-facebook/yv35-hda1/src/platform/plat_guid.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_guid.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "guid.h"
+#include "plat_guid.h"
+#include "fru.h"
+
+#define MB_GUID_PORT 0x01
+#define MB_GUID_ADDR 0x54
+
+const EEPROM_CFG guid_config[] = {
+	{
+		NV_ATMEL_24C128,
+		MB_SYS_GUID_ID,
+		MB_GUID_PORT,
+		MB_GUID_ADDR,
+		GUID_ACCESS_BYTE,
+		GUID_START,
+		GUID_SIZE,
+	},
+};
+
+uint8_t get_system_guid(uint16_t *data_len, uint8_t *data)
+{
+	EEPROM_ENTRY guid_entry;
+
+	if (data == NULL) {
+		return GUID_FAIL_TO_ACCESS;
+	}
+
+	guid_entry.offset = 0;
+	guid_entry.data_len = 16;
+	guid_entry.config.dev_id = MB_SYS_GUID_ID;
+
+	uint8_t status = GUID_read(&guid_entry);
+	if (status == GUID_READ_SUCCESS) {
+		*data_len = guid_entry.data_len;
+		memcpy(data, &guid_entry.data, guid_entry.data_len);
+	}
+
+	return status;
+}
+
+uint8_t set_system_guid(const uint16_t *data_len, uint8_t *data)
+{
+	EEPROM_ENTRY guid_entry;
+
+	if (data == NULL) {
+		return GUID_FAIL_TO_ACCESS;
+	}
+
+	guid_entry.offset = 0;
+	guid_entry.data_len = *data_len;
+	guid_entry.config.dev_id = MB_SYS_GUID_ID;
+	memcpy(&guid_entry.data[0], data, guid_entry.data_len);
+	return GUID_write(&guid_entry);
+}


### PR DESCRIPTION
Summary:
- Support read and write FRU.
- Support read and write GUID.

Test Plan:
- Build code: Pass
- Read FRU: Pass
- Write FRU: Pass
- Read GUID: Pass
- Write GUID: Pass

LOG:
- FRU test (Use HalfDome FRU for test)
  - Write:
  ```
  root@bmc-oob:~# fruid-util slot1 --write fru.bin
  ```

  - Read:
   ```
  root@bmc-oob:~# fruid-util slot1
  
  FRU Information           : Server board 1
  ---------------           : ------------------
  Chassis Type              : Rack Mount Chassis
  Board Mfg Date            : Wed May  3 02:52:00 2023
  Board Mfg                 : Quanta
  Board Product             : HalfDome PVT
  Board Serial              : 11112222333344
  Board Part Number         : 33F0EMA09V0
  Board FRU ID              : FRU Ver 0.02
  Board Custom Data 1       : 02-000526
  Board Custom Data 2       : 1234567
  Board Custom Data 3       : 
  Product Manufacturer      : Quanta
  Product Name              : HalfDome PVT
  Product Version           : HalfDome PVT
  ```

- GUID test
  - Read:
  ```
  root@bmc-oob:~# bic-util slot1 0x18 0x37
  91 9E 0A 00 52 04 A5 1A B7 EB 00 64 00 65 00 66
  ```