### PR TITLE
fby3.5: gl: Fix dimm pre read function arg check NULL

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_hook.c
@@ -134,7 +134,7 @@ bool post_cpu_margin_read(sensor_cfg *cfg, void *args, int *reading)
 bool pre_intel_peci_dimm_read(sensor_cfg *cfg, void *args)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
-	CHECK_NULL_ARG_WITH_RETURN(args, false);
+	ARG_UNUSED(args);
 
 	if (get_post_status() == false) {
 		return true;


### PR DESCRIPTION
# Description:
Fix dimm pre read function arg check NULL

# Motivation:
The arg in dimm pre read function is NULL now
Currently, BIC check the arg is NULL or not
In that case, it will result in dimm init fail
and BIC could not read dimm

# Test plan:
Check dimm values - pass

# Test log:
MB_DIMMA_TEMP_C              (0x5) :   30.00 C     | (ok)
MB_DIMMB_TEMP_C              (0x6) : NA | (na)
MB_DIMMC_TEMP_C              (0x7) : NA | (na)
MB_DIMMD_TEMP_C              (0x8) : NA | (na)
MB_DIMME_TEMP_C              (0x9) : NA | (na)
MB_DIMMF_TEMP_C              (0xA) : NA | (na)
MB_DIMMG_TEMP_C              (0xB) : NA | (na)
MB_DIMMH_TEMP_C              (0xC) : NA | (na)