### PR TITLE
fby35: hda1: Support mctp-pldm for mpro

### DIFF
--- a/common/lib/libutil.c
+++ b/common/lib/libutil.c
@@ -144,7 +144,7 @@ void convert_uint8_t_pointer_to_uint32_t(uint32_t *data_32, uint8_t *data_8, uin
 	}
 }
 
-double power(double x, double y)
+double power(double x, int y)
 {
 	double result = 1;
 

--- a/common/lib/libutil.c
+++ b/common/lib/libutil.c
@@ -143,3 +143,19 @@ void convert_uint8_t_pointer_to_uint32_t(uint32_t *data_32, uint8_t *data_8, uin
 		*data_32 = (data_8[0] << 24) + (data_8[1] << 16) + (data_8[2] << 8) + data_8[3];
 	}
 }
+
+double power(double x, double y)
+{
+	double result = 1;
+
+	if (y < 0) {
+		y = -y;
+		while (y--)
+			result /= x;
+	} else {
+		while (y--)
+			result *= x;
+	}
+
+	return result;
+}

--- a/common/lib/libutil.h
+++ b/common/lib/libutil.h
@@ -101,5 +101,6 @@ void convert_uint32_t_to_uint8_t_pointer(uint32_t data_32, uint8_t *data_8, uint
 					 uint8_t endian);
 void convert_uint8_t_pointer_to_uint32_t(uint32_t *data_32, uint8_t *data_8, uint8_t len,
 					 uint8_t endian);
+double power(double x, double y);
 
 #endif

--- a/common/lib/libutil.h
+++ b/common/lib/libutil.h
@@ -101,6 +101,6 @@ void convert_uint32_t_to_uint8_t_pointer(uint32_t data_32, uint8_t *data_8, uint
 					 uint8_t endian);
 void convert_uint8_t_pointer_to_uint32_t(uint32_t *data_32, uint8_t *data_8, uint8_t len,
 					 uint8_t endian);
-double power(double x, double y);
+double power(double x, int y);
 
 #endif

--- a/common/service/ipmb/ipmb.c
+++ b/common/service/ipmb/ipmb.c
@@ -34,6 +34,10 @@
 #include <zephyr.h>
 #include "plat_ipmb.h"
 
+#ifdef ENABLE_MPRO
+#include "plat_pldm.h"
+#endif
+
 #include "pldm.h"
 #include <logging/log.h>
 
@@ -516,6 +520,10 @@ void IPMB_TXTask(void *pvParameters, void *arvg0, void *arvg1)
 						LOG_ERR("The request message is from RESERVED");
 					} else if (current_msg_tx->buffer.InF_source == SELF) {
 						LOG_ERR("Failed to send command");
+					} else if (current_msg_tx->buffer.InF_source == MPRO_PLDM) {
+#ifdef ENABLE_MPRO
+						LOG_ERR("Failed to send command from Mpro");
+#endif
 					} else if ((current_msg_tx->buffer.InF_source & 0xF0) ==
 						   HOST_KCS_1) {
 						// the source is KCS if the bit[7:4] are 0101b.
@@ -732,6 +740,11 @@ void IPMB_RXTask(void *pvParameters, void *arvg0, void *arvg1)
 							  kcs_buff,
 							  current_msg_rx->buffer.data_len + 3);
 						SAFE_FREE(kcs_buff);
