### PR TITLE
fby35: hda1: Modify ADC sensor sdr alert border

### DIFF
--- a/meta-facebook/yv35-hda1/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_sdr_table.c
@@ -1537,7 +1537,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x5A, // UCT
+		0x5D, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x50, // LCT
@@ -1781,10 +1781,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x58, // UCT
+		0x5A, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x54, // LCT
+		0x4F, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -2025,7 +2025,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x5A, // UCT
+		0x5D, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x50, // LCT


### PR DESCRIPTION
Summary:
- Modify ADC sensor sdr alert border

TestPlan:
- BuildCode: PASS
- Check sensor borders by BMC console: PASS

Log:
- BMC console:
  ```
  MB_ADC_SOC_RC_DDR0_VOLT_V    (0x1A) :    0.89 Volts  | (ok) | UCR: 0.93 | UNC: NA | UNR: NA | LCR: 0.80 | LNC: NA | LNR: NA
  MB_ADC_P0V8_D2D_VOLT_V       (0x1E) :    0.85 Volts  | (ok) | UCR: 0.90 | UNC: NA | UNR: NA | LCR: 0.79 | LNC: NA | LNR: NA
  MB_ADC_SOC_RC_DDR1_VOLT_V    (0x22) :    0.91 Volts  | (ok) | UCR: 0.93 | UNC: NA | UNR: NA | LCR: 0.80 | LNC: NA | LNR: NA
  ```