### PR TITLE
Artemis: common: Fix dc sensor reading fail

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -340,7 +340,7 @@ uint8_t get_sensor_reading(sensor_cfg *cfg_table, uint8_t cfg_count, uint8_t sen
 				return cfg->cache_status;
 			}
 			if ((cfg->cache_status == SENSOR_NOT_PRESENT) ||
-			    (cfg->cache_status == SENSOR_NOT_ACCESSIBLE)) {
+			    (cfg->cache_status == SENSOR_POLLING_DISABLE)) {
 				return cfg->cache_status;
 			}
 		}


### PR DESCRIPTION
# Description:
- Root cause: When the dc is power off, the cache status of dc sensor will be saved as sensor_not_accessible. After the dc is power on, it will return directly because the cache status is still sensor_not_accessible after the pre-read function is executed, and the reading function will not continue to be executed.
- Solution: Change it to judge that if sensor_polling_disable, just return directly. Allow the sensor pre-read function to dynamically modify whether to continue polling a sensor.

# Motivation:
- Fix dc sensor reading fail issue.
- Allow the sensor pre-read function to dynamically modify whether to continue polling a sensor.

# Test Plan:
- Build code: Pass
- Get dc sensor: Pass

# Log:
root@bmc-oob:~# sensor-util cb
cb:
CB_INLET_TEMP_C              (0x67) :   30.25 C     | (ok)
CB_OUTLET_1_TEMP_C           (0x1) :   32.00 C     | (ok)
CB_OUTLET_2_TEMP_C           (0x2) :   34.00 C     | (ok)
CB_HSC1_TEMP _C              (0x3) :   28.31 C     | (ok)
CB_HSC2_TEMP_C               (0x4) :   32.83 C     | (ok)
CB_PEX0_TEMP_C               (0x5) :   55.67 C     | (ok)
CB_PEX1_TEMP_C               (0x6) :   57.34 C     | (ok)
CB_POWER_BRICK_1_TEMP_C      (0x9) :   32.00 C     | (ok)
CB_POWER_BRICK_2_TEMP_C      (0xA) :   37.00 C     | (ok)
CB_P51V_AUX_L_V              (0xB) :   50.94 Volts | (ok)
CB_P51V_AUX_R_V              (0xC) :   50.98 Volts | (ok)
CB_P12V_AUX_1_V              (0xD) :   12.12 Volts | (ok)
CB_P12V_AUX_2_V              (0xE) :   12.11 Volts | (ok)
CB_P5V_AUX_V                 (0x10) :    5.10 Volts | (ok)
CB_P3V3_AUX_V                (0x11) :    3.31 Volts | (ok)
CB_P1V2_AUX_V                (0x12) :    1.21 Volts | (ok)
CB_P1V8_PEX_V                (0x13) :    1.82 Volts | (ok)
CB_P1V8_1_VDD_V              (0x1E) :    1.80 Volts | (ok)
CB_P1V8_2_VDD_V              (0x1F) :    1.81 Volts | (ok)
CB_P1V25_1_VDD_V             (0x20) :    1.25 Volts | (ok)
CB_P1V25_2_VDD_V             (0x21) :    1.26 Volts | (ok)
CB_P12V_ACCL1_V              (0x23) :   12.14 Volts | (ok)
CB_P12V_ACCL2_V              (0x24) :   12.14 Volts | (ok)
CB_P12V_ACCL3_V              (0x25) :   12.14 Volts | (ok)
CB_P12V_ACCL4_V              (0x26) :   12.14 Volts | (ok)
CB_P12V_ACCL5_V              (0x27) :   12.14 Volts | (ok)
CB_P12V_ACCL6_V              (0x28) :   12.14 Volts | (ok)
CB_P12V_ACCL7_V              (0x29) :   12.14 Volts | (ok)
CB_P12V_ACCL8_V              (0x2A) :   12.14 Volts | (ok)
CB_P12V_ACCL9_V              (0x2C) :   12.14 Volts | (ok)
CB_P12V_ACCL10_V             (0x2D) :   12.14 Volts | (ok)
CB_P12V_ACCL11_V             (0x2E) :   12.14 Volts | (ok)
CB_P12V_ACCL12_V             (0x2F) :   12.14 Volts | (ok)
CB_P51V_AUX_L_A              (0x30) :    1.43 Amps  | (ok)
CB_P51V_AUX_R_A              (0x31) :    1.48 Amps  | (ok)
CB_P12V_AUX_1_A              (0x32) :   19.75 Amps  | (ok)
CB_P12V_AUX_2_A              (0x33) :   18.00 Amps  | (ok)
CB_P12V_ACCL1_A              (0x34) :    3.10 Amps  | (ok)
CB_P12V_ACCL2_A              (0x35) :    3.00 Amps  | (ok)
CB_P12V_ACCL3_A              (0x36) :    2.98 Amps  | (ok)
CB_P12V_ACCL4_A              (0x37) :    3.01 Amps  | (ok)
CB_P12V_ACCL5_A              (0x38) :    2.84 Amps  | (ok)
CB_P12V_ACCL6_A              (0x39) :    2.63 Amps  | (ok)
CB_P12V_ACCL7_A              (0x3A) :    2.97 Amps  | (ok)
CB_P12V_ACCL8_A              (0x3C) :    2.85 Amps  | (ok)
CB_P12V_ACCL9_A              (0x3D) :    2.87 Amps  | (ok)
CB_P12V_ACCL10_A             (0x3E) :    2.91 Amps  | (ok)
CB_P12V_ACCL11_A             (0x3F) :    2.88 Amps  | (ok)
CB_P12V_ACCL12_A             (0x40) :    2.50 Amps  | (ok)
CB_P51V_AUX_L_W              (0x41) :   72.98 Watts | (ok)
CB_P51V_AUX_R_W              (0x42) :   75.36 Watts | (ok)
CB_P12V_AUX_1_W              (0x43) :  208.90 Watts | (ok)
CB_P12V_AUX_2_W              (0x44) :  221.01 Watts | (ok)
CB_P12V_ACCL1_W              (0x45) :   37.58 Watts | (ok)
CB_P12V_ACCL2_W              (0x46) :   36.42 Watts | (ok)
CB_P12V_ACCL3_W              (0x47) :   36.15 Watts | (ok)
CB_P12V_ACCL4_W              (0x48) :   36.47 Watts | (ok)
CB_P12V_ACCL5_W              (0x49) :   34.50 Watts | (ok)
CB_P12V_ACCL6_W              (0x4A) :   31.95 Watts | (ok)
CB_P12V_ACCL7_W              (0x4B) :   36.05 Watts | (ok)
CB_P12V_ACCL8_W              (0x4C) :   34.58 Watts | (ok)
CB_P12V_ACCL9_W              (0x4D) :   34.85 Watts | (ok)
CB_P12V_ACCL10_W             (0x50) :   35.38 Watts | (ok)
CB_P12V_ACCL11_W             (0x51) :   34.92 Watts | (ok)
CB_P12V_ACCL12_W             (0x52) :   30.40 Watts | (ok)
CB_P51V_AUX_L_A              (0x30) :    1.43 Amps  | (ok)
CB_P51V_AUX_R_A              (0x31) :    1.48 Amps  | (ok)
CB_P12V_AUX_1_A              (0x32) :   19.75 Amps  | (ok)
CB_P12V_AUX_2_A              (0x33) :   18.00 Amps  | (ok)
CB_P12V_ACCL1_A              (0x34) :    3.10 Amps  | (ok)
CB_P12V_ACCL2_A              (0x35) :    3.00 Amps  | (ok)
CB_P12V_ACCL3_A              (0x36) :    2.98 Amps  | (ok)
CB_P12V_ACCL4_A              (0x37) :    3.01 Amps  | (ok)
CB_P12V_ACCL5_A              (0x38) :    2.84 Amps  | (ok)
CB_P12V_ACCL6_A              (0x39) :    2.63 Amps  | (ok)
CB_P12V_ACCL7_A              (0x3A) :    2.97 Amps  | (ok)
CB_P12V_ACCL8_A              (0x3C) :    2.85 Amps  | (ok)
CB_P12V_ACCL9_A              (0x3D) :    2.87 Amps  | (ok)
CB_P12V_ACCL10_A             (0x3E) :    2.91 Amps  | (ok)
CB_P12V_ACCL11_A             (0x3F) :    2.88 Amps  | (ok)
CB_P12V_ACCL12_A             (0x40) :    2.50 Amps  | (ok)
CB_P51V_AUX_L_W              (0x41) :   72.98 Watts | (ok)
CB_P51V_AUX_R_W              (0x42) :   75.36 Watts | (ok)
CB_P12V_AUX_1_W              (0x43) :  208.90 Watts | (ok)
CB_P12V_AUX_2_W              (0x44) :  221.01 Watts | (ok)
CB_P12V_ACCL1_W              (0x45) :   37.58 Watts | (ok)
CB_P12V_ACCL2_W              (0x46) :   36.42 Watts | (ok)
CB_P12V_ACCL3_W              (0x47) :   36.15 Watts | (ok)
CB_P12V_ACCL4_W              (0x48) :   36.47 Watts | (ok)
CB_P12V_ACCL5_W              (0x49) :   34.50 Watts | (ok)
CB_P12V_ACCL6_W              (0x4A) :   31.95 Watts | (ok)
CB_P12V_ACCL7_W              (0x4B) :   36.05 Watts | (ok)
CB_P12V_ACCL8_W              (0x4C) :   34.58 Watts | (ok)
CB_P12V_ACCL9_W              (0x4D) :   34.85 Watts | (ok)
CB_P12V_ACCL10_W             (0x50) :   35.38 Watts | (ok)
CB_P12V_ACCL11_W             (0x51) :   34.92 Watts | (ok)
CB_P12V_ACCL12_W             (0x52) :   30.40 Watts | (ok)