+#endif
+					} else if ((current_msg_rx->buffer.InF_source) ==
+						   MPRO_PLDM) {
+#ifdef ENABLE_MPRO
+						pldm_send_ipmb_rsp(&current_msg_rx->buffer);
 #endif
 					} else if (current_msg_rx->buffer.InF_source == ME_IPMB) {
 						ipmi_msg *bridge_msg =

--- a/common/service/ipmb/ipmb.h
+++ b/common/service/ipmb/ipmb.h
@@ -116,6 +116,7 @@ enum Channel_Target {
 	/* 21h-39h reserved. */
 	PLDM = 0x40,
 	MCTP = 0x41,
+	MPRO_PLDM = 0x42,
 	/* 41h-4Fh reserved. */
 	HOST_KCS_1 = 0x50,
 	HOST_KCS_2 = 0x51,

--- a/common/service/pldm/pldm_monitor.h
+++ b/common/service/pldm/pldm_monitor.h
@@ -154,6 +154,13 @@ enum pldm_oem_platform_completion_codes {
 	PLDM_OEM_GPIO_EFFECTER_VALUE_UNKNOWN = 0x85,
 };
 
+/* Y = (mX + b) * 10^r */
+typedef struct _pldm_sensor_pdr_parm {
+	float resolution; // from PDR (m)
+	float ofst; // from PDR (b)
+	int8_t unit_modifier; // from PDR (r)
+} pldm_sensor_pdr_parm;
+
 struct pldm_get_sensor_reading_req {
 	uint16_t sensor_id;
 	uint8_t rearm_event_state;
@@ -203,6 +210,24 @@ enum pldm_event_message_global_enable {
 	PLDM_EVENT_MESSAGE_GLOBAL_ENABLE_POLLING,
 	PLDM_EVENT_MESSAGE_GLOBAL_ENABLE_ASYNC_KEEP_ALIVE
 };
+
+struct pldm_sensor_event_op_exp_data {
+	uint8_t op_state;
+	uint8_t pre_op_state;
+} __attribute__((packed));
+
+struct pldm_sensor_event_state_exp_data {
+	uint16_t sensor_ofst;
+	uint8_t event_state;
+	uint8_t pre_event_state;
+} __attribute__((packed));
+
+struct pldm_sensor_event_numeric_exp_data {
+	uint8_t event_state;
+	uint8_t pre_event_state;
+	uint8_t sensor_data_size;
+	uint8_t reading[1];
+} __attribute__((packed));
 
 struct pldm_platform_event_message_req {
 	uint8_t format_version;
@@ -258,6 +283,10 @@ struct pldm_set_event_receiver_req {
 	uint16_t heartbeat_timer;
 } __attribute__((packed));
 
+struct pldm_set_event_receiver_resp {
+	uint8_t completion_code;
+} __attribute__((packed));
+
 typedef struct state_field_state_effecter_set {
 	uint8_t set_request;
 	uint8_t effecter_state;
@@ -285,6 +314,14 @@ struct pldm_get_state_effecter_states_resp {
 	get_effecter_state_field_t field[8];
 } __attribute__((packed));
 
+struct pldm_event_message_buffer_size_req {
+	uint16_t event_receiver_max_buffer_size;
+} __attribute__((packed));
+
+struct pldm_event_message_buffer_size_resp {
+	uint8_t completion_code;
+} __attribute__((packed));
+
 uint8_t pldm_monitor_handler_query(uint8_t code, void **ret_fn);
 
 uint8_t pldm_platform_event_message_req(void *mctp_inst, mctp_ext_params ext_params,
@@ -309,6 +346,10 @@ uint8_t plat_pldm_set_state_effecter_state_handler(const uint8_t *buf, uint16_t 
 
 uint8_t plat_pldm_get_state_effecter_state_handler(const uint8_t *buf, uint16_t len, uint8_t *resp,
 						   uint16_t *resp_len);
+
+uint8_t pldm_event_len_check(uint8_t *buf, uint16_t len);
+float pldm_sensor_cal(uint8_t *buf, uint8_t len, pldm_sensor_readings_data_type_t data_type,
+		      pldm_sensor_pdr_parm parm);
 
 #ifdef __cplusplus
 }

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -154,6 +154,7 @@ enum SENSOR_DEV {
 	sensor_dev_tmp461 = 0x29,
 	sensor_dev_mp2985 = 0x2A,
 	sensor_dev_m88rt51632 = 0x2B,
+	sensor_dev_mpro = 0x2C,
 	sensor_dev_max
 };
 

--- a/common/shell/commands/pldm_shell.c
+++ b/common/shell/commands/pldm_shell.c
@@ -59,7 +59,8 @@ void cmd_pldm_send_req(const struct shell *shell, size_t argc, char **argv)
 		return;
 	}
 
-	shell_print(shell, "* mctp: 0x%x addr: 0x%x eid: 0x%x msg_type: 0x%x", mctp_inst, pmsg.ext_params.smbus_ext_params.addr, mctp_dest_eid, MCTP_MSG_TYPE_PLDM);
+	shell_print(shell, "* mctp: 0x%x addr: 0x%x eid: 0x%x msg_type: 0x%x", mctp_inst,
+		    pmsg.ext_params.smbus_ext_params.addr, mctp_dest_eid, MCTP_MSG_TYPE_PLDM);
 	shell_print(shell, "  pldm_type: 0x%x pldm cmd: 0x%x", pldm_type, pldm_cmd);
 	shell_hexdump(shell, pmsg.buf, pmsg.len);
 

--- a/common/shell/commands/pldm_shell.c
+++ b/common/shell/commands/pldm_shell.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pldm.h"
+#include "pldm_shell.h"
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Command Functions
+ */
+
+void cmd_pldm_send_req(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc < 4) {
+		shell_warn(
+			shell,
+			"Help: platform pldm sendreq <mctp_dest_eid> <pldm_type> <cmd> <data...>");
+		return;
+	}
+
+	uint8_t mctp_dest_eid = strtol(argv[1], NULL, 16);
+	uint8_t pldm_type = strtol(argv[2], NULL, 16);
+	uint8_t pldm_cmd = strtol(argv[3], NULL, 16);
+	uint16_t pldm_data_len = argc - 4;
+
+	uint8_t resp_buf[PLDM_MAX_DATA_SIZE] = { 0 };
+	pldm_msg pmsg = { 0 };
+	pmsg.hdr.msg_type = MCTP_MSG_TYPE_PLDM;
+	pmsg.hdr.pldm_type = pldm_type;
+	pmsg.hdr.cmd = pldm_cmd;
+	pmsg.hdr.rq = PLDM_REQUEST;
+	pmsg.len = pldm_data_len;
+	for (int i = 0; i < pmsg.len; i++)
+		pmsg.buf[i] = strtol(argv[4 + i], NULL, 16);
+
+	mctp *mctp_inst = NULL;
+	if (get_mctp_info_by_eid(mctp_dest_eid, &mctp_inst, &pmsg.ext_params) == false) {
+		shell_error(shell, "Failed to get mctp info by eid 0x%x", mctp_dest_eid);
+		return;
+	}
+
+	uint16_t resp_len = mctp_pldm_read(mctp_inst, &pmsg, resp_buf, sizeof(resp_buf));
+	if (resp_len == 0) {
+		shell_error(shell, "Failed to get mctp response");
+		return;
+	}
+
+	shell_print(shell, "* mctp: 0x%x addr: 0x%x eid: 0x%x msg_type: 0x%x", mctp_inst, pmsg.ext_params.smbus_ext_params.addr, mctp_dest_eid, MCTP_MSG_TYPE_PLDM);
+	shell_print(shell, "  pldm_type: 0x%x pldm cmd: 0x%x", pldm_type, pldm_cmd);
+	shell_hexdump(shell, pmsg.buf, pmsg.len);
+
+	if (resp_buf[0] != PLDM_SUCCESS)
+		shell_error(shell, "Response with bad cc 0x%x", resp_buf[0]);
+	else {
+		shell_hexdump(shell, resp_buf, resp_len);
+		shell_print(shell, "");
+	}
+}

--- a/common/shell/commands/pldm_shell.h
+++ b/common/shell/commands/pldm_shell.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLDM_SHELL_H
+#define PLDM_SHELL_H
+
+#include <shell/shell.h>
+
+void cmd_pldm_send_req(const struct shell *shell, size_t argc, char **argv);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_pldm_cmds,
+			       SHELL_CMD(sendreq, NULL, "Send out PLDM request.",
+					 cmd_pldm_send_req),
+			       SHELL_SUBCMD_SET_END);
+
+#endif

--- a/common/shell/shell_platform.c
+++ b/common/shell/shell_platform.c
@@ -20,6 +20,7 @@
 #include "commands/flash_shell.h"
 #include "commands/ipmi_shell.h"
 #include "commands/power_shell.h"
+#include "commands/pldm_shell.h"
 
 /* MAIN command */
 SHELL_STATIC_SUBCMD_SET_CREATE(
@@ -28,6 +29,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(sensor, &sub_sensor_cmds, "SENSOR relative command.", NULL),
 	SHELL_CMD(flash, &sub_flash_cmds, "FLASH(spi) relative command.", NULL),
 	SHELL_CMD(ipmi, &sub_ipmi_cmds, "IPMI relative command.", NULL),
-	SHELL_CMD(power, &sub_power_cmds, "POWER relative command.", NULL), SHELL_SUBCMD_SET_END);
+	SHELL_CMD(power, &sub_power_cmds, "POWER relative command.", NULL),
+	SHELL_CMD(pldm, &sub_pldm_cmds, "PLDM over MCTP relative command.", NULL),
+	SHELL_SUBCMD_SET_END);
 
 SHELL_CMD_REGISTER(platform, &sub_platform_cmds, "Platform commands", NULL);

--- a/meta-facebook/yv35-hda1/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/yv35-hda1/src/ipmi/include/plat_ipmi.h
@@ -17,4 +17,9 @@
 #ifndef PLAT_IPMI_H
 #define PLAT_IPMI_H
 
+enum REQ_GET_CARD_TYPE {
+	GET_1OU_CARD_TYPE = 0x0,
+	GET_2OU_CARD_TYPE,
+};
+
 #endif

--- a/meta-facebook/yv35-hda1/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-hda1/src/ipmi/plat_ipmi.c
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <logging/log.h>
+#include "ipmi.h"
+#include "plat_ipmi.h"
+#include "plat_ipmb.h"
+#include "plat_class.h"
+#include "libutil.h"
+#include "plat_fru.h"
+#include "util_spi.h"
+#include "plat_sensor_table.h"
+#include "ipmb.h"
+#include "mctp.h"
+#include "pldm.h"
+#include "plat_mctp.h"
+#include "sensor.h"
+#include "pmbus.h"
+
+LOG_MODULE_REGISTER(plat_ipmi);
+
+bool pal_request_msg_to_BIC_from_HOST(uint8_t netfn, uint8_t cmd)
+{
+	if (netfn == NETFN_OEM_1S_REQ) {
+		if ((cmd == CMD_OEM_1S_FW_UPDATE) || (cmd == CMD_OEM_1S_RESET_BMC) ||
+		    (cmd == CMD_OEM_1S_GET_BIC_STATUS) || (cmd == CMD_OEM_1S_RESET_BIC) ||
+		    (cmd == CMD_OEM_1S_GET_BIC_FW_INFO) ||
+		    (cmd == CMD_OEM_1S_GET_DIMM_I3C_MUX_SELECTION))
+			return true;
+	}
+
+	return false;
+}
+
+void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg)
+
+	if (msg->data_len != 1) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	CARD_STATUS _1ou_status = get_1ou_status();
+	CARD_STATUS _2ou_status = get_2ou_status();
+	switch (msg->data[0]) {
+	case GET_1OU_CARD_TYPE:
+		msg->data_len = 2;
+		msg->completion_code = CC_SUCCESS;
+		msg->data[0] = GET_1OU_CARD_TYPE;
+		if (_1ou_status.present) {
+			msg->data[1] = _1ou_status.card_type;
+		} else {
+			msg->data[1] = TYPE_1OU_ABSENT;
+		}
+		break;
+	case GET_2OU_CARD_TYPE:
+		msg->data_len = 2;
+		msg->completion_code = CC_SUCCESS;
+		msg->data[0] = GET_2OU_CARD_TYPE;
+		if (_2ou_status.present) {
+			msg->data[1] = _2ou_status.card_type;
+		} else {
+			msg->data[1] = TYPE_2OU_ABSENT;
+		}
+		break;
+	default:
+		msg->data_len = 0;
+		msg->completion_code = CC_INVALID_DATA_FIELD;
+		break;
+	}
+
+	return;
+}
+
+int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, -1);
+
+	int ret = -1;
+	EEPROM_ENTRY set_bios_ver = { 0 };
+	EEPROM_ENTRY get_bios_ver = { 0 };
+
+	const uint8_t block_index = buf[3];
+	if (block_index >= BIOS_FW_VERSION_BLOCK_NUM) {
+		LOG_ERR("BIOS version block index is out of range");
+		return -1;
+	}
+
+	ret = get_bios_version(&get_bios_ver, block_index);
+	if (ret == -1) {
+		LOG_ERR("Get BIOS version failed");
+		return -1;
+	}
+
+	set_bios_ver.data_len = size - 3; // skip netfn, cmd and command code
+	memcpy(&set_bios_ver.data[0], &buf[3], set_bios_ver.data_len);
+
+	// Check the written BIOS version is the same with the stored
+	ret = memcmp(&get_bios_ver.data[0], &set_bios_ver.data[0],
+		     BIOS_FW_VERSION_BLOCK_MAX_SIZE * sizeof(uint8_t));
+	if (ret == 0) {
+		LOG_DBG("The Written BIOS version is the same as the stored BIOS version in EEPROM");
+	} else {
+		LOG_DBG("BIOS version set successfully");
+
+		ret = set_bios_version(&set_bios_ver, block_index);
+		if (ret == -1) {
+			LOG_ERR("Set BIOS version failed");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+void OEM_1S_GET_BIOS_VERSION(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	msg->data_len = 0;
+
+	for (uint8_t block_index = 0; block_index < BIOS_FW_VERSION_BLOCK_NUM; block_index++) {
+		EEPROM_ENTRY get_bios_ver = { 0 };
+		int ret = get_bios_version(&get_bios_ver, block_index);
+		if (ret == -1) {
+			LOG_ERR("Get BIOS version failed");
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+			return;
+		}
+
+		memcpy(msg->data + msg->data_len, get_bios_ver.data, get_bios_ver.data_len);
+		msg->data_len += get_bios_ver.data_len;
+	}
+
+	msg->completion_code = CC_SUCCESS;
+	return;
+}
+
+#ifdef CONFIG_I2C_IPMB_SLAVE
+
+static void mpro_resp_handler(void *args, uint8_t *buf, uint16_t len)
+{
+	CHECK_NULL_ARG(args);
+	CHECK_NULL_ARG(buf);
+
+	LOG_HEXDUMP_DBG(buf, len, "mpro rsp:");
+
+	ipmi_msg *msg = (ipmi_msg *)args;
+
+	if (!len)
+		return;
+
+	msg->InF_source = BMC_IPMB;
+	msg->netfn = NETFN_OEM_1S_REQ;
+	msg->cmd = CMD_OEM_1S_MSG_OUT;
+	msg->completion_code = CC_SUCCESS;
+	msg->data_len = len + 3;
+	msg->data[0] = IANA_ID & 0xFF;
+	msg->data[1] = (IANA_ID >> 8) & 0xFF;
+	msg->data[2] = (IANA_ID >> 16) & 0xFF;
+
+	memcpy(&msg->data[3], buf, len);
+
+	ipmb_error status = ipmb_send_response(msg, IPMB_inf_index_map[msg->InF_source]);
+	if (status != IPMB_ERROR_SUCCESS) {
+		LOG_ERR("OEM_MSG_OUT send IPMB resp fail status: %x", status);
+	}
+}
+
+void OEM_1S_MSG_OUT(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+#if MAX_IPMB_IDX
+	uint8_t target_IF;
+	ipmb_error status;
+	ipmi_msg *bridge_msg = NULL;
+
+	// If command is valid the default cc is CC_INVALID_CMD, set cc to CC_SUCCESS before we execute the command.
+	// If the default cc is CC_INVALID_IANA, call ipmb_send_response for this invalid command.
+	if (msg->completion_code != CC_INVALID_IANA) {
+		msg->completion_code = CC_SUCCESS;
+	}
+
+	// Should input target, netfn, cmd
+	if (msg->data_len <= 2) {
+		msg->completion_code = CC_INVALID_LENGTH;
+	}
+
+	CARD_STATUS _1ou_status = get_1ou_status();
+	target_IF = msg->data[0];
+
+	switch (target_IF) {
+	case PEER_BMC_IPMB:
+		switch (msg->InF_source) {
+		case SLOT1_BIC:
+			target_IF = msg->data[0] = SLOT3_BIC;
+			break;
+		case SLOT3_BIC:
+			target_IF = msg->data[0] = SLOT1_BIC;
+			break;
+		default:
+			msg->completion_code = CC_INVALID_DATA_FIELD;
+			break;
+		}
+
+		if (msg->data[1] == NETFN_STORAGE_REQ) {
+			msg->data[1] = msg->data[1] << 2;
+		}
+		break;
+	case EXP2_IPMB:
+		if (_1ou_status.card_type == TYPE_1OU_EXP_WITH_E1S) {
+			target_IF = EXP1_IPMB;
+		}
+		break;
+	case EXP4_IPMB:
+		target_IF = EXP3_IPMB;
+		break;
+	case MPRO_PLDM:
+		if (msg->data_len < 3) {
+			msg->completion_code = CC_INVALID_LENGTH;
+			return;
+		}
+
+		pldm_msg pmsg = { 0 };
+		pmsg.hdr.msg_type = MCTP_MSG_TYPE_PLDM;
+		pmsg.hdr.rq = PLDM_REQUEST;
+		pmsg.hdr.pldm_type = msg->data[1];
+		pmsg.hdr.cmd = msg->data[2];
+		pmsg.len = msg->data_len - 3;
+		if (pmsg.len)
+			pmsg.buf = &msg->data[3];
+
+		LOG_DBG("*Bridge pldm command 0x%x 0x%x", pmsg.hdr.pldm_type, pmsg.hdr.cmd);
+		LOG_HEXDUMP_DBG(pmsg.buf, pmsg.len, "mpro req:");
+
+		ipmi_msg save = { 0 };
+		memcpy(&save, msg, sizeof(ipmi_msg));
+
+		pmsg.recv_resp_cb_fn = mpro_resp_handler;
+		pmsg.recv_resp_cb_args = &save;
+		pmsg.timeout_cb_fn = NULL;
+		pmsg.timeout_cb_fn_args = NULL;
+
+		mctp *mctp_inst = NULL;
+		if (get_mctp_info_by_eid(MCTP_EID_MPRO, &mctp_inst, &pmsg.ext_params) == false) {
+			LOG_ERR("Failed to get mctp info by eid 0x%x", MCTP_EID_MPRO);
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+			return;
+		}
+
+		if (mctp_pldm_send_msg(mctp_inst, &pmsg) != PLDM_SUCCESS) {
+			LOG_ERR("Failed to send mctp-pldm request command to mpro");
+			msg->completion_code = CC_BRIDGE_MSG_ERR;
+			return;
+		}
+
+		return;
+
+	default:
+		break;
+	}
+
+	// Bridge to invalid or disabled interface
+	if ((IPMB_inf_index_map[target_IF] == RESERVED) ||
+	    (IPMB_config_table[IPMB_inf_index_map[target_IF]].interface == RESERVED_IF) ||
+	    (IPMB_config_table[IPMB_inf_index_map[target_IF]].enable_status == DISABLE)) {
+		LOG_ERR("OEM_MSG_OUT: Invalid bridge interface: %x", target_IF);
+		msg->completion_code = CC_NOT_SUPP_IN_CURR_STATE;
+	}
+
+	// only send to target while msg is valid
+	if (msg->completion_code == CC_SUCCESS) {
+		bridge_msg = (ipmi_msg *)malloc(sizeof(ipmi_msg));
+		if (bridge_msg == NULL) {
+			msg->completion_code = CC_OUT_OF_SPACE;
+			return;
+		} else {
+			memset(bridge_msg, 0, sizeof(ipmi_msg));
+
+			LOG_DBG("bridge targetIf %x, len %d, netfn %x, cmd %x", target_IF,
+				msg->data_len, msg->data[1] >> 2, msg->data[2]);
+
+			if ((_1ou_status.card_type == TYPE_1OU_EXP_WITH_E1S) &&
+			    ((msg->data[0] == EXP2_IPMB) || (msg->data[0] == EXP4_IPMB))) {
+				bridge_msg->seq_source = msg->seq_source;
+				bridge_msg->InF_target = msg->data[0];
+				bridge_msg->InF_source = msg->InF_source;
+				bridge_msg->netfn = NETFN_OEM_1S_REQ;
+				bridge_msg->cmd = CMD_OEM_1S_MSG_OUT;
+				bridge_msg->data[0] = IANA_ID & 0xFF;
+				bridge_msg->data[1] = (IANA_ID >> 8) & 0xFF;
+				bridge_msg->data[2] = (IANA_ID >> 16) & 0xFF;
+
+				if (msg->data_len != 0) {
+					memcpy(&bridge_msg->data[3], &msg->data[0],
+					       msg->data_len * sizeof(msg->data[0]));
+				}
+
+				bridge_msg->data_len = msg->data_len + 3;
+			} else {
+				bridge_msg->data_len = msg->data_len - 3;
+				bridge_msg->seq_source = msg->seq_source;
+				bridge_msg->InF_target = msg->data[0];
+				bridge_msg->InF_source = msg->InF_source;
+				bridge_msg->netfn = msg->data[1] >> 2;
+				bridge_msg->cmd = msg->data[2];
+
+				if (bridge_msg->data_len != 0) {
+					memcpy(&bridge_msg->data[0], &msg->data[3],
+					       bridge_msg->data_len * sizeof(msg->data[0]));
+				}
+			}
+
+			status = ipmb_send_request(bridge_msg, IPMB_inf_index_map[target_IF]);
+
+			if (status != IPMB_ERROR_SUCCESS) {
+				LOG_ERR("OEM_MSG_OUT send IPMB req fail status: %x", status);
+				msg->completion_code = CC_BRIDGE_MSG_ERR;
+			}
+			SAFE_FREE(bridge_msg);
+		}
+	}
+
+	// Return to source while data is invalid or sending req to Tx task fail
+	if (msg->completion_code != CC_SUCCESS) {
+		msg->data_len = 0;
+		status = ipmb_send_response(msg, IPMB_inf_index_map[msg->InF_source]);
+		if (status != IPMB_ERROR_SUCCESS) {
+			LOG_ERR("OEM_MSG_OUT send IPMB resp fail status: %x", status);
+		}
+	}
+#else
+	msg->completion_code = CC_UNSPECIFIED_ERROR;
+#endif
+	return;
+}
+#endif
+
+void OEM_1S_GET_HSC_STATUS(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	uint8_t hsc_type = get_hsc_module();
+	I2C_MSG i2c_msg;
+	uint8_t retry = 5;
+
+	i2c_msg.bus = I2C_BUS2;
+	i2c_msg.tx_len = 1;
+	i2c_msg.rx_len = 1;
+
+	switch (hsc_type) {
+	case HSC_MODULE_ADM1278:
+		i2c_msg.target_addr = ADM1278_ADDR;
+		i2c_msg.data[0] = PMBUS_STATUS_BYTE;
+		break;
+	case HSC_MODULE_LTC4282:
+		i2c_msg.target_addr = LTC4282_ADDR;
+		i2c_msg.data[0] = LTC4282_STATUS_OFFSET_BYTE1;
+		break;
+	case HSC_MODULE_MP5990:
+		i2c_msg.target_addr = MP5990_ADDR;
+		i2c_msg.data[0] = PMBUS_STATUS_BYTE;
+		break;
+	default:
+		LOG_WRN("Unknown hsc module %d", hsc_type);
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
+		return;
+	}
+
+	if (i2c_master_read(&i2c_msg, retry)) {
+		LOG_WRN("Failed to read hsc status.");
+		msg->completion_code = CC_TIMEOUT;
+		return;
+	}
+
+	switch (hsc_type) {
+	case HSC_MODULE_ADM1278:
+	case HSC_MODULE_MP5990:
+		msg->data[1] = i2c_msg.data[0] & 0x1C;
+		break;
+	case HSC_MODULE_LTC4282:
+		msg->data[1] = ((i2c_msg.data[0] & BIT(0)) ? BIT(5) : 0) |
+			       ((i2c_msg.data[0] & BIT(1)) ? BIT(3) : 0) |
+			       ((i2c_msg.data[0] & BIT(2)) ? BIT(4) : 0);
+		break;
+	default:
+		LOG_WRN("Unknown hsc module %d", hsc_type);
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
+		return;
+	}
+
+	msg->data_len = 2;
+	msg->data[0] = hsc_type;
+	msg->completion_code = CC_SUCCESS;
+	return;
+}

--- a/meta-facebook/yv35-hda1/src/platform/plat_init.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_init.c
@@ -20,6 +20,7 @@
 #include "util_sys.h"
 #include "plat_gpio.h"
 #include "plat_class.h"
+#include "mpro.h"
 #include "plat_i2c.h"
 #include "plat_mctp.h"
 #include "plat_ssif.h"
@@ -49,6 +50,8 @@ void pal_pre_init()
 	init_platform_config();
 
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
+
+	mpro_postcode_read_init();
 
 	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
 }

--- a/meta-facebook/yv35-hda1/src/platform/plat_init.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_init.c
@@ -21,6 +21,7 @@
 #include "plat_gpio.h"
 #include "plat_class.h"
 #include "plat_i2c.h"
+#include "plat_mctp.h"
 #include "plat_ssif.h"
 #include "plat_power_status.h"
 #include "util_worker.h"
@@ -54,6 +55,8 @@ void pal_pre_init()
 
 void pal_post_init()
 {
+	plat_mctp_init();
+
 	ssif_init();
 }
 

--- a/meta-facebook/yv35-hda1/src/platform/plat_mctp.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_mctp.c
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2012-2014 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <logging/log.h>
+#include <logging/log_ctrl.h>
+#include <stdlib.h>
+#include "mctp.h"
+#include "mctp_ctrl.h"
+#include "pldm.h"
+#include "ipmi.h"
+#include "sensor.h"
+#include "plat_power_status.h"
+#include "plat_mctp.h"
+#include "plat_pldm.h"
+#include "plat_gpio.h"
+#include "plat_i2c.h"
+#include "hal_i2c_target.h"
+
+LOG_MODULE_REGISTER(plat_mctp);
+
+#define MCTP_MSG_TYPE_SHIFT 0
+#define MCTP_MSG_TYPE_MASK 0x7F
+#define MCTP_IC_SHIFT 7
+#define MCTP_IC_MASK 0x80
+
+#define MAX_PLDM_EVENT_RECV_BUFF_SIZE 0xC0 //192 Bytes
+
+K_WORK_DEFINE(send_cmd_work, send_cmd_to_dev_handler);
+
+typedef struct _mctp_smbus_port {
+	mctp *mctp_inst;
+	mctp_medium_conf conf;
+	uint8_t user_idx;
+} mctp_smbus_port;
+
+/* mctp route entry struct */
+typedef struct _mctp_route_entry {
+	uint8_t endpoint;
+	uint8_t bus; /* TODO: only consider smbus/i3c */
+	uint8_t addr; /* TODO: only consider smbus/i3c */
+	uint8_t dev_present_pin;
+} mctp_route_entry;
+
+typedef struct _mctp_msg_handler {
+	MCTP_MSG_TYPE type;
+	mctp_fn_cb msg_handler_cb;
+} mctp_msg_handler;
+
+static mctp_smbus_port smbus_port[] = {
+	{ .conf.smbus_conf.addr = I2C_ADDR_BIC, .conf.smbus_conf.bus = I2C_BUS_MPRO },
+};
+
+mctp_route_entry mctp_route_tbl[] = {
+	{ MCTP_EID_MPRO, I2C_BUS_MPRO, I2C_ADDR_MPRO },
+};
+
+static mctp *find_mctp_by_smbus(uint8_t bus)
+{
+	uint8_t i;
+	for (i = 0; i < ARRAY_SIZE(smbus_port); i++) {
+		mctp_smbus_port *p = smbus_port + i;
+
+		if (bus == p->conf.smbus_conf.bus)
+			return p->mctp_inst;
+	}
+
+	return NULL;
+}
+
+static uint8_t get_mctp_route_info(uint8_t dest_endpoint, void **mctp_inst,
+				   mctp_ext_params *ext_params)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(ext_params, MCTP_ERROR);
+
+	uint8_t ret = MCTP_ERROR;
+	uint32_t index = 0;
+
+	for (index = 0; index < ARRAY_SIZE(mctp_route_tbl); index++) {
+		mctp_route_entry *port = mctp_route_tbl + index;
+		CHECK_NULL_ARG_WITH_RETURN(port, MCTP_ERROR);
+
+		if (port->endpoint == dest_endpoint) {
+			*mctp_inst = find_mctp_by_smbus(port->bus);
+			CHECK_NULL_ARG_WITH_RETURN(mctp_inst, MCTP_ERROR);
+
+			ext_params->ep = port->endpoint;
+			ext_params->type = MCTP_MEDIUM_TYPE_SMBUS;
+			ext_params->smbus_ext_params.addr = port->addr;
+			ret = MCTP_SUCCESS;
+			break;
+		}
+	}
+	return ret;
+}
+
+uint8_t get_mctp_info(uint8_t dest_endpoint, mctp **mctp_inst, mctp_ext_params *ext_params)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(ext_params, MCTP_ERROR);
+
+	uint8_t rc = MCTP_ERROR;
+	uint32_t i;
+
+	for (i = 0; i < ARRAY_SIZE(mctp_route_tbl); i++) {
+		mctp_route_entry *p = mctp_route_tbl + i;
+		if (!p) {
+			return MCTP_ERROR;
+		}
+		if (p->endpoint == dest_endpoint) {
+			*mctp_inst = find_mctp_by_smbus(p->bus);
+			ext_params->type = MCTP_MEDIUM_TYPE_SMBUS;
+			ext_params->smbus_ext_params.addr = p->addr;
+			rc = MCTP_SUCCESS;
+			break;
+		}
+	}
+	return rc;
+}
+
+static void set_endpoint_resp_handler(void *args, uint8_t *buf, uint16_t len)
+{
+	if (!buf || !len)
+		return;
+	LOG_HEXDUMP_INF(buf, len, "Set device eid:");
+}
+
+static void set_endpoint_resp_timeout(void *args)
+{
+	mctp_route_entry *p = (mctp_route_entry *)args;
+	LOG_ERR("Endpoint 0x%x set endpoint failed on bus %d", p->endpoint, p->bus);
+}
+
+static void set_dev_endpoint(void)
+{
+	mctp_route_entry *p = mctp_route_tbl;
+
+	for (uint8_t j = 0; j < ARRAY_SIZE(smbus_port); j++) {
+		if (p->bus != smbus_port[j].conf.smbus_conf.bus)
+			continue;
+
+		struct _set_eid_req req = { 0 };
+		req.op = SET_EID_REQ_OP_SET_EID;
+		req.eid = p->endpoint;
+
+		mctp_ctrl_msg msg;
+		memset(&msg, 0, sizeof(msg));
+		msg.ext_params.type = MCTP_MEDIUM_TYPE_SMBUS;
+		msg.ext_params.smbus_ext_params.addr = p->addr;
+
+		msg.hdr.cmd = MCTP_CTRL_CMD_SET_ENDPOINT_ID;
+		msg.hdr.rq = 1;
+
+		msg.cmd_data = (uint8_t *)&req;
+		msg.cmd_data_len = sizeof(req);
+
+		msg.recv_resp_cb_fn = set_endpoint_resp_handler;
+		msg.timeout_cb_fn = set_endpoint_resp_timeout;
+		msg.timeout_cb_fn_args = p;
+
+		mctp_ctrl_send_msg(find_mctp_by_smbus(p->bus), &msg);
+	}
+}
+
+static void set_tid(void)
+{
+	uint8_t ret = MCTP_ERROR;
+	uint8_t resp_len = 0;
+	pldm_msg pmsg = { 0 };
+	uint8_t resp_buf[PLDM_MAX_DATA_SIZE] = { 0 };
+	mctp *mctp_inst = NULL;
+
+	ret = get_mctp_route_info(MCTP_EID_MPRO, (void **)&mctp_inst, &pmsg.ext_params);
+	if (ret != MCTP_SUCCESS) {
+		LOG_ERR("Invalid EID: 0x%x, unable to get route information", MCTP_EID_MPRO);
+	}
+
+	pmsg.hdr.msg_type = MCTP_MSG_TYPE_PLDM;
+	pmsg.hdr.pldm_type = PLDM_TYPE_BASE;
+	pmsg.hdr.cmd = PLDM_BASE_CMD_CODE_SETTID;
+	pmsg.hdr.rq = PLDM_REQUEST;
+
+	struct _set_tid_req req = { 0 };
+	req.tid = PLDM_TID_MPRO;
+
+	pmsg.buf = (uint8_t *)&req;
+	pmsg.len = sizeof(req);
+
+	resp_len = mctp_pldm_read(mctp_inst, &pmsg, resp_buf, sizeof(resp_buf));
+	if (resp_len == 0) {
+		LOG_ERR("Set tid receiver FAILED!");
+		return;
+	}
+
+	struct _set_tid_resp *resp = (struct _set_tid_resp *)resp_buf;
+	if (resp->completion_code == PLDM_SUCCESS)
+		LOG_INF("Set tid receiver SUCCESS!");
+	else
+		LOG_ERR("Set tid receiver response = 0x%x", resp->completion_code);
+}
+
+static void set_event_receiver(void)
+{
+	uint8_t ret = MCTP_ERROR;
+	uint8_t resp_len = 0;
+	pldm_msg pmsg = { 0 };
+	uint8_t resp_buf[PLDM_MAX_DATA_SIZE] = { 0 };
+	mctp *mctp_inst = NULL;
+
+	ret = get_mctp_route_info(MCTP_EID_MPRO, (void **)&mctp_inst, &pmsg.ext_params);
+	if (ret != MCTP_SUCCESS) {
+		LOG_ERR("Invalid EID: 0x%x, unable to get route information", MCTP_EID_MPRO);
+	}
+
+	pmsg.hdr.msg_type = MCTP_MSG_TYPE_PLDM;
+	pmsg.hdr.pldm_type = PLDM_TYPE_PLAT_MON_CTRL;
+	pmsg.hdr.cmd = 0x04;
+	pmsg.hdr.rq = PLDM_REQUEST;
+
+	struct pldm_set_event_receiver_req req = { 0 };
+	req.event_message_global_enable = 0x02; //Victor test
+	req.transport_protocol_type = 0x00;
+	req.event_receiver_address_info = 0x0A;
+	req.heartbeat_timer = 0x0000;
+
+	pmsg.buf = (uint8_t *)&req;
+	pmsg.len = sizeof(req);
+
+	resp_len = mctp_pldm_read(mctp_inst, &pmsg, resp_buf, sizeof(resp_buf));
+	if (resp_len == 0) {
+		LOG_ERR("Set event receiver FAILED!");
+		return;
+	}
+
+	struct pldm_set_event_receiver_resp *resp = (struct pldm_set_event_receiver_resp *)resp_buf;
+	if (resp->completion_code == PLDM_SUCCESS)
+		LOG_INF("Set event receiver SUCCESS!");
+	else
+		LOG_ERR("Set event receiver response = 0x%x", resp->completion_code);
+}
+
+static void event_message_buffer_size(void)
+{
+	uint8_t ret = MCTP_ERROR;
+	uint8_t resp_len = 0;
+	pldm_msg pmsg = { 0 };
+	uint8_t resp_buf[PLDM_MAX_DATA_SIZE] = { 0 };
+	mctp *mctp_inst = NULL;
+
+	ret = get_mctp_route_info(MCTP_EID_MPRO, (void **)&mctp_inst, &pmsg.ext_params);
+	if (ret != MCTP_SUCCESS) {
+		LOG_ERR("Invalid EID: 0x%x, unable to get route information", MCTP_EID_MPRO);
+	}
+
+	pmsg.hdr.msg_type = MCTP_MSG_TYPE_PLDM;
+	pmsg.hdr.pldm_type = PLDM_TYPE_PLAT_MON_CTRL;
+	pmsg.hdr.cmd = 0x0D;
+	pmsg.hdr.rq = PLDM_REQUEST;
+
+	struct pldm_event_message_buffer_size_req req = { 0 };
+	req.event_receiver_max_buffer_size = MAX_PLDM_EVENT_RECV_BUFF_SIZE;
+
+	pmsg.buf = (uint8_t *)&req;
+	pmsg.len = sizeof(req);
+
+	resp_len = mctp_pldm_read(mctp_inst, &pmsg, resp_buf, sizeof(resp_buf));
+	if (resp_len == 0) {
+		LOG_ERR("Event message buffer size set FAILED!");
+		return;
+	}
+
+	struct pldm_event_message_buffer_size_resp *resp =
+		(struct pldm_event_message_buffer_size_resp *)resp_buf;
+	if (resp->completion_code == PLDM_SUCCESS)
+		LOG_INF("Event message buffer size set SUCCESS!");
+	else
+		LOG_ERR("Event message buffer size response = 0x%x", resp->completion_code);
+}
+
+static uint8_t mctp_msg_recv(void *mctp_p, uint8_t *buf, uint32_t len, mctp_ext_params ext_params)
+{
+	if (!mctp_p || !buf || !len)
+		return MCTP_ERROR;
+
+	/* first byte is message type and ic */
+	uint8_t msg_type = (buf[0] & MCTP_MSG_TYPE_MASK) >> MCTP_MSG_TYPE_SHIFT;
+	uint8_t ic = (buf[0] & MCTP_IC_MASK) >> MCTP_IC_SHIFT;
+	(void)ic;
+
+	switch (msg_type) {
+	case MCTP_MSG_TYPE_CTRL:
+		mctp_ctrl_cmd_handler(mctp_p, buf, len, ext_params);
+		break;
+
+	case MCTP_MSG_TYPE_PLDM:
+		if (pldm_request_msg_need_bypass(buf, len) == true) {
+			ipmi_msg bridge_msg = { 0 };
+			bridge_msg.seq_source = 0xff; // No seq for MPRO
+			bridge_msg.InF_source = MPRO_PLDM;
+			bridge_msg.InF_target =
+				BMC_IPMB; // default bypassing IPMI standard command to BMC
+			bridge_msg.netfn = NETFN_OEM_1S_REQ;
+			bridge_msg.cmd = CMD_OEM_1S_MSG_IN;
+
+			bridge_msg.data_len =
+				len - 1 + 3 + 1; // exclude msg_type and include IANA, channel
+			bridge_msg.data[0] = IANA_ID & 0xFF;
+			bridge_msg.data[1] = (IANA_ID >> 8) & 0xFF;
+			bridge_msg.data[2] = (IANA_ID >> 16) & 0xFF;
+			bridge_msg.data[3] = MPRO_PLDM;
+
+			memcpy(&bridge_msg.data[4], &buf[1], len - 1);
+
+			LOG_HEXDUMP_INF(&bridge_msg.data[0], bridge_msg.data_len,
+					"Bridging pldm req msg:");
+
+			ipmb_error status =
+				ipmb_send_request(&bridge_msg, IPMB_inf_index_map[BMC_IPMB]);
+			if (status != IPMB_ERROR_SUCCESS) {
+				LOG_ERR("Fail to send pldm bridge ipmb request msg with ret 0x%x",
+					status);
+				return MCTP_ERROR;
+			}
+
+			/* Record mctp relative info */
+			pldm_hdr *hdr = (pldm_hdr *)buf;
+			if (pldm_save_mctp_inst_from_ipmb_req(mctp_p, hdr->inst_id, ext_params) ==
+			    false) {
+				LOG_ERR("Failed to save bridge info via inst id %d", hdr->inst_id);
+				return MCTP_ERROR;
+			}
+
+			return MCTP_SUCCESS;
+		}
+
+		mctp_pldm_cmd_handler(mctp_p, buf, len, ext_params);
+		break;
+
+	default:
+		LOG_WRN("Cannot find message receive function!!");
+		return MCTP_ERROR;
+	}
+
+	return MCTP_SUCCESS;
+}
+
+void send_cmd_to_dev_handler(struct k_work *work)
+{
+	/* mctp - base */
+	set_dev_endpoint();
+	/* pldm - base */
+	set_tid();
+	/* pldm - monitor */
+	set_event_receiver();
+	event_message_buffer_size();
+
+	set_mpro_status();
+}
+
+void send_cmd_to_dev(struct k_timer *timer)
+{
+	k_work_submit(&send_cmd_work);
+}
+
+void plat_mctp_init(void)
+{
+	LOG_INF("plat_mctp_init");
+
+	/* init the mctp/pldm instance */
+	for (uint8_t i = 0; i < ARRAY_SIZE(smbus_port); i++) {
+		mctp_smbus_port *p = smbus_port + i;
+		LOG_DBG("smbus port %d", i);
+		LOG_DBG("bus = %x, addr = %x", p->conf.smbus_conf.bus, p->conf.smbus_conf.addr);
+
+		struct _i2c_target_config cfg;
+		memset(&cfg, 0, sizeof(cfg));
+		cfg.address = p->conf.smbus_conf.addr;
+		cfg.i2c_msg_count = 0x0A;
+
+		if (i2c_target_control(p->conf.smbus_conf.bus, &cfg, I2C_CONTROL_REGISTER) !=
+		    I2C_TARGET_API_NO_ERR) {
+			LOG_ERR("i2c %d register target failed", p->conf.smbus_conf.bus);
+			continue;
+		}
+
+		p->mctp_inst = mctp_init();
+		if (!p->mctp_inst) {
+			LOG_ERR("mctp_init failed!!");
+			continue;
+		}
+
+		LOG_DBG("mctp_inst = %p", p->mctp_inst);
+		uint8_t rc =
+			mctp_set_medium_configure(p->mctp_inst, MCTP_MEDIUM_TYPE_SMBUS, p->conf);
+		LOG_DBG("mctp_set_medium_configure %s",
+			(rc == MCTP_SUCCESS) ? "success" : "failed");
+
+		mctp_reg_endpoint_resolve_func(p->mctp_inst, get_mctp_route_info);
+		mctp_reg_msg_rx_func(p->mctp_inst, mctp_msg_recv);
+
+		mctp_start(p->mctp_inst);
+	}
+}

