### PR TITLE
common: ssif: Solve host command to BIC not response problem

### DIFF
--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -25,6 +25,11 @@
 #include "kcs.h"
 #endif
 
+#include "plat_def.h"
+#ifdef ENABLE_SSIF
+#include "ssif.h"
+#endif
+
 #include "usb.h"
 #include <string.h>
 #include <stdlib.h>
@@ -392,10 +397,8 @@ void ipmi_cmd_handle(void *parameters, void *arvg0, void *arvg1)
 #ifdef ENABLE_SSIF
 	case HOST_SSIF_1:
 		msg_cfg.buffer.netfn = (msg_cfg.buffer.netfn + 1) << 2;
-		if (ssif_set_data(msg_cfg.buffer.InF_source - HOST_SSIF_1, &msg_cfg) == false) {
+		if (ssif_set_data(msg_cfg.buffer.InF_source - HOST_SSIF_1, &msg_cfg) == false)
 			LOG_ERR("Failed to write ssif response data");
-			continue;
-		}
 		break;
 #endif
 	case PLDM:


### PR DESCRIPTION
Summary:
- Fix ssif.h not include in ipmi.c problem.

TestPlan:
- Build Code: PASS
- Send ipmi command to BIC: PASS

Log:
- HOST console:
  ```
  [root@localhost ~]# ipmitool raw 0x38 0x0a 0x15 0xa0 0x00 0x01
   15 a0 00 59 6f 73 65 6d 69 74 65 20 56 33 2e 35
  ```