### PR TITLE
Artemis: cb: Support power brick second source sensor reading

### DIFF
--- a/common/dev/bmr351.c
+++ b/common/dev/bmr351.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <logging/log.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "pmbus.h"
+#include "util_pmbus.h"
+#include "libutil.h"
+
+LOG_MODULE_REGISTER(dev_bmr351);
+
+static int bmr351_read_pout(sensor_cfg *cfg, float *pout_value)
+{
+	int ret = 0;
+	float vout = 0;
+	float iout = 0;
+	float exponent = 1;
+	uint8_t read_len = 2;
+	uint16_t tmp = 0;
+
+	/* Read Vout */
+	if (get_exponent_from_vout_mode(cfg, &exponent) == false) {
+		LOG_ERR("Fail to get exponent from VOUT mode command");
+		return -1;
+	}
+
+	ret = pmbus_read_command(cfg, PMBUS_READ_VOUT, (uint8_t *)&tmp, read_len);
+	if (ret != 0) {
+		return -1;
+	}
+	vout = (float)tmp * exponent;
+
+	/* Read Iout */
+	ret = pmbus_read_command(cfg, PMBUS_READ_IOUT, (uint8_t *)&tmp, read_len);
+	if (ret != 0) {
+		return -1;
+	}
+	iout = slinear11_to_float(tmp);
+
+	*pout_value = vout * iout;
+	return 0;
+}
+
+uint8_t bmr351_read(sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("sensor num: 0x%x is invalid", cfg->num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	int ret = 0;
+	float val = 0;
+	float exponent = 1;
+	uint16_t tmp = 0;
+	uint8_t read_len = 2;
+	uint8_t offset = cfg->offset;
+
+	switch (offset) {
+	case PMBUS_READ_VOUT:
+		if (get_exponent_from_vout_mode(cfg, &exponent) == false) {
+			LOG_ERR("Fail to get exponent from VOUT mode command");
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+
+		ret = pmbus_read_command(cfg, offset, (uint8_t *)&tmp, read_len);
+		if (ret != 0) {
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+		val = (float)tmp * exponent;
+		break;
+	case PMBUS_READ_IOUT:
+	case PMBUS_READ_TEMPERATURE_1:
+		ret = pmbus_read_command(cfg, offset, (uint8_t *)&tmp, read_len);
+		if (ret != 0) {
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+		val = slinear11_to_float(tmp);
+		break;
+	case PMBUS_READ_POUT:
+		ret = bmr351_read_pout(cfg, &val);
+		if (ret != 0) {
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+		break;
+	default:
+		LOG_ERR("Offset not supported: 0x%x", offset);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	sval->integer = (int)val & 0xFFFF;
+	sval->fraction = (val - sval->integer) * 1000;
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t bmr351_init(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	cfg->read = bmr351_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -116,6 +116,7 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(mp2985)
 	sensor_name_to_num(m88rt51632)
 	sensor_name_to_num(mpro)
+	sensor_name_to_num(bmr351)
 };
 // clang-format on
 
@@ -169,6 +170,7 @@ SENSOR_DRIVE_INIT_DECLARE(m88rt51632);
 #ifdef ENABLE_MPRO
 SENSOR_DRIVE_INIT_DECLARE(mpro);
 #endif
+SENSOR_DRIVE_INIT_DECLARE(bmr351);
 
 struct sensor_drive_api {
 	enum SENSOR_DEV dev;
@@ -224,6 +226,7 @@ struct sensor_drive_api {
 #ifdef ENABLE_MPRO
 	SENSOR_DRIVE_TYPE_INIT_MAP(mpro),
 #endif
+	SENSOR_DRIVE_TYPE_INIT_MAP(bmr351),
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -155,6 +155,7 @@ enum SENSOR_DEV {
 	sensor_dev_mp2985 = 0x2A,
 	sensor_dev_m88rt51632 = 0x2B,
 	sensor_dev_mpro = 0x2C,
+	sensor_dev_bmr351 = 0x2D,
 	sensor_dev_max
 };
 

--- a/meta-facebook/at-cb/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-cb/src/platform/plat_sensor_table.c
@@ -82,33 +82,6 @@ sensor_cfg plat_sensor_config[] = {
 	  1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	/** Power module **/
-	{ SENSOR_NUM_TEMP_POWER_BRICK_1, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_1_ADDR,
-	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_VOL_P12V_AUX_1, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_1_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_CUR_P12V_AUX_1, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_1_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_PWR_P12V_AUX_1, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_1_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-
-	{ SENSOR_NUM_TEMP_POWER_BRICK_2, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_2_ADDR,
-	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_VOL_P12V_AUX_2, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_2_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_CUR_P12V_AUX_2, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_2_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-	{ SENSOR_NUM_PWR_P12V_AUX_2, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_2_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
-
 	/** VR **/
 	{ SENSOR_NUM_TEMP_P0V8_VDD_1, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
 	  PMBUS_READ_TEMPERATURE_1, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
@@ -1345,6 +1318,62 @@ sensor_cfg ltc4286_sensor_config_table[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &ltc4286_init_args[1] },
 };
 
+sensor_cfg q50sn120a1_sensor_config_table[] = {
+	{ SENSOR_NUM_TEMP_POWER_BRICK_1, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_1_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_VOL_P12V_AUX_1, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_1_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_CUR_P12V_AUX_1, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_1_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_PWR_P12V_AUX_1, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_1_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+
+	{ SENSOR_NUM_TEMP_POWER_BRICK_2, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_2_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_VOL_P12V_AUX_2, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_2_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_CUR_P12V_AUX_2, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_2_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_PWR_P12V_AUX_2, sensor_dev_q50sn120a1, I2C_BUS1, POWER_BRICK_2_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+};
+
+sensor_cfg bmr351_sensor_config_table[] = {
+	{ SENSOR_NUM_TEMP_POWER_BRICK_1, sensor_dev_bmr351, I2C_BUS1, POWER_BRICK_1_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_VOL_P12V_AUX_1, sensor_dev_bmr351, I2C_BUS1, POWER_BRICK_1_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_CUR_P12V_AUX_1, sensor_dev_bmr351, I2C_BUS1, POWER_BRICK_1_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_PWR_P12V_AUX_1, sensor_dev_bmr351, I2C_BUS1, POWER_BRICK_1_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+
+	{ SENSOR_NUM_TEMP_POWER_BRICK_2, sensor_dev_bmr351, I2C_BUS1, POWER_BRICK_2_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_VOL_P12V_AUX_2, sensor_dev_bmr351, I2C_BUS1, POWER_BRICK_2_ADDR,
+	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_CUR_P12V_AUX_2, sensor_dev_bmr351, I2C_BUS1, POWER_BRICK_2_ADDR,
+	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+	{ SENSOR_NUM_PWR_P12V_AUX_2, sensor_dev_bmr351, I2C_BUS1, POWER_BRICK_2_ADDR,
+	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+};
+
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
 const int ACCL_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_accl1_sensor_config);
 
@@ -1400,6 +1429,7 @@ uint8_t pal_get_extend_sensor_config()
 {
 	uint8_t extend_sensor_config_size = 0;
 	uint8_t hsc_module = get_hsc_module();
+	uint8_t power_brick_module = get_pwr_brick_module();
 
 	switch (hsc_module) {
 	case HSC_MODULE_ADM1272:
@@ -1413,6 +1443,18 @@ uint8_t pal_get_extend_sensor_config()
 		break;
 	}
 
+	switch (power_brick_module) {
+	case POWER_BRICK_Q50SN120A1:
+		extend_sensor_config_size += ARRAY_SIZE(q50sn120a1_sensor_config_table);
+		break;
+	case POWER_BRICK_BMR3512202:
+		extend_sensor_config_size += ARRAY_SIZE(bmr351_sensor_config_table);
+		break;
+	default:
+		LOG_ERR("Invalid power brick module: 0x%x", power_brick_module);
+		break;
+	}
+
 	return extend_sensor_config_size;
 }
 
@@ -1421,6 +1463,7 @@ void pal_extend_sensor_config()
 	uint8_t index = 0;
 	uint8_t sensor_count = 0;
 	uint8_t hsc_module = get_hsc_module();
+	uint8_t power_brick_module = get_pwr_brick_module();
 
 	switch (hsc_module) {
 	case HSC_MODULE_ADM1272:
@@ -1437,6 +1480,24 @@ void pal_extend_sensor_config()
 		break;
 	default:
 		LOG_ERR("Invalid hsc module: 0x%x", hsc_module);
+		break;
+	}
+
+	switch (power_brick_module) {
+	case POWER_BRICK_Q50SN120A1:
+		sensor_count = ARRAY_SIZE(q50sn120a1_sensor_config_table);
+		for (index = 0; index < sensor_count; index++) {
+			add_sensor_config(q50sn120a1_sensor_config_table[index]);
+		}
+		break;
+	case POWER_BRICK_BMR3512202:
+		sensor_count = ARRAY_SIZE(bmr351_sensor_config_table);
+		for (index = 0; index < sensor_count; index++) {
+			add_sensor_config(bmr351_sensor_config_table[index]);
+		}
+		break;
+	default:
+		LOG_ERR("Invalid power brick module: 0x%x", power_brick_module);
 		break;
 	}
 }
@@ -1513,10 +1574,10 @@ bool is_accl_power_good(uint8_t card_id)
 	msg.rx_len = 1;
 	msg.tx_len = 1;
 
-	if (card_id >= PCIE_CARD_1 && card_id <= PCIE_CARD_6) {
+	if (card_id <= PCIE_CARD_6) {
 		msg.data[0] = CPLD_ACCLB_PWRGD_OFFSET;
 		power_good_bit = (1 << (card_id - PCIE_CARD_1));
-	} else if (card_id >= PCIE_CARD_7 && card_id <= PCIE_CARD_12) {
+	} else if (card_id <= PCIE_CARD_12) {
 		msg.data[0] = CPLD_ACCLA_PWRGD_OFFSET;
 		power_good_bit = (1 << (card_id - PCIE_CARD_7));
 	} else {


### PR DESCRIPTION
# Description
- Support power brick second source(BMR351) sensor reading.

# Motivation
- Support power brick second source sensor reading.

# Test Plan
- Build code: Pass
- Get power brick(Q50SN120A1) sensor reading: Pass

# Log
CB_POWER_BRICK_1_TEMP_C      (0x9) :   28.00 C     | (ok)
CB_POWER_BRICK_2_TEMP_C      (0xA) :   30.00 C     | (ok)
CB_P12V_AUX_1_V              (0xD) :   12.17 Volts | (ok)
CB_P12V_AUX_2_V              (0xE) :   12.16 Volts | (ok)
CB_P12V_AUX_1_A              (0x32) :    3.50 Amps  | (ok)
CB_P12V_AUX_2_A              (0x33) :    3.75 Amps  | (ok)
CB_P12V_AUX_1_W              (0x43) :   39.55 Watts | (ok)
CB_P12V_AUX_2_W              (0x44) :   57.76 Watts | (ok)