--- a/meta-facebook/yv35-hda1/src/platform/plat_mctp.h
+++ b/meta-facebook/yv35-hda1/src/platform/plat_mctp.h
@@ -14,12 +14,25 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#ifndef _PLAT_MCTP_h
+#define _PLAT_MCTP_h
 
-#define BMC_USB_PORT "CDC_ACM_0"
+#include "plat_i2c.h"
 
-#define ENABLE_SSIF
-#define ENABLE_MPRO
+/* i2c 8 bit address */
+#define I2C_ADDR_BIC 0x40
+#define I2C_ADDR_MPRO 0x9E
 
-#endif
+/* i2c dev bus */
+#define I2C_BUS_MPRO I2C_BUS14
+
+/* mctp endpoint */
+#define MCTP_EID_MPRO 0x10
+#define PLDM_TID_MPRO 0x01
+
+/* init the mctp moduel for platform */
+void plat_mctp_init(void);
+void send_cmd_to_dev(struct k_timer *timer);
+void send_cmd_to_dev_handler(struct k_work *work);
+
+#endif /* _PLAT_MCTP_h */

--- a/meta-facebook/yv35-hda1/src/platform/plat_pldm.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_pldm.c
@@ -90,8 +90,8 @@ bool pldm_request_msg_need_bypass(uint8_t *buf, uint32_t len)
 			(struct pldm_platform_event_message_req *)(buf + sizeof(*hdr));
 		if (req_p->event_class == PLDM_SENSOR_EVENT) {
 			uint16_t sensor_id = req_p->event_data[0] | (req_p->event_data[1] << 8);
-			for (int i = 0; i < ARRAY_SIZE(event_sensor_sup_lst); i++) {
-				if (sensor_id == event_sensor_sup_lst[i].sensor_id)
+			for (int j = 0; j < ARRAY_SIZE(event_sensor_sup_lst); j++) {
+				if (sensor_id == event_sensor_sup_lst[j].sensor_id)
 					return false;
 			}
 		}

--- a/meta-facebook/yv35-hda1/src/platform/plat_pldm.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_pldm.c
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2012-2014 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <logging/log.h>
+#include <logging/log_ctrl.h>
+#include <stdlib.h>
+#include "mctp.h"
+#include "mctp_ctrl.h"
+#include "pldm.h"
+#include "ipmi.h"
+#include "sensor.h"
+#include "mpro.h"
+#include "plat_hook.h"
+#include "plat_mctp.h"
+#include "plat_gpio.h"
+#include "plat_pldm.h"
+
+LOG_MODULE_REGISTER(plat_pldm);
+
+struct _pldm_cmd_sup_lst {
+	uint8_t pldm_type;
+	uint8_t cmd;
+};
+
+struct _pldm_sensor_event_sup_lst {
+	uint16_t sensor_id;
+	uint8_t sensor_event_class;
+	bool (*event_handler_func)(uint8_t *, uint16_t);
+};
+
+static bool mpro_postcode_collect(uint8_t *buf, uint16_t len);
+
+static struct _pldm_sensor_event_sup_lst event_sensor_sup_lst[] = {
+	{ MPRO_SENSOR_NUM_STA_OVERALL_BOOT, PLDM_NUMERIC_SENSOR_STATE, mpro_postcode_collect },
+};
+
+struct _pldm_cmd_sup_lst pldm_cmd_sup_tbl[] = {
+	{ PLDM_TYPE_BASE, PLDM_BASE_CMD_CODE_GETTID },
+	{ PLDM_TYPE_BASE, PLDM_BASE_CMD_CODE_GET_PLDM_TYPE },
+	{ PLDM_TYPE_BASE, PLDM_BASE_CMD_CODE_GET_PLDM_CMDS },
+
+	{ PLDM_TYPE_PLAT_MON_CTRL, PLDM_MONITOR_CMD_CODE_PLATFORM_EVENT_MESSAGE },
+	{ PLDM_TYPE_PLAT_MON_CTRL, PLDM_MONITOR_CMD_CODE_GET_STATE_EFFECTER_STATES },
+};
+
+bool pldm_request_msg_need_bypass(uint8_t *buf, uint32_t len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, false);
+	pldm_hdr *hdr = (pldm_hdr *)buf;
+
+	/* Do not filter response message */
+	if (!hdr->rq)
+		return false;
+
+	int i = 0;
+	for (; i < ARRAY_SIZE(pldm_cmd_sup_tbl); i++) {
+		if ((hdr->pldm_type == pldm_cmd_sup_tbl[i].pldm_type) &&
+		    (hdr->cmd == pldm_cmd_sup_tbl[i].cmd))
+			break;
+	}
+
+	if (i == ARRAY_SIZE(pldm_cmd_sup_tbl))
+		return true;
+
+	/* Filter some commands with certain data */
+	if ((hdr->pldm_type == PLDM_TYPE_PLAT_MON_CTRL) &&
+	    (hdr->cmd == PLDM_MONITOR_CMD_CODE_PLATFORM_EVENT_MESSAGE)) {
+		struct pldm_platform_event_message_req *req_p =
+			(struct pldm_platform_event_message_req *)(buf + sizeof(*hdr));
+		if (req_p->event_class == PLDM_SENSOR_EVENT) {
+			uint16_t sensor_id = req_p->event_data[0] | (req_p->event_data[1] << 8);
+			for (int i = 0; i < ARRAY_SIZE(event_sensor_sup_lst); i++) {
+				if (sensor_id == event_sensor_sup_lst[i].sensor_id)
+					return false;
+			}
+		}
+		return true;
+	}
+
+	return true;
+}
+
+uint8_t pldm_platform_event_message(void *mctp_inst, uint8_t *buf, uint16_t len,
+				    uint8_t instance_id, uint8_t *resp, uint16_t *resp_len,
+				    void *ext_params)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(buf, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(ext_params, PLDM_ERROR);
+
+	struct pldm_platform_event_message_req *req_p =
+		(struct pldm_platform_event_message_req *)buf;
+	struct pldm_platform_event_message_resp *res_p =
+		(struct pldm_platform_event_message_resp *)resp;
+
+	LOG_DBG("Recieved event class 0x%x", req_p->event_class);
+	LOG_HEXDUMP_DBG(req_p->event_data, len - 3, "event data:");
+
+	uint8_t ret_cc = PLDM_SUCCESS;
+
+	uint8_t ret = pldm_event_len_check(&req_p->event_class, len - 2);
+	if (ret != PLDM_SUCCESS) {
+		ret_cc = ret;
+		goto exit;
+	}
+
+	switch (req_p->event_class) {
+	case PLDM_SENSOR_EVENT: {
+		uint16_t sensor_id = req_p->event_data[0] | (req_p->event_data[1] << 8);
+		uint8_t sensor_event_class = req_p->event_data[2];
+
+		int i = 0;
+		for (i = 0; i < ARRAY_SIZE(event_sensor_sup_lst); i++) {
+			if ((sensor_id == event_sensor_sup_lst[i].sensor_id) &&
+			    (sensor_event_class == event_sensor_sup_lst[i].sensor_event_class)) {
+				break;
+			}
+		}
+
+		if (i == ARRAY_SIZE(event_sensor_sup_lst))
+			goto exit;
+
+		if (!event_sensor_sup_lst[i].event_handler_func) {
+			LOG_ERR("Event class 0x%x sensor id 0x%x lost handler", req_p->event_class,
+				sensor_id);
+			goto exit;
+		}
+
+		if (event_sensor_sup_lst[i].event_handler_func(req_p->event_data, len - 3) ==
+		    false) {
+			LOG_ERR("Event class 0x%x sensor id 0x%x got error", req_p->event_class,
+				sensor_id);
+			goto exit;
+		}
+		break;
+	}
+
+	default:
+		LOG_WRN("Event class 0x%x not supported yet!", req_p->event_class);
+		goto exit;
+	}
+
+exit:
+	res_p->completion_code = ret_cc;
+	res_p->platform_event_status = 0x00; // BIC always not log record
+
+	*resp_len = 2;
+
+	return PLDM_SUCCESS;
+}
+
+static bool mpro_postcode_collect(uint8_t *buf, uint16_t len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, false);
+
+	if ((len - 6) != 4) {
+		LOG_ERR("Received invalid length postcode data");
+		return false;
+	}
+
+	LOG_HEXDUMP_INF(&buf[6], len - 6, "* postcode: ");
+
+	uint32_t postcode = 0;
+	for (int i = 6; i < len; i++)
+		postcode |= (buf[i] << ((i - 6) * 8));
+
+	mpro_postcode_insert(postcode);
+
+	return true;
+}
+
+#define PLDM_MAX_INSTID_COUNT 32
+static uint32_t inst_table_for_ipmb;
+static bridge_store store_table[PLDM_MAX_INSTID_COUNT];
+
+bool pldm_save_mctp_inst_from_ipmb_req(void *mctp_inst, uint8_t inst_num,
+				       mctp_ext_params ext_params)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, false);
+
+	if (inst_num >= PLDM_MAX_INSTID_COUNT) {
+		LOG_ERR("Invalid instance number %d", inst_num);
+		return false;
+	}
+
+	WRITE_BIT(inst_table_for_ipmb, inst_num, 1);
+	store_table[inst_num].mctp_inst = (mctp *)mctp_inst;
+	store_table[inst_num].ext_params = ext_params;
+
+	return true;
+}
+
+bridge_store *pldm_find_mctp_inst_by_inst_id(uint8_t inst_num)
+{
+	if (!(inst_table_for_ipmb & BIT(inst_num))) {
+		LOG_ERR("Received unexpected inatant id %d not register yet!", inst_num);
+		return NULL;
+	}
+
+	WRITE_BIT(inst_table_for_ipmb, inst_num, 0);
+
+	return &store_table[inst_num];
+}
+
+bool pldm_send_ipmb_rsp(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+
+	if ((msg->netfn != (NETFN_OEM_1S_REQ + 1)) || (msg->cmd != CMD_OEM_1S_MSG_IN)) {
+		LOG_ERR("Unexpected message NetFn: 0x%x Cmd: 0x%x", msg->netfn, msg->cmd);
+		return false;
+	}
+
+	if (msg->data_len < (sizeof(struct bypass_pldm_cmd_req_rsp))) {
+		LOG_ERR("Received invalid data length while received cc 0x%x",
+			msg->completion_code);
+		return false;
+	}
+
+	struct bypass_pldm_cmd_req_rsp *rsp_data = (struct bypass_pldm_cmd_req_rsp *)msg->data;
+
+	uint32_t iana = rsp_data->iana[0] | (rsp_data->iana[1] << 8) | (rsp_data->iana[2] << 16);
+	if (iana != IANA_ID) {
+		LOG_ERR("Received invalid iana 0x%x", iana);
+		return false;
+	}
+
+	bridge_store *hdr_info = pldm_find_mctp_inst_by_inst_id(rsp_data->inst_id);
+	if (!hdr_info) {
+		LOG_ERR("Given instant num %d can't get mctp header while ipmb response",
+			rsp_data->inst_id);
+		return false;
+	}
+
+	pldm_msg pmsg = { 0 };
+	pmsg.ext_params = hdr_info->ext_params;
+	pmsg.hdr.msg_type = MCTP_MSG_TYPE_PLDM;
+	memcpy(&pmsg.hdr.req_d_id, &rsp_data->req_d_id, sizeof(struct bypass_pldm_cmd_req_rsp) - 3);
+	pmsg.hdr.rq = PLDM_RESPONSE;
+
+	pmsg.len = msg->data_len - sizeof(struct bypass_pldm_cmd_req_rsp) +
+		   1; /* at least have a one-byte completion code */
+	uint8_t tbuf[pmsg.len];
+	memset(tbuf, 0, pmsg.len);
+
+	if (pmsg.len) {
+		memcpy(tbuf, rsp_data->payload, pmsg.len);
+		pmsg.buf = tbuf;
+	}
+
+	LOG_HEXDUMP_DBG(pmsg.buf, pmsg.len, "Receive pldm rsp from ipmb:");
+
+	mctp_pldm_send_msg(hdr_info->mctp_inst, &pmsg);
+
+	return true;
+}

