### PR TITLE
fby35: cl: Disable MPS5990 VIN_UVLO fault

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.h
@@ -31,6 +31,7 @@
 #define ADI_ADM1278_ADDR (0x80 >> 1)
 #define ADI_LTC4286_ADDR (0x84 >> 1)
 #define MPS_MP5990_ADDR (0x16 >> 1)
+#define MPS_MP5990_OFFSET_EFUSE_CFG 0xC4
 #define ADI_LTC4282_ADDR (0x88 >> 1)
 #define PCH_ADDR (0x2C >> 1)
 #define ME_SENSOR_NUM_TEMP_PCH 0x08


### PR DESCRIPTION
# Description
- Disable MPS5990 VIN_UVLO fault event.

# Motivation
- MP5990 eFuse – HSC_FAULT recorded when sled unplugged because Vin UV triggered and power team mentioned VIN UVLO fault event is no needed.

# Test plan
1. Build Y35-CL pass.
2. Read MPS5990 EFUSE_CFG(0xC4).
- Before uart:~$ i2c read I2C_1 0x0b 0xC4 0x2
00000000: c8 68

- After uart:~$ i2c read I2C_1 0x0b 0xC4 0x2
00000000: 48 68