### PR TITLE
fby3.5: gl: Fix that CPU margin shows positive

### DIFF
--- a/common/dev/intel_peci.c
+++ b/common/dev/intel_peci.c
@@ -353,6 +353,13 @@ static bool get_cpu_margin(uint8_t addr, int *reading)
 
 	sensor_val *sval = (sensor_val *)reading;
 	sval->integer = ((int16_t)((rbuf[2] << 8) | rbuf[1]) >> 6) + 1;
+
+	// CPU margin value should be negative
+	if (sval->integer > 0) {
+		LOG_ERR("CPU margin value is larger then 0, the raw data rbuf[1]: 0x%x rbuf[2]: 0x%x",
+			rbuf[1], rbuf[2]);
+	}
+
 	return true;
 }
 

--- a/meta-facebook/yv35-gl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_hook.c
@@ -117,6 +117,7 @@ bool pre_nvme_read(sensor_cfg *cfg, void *args)
 
 	return true;
 }
+
 bool post_cpu_margin_read(sensor_cfg *cfg, void *args, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
@@ -126,8 +127,13 @@ bool post_cpu_margin_read(sensor_cfg *cfg, void *args, int *reading)
 		return check_reading_pointer_null_is_allowed(cfg);
 
 	sensor_val *sval = (sensor_val *)reading;
+
 	// The margin sensor should be shown as negative value in BMC.
-	sval->integer = -sval->integer;
+	if (sval->integer > 0) {
+		LOG_ERR("CPU margin value should not be positive, return NA");
+		return false;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
# Description:
Fix that CPU margin shows positive
Furthermore, return NA if CPU margin is larger 0

# Motivation:
The CPU margin sensor should be negative.
However, it shows positive now.

# Test Plan:
Check MB_SOC_THERMAL_MARGIN_C sensor value

# Test Log:
root@bmc-oob:~# sensor-util slot3
MB_SOC_THERMAL_MARGIN_C      (0x15) :  -69.00 C     | (ok)