--- a/meta-facebook/yv35-hda1/src/platform/plat_pldm.h
+++ b/meta-facebook/yv35-hda1/src/platform/plat_pldm.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _PLAT_PLDM_h
+#define _PLAT_PLDM_h
+
+#include "mctp.h"
+
+typedef struct _bridge_store {
+	mctp *mctp_inst;
+	mctp_ext_params ext_params;
+} bridge_store;
+
+struct bypass_pldm_cmd_req_rsp {
+	uint8_t iana[3];
+	union {
+		struct {
+			uint8_t inst_id : 5;
+			uint8_t rsvd : 1;
+			uint8_t d : 1;
+			uint8_t rq : 1;
+		};
+		uint8_t req_d_id;
+	};
+
+	uint8_t pldm_type : 6;
+	uint8_t ver : 2;
+	uint8_t cmd;
+	uint8_t payload[1];
+} __attribute__((packed));
+
+bool pldm_request_msg_need_bypass(uint8_t *buf, uint32_t len);
+bool pldm_save_mctp_inst_from_ipmb_req(void *mctp_inst, uint8_t inst_num,
+				       mctp_ext_params ext_params);
+bridge_store *pldm_find_mctp_inst_by_inst_id(uint8_t inst_num);
+bool pldm_send_ipmb_rsp(ipmi_msg *msg);
+
+#endif /* _PLAT_PLDM_h */

