### PR TITLE
GT: Disable check null in hsc post read

### DIFF
--- a/meta-facebook/gt-cc/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/gt-cc/src/ipmi/plat_ipmi.c
@@ -105,11 +105,6 @@ void OEM_1S_FW_UPDATE(ipmi_msg *msg)
 	}
 
 	if ((target == GT_COMPNT_BIC) || (target == (GT_COMPNT_BIC | IS_SECTOR_END_MASK))) {
-		// Expect BIC firmware size not bigger than 320k
-		if (offset > BIC_UPDATE_MAX_OFFSET) {
-			msg->completion_code = CC_PARAM_OUT_OF_RANGE;
-			return;
-		}
 		status = fw_update(offset, length, &msg->data[7], (target & IS_SECTOR_END_MASK),
 				   DEVSPI_FMC_CS0);
 	} else if (((target & WITHOUT_SENCTOR_END_MASK) == GT_COMPNT_PEX0) ||

--- a/meta-facebook/gt-cc/src/platform/plat_hook.c
+++ b/meta-facebook/gt-cc/src/platform/plat_hook.c
@@ -1009,12 +1009,7 @@ bool post_i2c_bus_read(sensor_cfg *cfg, void *args, int *reading)
 bool post_mp5990_read(sensor_cfg *cfg, void *args, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
-	CHECK_NULL_ARG_WITH_RETURN(args, false);
-
-	if (!reading) {
-		post_i2c_bus_read((void *)cfg, args, reading);
-		return false;
-	}
+	ARG_UNUSED(args);
 
 	if (!post_i2c_bus_read((void *)cfg, args, reading))
 		return false;
@@ -1047,12 +1042,7 @@ bool post_mp5990_read(sensor_cfg *cfg, void *args, int *reading)
 bool post_ltc4282_read(sensor_cfg *cfg, void *args, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
-	CHECK_NULL_ARG_WITH_RETURN(args, false);
-
-	if (!reading) {
-		post_i2c_bus_read((void *)cfg, args, reading);
-		return false;
-	}
+	ARG_UNUSED(args);
 
 	if (!post_i2c_bus_read(cfg, args, reading))
 		return false;
@@ -1083,12 +1073,7 @@ bool post_ltc4282_read(sensor_cfg *cfg, void *args, int *reading)
 bool post_ltc4286_read(sensor_cfg *cfg, void *args, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
-	CHECK_NULL_ARG_WITH_RETURN(args, false);
-
-	if (!reading) {
-		post_i2c_bus_read((void *)cfg, args, reading);
-		return false;
-	}
+	ARG_UNUSED(args);
 
 	if (!post_i2c_bus_read((void *)cfg, args, reading))
 		return false;


### PR DESCRIPTION
Summary:
- Disable check null on unused arguments in HSC post read.

TestPlan:
- Build Code: PASS