### PR TITLE
common:patch:driver: adc extend the delay time

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0053-adc-aspeed-Extend-the-delay-time-to-meet-our-ADC-spe.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0053-adc-aspeed-Extend-the-delay-time-to-meet-our-ADC-spe.patch
@@ -1,0 +1,63 @@
+From da24f371cade77f408e5c674a5c684fb7a123d91 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Tue, 13 Jun 2023 17:51:02 +0800
+Subject: [PATCH] adc: aspeed: Extend the delay time to meet our ADC spec.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: Ib1e8c96ea94b0b88c1cca3b140843dffa5ef4179
+---
+ drivers/adc/aspeed/adc_aspeed.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/adc/aspeed/adc_aspeed.c b/drivers/adc/aspeed/adc_aspeed.c
+index b2249a9cc2b..be1754e19d7 100644
+--- a/drivers/adc/aspeed/adc_aspeed.c
++++ b/drivers/adc/aspeed/adc_aspeed.c
+@@ -32,6 +32,7 @@ struct adc_aspeed_data {
+ 	uint32_t channels;
+ 	uint32_t clk_rate;
+ 	uint32_t sampling_period_us;
++	uint32_t required_eoc_num;
+ 	bool battery_sensing_enable;
+ 	uint16_t *buffer;
+ 	uint16_t *repeat_buffer;
+@@ -106,7 +107,6 @@ static int adc_aspeed_read_channel(const struct device *dev, uint8_t channel,
+ 				   int32_t *result)
+ {
+ 	struct adc_aspeed_data *priv = DEV_DATA(dev);
+-	const struct adc_aspeed_cfg *config = DEV_CFG(dev);
+ 
+ 	if (priv->battery_sensing_enable && channel == 7) {
+ 		*result = aspeed_adc_battery_read(dev, channel);
+@@ -115,8 +115,7 @@ static int adc_aspeed_read_channel(const struct device *dev, uint8_t channel,
+ 		if (priv->deglitch_en[channel]) {
+ 			if (*result >= priv->upper_bound[channel] ||
+ 			    *result <= priv->lower_bound[channel]) {
+-				k_busy_wait(priv->sampling_period_us *
+-					    popcount(config->channels_used));
++				k_busy_wait(priv->sampling_period_us * priv->required_eoc_num);
+ 				*result = aspeed_adc_read_raw(dev, channel);
+ 			}
+ 		}
+@@ -446,6 +445,7 @@ static int aspeed_adc_engine_init(const struct device *dev,
+ 				  uint32_t timeout_ms)
+ {
+ 	const struct adc_aspeed_cfg *config = DEV_CFG(dev);
++	struct adc_aspeed_data *priv = DEV_DATA(dev);
+ 	struct adc_register_s *adc_register = config->base;
+ 	union adc_engine_control_s engine_ctrl;
+ 	int ret;
+@@ -466,6 +466,10 @@ static int aspeed_adc_engine_init(const struct device *dev,
+ 	engine_ctrl.fields.channel_enable = config->channels_used;
+ 	adc_register->engine_ctrl.value = engine_ctrl.value;
+ 
++	priv->required_eoc_num = popcount(config->channels_used);
++	if (config->channels_used & BIT(ASPEED_ADC_CH_NUMBER - 1))
++		priv->required_eoc_num += 10;
++
+ 	return 0;
+ }
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Summary:
- adc aspeed Extend the delay time to meet our ADC spec

Test Plan:
- BuildCode: PASS
- git am: PASS