--- a/meta-facebook/yv35-hda1/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_sensor_table.c
@@ -19,8 +19,12 @@
 #include <logging/log.h>
 #include "plat_sensor_table.h"
 #include "sensor.h"
+#include "mpro.h"
 
 LOG_MODULE_REGISTER(plat_sensor_table);
+
+struct plat_mpro_sensor_mapping mpro_sensor_map[] = {};
+const int MPRO_MAP_TAB_SIZE = ARRAY_SIZE(mpro_sensor_map);
 
 sensor_cfg plat_sensor_config[] = {
 	/* number, type, port, address, offset, access check, arg0, arg1, cache, cache_status,

--- a/meta-facebook/yv35-hda1/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-hda1/src/platform/plat_sensor_table.h
@@ -17,6 +17,18 @@
 #ifndef PLAT_SENSOR_TABLE_H
 #define PLAT_SENSOR_TABLE_H
 
+/* SENSOR ADDRESS(7-bit)/OFFSET */
+#define TMP75_IN_ADDR (0x94 >> 1)
+#define TMP75_OUT_ADDR (0x92 >> 1)
+#define TMP75_FIO_ADDR (0x90 >> 1)
+#define SSD_ADDR (0xD4 >> 1)
+#define MPRO_ADDR (0x9E >> 1)
+
+#define ADM1278_ADDR (0x80 >> 1)
+#define LTC4282_ADDR (0x82 >> 1)
+#define TEMP_HSC_ADDR (0x98 >> 1)
+#define MP5990_ADDR (0xA0 >> 1)
+
 /* SENSOR NUMBER - sel */
 #define SENSOR_NUM_SYSTEM_STATUS 0x10
 #define SENSOR_NUM_POWER_ERROR 0x56


### PR DESCRIPTION
Summary:
- Enable mctp-pldm channel for Ampere Mpro device.
- Support 4byte post code oem command (NetFn:0x38, Cmd:0x2A)
- Support mctp-pldm shell command in BIC console.
- Support platform event message command for hda1.
- Support pldm request bridge(pldm->ipmb) command for Mpro to BMC.
- Support pldm request bridge(ipmb->pldm) command for BMC to Mpro.

Test Plan:
- BuildCode: PASS
- Check PLDM request command from BIC to Mpro: PASS
- Check PLDM request command from BMC to Mpro: PASS
- Check get post code command from BMC: PASS

Log:
- Check PLDM request command from BIC to Mpro:
  ```
  uart:~$ platform pldm sendreq 0x10 0x02 0x11 0x03 0x00 0x00
  * mctp: 0x44ff8 addr: 0x9e eid: 0x10 msg_type: 0x1
    pldm_type: 0x2 pldm cmd: 0x11
  00000000: 03 00 00                                         |...              |
  00000000: 00 05 00 02 01 00 01 2f  00 00 00                |......./ ...     |
  ``` 

- Check PLDM request command from BMC to Mpro
  ```
  root@bmc-oob:~# bic-util slot1 0xe0 0x02 0x15 0xa0 0x00 0x42 0x02 0x11 0x03 0x00 0x00
  15 A0 00 00 05 00 02 01 00 01 2f 00 00 00
  ```

- Check get post code command from BMC:
  ```
  root@bmc-oob:~# bic-util slot1 --get_gpio |grep -i POST
  11 AMP_FM_BIOS_POST_CMPLT_BIC_N: 0
  root@bmc-oob:~# bic-util slot1 --get_post_code
  util_get_post_buf: returns 38 dword
  [03101019] [03051001] [03051002] [03051001] 
  [03051002] [03051001] [03051002] [03051001] 
  [03051002] [03051001] [02020000] [02010000] 
  [02020000] [02020003] [02020004] [02020000] 
  [02010000] [02011001] [02010000] [03051005] 
  [03041001] [03021001] [97808001] [98808001] 
  [98808000] [97808000] [93808001] [93808000] 
  [94808001] [95808002] [95804201] [95802101] 
  [95808000] [94808000] [92808001] [92808000] 
  [91808001] [91808000] 
  ```