### PR TITLE
fby35: rf : Fix xdpe12284 vr current shows negatve

### DIFF
--- a/common/dev/xdpe12284c.c
+++ b/common/dev/xdpe12284c.c
@@ -604,8 +604,13 @@ uint8_t xdpe12284c_read(sensor_cfg *cfg, int *reading)
 	case PMBUS_READ_POUT:
 	case PMBUS_READ_TEMPERATURE_1:
 		actual_value = slinear11_to_float(val);
-		sval->integer = actual_value;
-		sval->fraction = (actual_value - sval->integer) * 1000;
+		if (offset == PMBUS_READ_IOUT && actual_value < 0) {
+			sval->integer = 0;
+			sval->fraction = 0;
+		} else {
+			sval->integer = actual_value;
+			sval->fraction = (actual_value - sval->integer) * 1000;
+		}
 		break;
 	case PMBUS_READ_VOUT:
 		msg.tx_len = 1;


### PR DESCRIPTION
Description:
Fix xdpe12284 vr current shows negatve

Motivation:
In the case POUT is 0, IOUT may read small negative value, replace this case with 0

Test Plan:
Check the sensor values for RF_PVDDQ_AB_CURR_A and RF_PVDDQ_CD_CURR_A

Test Log:
RF_PVDDQ_AB_CURR_A           (0x71) :    0.00 Amps  | (ok)
RF_PVDDQ_CD_CURR_A           (0x72) :    0.00 Amps  | (ok)
RF_PVDDQ_AB_PWR_W            (0x78) :    1.00 Watts  | (ok)
RF_PVDDQ_CD_PWR_W            (0x79) :    0.00 Watts  | (ok)