### PR TITLE
GT: Disable check null in hsc post read

### DIFF
--- a/meta-facebook/gt-cc/src/platform/plat_hook.c
+++ b/meta-facebook/gt-cc/src/platform/plat_hook.c
@@ -1009,7 +1009,7 @@ bool post_i2c_bus_read(sensor_cfg *cfg, void *args, int *reading)
 bool post_mp5990_read(sensor_cfg *cfg, void *args, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
-	CHECK_NULL_ARG_WITH_RETURN(args, false);
+	ARG_UNUSED(args);
 
 	if (!reading) {
 		post_i2c_bus_read((void *)cfg, args, reading);
@@ -1047,7 +1047,7 @@ bool post_mp5990_read(sensor_cfg *cfg, void *args, int *reading)
 bool post_ltc4282_read(sensor_cfg *cfg, void *args, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
-	CHECK_NULL_ARG_WITH_RETURN(args, false);
+	ARG_UNUSED(args);
 
 	if (!reading) {
 		post_i2c_bus_read((void *)cfg, args, reading);
@@ -1083,7 +1083,7 @@ bool post_ltc4282_read(sensor_cfg *cfg, void *args, int *reading)
 bool post_ltc4286_read(sensor_cfg *cfg, void *args, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
-	CHECK_NULL_ARG_WITH_RETURN(args, false);
+	ARG_UNUSED(args);
 
 	if (!reading) {
 		post_i2c_bus_read((void *)cfg, args, reading);


### PR DESCRIPTION
Summary:
- Disable check null on unused arguments in HSC post read.

TestPlan:
- Build Code: PASS