### PR TITLE
fby35: cl: Enable internal PD ADC6 if 1OU not present

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.c
@@ -412,6 +412,11 @@ void init_platform_config()
 		read_value = sys_read32(REG_SCU + 0x430);
 		read_value = SETBIT(read_value, 30);
 		sys_write32(read_value, REG_SCU + 0x430);
+
+		// Enable internal PD
+		read_value = sys_read32(REG_SCU + 0x630);
+		read_value = CLEARBIT(read_value, 30);
+		sys_write32(read_value, REG_SCU + 0x630);
 	}
 
 	if (_2ou_status.present) {


### PR DESCRIPTION
Description
- Enable internal PD ADC6 if 1OU not present

Test plan
1. Build code pass.

Without 1OU:
md 7e6e2630
[7e6e2630] bf000000

With 1OU:
md 7e6e2630
[7e6e2630] ff000000