### PR TITLE
Artemis: cb: Merge ACB FRUs sensor one sensor table

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -920,3 +920,8 @@ bool init_drive_type_delayed(sensor_cfg *cfg)
 
 	return false;
 }
+
+bool get_sensor_init_done_flag()
+{
+	return is_sensor_initial_done;
+}

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -662,5 +662,6 @@ uint8_t pal_get_monitor_sensor_count();
 void plat_fill_monitor_sensor_table();
 sensor_cfg *find_sensor_cfg_via_sensor_num(sensor_cfg *cfg_table, uint8_t cfg_count,
 					   uint8_t sensor_num);
+bool get_sensor_init_done_flag();
 
 #endif

--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -36,6 +36,7 @@
 LOG_MODULE_REGISTER(plat_hook);
 
 #define PEX_SWITCH_INIT_RETRY_COUNT 3
+#define ACCL_SENSOR_COUNT 6
 
 struct k_mutex xdpe15284_mutex;
 
@@ -172,345 +173,6 @@ pex89000_init_arg pex_sensor_init_args[] = {
 	[1] = { .idx = 1, .is_init = false },
 };
 
-ina233_init_arg accl_ina233_init_args[] = {
-	// ACCL 1
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	// ACCL 2
-	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	// ACCL 3
-	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	// ACCL 4
-	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	// ACCL 5
-	[12] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[13] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[14] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	// ACCL 6
-	[15] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[16] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[17] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	// ACCL 7
-	[18] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[19] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[20] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	// ACCL 8
-	[21] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[22] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[23] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	// ACCL 9
-	[24] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[25] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[26] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	// ACCL 10
-	[27] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[28] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[29] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	// ACCL 11
-	[30] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[31] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[32] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	// ACCL 12
-	[33] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[34] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-	[35] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
-	.mfr_config = {
-		.operating_mode =0b111,
-		.shunt_volt_time = 0b100,
-		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
-		.rsvd = 0b0100,
-	},
-	},
-};
-
 sq52205_init_arg sq52205_init_args[] = {
 	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
 	.config = {
@@ -584,6 +246,36 @@ mux_config pca9546_configs[] = {
 	[3] = { .target_addr = 0x72, .channel = PCA9546A_CHANNEL_3 },
 };
 
+accl_card_info accl_card_info_args[] = {
+	[0] = { .card_id = 0, .freya_info_ptr = &accl_freya_info[0] },
+	[1] = { .card_id = 1, .freya_info_ptr = &accl_freya_info[1] },
+	[2] = { .card_id = 2, .freya_info_ptr = &accl_freya_info[2] },
+	[3] = { .card_id = 3, .freya_info_ptr = &accl_freya_info[3] },
+	[4] = { .card_id = 4, .freya_info_ptr = &accl_freya_info[4] },
+	[5] = { .card_id = 5, .freya_info_ptr = &accl_freya_info[5] },
+	[6] = { .card_id = 6, .freya_info_ptr = &accl_freya_info[6] },
+	[7] = { .card_id = 7, .freya_info_ptr = &accl_freya_info[7] },
+	[8] = { .card_id = 8, .freya_info_ptr = &accl_freya_info[8] },
+	[9] = { .card_id = 9, .freya_info_ptr = &accl_freya_info[9] },
+	[10] = { .card_id = 10, .freya_info_ptr = &accl_freya_info[10] },
+	[11] = { .card_id = 11, .freya_info_ptr = &accl_freya_info[11] },
+};
+
+accl_card_sensor_info accl_sensor_info_args[] = {
+	[0] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_1_FREYA_1 },
+	[1] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_2_FREYA_1 },
+	[2] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_3_FREYA_1 },
+	[3] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_4_FREYA_1 },
+	[4] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_5_FREYA_1 },
+	[5] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_6_FREYA_1 },
+	[6] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_7_FREYA_1 },
+	[7] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_8_FREYA_1 },
+	[8] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_9_FREYA_1 },
+	[9] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_10_FREYA_1 },
+	[10] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_11_FREYA_1 },
+	[11] = { .is_sensor_init = false, .start_sensor_num = SENSOR_NUM_TEMP_ACCL_12_FREYA_1 },
+};
+
 uint8_t plat_monitor_table_arg[] = { PCIE_CARD_1, PCIE_CARD_2,	PCIE_CARD_3,  PCIE_CARD_4,
 				     PCIE_CARD_5, PCIE_CARD_6,	PCIE_CARD_7,  PCIE_CARD_8,
 				     PCIE_CARD_9, PCIE_CARD_10, PCIE_CARD_11, PCIE_CARD_12 };
@@ -598,6 +290,8 @@ bool pre_ina233_read(sensor_cfg *cfg, void *args)
 
 	// Select Channel
 	bool ret = true;
+	bool is_power_good = false;
+	bool is_sensor_init_done = false;
 	int mutex_status = 0;
 	pwr_monitor_pre_proc_arg *pre_args = (pwr_monitor_pre_proc_arg *)args;
 	mux_config mux_cfg = pre_args->mux_configs;
@@ -606,6 +300,19 @@ bool pre_ina233_read(sensor_cfg *cfg, void *args)
 	if (asic_card_info[pre_args->card_id].card_status == ASIC_CARD_NOT_PRESENT) {
 		cfg->is_enable_polling = false;
 		return false;
+	}
+
+	is_sensor_init_done = get_sensor_init_done_flag();
+	if (is_sensor_init_done) {
+		is_power_good = is_accl_power_good(pre_args->card_id);
+		if (is_power_good != true) {
+			cfg->cache_status = SENSOR_POLLING_DISABLE;
+			return true;
+		}
+
+		if (cfg->cache_status == SENSOR_POLLING_DISABLE) {
+			cfg->cache_status = SENSOR_INIT_STATUS;
+		}
 	}
 
 	struct k_mutex *mutex = get_i2c_mux_mutex(mux_cfg.bus);
@@ -765,90 +472,111 @@ bool post_pex89000_read(sensor_cfg *cfg, void *args, int *reading)
 	return true;
 }
 
-bool pre_accl_mux_switch(uint8_t sensor_num, void *arg)
-{
-	CHECK_NULL_ARG_WITH_RETURN(arg, false);
-
-	bool ret = false;
-	mux_config accl_mux = { 0 };
-	mux_config channel_mux = { 0 };
-	uint8_t *card_id = (uint8_t *)arg;
-
-	if (get_accl_mux_config(*card_id, &accl_mux) != true) {
-		return false;
-	}
-
-	if (get_mux_channel_config(*card_id, sensor_num, &channel_mux) != true) {
-		return false;
-	}
-
-	int mutex_status = 0;
-	struct k_mutex *mutex = get_i2c_mux_mutex(accl_mux.bus);
-
-	mutex_status = k_mutex_lock(mutex, K_MSEC(MUTEX_LOCK_INTERVAL_MS));
-	if (mutex_status != 0) {
-		LOG_ERR("Mutex lock fail, status: %d", mutex_status);
-		return false;
-	}
-
-	ret = set_mux_channel(accl_mux, MUTEX_LOCK_ENABLE);
-	if (ret == false) {
-		LOG_ERR("ACCL switch mux fail");
-		k_mutex_unlock(mutex);
-		return false;
-	}
-
-	ret = set_mux_channel(channel_mux, MUTEX_LOCK_ENABLE);
-	if (ret == false) {
-		LOG_ERR("ACCL switch mux fail");
-		k_mutex_unlock(mutex);
-		return false;
-	}
-
-	return true;
-}
-
-bool post_accl_mux_switch(uint8_t sensor_num, void *arg)
-{
-	CHECK_NULL_ARG_WITH_RETURN(arg, false);
-
-	mux_config accl_mux = { 0 };
-	uint8_t *card_id = (uint8_t *)arg;
-
-	if (get_accl_mux_config(*card_id, &accl_mux) != true) {
-		return false;
-	}
-
-	int unlock_status = 0;
-	struct k_mutex *mutex = get_i2c_mux_mutex(accl_mux.bus);
-	if (mutex->lock_count != 0) {
-		unlock_status = k_mutex_unlock(mutex);
-	}
-
-	if (unlock_status != 0) {
-		LOG_ERR("Mutex unlock fail, status: %d", unlock_status);
-		return false;
-	}
-
-	return true;
-}
-
 bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(args, false);
 
+	accl_card_info *card_info_args = (accl_card_info *)args;
+	uint8_t card_id = card_info_args->card_id;
+	freya_info *accl_freya = card_info_args->freya_info_ptr;
+
+	CHECK_NULL_ARG_WITH_RETURN(card_info_args->freya_info_ptr, false);
+
+	/** Check whether Freya is accessible **/
+	if (asic_card_info[card_id].card_status != ASIC_CARD_PRESENT) {
+		cfg->cache_status = SENSOR_NOT_PRESENT;
+		return true;
+	}
+
+	switch (cfg->target_addr) {
+	case ACCL_FREYA_1_ADDR:
+		if (asic_card_info[card_id].asic_1_status != ASIC_CARD_DEVICE_PRESENT) {
+			cfg->cache_status = SENSOR_NOT_PRESENT;
+			return true;
+		}
+		break;
+	case ACCL_FREYA_2_ADDR:
+		if (asic_card_info[card_id].asic_2_status != ASIC_CARD_DEVICE_PRESENT) {
+			cfg->cache_status = SENSOR_NOT_PRESENT;
+			return true;
+		}
+		break;
+	default:
+		break;
+	}
+
+	/** Check ACCL card power status **/
+	bool is_power_good = false;
+	uint8_t index = 0;
+
+	is_power_good = is_accl_power_good(card_id);
+	if (is_power_good != true) {
+		cfg->cache_status = SENSOR_POLLING_DISABLE;
+		accl_sensor_info_args[card_id].is_sensor_init = false;
+		return true;
+	}
+
+	if (cfg->cache_status == SENSOR_POLLING_DISABLE) {
+		cfg->cache_status = SENSOR_INIT_STATUS;
+	}
+
+	mux_config accl_mux = { 0 };
+	if (get_accl_mux_config(card_id, &accl_mux) != true) {
+		LOG_ERR("Fail to get ACCL card mux config, card id: 0x%x, sensor num: 0x%x",
+			card_id, cfg->num);
+		return false;
+	}
+
+	int mutex_status = 0;
+	struct k_mutex *mutex = get_i2c_mux_mutex(cfg->port);
+
+	mutex_status = k_mutex_lock(mutex, K_MSEC(MUTEX_LOCK_INTERVAL_MS));
+	if (mutex_status != 0) {
+		LOG_ERR("Mutex lock fail, status: %d, card id: 0x%x, sensor num: 0x%x",
+			mutex_status, card_id, cfg->num);
+		return false;
+	}
+
+	if (set_mux_channel(accl_mux, MUTEX_LOCK_ENABLE) == false) {
+		LOG_ERR("ACCL switch card mux fail, card id: 0x%x, sensor num: 0x%x", card_id,
+			cfg->num);
+		goto error_exit;
+	}
+
+	if (accl_sensor_info_args[card_id].is_sensor_init != true) {
+		for (index = 0; index < ACCL_SENSOR_COUNT; ++index) {
+			uint8_t sensor_num =
+				accl_sensor_info_args[card_id].start_sensor_num + index;
+
+			sensor_cfg *accl_sensor_cfg = get_common_sensor_cfg_info(sensor_num);
+			if (accl_sensor_cfg == NULL) {
+				LOG_ERR("Fail to get sensor cfg info, card id: 0x%x, sensor num: 0x%x",
+					card_id, sensor_num);
+				goto error_exit;
+			}
+
+			if (init_drive_type_delayed(accl_sensor_cfg) != true) {
+				LOG_ERR("Fail to delayed init sensor, card id: 0x%x, sensor num: 0x%x",
+					card_id, accl_sensor_cfg->num);
+				goto error_exit;
+			}
+		}
+
+		accl_sensor_info_args[card_id].is_sensor_init = true;
+	}
+
 	int ret = 0;
 	uint8_t nvme_temp = 0;
 	uint8_t drive_ready_bit = 0;
 	uint8_t nvme_status[FREYA_STATUS_BLOCK_LENGTH] = { 0 };
-	freya_info *accl_freya = (freya_info *)args;
 
 	ret = read_nvme_info(cfg->port, cfg->target_addr, FREYA_STATUS_BLOCK_OFFSET,
 			     FREYA_STATUS_BLOCK_LENGTH, nvme_status);
 	if (ret != 0) {
-		LOG_ERR("ACCL pre-read get freya status fail, sensor num: 0x%x", cfg->num);
-		return false;
+		LOG_ERR("ACCL pre-read get freya status fail, card id: 0x%x, sensor num: 0x%x",
+			card_id, cfg->num);
+		goto error_exit;
 	}
 
 	nvme_temp = nvme_status[NVME_TEMPERATURE_INDEX];
@@ -867,11 +595,9 @@ bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 		default:
 			break;
 		}
+
+		k_mutex_unlock(mutex);
 		return true;
-	} else {
-		if (cfg->cache_status == SENSOR_POLLING_DISABLE) {
-			cfg->cache_status = SENSOR_INIT_STATUS;
-		}
 	}
 
 	switch (cfg->target_addr) {
@@ -896,15 +622,43 @@ bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 		}
 		break;
 	default:
-		LOG_ERR("Invalid sensor address: 0x%x, sensor num: 0x%x", cfg->target_addr,
+		LOG_ERR("Invalid Freya sensor address, card id: 0x%x, sensor num: 0x%x", card_id,
 			cfg->num);
-		return false;
+		goto error_exit;
 	}
 
 	if (ret != 0) {
 		if (ret != FREYA_NOT_READY_RET_CODE) {
 			LOG_ERR("Get freya info fail, sensor num: 0x%x", cfg->num);
 		}
+		goto error_exit;
+	}
+
+	return true;
+
+error_exit:
+	k_mutex_unlock(mutex);
+	return false;
+}
+
+bool post_accl_nvme_read(sensor_cfg *cfg, void *args, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(args, false);
+	ARG_UNUSED(reading);
+
+	int unlock_status = 0;
+	uint8_t bus = cfg->port;
+	accl_card_info *card_info_args = (accl_card_info *)args;
+
+	struct k_mutex *mutex = get_i2c_mux_mutex(bus);
+	if (mutex->lock_count != 0) {
+		unlock_status = k_mutex_unlock(mutex);
+	}
+
+	if (unlock_status != 0) {
+		LOG_ERR("Mutex unlock fail, status: %d, card id: 0x%x, sensor num: 0x%x",
+			unlock_status, card_info_args->card_id, cfg->num);
 		return false;
 	}
 

--- a/meta-facebook/at-cb/src/platform/plat_hook.h
+++ b/meta-facebook/at-cb/src/platform/plat_hook.h
@@ -19,12 +19,23 @@
 
 #include "pmbus.h"
 #include "sensor.h"
+#include "plat_dev.h"
 #include "common_i2c_mux.h"
 
 typedef struct _pwr_monitor_pre_proc_arg {
 	mux_config mux_configs;
 	uint8_t card_id;
 } pwr_monitor_pre_proc_arg;
+
+typedef struct _accl_card_info {
+	uint8_t card_id;
+	freya_info *freya_info_ptr;
+} accl_card_info;
+
+typedef struct _accl_card_sensor_info {
+	bool is_sensor_init;
+	uint8_t start_sensor_num;
+} accl_card_sensor_info;
 
 /**************************************************************************************************
  * INIT ARGS
@@ -34,7 +45,6 @@ extern adm1272_init_arg adm1272_init_args[];
 extern ltc4286_init_arg ltc4286_init_args[];
 extern ina233_init_arg ina233_init_args[];
 extern pex89000_init_arg pex_sensor_init_args[];
-extern ina233_init_arg accl_ina233_init_args[];
 extern sq52205_init_arg sq52205_init_args[];
 
 /**************************************************************************************************
@@ -46,6 +56,7 @@ extern mux_config pca9548_configs[];
 extern mux_config pca9546_configs[];
 extern uint8_t plat_monitor_table_arg[];
 extern pwr_monitor_pre_proc_arg pwr_monitor_pre_proc_args[];
+extern accl_card_info accl_card_info_args[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK FUNC
@@ -56,8 +67,7 @@ bool pre_pex89000_read(sensor_cfg *cfg, void *args);
 bool post_pex89000_read(sensor_cfg *cfg, void *args, int *reading);
 bool pre_xdpe15284_read(sensor_cfg *cfg, void *args);
 bool post_xdpe15284_read(sensor_cfg *cfg, void *args, int *reading);
-bool pre_accl_mux_switch(uint8_t sensor_num, void *arg);
-bool post_accl_mux_switch(uint8_t sensor_num, void *arg);
 bool pre_accl_nvme_read(sensor_cfg *cfg, void *args);
+bool post_accl_nvme_read(sensor_cfg *cfg, void *args, int *reading);
 
 #endif

--- a/meta-facebook/at-cb/src/platform/plat_sdr_table.c
+++ b/meta-facebook/at-cb/src/platform/plat_sdr_table.c
@@ -5207,6 +5207,4410 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
 		"P12V_2_M_AUX PWR",
 	},
+	// ACCL card 1
+	{
+		// ACCL 1 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_1_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_1_Freya_1_Temp",
+	},
+	{
+		// ACCL 1 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_1_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_1_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 1 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_1_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_1_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 1 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_1_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_1_Freya_2_Temp",
+	},
+	{
+		// ACCL 1 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_1_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_1_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 1 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_1_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_1_Freya_2_VOL_2",
+	},
+	// ACCL card 2
+	{
+		// ACCL 2 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_2_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_2_Freya_1_Temp",
+	},
+	{
+		// ACCL 2 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_2_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_2_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 2 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_2_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_2_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 2 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_2_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_2_Freya_2_Temp",
+	},
+	{
+		// ACCL 2 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_2_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_2_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 2 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_2_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_2_Freya_2_VOL_2",
+	},
+	// ACCL card 3
+	{
+		// ACCL 3 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_3_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_3_Freya_1_Temp",
+	},
+	{
+		// ACCL 3 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_3_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_3_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 3 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_3_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_3_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 3 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_3_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_3_Freya_2_Temp",
+	},
+	{
+		// ACCL 3 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_3_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_3_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 3 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_3_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_3_Freya_2_VOL_2",
+	},
+	// ACCL card 4
+	{
+		// ACCL 4 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_4_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_4_Freya_1_Temp",
+	},
+	{
+		// ACCL 4 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_4_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_4_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 4 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_4_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_4_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 4 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_4_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_4_Freya_2_Temp",
+	},
+	{
+		// ACCL 4 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_4_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_4_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 4 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_4_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_4_Freya_2_VOL_2",
+	},
+	// ACCL card 5
+	{
+		// ACCL 5 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_5_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_5_Freya_1_Temp",
+	},
+	{
+		// ACCL 5 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_5_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_5_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 5 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_5_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_5_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 5 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_5_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_5_Freya_2_Temp",
+	},
+	{
+		// ACCL 5 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_5_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_5_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 5 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_5_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_5_Freya_2_VOL_2",
+	},
+	// ACCL card 6
+	{
+		// ACCL 6 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_6_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_6_Freya_1_Temp",
+	},
+	{
+		// ACCL 6 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_6_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_6_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 6 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_6_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_6_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 6 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_6_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_6_Freya_2_Temp",
+	},
+	{
+		// ACCL 6 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_6_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_6_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 6 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_6_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_6_Freya_2_VOL_2",
+	},
+	// ACCL card 7
+	{
+		// ACCL 7 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_7_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_7_Freya_1_Temp",
+	},
+	{
+		// ACCL 7 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_7_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_7_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 7 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_7_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_7_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 7 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_7_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_7_Freya_2_Temp",
+	},
+	{
+		// ACCL 7 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_7_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_7_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 7 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_7_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_7_Freya_2_VOL_2",
+	},
+	// ACCL card 8
+	{
+		// ACCL 8 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_8_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_8_Freya_1_Temp",
+	},
+	{
+		// ACCL 8 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_8_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_8_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 8 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_8_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_8_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 8 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_8_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_8_Freya_2_Temp",
+	},
+	{
+		// ACCL 8 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_8_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_8_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 8 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_8_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_8_Freya_2_VOL_2",
+	},
+	// ACCL card 9
+	{
+		// ACCL 9 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_9_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_9_Freya_1_Temp",
+	},
+	{
+		// ACCL 9 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_9_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_9_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 9 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_9_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_9_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 9 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_9_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_9_Freya_2_Temp",
+	},
+	{
+		// ACCL 9 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_9_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_9_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 9 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_9_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_9_Freya_2_VOL_2",
+	},
+	// ACCL card 10
+	{
+		// ACCL 10 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_10_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_10_Freya_1_Temp",
+	},
+	{
+		// ACCL 10 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_10_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_10_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 10 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_10_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_10_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 10 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_10_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_10_Freya_2_Temp",
+	},
+	{
+		// ACCL 10 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_10_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_10_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 10 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_10_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_10_Freya_2_VOL_2",
+	},
+	// ACCL card 11
+	{
+		// ACCL 11 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_11_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_11_Freya_1_Temp",
+	},
+	{
+		// ACCL 11 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_11_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_11_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 11 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_11_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_11_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 11 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_11_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_11_Freya_2_Temp",
+	},
+	{
+		// ACCL 11 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_11_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_11_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 11 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_11_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_11_Freya_2_VOL_2",
+	},
+	// ACCL card 12
+	{
+		// ACCL 12 freya 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_12_FREYA_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_12_Freya_1_Temp",
+	},
+	{
+		// ACCL 12 freya 1 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_12_FREYA_1_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_12_Freya_1_VOL_1",
+	},
+	{
+		// ACCL 12 freya 1 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_12_FREYA_1_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_12_Freya_1_VOL_2",
+	},
+	{
+		// ACCL 12 freya 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_ACCL_12_FREYA_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_12_Freya_2_Temp",
+	},
+	{
+		// ACCL 12 freya 2 voltage 1
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_12_FREYA_2_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_12_Freya_2_VOL_1",
+	},
+	{
+		// ACCL 12 freya 2 voltage 2
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ACCL_12_FREYA_2_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"ACCL_12_Freya_2_VOL_2",
+	},
 };
 
 const int SDR_TABLE_SIZE = ARRAY_SIZE(plat_sdr_table);

--- a/meta-facebook/at-cb/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-cb/src/platform/plat_sensor_table.c
@@ -35,6 +35,8 @@
 
 LOG_MODULE_REGISTER(plat_sensor_table);
 
+#define COMMON_SENSOR_MONITOR_INDEX 0
+
 struct k_mutex i2c_2_tca9543_mutex;
 struct k_mutex i2c_3_tca9543_mutex;
 struct k_mutex i2c_4_pi4msd5v9542_mutex;
@@ -357,870 +359,318 @@ sensor_cfg plat_sensor_config[] = {
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read,
 	  &pwr_monitor_pre_proc_args[11], post_ina233_read, &pwr_monitor_pre_proc_args[11],
 	  &ina233_init_args[11] },
-};
 
-sensor_cfg plat_accl1_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	/** ACCL card 1 **/
+	{ SENSOR_NUM_TEMP_ACCL_1_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[0],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[0],
+	  post_accl_nvme_read, &accl_card_info_args[0], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_1_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[0],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[0],
+	  post_accl_nvme_read, &accl_card_info_args[0], NULL },
+	{ SENSOR_NUM_VOL_ACCL_1_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[0],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[0],
+	  post_accl_nvme_read, &accl_card_info_args[0], NULL },
+	{ SENSOR_NUM_VOL_ACCL_1_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[0],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[0],
+	  post_accl_nvme_read, &accl_card_info_args[0], NULL },
+	{ SENSOR_NUM_VOL_ACCL_1_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[0],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[0],
+	  post_accl_nvme_read, &accl_card_info_args[0], NULL },
+	{ SENSOR_NUM_VOL_ACCL_1_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[0],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[0],
+	  post_accl_nvme_read, &accl_card_info_args[0], NULL },
 
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[0], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[1], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[2], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[0], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[1], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[2], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[0], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[1], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[2], &pca9546_configs[3] },
-};
-
-sensor_cfg plat_accl2_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	/** ACCL card 2 **/
+	{ SENSOR_NUM_TEMP_ACCL_2_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[1],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[1],
+	  post_accl_nvme_read, &accl_card_info_args[1], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_2_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[1],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[1],
+	  post_accl_nvme_read, &accl_card_info_args[1], NULL },
+	{ SENSOR_NUM_VOL_ACCL_2_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[1],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[1],
+	  post_accl_nvme_read, &accl_card_info_args[1], NULL },
+	{ SENSOR_NUM_VOL_ACCL_2_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[1],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[1],
+	  post_accl_nvme_read, &accl_card_info_args[1], NULL },
+	{ SENSOR_NUM_VOL_ACCL_2_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[1],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[1],
+	  post_accl_nvme_read, &accl_card_info_args[1], NULL },
+	{ SENSOR_NUM_VOL_ACCL_2_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[1],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[1],
+	  post_accl_nvme_read, &accl_card_info_args[1], NULL },
 
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[3], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[4], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[5], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[3], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[4], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[5], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[3], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[4], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[5], &pca9546_configs[3] },
-};
-
-sensor_cfg plat_accl3_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	/** ACCL card 3 **/
+	{ SENSOR_NUM_TEMP_ACCL_3_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[2],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[2],
+	  post_accl_nvme_read, &accl_card_info_args[2], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_3_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[2],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[2],
+	  post_accl_nvme_read, &accl_card_info_args[2], NULL },
+	{ SENSOR_NUM_VOL_ACCL_3_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[2],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[2],
+	  post_accl_nvme_read, &accl_card_info_args[2], NULL },
+	{ SENSOR_NUM_VOL_ACCL_3_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[2],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[2],
+	  post_accl_nvme_read, &accl_card_info_args[2], NULL },
+	{ SENSOR_NUM_VOL_ACCL_3_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[2],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[2],
+	  post_accl_nvme_read, &accl_card_info_args[2], NULL },
+	{ SENSOR_NUM_VOL_ACCL_3_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[2],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[2],
+	  post_accl_nvme_read, &accl_card_info_args[2], NULL },
 
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[6], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[7], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[8], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[6], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[7], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[8], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[6], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[7], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[8], &pca9546_configs[3] },
-};
-
-sensor_cfg plat_accl4_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	/** ACCL card 4 **/
+	{ SENSOR_NUM_TEMP_ACCL_4_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[3],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[3],
+	  post_accl_nvme_read, &accl_card_info_args[3], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_4_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[3],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[3],
+	  post_accl_nvme_read, &accl_card_info_args[3], NULL },
+	{ SENSOR_NUM_VOL_ACCL_4_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[3],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[3],
+	  post_accl_nvme_read, &accl_card_info_args[3], NULL },
+	{ SENSOR_NUM_VOL_ACCL_4_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[3],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[3],
+	  post_accl_nvme_read, &accl_card_info_args[3], NULL },
+	{ SENSOR_NUM_VOL_ACCL_4_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[3],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[3],
+	  post_accl_nvme_read, &accl_card_info_args[3], NULL },
+	{ SENSOR_NUM_VOL_ACCL_4_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[3],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[3],
+	  post_accl_nvme_read, &accl_card_info_args[3], NULL },
 
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[9], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[10], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[11], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[9], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[10], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[11], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[9], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[10], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[11], &pca9546_configs[3] },
-};
-
-sensor_cfg plat_accl5_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	/** ACCL card 5 **/
+	{ SENSOR_NUM_TEMP_ACCL_5_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[4],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[4],
+	  post_accl_nvme_read, &accl_card_info_args[4], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_5_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[4],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[4],
+	  post_accl_nvme_read, &accl_card_info_args[4], NULL },
+	{ SENSOR_NUM_VOL_ACCL_5_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[4],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[4],
+	  post_accl_nvme_read, &accl_card_info_args[4], NULL },
+	{ SENSOR_NUM_VOL_ACCL_5_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[4],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[4],
+	  post_accl_nvme_read, &accl_card_info_args[4], NULL },
+	{ SENSOR_NUM_VOL_ACCL_5_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[4],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[4],
+	  post_accl_nvme_read, &accl_card_info_args[4], NULL },
+	{ SENSOR_NUM_VOL_ACCL_5_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[4],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[4],
+	  post_accl_nvme_read, &accl_card_info_args[4], NULL },
 
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[12], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[13], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[14], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[12], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[13], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[14], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[12], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[13], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[14], &pca9546_configs[3] },
-};
-
-sensor_cfg plat_accl6_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	/** ACCL card 6 **/
+	{ SENSOR_NUM_TEMP_ACCL_6_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[5],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[5],
+	  post_accl_nvme_read, &accl_card_info_args[5], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_6_FREYA_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[5],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[5],
+	  post_accl_nvme_read, &accl_card_info_args[5], NULL },
+	{ SENSOR_NUM_VOL_ACCL_6_FREYA_1_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[5],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[5],
+	  post_accl_nvme_read, &accl_card_info_args[5], NULL },
+	{ SENSOR_NUM_VOL_ACCL_6_FREYA_1_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[5],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[5],
+	  post_accl_nvme_read, &accl_card_info_args[5], NULL },
+	{ SENSOR_NUM_VOL_ACCL_6_FREYA_2_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[5],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[5],
+	  post_accl_nvme_read, &accl_card_info_args[5], NULL },
+	{ SENSOR_NUM_VOL_ACCL_6_FREYA_2_2, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[5],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[5],
+	  post_accl_nvme_read, &accl_card_info_args[5], NULL },
 
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[15], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[16], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[17], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[15], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[16], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[17], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS8, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[15], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[16], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS8, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[17], &pca9546_configs[3] },
-};
-
-sensor_cfg plat_accl7_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	/** ACCL card 7 **/
+	{ SENSOR_NUM_TEMP_ACCL_7_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[6],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[6],
+	  post_accl_nvme_read, &accl_card_info_args[6], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_7_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[6],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[6],
+	  post_accl_nvme_read, &accl_card_info_args[6], NULL },
+	{ SENSOR_NUM_VOL_ACCL_7_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[6],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[6],
+	  post_accl_nvme_read, &accl_card_info_args[6], NULL },
+	{ SENSOR_NUM_VOL_ACCL_7_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[6],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[6],
+	  post_accl_nvme_read, &accl_card_info_args[6], NULL },
+	{ SENSOR_NUM_VOL_ACCL_7_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[6],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[6],
+	  post_accl_nvme_read, &accl_card_info_args[6], NULL },
+	{ SENSOR_NUM_VOL_ACCL_7_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[6],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[6],
+	  post_accl_nvme_read, &accl_card_info_args[6], NULL },
 
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[18], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[19], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[20], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[18], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[19], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[20], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[18], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[19], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[20], &pca9546_configs[3] },
-};
-
-sensor_cfg plat_accl8_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	/** ACCL card 8 **/
+	{ SENSOR_NUM_TEMP_ACCL_8_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[7],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[7],
+	  post_accl_nvme_read, &accl_card_info_args[7], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_8_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[7],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[7],
+	  post_accl_nvme_read, &accl_card_info_args[7], NULL },
+	{ SENSOR_NUM_VOL_ACCL_8_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[7],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[7],
+	  post_accl_nvme_read, &accl_card_info_args[7], NULL },
+	{ SENSOR_NUM_VOL_ACCL_8_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[7],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[7],
+	  post_accl_nvme_read, &accl_card_info_args[7], NULL },
+	{ SENSOR_NUM_VOL_ACCL_8_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[7],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[7],
+	  post_accl_nvme_read, &accl_card_info_args[7], NULL },
+	{ SENSOR_NUM_VOL_ACCL_8_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[7],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[7],
+	  post_accl_nvme_read, &accl_card_info_args[7], NULL },
 
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[21], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[22], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[23], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[21], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[22], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[23], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[21], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[22], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[23], &pca9546_configs[3] },
-};
-
-sensor_cfg plat_accl9_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	/** ACCL card 9 **/
+	{ SENSOR_NUM_TEMP_ACCL_9_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[8],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[8],
+	  post_accl_nvme_read, &accl_card_info_args[8], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_9_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[8],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[8],
+	  post_accl_nvme_read, &accl_card_info_args[8], NULL },
+	{ SENSOR_NUM_VOL_ACCL_9_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[8],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[8],
+	  post_accl_nvme_read, &accl_card_info_args[8], NULL },
+	{ SENSOR_NUM_VOL_ACCL_9_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[8],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[8],
+	  post_accl_nvme_read, &accl_card_info_args[8], NULL },
+	{ SENSOR_NUM_VOL_ACCL_9_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[8],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[8],
+	  post_accl_nvme_read, &accl_card_info_args[8], NULL },
+	{ SENSOR_NUM_VOL_ACCL_9_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[8],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[8],
+	  post_accl_nvme_read, &accl_card_info_args[8], NULL },
 
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[24], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[25], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[26], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[24], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[25], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[26], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[24], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[25], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[26], &pca9546_configs[3] },
-};
-
-sensor_cfg plat_accl10_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	/** ACCL card 10 **/
+	{ SENSOR_NUM_TEMP_ACCL_10_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[9],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[9],
+	  post_accl_nvme_read, &accl_card_info_args[9], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_10_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[9],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[9],
+	  post_accl_nvme_read, &accl_card_info_args[9], NULL },
+	{ SENSOR_NUM_VOL_ACCL_10_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[9],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[9],
+	  post_accl_nvme_read, &accl_card_info_args[9], NULL },
+	{ SENSOR_NUM_VOL_ACCL_10_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[9],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[9],
+	  post_accl_nvme_read, &accl_card_info_args[9], NULL },
+	{ SENSOR_NUM_VOL_ACCL_10_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[9],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[9],
+	  post_accl_nvme_read, &accl_card_info_args[9], NULL },
+	{ SENSOR_NUM_VOL_ACCL_10_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[9],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_card_info_args[9],
+	  post_accl_nvme_read, &accl_card_info_args[9], NULL },
 
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[27], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[28], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[29], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[27], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[28], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[29], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[27], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[28], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[29], &pca9546_configs[3] },
-};
-
-sensor_cfg plat_accl11_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	/** ACCL card 11 **/
+	{ SENSOR_NUM_TEMP_ACCL_11_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[10],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[10], post_accl_nvme_read, &accl_card_info_args[10], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_11_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[10],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[10], post_accl_nvme_read, &accl_card_info_args[10], NULL },
+	{ SENSOR_NUM_VOL_ACCL_11_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[10],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[10], post_accl_nvme_read, &accl_card_info_args[10], NULL },
+	{ SENSOR_NUM_VOL_ACCL_11_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[10],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[10], post_accl_nvme_read, &accl_card_info_args[10], NULL },
+	{ SENSOR_NUM_VOL_ACCL_11_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[10],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[10], post_accl_nvme_read, &accl_card_info_args[10], NULL },
+	{ SENSOR_NUM_VOL_ACCL_11_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[10],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[10], post_accl_nvme_read, &accl_card_info_args[10], NULL },
 
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[30], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[31], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[32], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[30], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[31], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[32], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[30], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[31], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[32], &pca9546_configs[3] },
-};
-
-sensor_cfg plat_accl12_sensor_config[] = {
-	/** Nvme Temperature **/
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	/** ACCL card 12 **/
+	{ SENSOR_NUM_TEMP_ACCL_12_FREYA_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[11],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_TEMP_ACCL_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[11], post_accl_nvme_read, &accl_card_info_args[11], NULL },
+	{ SENSOR_NUM_TEMP_ACCL_12_FREYA_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_TEMP_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[11],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** Nvme Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[11], post_accl_nvme_read, &accl_card_info_args[11], NULL },
+	{ SENSOR_NUM_VOL_ACCL_12_FREYA_1_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[11],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[11], post_accl_nvme_read, &accl_card_info_args[11], NULL },
+	{ SENSOR_NUM_VOL_ACCL_12_FREYA_1_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_1_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[11],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[11], post_accl_nvme_read, &accl_card_info_args[11], NULL },
+	{ SENSOR_NUM_VOL_ACCL_12_FREYA_2_1, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_1_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[11],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-	{ SENSOR_NUM_VOL_ACCL_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[11], post_accl_nvme_read, &accl_card_info_args[11], NULL },
+	{ SENSOR_NUM_VOL_ACCL_12_FREYA_2_2, sensor_dev_nvme, I2C_BUS7, ACCL_FREYA_2_ADDR,
 	  NVME_VOLTAGE_RAIL_2_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read, &accl_freya_info[11],
-	  NULL, NULL, NULL, &pca9546_configs[0] },
-
-	/** INA233 Voltage **/
-	{ SENSOR_NUM_VOL_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[33], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[34], &pca9546_configs[3] },
-	{ SENSOR_NUM_VOL_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_VOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[35], &pca9546_configs[3] },
-
-	/** INA233 Current **/
-	{ SENSOR_NUM_CUR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[33], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[34], &pca9546_configs[3] },
-	{ SENSOR_NUM_CUR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_IOUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[35], &pca9546_configs[3] },
-
-	/** INA233 Power **/
-	{ SENSOR_NUM_PWR_ACCL_P12V_EFUSE, sensor_dev_ina233, I2C_BUS7, ACCL_12V_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[33], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_1, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_1_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[34], &pca9546_configs[3] },
-	{ SENSOR_NUM_PWR_ACCL_P3V3_2, sensor_dev_ina233, I2C_BUS7, ACCL_3V3_2_INA233_ADDR,
-	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &accl_ina233_init_args[35], &pca9546_configs[3] },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_accl_nvme_read,
+	  &accl_card_info_args[11], post_accl_nvme_read, &accl_card_info_args[11], NULL },
 };
 
 sensor_cfg adm1272_sensor_config_table[] = {
@@ -1376,49 +826,6 @@ sensor_cfg bmr351_sensor_config_table[] = {
 };
 
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
-const int ACCL_SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_accl1_sensor_config);
-
-sensor_monitor_table_info plat_monitor_table[] = {
-	{ plat_accl1_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_1,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[0],
-	  (void *)&plat_monitor_table_arg[0], "ACCL 1 sensor table" },
-	{ plat_accl2_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_2,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[1],
-	  (void *)&plat_monitor_table_arg[1], "ACCL 2 sensor table" },
-	{ plat_accl3_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_3,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[2],
-	  (void *)&plat_monitor_table_arg[2], "ACCL 3 sensor table" },
-	{ plat_accl4_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_4,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[3],
-	  (void *)&plat_monitor_table_arg[3], "ACCL 4 sensor table" },
-	{ plat_accl5_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_5,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[4],
-	  (void *)&plat_monitor_table_arg[4], "ACCL 5 sensor table" },
-	{ plat_accl6_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_6,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[5],
-	  (void *)&plat_monitor_table_arg[5], "ACCL 6 sensor table" },
-	{ plat_accl7_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_7,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[6],
-	  (void *)&plat_monitor_table_arg[6], "ACCL 7 sensor table" },
-	{ plat_accl8_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_8,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[7],
-	  (void *)&plat_monitor_table_arg[7], "ACCL 8 sensor table" },
-	{ plat_accl9_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_9,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[8],
-	  (void *)&plat_monitor_table_arg[8], "ACCL 9 sensor table" },
-	{ plat_accl10_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_10,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[9],
-	  (void *)&plat_monitor_table_arg[9], "ACCL 10 sensor table" },
-	{ plat_accl11_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_11,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[10],
-	  (void *)&plat_monitor_table_arg[10], "ACCL 11 sensor table" },
-	{ plat_accl12_sensor_config, ACCL_SENSOR_CONFIG_SIZE, is_pcie_device_access, PCIE_CARD_12,
-	  pre_accl_mux_switch, post_accl_mux_switch, (void *)&plat_monitor_table_arg[11],
-	  (void *)&plat_monitor_table_arg[11], "ACCL 12 sensor table" },
-};
-
-bool accl_card_init_status[] = { false, false, false, false, false, false,
-				 false, false, false, false, false, false };
 
 void load_sensor_config(void)
 {
@@ -1506,16 +913,17 @@ void pal_extend_sensor_config()
 	}
 }
 
-uint8_t pal_get_monitor_sensor_count()
+sensor_cfg *get_common_sensor_cfg_info(uint8_t sensor_num)
 {
-	return ARRAY_SIZE(plat_monitor_table);
-}
+	uint8_t cfg_count = sensor_monitor_table[COMMON_SENSOR_MONITOR_INDEX].cfg_count;
+	sensor_cfg *cfg_table =
+		sensor_monitor_table[COMMON_SENSOR_MONITOR_INDEX].monitor_sensor_cfg;
 
-void plat_fill_monitor_sensor_table()
-{
-	uint8_t plat_monitor_sensor_count = ARRAY_SIZE(plat_monitor_table);
-	memcpy(&sensor_monitor_table[1], plat_monitor_table,
-	       plat_monitor_sensor_count * sizeof(sensor_monitor_table_info));
+	if (cfg_table != NULL) {
+		return find_sensor_cfg_via_sensor_num(cfg_table, cfg_count, sensor_num);
+	}
+
+	return NULL;
 }
 
 sensor_cfg *get_accl_sensor_cfg_info(uint8_t card_id, uint8_t *cfg_count)
@@ -1530,7 +938,7 @@ sensor_cfg *get_accl_sensor_cfg_info(uint8_t card_id, uint8_t *cfg_count)
 		uint8_t *val = (uint8_t *)sensor_monitor_table[index].priv_data;
 
 		if (*val == card_id) {
-			*cfg_count = ACCL_SENSOR_CONFIG_SIZE;
+			*cfg_count = sensor_monitor_table[index].cfg_count;
 			return sensor_monitor_table[index].monitor_sensor_cfg;
 		}
 	}
@@ -1603,101 +1011,6 @@ bool is_dc_access(uint8_t sensor_num)
 	return is_acb_power_good();
 }
 
-bool is_pcie_device_access(uint8_t card_id)
-{
-	if (card_id >= ASIC_CARD_COUNT) {
-		LOG_ERR("Invalid card id: 0x%x", card_id);
-		return false;
-	}
-
-	bool ret = false;
-	bool is_power_good = false;
-	uint8_t index = 0;
-	uint8_t cfg_count = 0;
-	sensor_cfg *cfg_table = NULL;
-
-	if (asic_card_info[card_id].card_status == ASIC_CARD_PRESENT) {
-		cfg_table = get_accl_sensor_cfg_info(card_id, &cfg_count);
-		if (cfg_table == NULL) {
-			LOG_ERR("Fail to get ACCL sensor cfg index to check pcie device, card id: 0x%x",
-				card_id);
-			return ret;
-		}
-		is_power_good = is_accl_power_good(card_id);
-
-		if (is_power_good) {
-			if (accl_card_init_status[card_id] == false) {
-				for (index = 0; index < cfg_count; ++index) {
-					sensor_cfg *cfg = &cfg_table[index];
-
-					if (pre_accl_mux_switch(cfg->num, (void *)&card_id) !=
-					    true) {
-						LOG_ERR("Fail to pre-switch ACCL mux to check access, card id: 0x%x",
-							card_id);
-						break;
-					}
-
-					if (init_drive_type_delayed(cfg) != true) {
-						post_accl_mux_switch(cfg->num, (void *)&card_id);
-						break;
-					}
-
-					if (post_accl_mux_switch(cfg->num, (void *)&card_id) !=
-					    true) {
-						LOG_ERR("Fail to post-switch ACCL mux to check access, card id: 0x%x",
-							card_id);
-					}
-				}
-
-				if (index >= cfg_count) {
-					accl_card_init_status[card_id] = true;
-				}
-			}
-
-			for (index = 0; index < cfg_count; ++index) {
-				sensor_cfg *cfg = &cfg_table[index];
-
-				switch (cfg->target_addr) {
-				case ACCL_FREYA_1_ADDR:
-					if (asic_card_info[card_id].asic_1_status !=
-					    ASIC_CARD_DEVICE_PRESENT) {
-						cfg->cache_status = SENSOR_NOT_PRESENT;
-					} else {
-						if (cfg->cache_status == SENSOR_NOT_PRESENT) {
-							cfg->cache_status = SENSOR_INIT_STATUS;
-						}
-					}
-					break;
-				case ACCL_FREYA_2_ADDR:
-					if (asic_card_info[card_id].asic_2_status !=
-					    ASIC_CARD_DEVICE_PRESENT) {
-						cfg->cache_status = SENSOR_NOT_PRESENT;
-					} else {
-						if (cfg_table[index].cache_status ==
-						    SENSOR_NOT_PRESENT) {
-							cfg->cache_status = SENSOR_INIT_STATUS;
-						}
-					}
-					break;
-				default:
-					break;
-				}
-			}
-			return true;
-		} else {
-			for (index = 0; index < cfg_count; ++index) {
-				sensor_cfg *cfg = &cfg_table[index];
-				cfg->cache_status = SENSOR_NOT_ACCESSIBLE;
-			}
-
-			accl_card_init_status[card_id] = false;
-			return false;
-		}
-	} else {
-		return false;
-	}
-}
-
 struct k_mutex *get_i2c_mux_mutex(uint8_t i2c_bus)
 {
 	struct k_mutex *mutex = NULL;
@@ -1768,32 +1081,5 @@ bool get_accl_mux_config(uint8_t card_id, mux_config *accl_mux)
 	}
 
 	*accl_mux = pca9548_configs[card_id];
-	return true;
-}
-
-bool get_mux_channel_config(uint8_t card_id, uint8_t sensor_number, mux_config *channel_mux)
-{
-	CHECK_NULL_ARG_WITH_RETURN(channel_mux, false);
-
-	if (card_id >= ASIC_CARD_COUNT) {
-		LOG_ERR("Invalid accl card id: 0x%x", card_id);
-		return false;
-	}
-
-	bool ret = false;
-	uint8_t accl_bus = get_accl_bus(card_id, sensor_number);
-	mux_config *mux_cfg = NULL;
-	sensor_cfg *cfg = NULL;
-
-	cfg = get_accl_sensor_config(card_id, sensor_number);
-	if (cfg == NULL) {
-		return ret;
-	}
-
-	CHECK_NULL_ARG_WITH_RETURN(cfg->priv_data, false);
-
-	mux_cfg = cfg->priv_data;
-	mux_cfg->bus = accl_bus;
-	*channel_mux = *mux_cfg;
 	return true;
 }

--- a/meta-facebook/at-cb/src/platform/plat_sensor_table.h
+++ b/meta-facebook/at-cb/src/platform/plat_sensor_table.h
@@ -147,46 +147,115 @@
 #define SENSOR_NUM_PWR_P12V_ACCL_11 0x51
 #define SENSOR_NUM_PWR_P12V_ACCL_12 0x52
 
+/** ACCL card 1 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_1_FREYA_1 0x70
+#define SENSOR_NUM_VOL_ACCL_1_FREYA_1_1 0x71
+#define SENSOR_NUM_VOL_ACCL_1_FREYA_1_2 0x72
+#define SENSOR_NUM_TEMP_ACCL_1_FREYA_2 0x73
+#define SENSOR_NUM_VOL_ACCL_1_FREYA_2_1 0x74
+#define SENSOR_NUM_VOL_ACCL_1_FREYA_2_2 0x75
+
+/** ACCL card 2 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_2_FREYA_1 0x76
+#define SENSOR_NUM_VOL_ACCL_2_FREYA_1_1 0x77
+#define SENSOR_NUM_VOL_ACCL_2_FREYA_1_2 0x78
+#define SENSOR_NUM_TEMP_ACCL_2_FREYA_2 0x79
+#define SENSOR_NUM_VOL_ACCL_2_FREYA_2_1 0x7A
+#define SENSOR_NUM_VOL_ACCL_2_FREYA_2_2 0x7B
+
+/** ACCL card 3 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_3_FREYA_1 0x7C
+#define SENSOR_NUM_VOL_ACCL_3_FREYA_1_1 0x7D
+#define SENSOR_NUM_VOL_ACCL_3_FREYA_1_2 0x7E
+#define SENSOR_NUM_TEMP_ACCL_3_FREYA_2 0x7F
+#define SENSOR_NUM_VOL_ACCL_3_FREYA_2_1 0x80
+#define SENSOR_NUM_VOL_ACCL_3_FREYA_2_2 0x81
+
+/** ACCL card 4 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_4_FREYA_1 0x82
+#define SENSOR_NUM_VOL_ACCL_4_FREYA_1_1 0x83
+#define SENSOR_NUM_VOL_ACCL_4_FREYA_1_2 0x84
+#define SENSOR_NUM_TEMP_ACCL_4_FREYA_2 0x85
+#define SENSOR_NUM_VOL_ACCL_4_FREYA_2_1 0x86
+#define SENSOR_NUM_VOL_ACCL_4_FREYA_2_2 0x87
+
+/** ACCL card 5 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_5_FREYA_1 0x88
+#define SENSOR_NUM_VOL_ACCL_5_FREYA_1_1 0x89
+#define SENSOR_NUM_VOL_ACCL_5_FREYA_1_2 0x8A
+#define SENSOR_NUM_TEMP_ACCL_5_FREYA_2 0x8B
+#define SENSOR_NUM_VOL_ACCL_5_FREYA_2_1 0x8C
+#define SENSOR_NUM_VOL_ACCL_5_FREYA_2_2 0x8D
+
+/** ACCL card 6 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_6_FREYA_1 0x8E
+#define SENSOR_NUM_VOL_ACCL_6_FREYA_1_1 0x8F
+#define SENSOR_NUM_VOL_ACCL_6_FREYA_1_2 0x90
+#define SENSOR_NUM_TEMP_ACCL_6_FREYA_2 0x91
+#define SENSOR_NUM_VOL_ACCL_6_FREYA_2_1 0x92
+#define SENSOR_NUM_VOL_ACCL_6_FREYA_2_2 0x93
+
+/** ACCL card 7 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_7_FREYA_1 0x94
+#define SENSOR_NUM_VOL_ACCL_7_FREYA_1_1 0x95
+#define SENSOR_NUM_VOL_ACCL_7_FREYA_1_2 0x96
+#define SENSOR_NUM_TEMP_ACCL_7_FREYA_2 0x97
+#define SENSOR_NUM_VOL_ACCL_7_FREYA_2_1 0x98
+#define SENSOR_NUM_VOL_ACCL_7_FREYA_2_2 0x99
+
+/** ACCL card 8 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_8_FREYA_1 0x9A
+#define SENSOR_NUM_VOL_ACCL_8_FREYA_1_1 0x9B
+#define SENSOR_NUM_VOL_ACCL_8_FREYA_1_2 0x9C
+#define SENSOR_NUM_TEMP_ACCL_8_FREYA_2 0x9D
+#define SENSOR_NUM_VOL_ACCL_8_FREYA_2_1 0x9E
+#define SENSOR_NUM_VOL_ACCL_8_FREYA_2_2 0x9F
+
+/** ACCL card 9 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_9_FREYA_1 0xA0
+#define SENSOR_NUM_VOL_ACCL_9_FREYA_1_1 0xA1
+#define SENSOR_NUM_VOL_ACCL_9_FREYA_1_2 0xA2
+#define SENSOR_NUM_TEMP_ACCL_9_FREYA_2 0xA3
+#define SENSOR_NUM_VOL_ACCL_9_FREYA_2_1 0xA4
+#define SENSOR_NUM_VOL_ACCL_9_FREYA_2_2 0xA5
+
+/** ACCL card 10 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_10_FREYA_1 0xA6
+#define SENSOR_NUM_VOL_ACCL_10_FREYA_1_1 0xA7
+#define SENSOR_NUM_VOL_ACCL_10_FREYA_1_2 0xA8
+#define SENSOR_NUM_TEMP_ACCL_10_FREYA_2 0xA9
+#define SENSOR_NUM_VOL_ACCL_10_FREYA_2_1 0xAA
+#define SENSOR_NUM_VOL_ACCL_10_FREYA_2_2 0xAB
+
+/** ACCL card 11 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_11_FREYA_1 0xAC
+#define SENSOR_NUM_VOL_ACCL_11_FREYA_1_1 0xAD
+#define SENSOR_NUM_VOL_ACCL_11_FREYA_1_2 0xAE
+#define SENSOR_NUM_TEMP_ACCL_11_FREYA_2 0xAF
+#define SENSOR_NUM_VOL_ACCL_11_FREYA_2_1 0xB0
+#define SENSOR_NUM_VOL_ACCL_11_FREYA_2_2 0xB1
+
+/** ACCL card 12 sensor number **/
+#define SENSOR_NUM_TEMP_ACCL_12_FREYA_1 0xB2
+#define SENSOR_NUM_VOL_ACCL_12_FREYA_1_1 0xB3
+#define SENSOR_NUM_VOL_ACCL_12_FREYA_1_2 0xB4
+#define SENSOR_NUM_TEMP_ACCL_12_FREYA_2 0xB5
+#define SENSOR_NUM_VOL_ACCL_12_FREYA_2_1 0xB6
+#define SENSOR_NUM_VOL_ACCL_12_FREYA_2_2 0xB7
+
 /** ACCL sensor config **/
 #define ACCL_FREYA_1_ADDR (0xD6 >> 1)
 #define ACCL_FREYA_2_ADDR (0xD0 >> 1)
-#define ACCL_12V_INA233_ADDR (0x80 >> 1)
-#define ACCL_3V3_1_INA233_ADDR (0x82 >> 1)
-#define ACCL_3V3_2_INA233_ADDR (0x84 >> 1)
-#define ACCL_12V_INA233_INIT_ARG_OFFSET 0
-#define ACCL_3V3_1_INA233_INIT_ARG_OFFSET 1
-#define ACCL_3V3_2_INA233_INIT_ARG_OFFSET 2
-
-/** ACCL sensor number **/
-#define SENSOR_NUM_TEMP_ACCL_FREYA_1 0x01
-#define SENSOR_NUM_TEMP_ACCL_FREYA_2 0x02
-#define SENSOR_NUM_VOL_ACCL_P12V_EFUSE 0x03
-#define SENSOR_NUM_VOL_ACCL_P3V3_1 0x04
-#define SENSOR_NUM_VOL_ACCL_P3V3_2 0x05
-#define SENSOR_NUM_VOL_ACCL_FREYA_1_1 0x06
-#define SENSOR_NUM_VOL_ACCL_FREYA_1_2 0x07
-#define SENSOR_NUM_VOL_ACCL_FREYA_2_1 0x0B
-#define SENSOR_NUM_VOL_ACCL_FREYA_2_2 0x0C
-#define SENSOR_NUM_CUR_ACCL_P12V_EFUSE 0x08
-#define SENSOR_NUM_CUR_ACCL_P3V3_1 0x09
-#define SENSOR_NUM_CUR_ACCL_P3V3_2 0x0A
-#define SENSOR_NUM_PWR_ACCL_P12V_EFUSE 0x0D
-#define SENSOR_NUM_PWR_ACCL_P3V3_1 0x0E
-#define SENSOR_NUM_PWR_ACCL_P3V3_2 0x0F
-#define SENSOR_NUM_PWR_ACCL_FREYA_1 0x10
-#define SENSOR_NUM_PWR_ACCL_FREYA_2 0x11
-
-extern const int ACCL_SENSOR_CONFIG_SIZE;
 
 void load_sensor_config(void);
 bool is_acb_power_good();
 bool is_dc_access(uint8_t sensor_num);
-bool is_pcie_device_access(uint8_t card_id);
 struct k_mutex *get_i2c_mux_mutex(uint8_t i2c_bus);
 int get_accl_bus(uint8_t card_id, uint8_t sensor_number);
 sensor_cfg *get_accl_sensor_config(uint8_t card_id, uint8_t sensor_num);
 bool get_accl_mux_config(uint8_t card_id, mux_config *accl_mux);
-bool get_mux_channel_config(uint8_t card_id, uint8_t sensor_number, mux_config *channel_mux);
 sensor_cfg *get_accl_sensor_cfg_info(uint8_t card_id, uint8_t *cfg_count);
+bool is_accl_power_good(uint8_t card_id);
+sensor_cfg *get_common_sensor_cfg_info(uint8_t sensor_num);
 
 #endif


### PR DESCRIPTION
# Description
- Merge ACB FRUs sensor one sensor table.
- Block ACCL card mapping INA233 sensor read when ACCL card power off.

# Motivation
- Merge ACB FRUs sensor one sensor table.
- No need monitor ACCL card mapping INA233 sensor when ACCL card power off.

# Test Plan
- Build code: Pass
- Get ACCL card sensor reading in ACB sensor table: Pass
- Block ACCL card mapping INA233 sensor read when ACCL card power off: Pass
- Block ACCL card mapping INA233 sensor read when ACCL card not present: Pass

# Log
- Get ACCL card sensor reading in ACB sensor table root@bmc-oob:~# sensor-util cb | grep ACCL
CB_P12V_ACCL1_V              (0x23) :   12.13 Volts | (ok)
CB_P12V_ACCL2_V              (0x24) :   12.14 Volts | (ok)
CB_P12V_ACCL3_V              (0x25) :   12.13 Volts | (ok)
CB_P12V_ACCL4_V              (0x26) :   12.13 Volts | (ok)
CB_P12V_ACCL5_V              (0x27) :   12.13 Volts | (ok)
CB_P12V_ACCL6_V              (0x28) :   12.13 Volts | (ok)
CB_P12V_ACCL7_V              (0x29) :   12.12 Volts | (ok)
CB_P12V_ACCL8_V              (0x2A) :   12.12 Volts | (ok)
CB_P12V_ACCL9_V              (0x2C) :   12.13 Volts | (ok)
CB_P12V_ACCL10_V             (0x2D) :   12.13 Volts | (ok)
CB_P12V_ACCL11_V             (0x2E) :   12.13 Volts | (ok)
CB_P12V_ACCL12_V             (0x2F) :   12.13 Volts | (ok)
CB_P12V_ACCL1_A              (0x34) :    3.02 Amps  | (ok)
CB_P12V_ACCL2_A              (0x35) :    3.05 Amps  | (ok)
CB_P12V_ACCL3_A              (0x36) :    3.07 Amps  | (ok)
CB_P12V_ACCL4_A              (0x37) :    2.97 Amps  | (ok)
CB_P12V_ACCL5_A              (0x38) :    3.01 Amps  | (ok)
CB_P12V_ACCL6_A              (0x39) :    2.49 Amps  | (ok)
CB_P12V_ACCL7_A              (0x3A) :    2.91 Amps  | (ok)
CB_P12V_ACCL8_A              (0x3C) :    2.95 Amps  | (ok)
CB_P12V_ACCL9_A              (0x3D) :    2.85 Amps  | (ok)
CB_P12V_ACCL10_A             (0x3E) :    2.94 Amps  | (ok)
CB_P12V_ACCL11_A             (0x3F) :    2.89 Amps  | (ok)
CB_P12V_ACCL12_A             (0x40) :    2.61 Amps  | (ok)
CB_P12V_ACCL1_W              (0x45) :   36.65 Watts | (ok)
CB_P12V_ACCL2_W              (0x46) :   37.05 Watts | (ok)
CB_P12V_ACCL3_W              (0x47) :   37.28 Watts | (ok)
CB_P12V_ACCL4_W              (0x48) :   36.08 Watts | (ok)
CB_P12V_ACCL5_W              (0x49) :   36.58 Watts | (ok)
CB_P12V_ACCL6_W              (0x4A) :   30.20 Watts | (ok)
CB_P12V_ACCL7_W              (0x4B) :   35.33 Watts | (ok)
CB_P12V_ACCL8_W              (0x4C) :   35.80 Watts | (ok)
CB_P12V_ACCL9_W              (0x4D) :   34.55 Watts | (ok)
CB_P12V_ACCL10_W             (0x50) :   35.70 Watts | (ok)
CB_P12V_ACCL11_W             (0x51) :   35.08 Watts | (ok)
CB_P12V_ACCL12_W             (0x52) :   31.73 Watts | (ok)
CB_ACCL1_Freya_1_Temp_C      (0x70) :   39.00 C     | (ok)
CB_ACCL1_Freya_1_VOL_1_V     (0x71) :    5.12 Volts | (unr)
CB_ACCL1_Freya_1_VOL_2_V     (0x72) :    5.18 Volts | (unr)
CB_ACCL1_Freya_2_Temp_C      (0x73) :   44.00 C     | (ok)
CB_ACCL1_Freya_2_VOL_1_V     (0x74) :    4.36 Volts | (unr)
CB_ACCL1_Freya_2_VOL_2_V     (0x75) :    4.42 Volts | (unr)
CB_ACCL2_Freya_1_Temp_C      (0x76) :   39.00 C     | (ok)
CB_ACCL2_Freya_1_VOL_1_V     (0x77) :    4.87 Volts | (unr)
CB_ACCL2_Freya_1_VOL_2_V     (0x78) :    0.68 Volts | (lnr)
CB_ACCL2_Freya_2_Temp_C      (0x79) :   43.00 C     | (ok)
CB_ACCL2_Freya_2_VOL_1_V     (0x7A) :    5.12 Volts | (unr)
CB_ACCL2_Freya_2_VOL_2_V     (0x7B) :    5.70 Volts | (unr)
CB_ACCL3_Freya_1_Temp_C      (0x7C) :   40.00 C     | (ok)
CB_ACCL3_Freya_1_VOL_1_V     (0x7D) :    3.33 Volts | (ok)
CB_ACCL3_Freya_1_VOL_2_V     (0x7E) :    0.68 Volts | (lnr)
CB_ACCL3_Freya_2_Temp_C      (0x7F) :   42.00 C     | (ok)
CB_ACCL3_Freya_2_VOL_1_V     (0x80) :    4.10 Volts | (unr)
CB_ACCL3_Freya_2_VOL_2_V     (0x81) :    3.49 Volts | (unr)
CB_ACCL4_Freya_1_Temp_C      (0x82) :   41.00 C     | (ok)
CB_ACCL4_Freya_1_VOL_1_V     (0x83) :    3.84 Volts | (unr)
CB_ACCL4_Freya_1_VOL_2_V     (0x84) :    4.52 Volts | (unr)
CB_ACCL4_Freya_2_Temp_C      (0x85) :   40.00 C     | (ok)
CB_ACCL4_Freya_2_VOL_1_V     (0x86) :    4.61 Volts | (unr)
CB_ACCL4_Freya_2_VOL_2_V     (0x87) :    2.21 Volts | (lnr)
CB_ACCL5_Freya_1_Temp_C      (0x88) :   39.00 C     | (ok)
CB_ACCL5_Freya_1_VOL_1_V     (0x89) :    4.61 Volts | (unr)
CB_ACCL5_Freya_1_VOL_2_V     (0x8A) :    6.05 Volts | (unr)
CB_ACCL5_Freya_2_Temp_C      (0x8B) :   42.00 C     | (ok)
CB_ACCL5_Freya_2_VOL_1_V     (0x8C) :    4.10 Volts | (unr)
CB_ACCL5_Freya_2_VOL_2_V     (0x8D) :    5.70 Volts | (unr)
CB_ACCL6_Freya_1_Temp_C      (0x8E) :   39.00 C     | (ok)
CB_ACCL6_Freya_1_VOL_1_V     (0x8F) :    4.10 Volts | (unr)
CB_ACCL6_Freya_1_VOL_2_V     (0x90) :    4.62 Volts | (unr)
CB_ACCL6_Freya_2_Temp_C      (0x91) :   42.00 C     | (ok)
CB_ACCL6_Freya_2_VOL_1_V     (0x92) :    5.38 Volts | (unr)
CB_ACCL6_Freya_2_VOL_2_V     (0x93) :    3.75 Volts | (unr)
CB_ACCL7_Freya_1_Temp_C      (0x94) :   38.00 C     | (ok)
CB_ACCL7_Freya_1_VOL_1_V     (0x95) :    4.36 Volts | (unr)
CB_ACCL7_Freya_1_VOL_2_V     (0x96) :    1.45 Volts | (lnr)
CB_ACCL7_Freya_2_Temp_C      (0x97) :   43.00 C     | (ok)
CB_ACCL7_Freya_2_VOL_1_V     (0x98) :    4.87 Volts | (unr)
CB_ACCL7_Freya_2_VOL_2_V     (0x99) :    0.68 Volts | (lnr)
CB_ACCL8_Freya_1_Temp_C      (0x9A) :   38.00 C     | (ok)
CB_ACCL8_Freya_1_VOL_1_V     (0x9B) :    4.61 Volts | (unr)
CB_ACCL8_Freya_1_VOL_2_V     (0x9C) :    2.21 Volts | (lnr)
CB_ACCL8_Freya_2_Temp_C      (0x9D) :   42.00 C     | (ok)
CB_ACCL8_Freya_2_VOL_1_V     (0x9E) :    4.87 Volts | (unr)
CB_ACCL8_Freya_2_VOL_2_V     (0x9F) :    5.18 Volts | (unr)
CB_ACCL9_Freya_1_Temp_C      (0xA0) :   39.00 C     | (ok)
CB_ACCL9_Freya_1_VOL_1_V     (0xA1) :    5.38 Volts | (unr)
CB_ACCL9_Freya_1_VOL_2_V     (0xA2) :    6.46 Volts | (unr)
CB_ACCL9_Freya_2_Temp_C      (0xA3) :   41.00 C     | (ok)
CB_ACCL9_Freya_2_VOL_1_V     (0xA4) :    4.36 Volts | (unr)
CB_ACCL9_Freya_2_VOL_2_V     (0xA5) :    2.88 Volts | (lnr)
CB_ACCL10_Freya_1_Temp_C     (0xA6) :   38.00 C     | (ok)
CB_ACCL10_Freya_1_VOL_1_V    (0xA7) :    4.87 Volts | (unr)
CB_ACCL10_Freya_1_VOL_2_V    (0xA8) :    5.70 Volts | (unr)
CB_ACCL10_Freya_2_Temp_C     (0xA9) :   41.00 C     | (ok)
CB_ACCL10_Freya_2_VOL_1_V    (0xAA) :    4.61 Volts | (unr)
CB_ACCL10_Freya_2_VOL_2_V    (0xAB) :    2.88 Volts | (lnr)
CB_ACCL11_Freya_1_Temp_C     (0xAC) :   37.00 C     | (ok)
CB_ACCL11_Freya_1_VOL_1_V    (0xAD) :    4.61 Volts | (unr)
CB_ACCL11_Freya_1_VOL_2_V    (0xAE) :    4.42 Volts | (unr)
CB_ACCL11_Freya_2_Temp_C     (0xAF) :   41.00 C     | (ok)
CB_ACCL11_Freya_2_VOL_1_V    (0xB0) :    4.10 Volts | (unr)
CB_ACCL11_Freya_2_VOL_2_V    (0xB1) :    6.46 Volts | (unr)
CB_ACCL12_Freya_1_Temp_C     (0xB2) :   39.00 C     | (ok)
CB_ACCL12_Freya_1_VOL_1_V    (0xB3) :    5.38 Volts | (unr)
CB_ACCL12_Freya_1_VOL_2_V    (0xB4) :    0.68 Volts | (lnr)
CB_ACCL12_Freya_2_Temp_C     (0xB5) :   44.00 C     | (ok)
CB_ACCL12_Freya_2_VOL_1_V    (0xB6) :    5.12 Volts | (unr)
CB_ACCL12_Freya_2_VOL_2_V    (0xB7) :    3.75 Volts | (unr)

- Block ACCL card mapping INA233 sensor read when ACCL card power off (ACCL 1,2,3,4,5,11 power off) [BMC console]
root@bmc-oob:~# sensor-util cb | grep ACCL
CB_P12V_ACCL1_V              (0x23) : NA | (na)
CB_P12V_ACCL2_V              (0x24) : NA | (na)
CB_P12V_ACCL3_V              (0x25) : NA | (na)
CB_P12V_ACCL4_V              (0x26) : NA | (na)
CB_P12V_ACCL5_V              (0x27) : NA | (na)
CB_P12V_ACCL6_V              (0x28) :   12.17 Volts | (ok)
CB_P12V_ACCL7_V              (0x29) :   12.13 Volts | (ok)
CB_P12V_ACCL8_V              (0x2A) :   12.13 Volts | (ok)
CB_P12V_ACCL9_V              (0x2C) :   12.13 Volts | (ok)
CB_P12V_ACCL10_V             (0x2D) :   12.13 Volts | (ok)
CB_P12V_ACCL11_V             (0x2E) : NA | (na)
CB_P12V_ACCL12_V             (0x2F) :   12.14 Volts | (ok)
CB_P12V_ACCL1_A              (0x34) : NA | (na)
CB_P12V_ACCL2_A              (0x35) : NA | (na)
CB_P12V_ACCL3_A              (0x36) : NA | (na)
CB_P12V_ACCL4_A              (0x37) : NA | (na)
CB_P12V_ACCL5_A              (0x38) : NA | (na)
CB_P12V_ACCL6_A              (0x39) :    2.47 Amps  | (ok)
CB_P12V_ACCL7_A              (0x3A) :    2.91 Amps  | (ok)
CB_P12V_ACCL8_A              (0x3C) :    2.95 Amps  | (ok)
CB_P12V_ACCL9_A              (0x3D) :    2.84 Amps  | (ok)
CB_P12V_ACCL10_A             (0x3E) :    2.94 Amps  | (ok)
CB_P12V_ACCL11_A             (0x3F) : NA | (na)
CB_P12V_ACCL12_A             (0x40) :    2.61 Amps  | (ok)
CB_P12V_ACCL1_W              (0x45) : NA | (na)
CB_P12V_ACCL2_W              (0x46) : NA | (na)
CB_P12V_ACCL3_W              (0x47) : NA | (na)
CB_P12V_ACCL4_W              (0x48) : NA | (na)
CB_P12V_ACCL5_W              (0x49) : NA | (na)
CB_P12V_ACCL6_W              (0x4A) :   30.12 Watts | (ok)
CB_P12V_ACCL7_W              (0x4B) :   35.30 Watts | (ok)
CB_P12V_ACCL8_W              (0x4C) :   35.75 Watts | (ok)
CB_P12V_ACCL9_W              (0x4D) :   34.50 Watts | (ok)
CB_P12V_ACCL10_W             (0x50) :   35.65 Watts | (ok)
CB_P12V_ACCL11_W             (0x51) : NA | (na)
CB_P12V_ACCL12_W             (0x52) :   31.70 Watts | (ok)
CB_ACCL1_Freya_1_Temp_C      (0x70) : NA | (na)
CB_ACCL1_Freya_1_VOL_1_V     (0x71) : NA | (na)
CB_ACCL1_Freya_1_VOL_2_V     (0x72) : NA | (na)
CB_ACCL1_Freya_2_Temp_C      (0x73) : NA | (na)
CB_ACCL1_Freya_2_VOL_1_V     (0x74) : NA | (na)
CB_ACCL1_Freya_2_VOL_2_V     (0x75) : NA | (na)
CB_ACCL2_Freya_1_Temp_C      (0x76) : NA | (na)
CB_ACCL2_Freya_1_VOL_1_V     (0x77) : NA | (na)
CB_ACCL2_Freya_1_VOL_2_V     (0x78) : NA | (na)
CB_ACCL2_Freya_2_Temp_C      (0x79) : NA | (na)
CB_ACCL2_Freya_2_VOL_1_V     (0x7A) : NA | (na)
CB_ACCL2_Freya_2_VOL_2_V     (0x7B) : NA | (na)
CB_ACCL3_Freya_1_Temp_C      (0x7C) : NA | (na)
CB_ACCL3_Freya_1_VOL_1_V     (0x7D) : NA | (na)
CB_ACCL3_Freya_1_VOL_2_V     (0x7E) : NA | (na)
CB_ACCL3_Freya_2_Temp_C      (0x7F) : NA | (na)
CB_ACCL3_Freya_2_VOL_1_V     (0x80) : NA | (na)
CB_ACCL3_Freya_2_VOL_2_V     (0x81) : NA | (na)
CB_ACCL4_Freya_1_Temp_C      (0x82) : NA | (na)
CB_ACCL4_Freya_1_VOL_1_V     (0x83) : NA | (na)
CB_ACCL4_Freya_1_VOL_2_V     (0x84) : NA | (na)
CB_ACCL4_Freya_2_Temp_C      (0x85) : NA | (na)
CB_ACCL4_Freya_2_VOL_1_V     (0x86) : NA | (na)
CB_ACCL4_Freya_2_VOL_2_V     (0x87) : NA | (na)
CB_ACCL5_Freya_1_Temp_C      (0x88) : NA | (na)
CB_ACCL5_Freya_1_VOL_1_V     (0x89) : NA | (na)
CB_ACCL5_Freya_1_VOL_2_V     (0x8A) : NA | (na)
CB_ACCL5_Freya_2_Temp_C      (0x8B) : NA | (na)
CB_ACCL5_Freya_2_VOL_1_V     (0x8C) : NA | (na)
CB_ACCL5_Freya_2_VOL_2_V     (0x8D) : NA | (na)
CB_ACCL6_Freya_1_Temp_C      (0x8E) :   39.00 C     | (ok)
CB_ACCL6_Freya_1_VOL_1_V     (0x8F) :    4.36 Volts | (unr)
CB_ACCL6_Freya_1_VOL_2_V     (0x90) :    4.62 Volts | (unr)
CB_ACCL6_Freya_2_Temp_C      (0x91) :   42.00 C     | (ok)
CB_ACCL6_Freya_2_VOL_1_V     (0x92) :    5.12 Volts | (unr)
CB_ACCL6_Freya_2_VOL_2_V     (0x93) :    3.75 Volts | (unr)
CB_ACCL7_Freya_1_Temp_C      (0x94) :   38.00 C     | (ok)
CB_ACCL7_Freya_1_VOL_1_V     (0x95) :    4.36 Volts | (unr)
CB_ACCL7_Freya_1_VOL_2_V     (0x96) :    1.45 Volts | (lnr)
CB_ACCL7_Freya_2_Temp_C      (0x97) :   43.00 C     | (ok)
CB_ACCL7_Freya_2_VOL_1_V     (0x98) :    4.87 Volts | (unr)
CB_ACCL7_Freya_2_VOL_2_V     (0x99) :    0.68 Volts | (lnr)
CB_ACCL8_Freya_1_Temp_C      (0x9A) :   38.00 C     | (ok)
CB_ACCL8_Freya_1_VOL_1_V     (0x9B) :    4.61 Volts | (unr)
CB_ACCL8_Freya_1_VOL_2_V     (0x9C) :    2.21 Volts | (lnr)
CB_ACCL8_Freya_2_Temp_C      (0x9D) :   42.00 C     | (ok)
CB_ACCL8_Freya_2_VOL_1_V     (0x9E) :    4.87 Volts | (unr)
CB_ACCL8_Freya_2_VOL_2_V     (0x9F) :    5.18 Volts | (unr)
CB_ACCL9_Freya_1_Temp_C      (0xA0) :   39.00 C     | (ok)
CB_ACCL9_Freya_1_VOL_1_V     (0xA1) :    4.87 Volts | (unr)
CB_ACCL9_Freya_1_VOL_2_V     (0xA2) :    6.46 Volts | (unr)
CB_ACCL9_Freya_2_Temp_C      (0xA3) :   41.00 C     | (ok)
CB_ACCL9_Freya_2_VOL_1_V     (0xA4) :    4.36 Volts | (unr)
CB_ACCL9_Freya_2_VOL_2_V     (0xA5) :    2.88 Volts | (lnr)
CB_ACCL10_Freya_1_Temp_C     (0xA6) :   38.00 C     | (ok)
CB_ACCL10_Freya_1_VOL_1_V    (0xA7) :    4.61 Volts | (unr)
CB_ACCL10_Freya_1_VOL_2_V    (0xA8) :    5.70 Volts | (unr)
CB_ACCL10_Freya_2_Temp_C     (0xA9) :   41.00 C     | (ok)
CB_ACCL10_Freya_2_VOL_1_V    (0xAA) :    4.61 Volts | (unr)
CB_ACCL10_Freya_2_VOL_2_V    (0xAB) :    2.88 Volts | (lnr)
CB_ACCL11_Freya_1_Temp_C     (0xAC) : NA | (na)
CB_ACCL11_Freya_1_VOL_1_V    (0xAD) : NA | (na)
CB_ACCL11_Freya_1_VOL_2_V    (0xAE) : NA | (na)
CB_ACCL11_Freya_2_Temp_C     (0xAF) : NA | (na)
CB_ACCL11_Freya_2_VOL_1_V    (0xB0) : NA | (na)
CB_ACCL11_Freya_2_VOL_2_V    (0xB1) : NA | (na)
CB_ACCL12_Freya_1_Temp_C     (0xB2) :   39.00 C     | (ok)
CB_ACCL12_Freya_1_VOL_1_V    (0xB3) :    5.64 Volts | (unr)
CB_ACCL12_Freya_1_VOL_2_V    (0xB4) :    0.68 Volts | (lnr)
CB_ACCL12_Freya_2_Temp_C     (0xB5) :   44.00 C     | (ok)
CB_ACCL12_Freya_2_VOL_1_V    (0xB6) :    5.12 Volts | (unr)
CB_ACCL12_Freya_2_VOL_2_V    (0xB7) :    3.75 Volts | (unr)

[BIC console]
uart:~$ platform sensor get_table_all_sensor 0
--------------------------------------------------------------------------------- Table name: common sensor table | index: 0x0  | sensor count: 0x9d | access[O]

[0x1 ] OUTLET_1_TEMP            : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    32.000
[0x2 ] OUTLET_2_TEMP            : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.000
[0x67] INLET_TEMP               : lm75bd118  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.000
[0x11] P3V3_AUX Vol             : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.280
[0x13] P1V8_PEX Vol             : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.787
[0x12] P1V2_AUX Vol             : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.193
[0x10] P5V_AUX Vol              : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.048
[0x1e] P1V8_1_VDD Vol           : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.816
[0x1f] P1V8_2_VDD Vol           : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.818
[0x20] P1V25_1_VDD Vol          : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.264
[0x21] P1V25_2_VDD Vol          : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.269
[0x5f] P0V8_VDD_1 Temp          : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0x57] P0V8_VDD_1 Vol           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.802
[0x59] P0V8_VDD_1 Cur           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.812
[0x5b] P0V8_VDD_1 PWR           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    23.125
[0x60] P0V8_VDD_2 Temp          : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0x58] P0V8_VDD_2 Vol           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.804
[0x5a] P0V8_VDD_2 Cur           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    29.062
[0x5c] P0V8_VDD_2 PWR           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    23.375
[0x5 ] PEX0_TEMP                : pex89000   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    56.148
[0x6 ] PEX1_TEMP                : pex89000   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    57.098
[0x61] P12V_1_M_AUX Vol         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.130
[0x63] P12V_1_M_AUX Cur         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.492
[0x65] P12V_1_M_AUX PWR         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    18.100
[0x62] P12V_2_M_AUX Vol         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.146
[0x64] P12V_2_M_AUX Cur         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.805
[0x66] P12V_2_M_AUX PWR         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    21.925
[0x23] P12V_ACCL1 Vol           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x34] P12V_ACCL1 Cur           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x45] P12V_ACCL1 PWR           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x24] P12V_ACCL2 Vol           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x35] P12V_ACCL2 Cur           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x46] P12V_ACCL2 PWR           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x25] P12V_ACCL3 Vol           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x36] P12V_ACCL3 Cur           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x47] P12V_ACCL3 PWR           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x26] P12V_ACCL4 Vol           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x37] P12V_ACCL4 Cur           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x48] P12V_ACCL4 PWR           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x27] P12V_ACCL5 Vol           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x38] P12V_ACCL5 Cur           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x49] P12V_ACCL5 PWR           : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x28] P12V_ACCL6 Vol           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.145
[0x39] P12V_ACCL6 Cur           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.480
[0x4a] P12V_ACCL6 PWR           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    30.100
[0x29] P12V_ACCL7 Vol           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.128
[0x3a] P12V_ACCL7 Cur           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.907
[0x4b] P12V_ACCL7 PWR           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    35.275
[0x2a] P12V_ACCL8 Vol           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.126
[0x3c] P12V_ACCL8 Cur           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.947
[0x4c] P12V_ACCL8 PWR           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    35.724
[0x2c] P12V_ACCL9 Vol           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.131
[0x3d] P12V_ACCL9 Cur           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.842
[0x4d] P12V_ACCL9 PWR           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    34.474
[0x2d] P12V_ACCL10 Vol          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.130
[0x3e] P12V_ACCL10 Cur          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.937
[0x50] P12V_ACCL10 PWR          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    35.625
[0x2e] P12V_ACCL11 Vol          : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x3f] P12V_ACCL11 Cur          : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x51] P12V_ACCL11 PWR          : ina233     | access[O] | poll[O] 1    sec | polling_disable           | na
[0x2f] P12V_ACCL12 Vol          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.132
[0x40] P12V_ACCL12 Cur          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.609
[0x52] P12V_ACCL12 PWR          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    31.674
[0x70] ACCL_1_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x73] ACCL_1_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x71] ACCL_1_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x72] ACCL_1_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x74] ACCL_1_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x75] ACCL_1_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x76] ACCL_2_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x79] ACCL_2_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x77] ACCL_2_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x78] ACCL_2_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x7a] ACCL_2_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x7b] ACCL_2_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x7c] ACCL_3_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x7f] ACCL_3_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x7d] ACCL_3_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x7e] ACCL_3_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x80] ACCL_3_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x81] ACCL_3_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x82] ACCL_4_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x85] ACCL_4_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x83] ACCL_4_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x84] ACCL_4_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x86] ACCL_4_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x87] ACCL_4_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x88] ACCL_5_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x8b] ACCL_5_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x89] ACCL_5_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x8a] ACCL_5_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x8c] ACCL_5_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x8d] ACCL_5_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0x8e] ACCL_6_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0x91] ACCL_6_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    42.000
[0x8f] ACCL_6_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.355
[0x90] ACCL_6_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.621
[0x92] ACCL_6_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.123
[0x93] ACCL_6_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.750
[0x94] ACCL_7_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0x97] ACCL_7_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    42.000
[0x95] ACCL_7_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.099
[0x96] ACCL_7_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.446
[0x98] ACCL_7_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.123
[0x99] ACCL_7_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.678
[0x9a] ACCL_8_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0x9d] ACCL_8_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    42.000
[0x9b] ACCL_8_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.867
[0x9c] ACCL_8_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.214
[0x9e] ACCL_8_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.867
[0x9f] ACCL_8_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.184
[0xa0] ACCL_9_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0xa3] ACCL_9_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    41.000
[0xa1] ACCL_9_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.611
[0xa2] ACCL_9_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     6.464
[0xa4] ACCL_9_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.099
[0xa5] ACCL_9_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.880
[0xa6] ACCL_10_Freya_1_Temp     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0xa9] ACCL_10_Freya_2_Temp     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    41.000
[0xa7] ACCL_10_Freya_1_VOL_1    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.611
[0xa8] ACCL_10_Freya_1_VOL_2    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.696
[0xaa] ACCL_10_Freya_2_VOL_1    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.867
[0xab] ACCL_10_Freya_2_VOL_2    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.880
[0xac] ACCL_11_Freya_1_Temp     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0xaf] ACCL_11_Freya_2_Temp     : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0xad] ACCL_11_Freya_1_VOL_1    : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0xae] ACCL_11_Freya_1_VOL_2    : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0xb0] ACCL_11_Freya_2_VOL_1    : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0xb1] ACCL_11_Freya_2_VOL_2    : nvme       | access[O] | poll[O] 1    sec | polling_disable           | na
[0xb2] ACCL_12_Freya_1_Temp     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0xb5] ACCL_12_Freya_2_Temp     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    44.000
[0xb3] ACCL_12_Freya_1_VOL_1    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.123
[0xb4] ACCL_12_Freya_1_VOL_2    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.678
[0xb6] ACCL_12_Freya_2_VOL_1    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.611
[0xb7] ACCL_12_Freya_2_VOL_2    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.750
[0x3 ] HSC 1 Temp               : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.071
[0x53] P51V_STBY_L Vol          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    50.861
[0xb ] P51V_AUX_L Vol           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    50.861
[0x5d] P51V_STBY_L Cur          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.379
[0x30] P51V_AUX_L Cur           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.372
[0x55] P51V_STBY_L PWR          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    70.147
[0x41] P51V_AUX_L PWR           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    69.810
[0x4 ] HSC 2 Temp               : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    26.880
[0x54] P51V_STBY_R Vol          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    50.861
[0xc ] P51V_AUX_R Vol           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    50.861
[0x5e] P51V_STBY_R Cur          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.076
[0x31] P51V_AUX_R Cur           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.070
[0x56] P51V_STBY_R PWR          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    54.769
[0x42] P51V_AUX_R PWR           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    54.467
[0x9 ] POWER_BRICK_1_TEMP       : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    32.000
[0xd ] P12V_AUX_1 Vol           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.129
[0x32] P12V_AUX_1 Cur           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    17.750
[0x43] P12V_AUX_1 PWR           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |   190.888
[0xa ] POWER_BRICK_2_TEMP       : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    32.000
[0xe ] P12V_AUX_2 Vol           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.119
[0x33] P12V_AUX_2 Cur           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    15.000
[0x44] P12V_AUX_2 PWR           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |   175.883
---------------------------------------------------------------------------------

- Block ACCL card mapping INA233 sensor read when ACCL card not present (ACCL 2,3,4 not present) [BMC console]
root@bmc-oob:~# sensor-util cb | grep ACCL
CB_P12V_ACCL1_V              (0x23) :   12.16 Volts | (ok)
CB_P12V_ACCL2_V              (0x24) : NA | (na)
CB_P12V_ACCL3_V              (0x25) : NA | (na)
CB_P12V_ACCL4_V              (0x26) : NA | (na)
CB_P12V_ACCL5_V              (0x27) :   12.16 Volts | (ok)
CB_P12V_ACCL6_V              (0x28) :   12.16 Volts | (ok)
CB_P12V_ACCL7_V              (0x29) :   12.13 Volts | (ok)
CB_P12V_ACCL8_V              (0x2A) :   12.12 Volts | (ok)
CB_P12V_ACCL9_V              (0x2C) :   12.13 Volts | (ok)
CB_P12V_ACCL10_V             (0x2D) :   12.13 Volts | (ok)
CB_P12V_ACCL11_V             (0x2E) :   12.13 Volts | (ok)
CB_P12V_ACCL12_V             (0x2F) :   12.13 Volts | (ok)
CB_P12V_ACCL1_A              (0x34) :    3.00 Amps  | (ok)
CB_P12V_ACCL2_A              (0x35) : NA | (na)
CB_P12V_ACCL3_A              (0x36) : NA | (na)
CB_P12V_ACCL4_A              (0x37) : NA | (na)
CB_P12V_ACCL5_A              (0x38) :    2.98 Amps  | (ok)
CB_P12V_ACCL6_A              (0x39) :    2.46 Amps  | (ok)
CB_P12V_ACCL7_A              (0x3A) :    2.90 Amps  | (ok)
CB_P12V_ACCL8_A              (0x3C) :    2.93 Amps  | (ok)
CB_P12V_ACCL9_A              (0x3D) :    2.83 Amps  | (ok)
CB_P12V_ACCL10_A             (0x3E) :    2.92 Amps  | (ok)
CB_P12V_ACCL11_A             (0x3F) :    2.88 Amps  | (ok)
CB_P12V_ACCL12_A             (0x40) :    2.59 Amps  | (ok)
CB_P12V_ACCL1_W              (0x45) :   36.50 Watts | (ok)
CB_P12V_ACCL2_W              (0x46) : NA | (na)
CB_P12V_ACCL3_W              (0x47) : NA | (na)
CB_P12V_ACCL4_W              (0x48) : NA | (na)
CB_P12V_ACCL5_W              (0x49) :   36.25 Watts | (ok)
CB_P12V_ACCL6_W              (0x4A) :   29.98 Watts | (ok)
CB_P12V_ACCL7_W              (0x4B) :   35.15 Watts | (ok)
CB_P12V_ACCL8_W              (0x4C) :   35.58 Watts | (ok)
CB_P12V_ACCL9_W              (0x4D) :   34.38 Watts | (ok)
CB_P12V_ACCL10_W             (0x50) :   35.47 Watts | (ok)
CB_P12V_ACCL11_W             (0x51) :   34.90 Watts | (ok)
CB_P12V_ACCL12_W             (0x52) :   31.40 Watts | (ok)
CB_ACCL1_Freya_1_Temp_C      (0x70) :   38.00 C     | (ok)
CB_ACCL1_Freya_1_VOL_1_V     (0x71) :    5.12 Volts | (unr)
CB_ACCL1_Freya_1_VOL_2_V     (0x72) :    5.18 Volts | (unr)
CB_ACCL1_Freya_2_Temp_C      (0x73) :   43.00 C     | (ok)
CB_ACCL1_Freya_2_VOL_1_V     (0x74) :    4.87 Volts | (unr)
CB_ACCL1_Freya_2_VOL_2_V     (0x75) :    4.42 Volts | (unr)
CB_ACCL2_Freya_1_Temp_C      (0x76) : NA | (na)
CB_ACCL2_Freya_1_VOL_1_V     (0x77) : NA | (na)
CB_ACCL2_Freya_1_VOL_2_V     (0x78) : NA | (na)
CB_ACCL2_Freya_2_Temp_C      (0x79) : NA | (na)
CB_ACCL2_Freya_2_VOL_1_V     (0x7A) : NA | (na)
CB_ACCL2_Freya_2_VOL_2_V     (0x7B) : NA | (na)
CB_ACCL3_Freya_1_Temp_C      (0x7C) : NA | (na)
CB_ACCL3_Freya_1_VOL_1_V     (0x7D) : NA | (na)
CB_ACCL3_Freya_1_VOL_2_V     (0x7E) : NA | (na)
CB_ACCL3_Freya_2_Temp_C      (0x7F) : NA | (na)
CB_ACCL3_Freya_2_VOL_1_V     (0x80) : NA | (na)
CB_ACCL3_Freya_2_VOL_2_V     (0x81) : NA | (na)
CB_ACCL4_Freya_1_Temp_C      (0x82) : NA | (na)
CB_ACCL4_Freya_1_VOL_1_V     (0x83) : NA | (na)
CB_ACCL4_Freya_1_VOL_2_V     (0x84) : NA | (na)
CB_ACCL4_Freya_2_Temp_C      (0x85) : NA | (na)
CB_ACCL4_Freya_2_VOL_1_V     (0x86) : NA | (na)
CB_ACCL4_Freya_2_VOL_2_V     (0x87) : NA | (na)
CB_ACCL5_Freya_1_Temp_C      (0x88) :   37.00 C     | (ok)
CB_ACCL5_Freya_1_VOL_1_V     (0x89) :    4.36 Volts | (unr)
CB_ACCL5_Freya_1_VOL_2_V     (0x8A) :    6.05 Volts | (unr)
CB_ACCL5_Freya_2_Temp_C      (0x8B) :   40.00 C     | (ok)
CB_ACCL5_Freya_2_VOL_1_V     (0x8C) :    4.10 Volts | (unr)
CB_ACCL5_Freya_2_VOL_2_V     (0x8D) :    5.70 Volts | (unr)
CB_ACCL6_Freya_1_Temp_C      (0x8E) :   37.00 C     | (ok)
CB_ACCL6_Freya_1_VOL_1_V     (0x8F) :    4.10 Volts | (unr)
CB_ACCL6_Freya_1_VOL_2_V     (0x90) :    4.62 Volts | (unr)
CB_ACCL6_Freya_2_Temp_C      (0x91) :   39.00 C     | (ok)
CB_ACCL6_Freya_2_VOL_1_V     (0x92) :    5.12 Volts | (unr)
CB_ACCL6_Freya_2_VOL_2_V     (0x93) :    3.75 Volts | (unr)
CB_ACCL7_Freya_1_Temp_C      (0x94) :   37.00 C     | (ok)
CB_ACCL7_Freya_1_VOL_1_V     (0x95) :    4.10 Volts | (unr)
CB_ACCL7_Freya_1_VOL_2_V     (0x96) :    1.45 Volts | (lnr)
CB_ACCL7_Freya_2_Temp_C      (0x97) :   41.00 C     | (ok)
CB_ACCL7_Freya_2_VOL_1_V     (0x98) :    4.87 Volts | (unr)
CB_ACCL7_Freya_2_VOL_2_V     (0x99) :    1.19 Volts | (lnr)
CB_ACCL8_Freya_1_Temp_C      (0x9A) :   37.00 C     | (ok)
CB_ACCL8_Freya_1_VOL_1_V     (0x9B) :    4.61 Volts | (unr)
CB_ACCL8_Freya_1_VOL_2_V     (0x9C) :    2.21 Volts | (lnr)
CB_ACCL8_Freya_2_Temp_C      (0x9D) :   39.00 C     | (ok)
CB_ACCL8_Freya_2_VOL_1_V     (0x9E) :    5.12 Volts | (unr)
CB_ACCL8_Freya_2_VOL_2_V     (0x9F) :    5.18 Volts | (unr)
CB_ACCL9_Freya_1_Temp_C      (0xA0) :   38.00 C     | (ok)
CB_ACCL9_Freya_1_VOL_1_V     (0xA1) :    4.87 Volts | (unr)
CB_ACCL9_Freya_1_VOL_2_V     (0xA2) :    6.46 Volts | (unr)
CB_ACCL9_Freya_2_Temp_C      (0xA3) :   39.00 C     | (ok)
CB_ACCL9_Freya_2_VOL_1_V     (0xA4) :    4.36 Volts | (unr)
CB_ACCL9_Freya_2_VOL_2_V     (0xA5) :    2.88 Volts | (lnr)
CB_ACCL10_Freya_1_Temp_C     (0xA6) :   37.00 C     | (ok)
CB_ACCL10_Freya_1_VOL_1_V    (0xA7) :    4.61 Volts | (unr)
CB_ACCL10_Freya_1_VOL_2_V    (0xA8) :    5.70 Volts | (unr)
CB_ACCL10_Freya_2_Temp_C     (0xA9) :   38.00 C     | (ok)
CB_ACCL10_Freya_2_VOL_1_V    (0xAA) :    4.87 Volts | (unr)
CB_ACCL10_Freya_2_VOL_2_V    (0xAB) :    2.88 Volts | (lnr)
CB_ACCL11_Freya_1_Temp_C     (0xAC) :   37.00 C     | (ok)
CB_ACCL11_Freya_1_VOL_1_V    (0xAD) :    4.61 Volts | (unr)
CB_ACCL11_Freya_1_VOL_2_V    (0xAE) :    4.42 Volts | (unr)
CB_ACCL11_Freya_2_Temp_C     (0xAF) :   38.00 C     | (ok)
CB_ACCL11_Freya_2_VOL_1_V    (0xB0) :    4.36 Volts | (unr)
CB_ACCL11_Freya_2_VOL_2_V    (0xB1) :    6.46 Volts | (unr)
CB_ACCL12_Freya_1_Temp_C     (0xB2) :   37.00 C     | (ok)
CB_ACCL12_Freya_1_VOL_1_V    (0xB3) :    5.64 Volts | (unr)
CB_ACCL12_Freya_1_VOL_2_V    (0xB4) :    0.68 Volts | (lnr)
CB_ACCL12_Freya_2_Temp_C     (0xB5) :   40.00 C     | (ok)
CB_ACCL12_Freya_2_VOL_1_V    (0xB6) :    5.38 Volts | (unr)
CB_ACCL12_Freya_2_VOL_2_V    (0xB7) :    3.75 Volts | (unr)

[BIC console]
uart:~$ platform sensor list_all_sensor
--------------------------------------------------------------------------------- Table name: common sensor table | index: 0x0  | sensor count: 0x9d | access[O]

[0x1 ] OUTLET_1_TEMP            : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    31.000
[0x2 ] OUTLET_2_TEMP            : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.000
[0x67] INLET_TEMP               : lm75bd118  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.500
[0x11] P3V3_AUX Vol             : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.280
[0x13] P1V8_PEX Vol             : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.787
[0x12] P1V2_AUX Vol             : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.193
[0x10] P5V_AUX Vol              : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.048
[0x1e] P1V8_1_VDD Vol           : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.816
[0x1f] P1V8_2_VDD Vol           : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.818
[0x20] P1V25_1_VDD Vol          : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.264
[0x21] P1V25_2_VDD Vol          : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.267
[0x5f] P0V8_VDD_1 Temp          : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0x57] P0V8_VDD_1 Vol           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.802
[0x59] P0V8_VDD_1 Cur           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.500
[0x5b] P0V8_VDD_1 PWR           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    22.875
[0x60] P0V8_VDD_2 Temp          : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    37.000
[0x58] P0V8_VDD_2 Vol           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.804
[0x5a] P0V8_VDD_2 Cur           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    23.062
[0x5c] P0V8_VDD_2 PWR           : xdpe15284  | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    18.500
[0x5 ] PEX0_TEMP                : pex89000   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    57.098
[0x6 ] PEX1_TEMP                : pex89000   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    54.486
[0x61] P12V_1_M_AUX Vol         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.127
[0x63] P12V_1_M_AUX Cur         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.491
[0x65] P12V_1_M_AUX PWR         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    18.075
[0x62] P12V_2_M_AUX Vol         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.158
[0x64] P12V_2_M_AUX Cur         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.219
[0x66] P12V_2_M_AUX PWR         : sq52205    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    14.824
[0x23] P12V_ACCL1 Vol           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.158
[0x34] P12V_ACCL1 Cur           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.014
[0x45] P12V_ACCL1 PWR           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    36.625
[0x24] P12V_ACCL2 Vol           : ina233     | access[O] | poll[X] 1    sec | polling_disable           | na
[0x35] P12V_ACCL2 Cur           : ina233     | access[O] | poll[X] 1    sec | polling_disable           | na
[0x46] P12V_ACCL2 PWR           : ina233     | access[O] | poll[X] 1    sec | polling_disable           | na
[0x25] P12V_ACCL3 Vol           : ina233     | access[O] | poll[X] 1    sec | polling_disable           | na
[0x36] P12V_ACCL3 Cur           : ina233     | access[O] | poll[X] 1    sec | polling_disable           | na
[0x47] P12V_ACCL3 PWR           : ina233     | access[O] | poll[X] 1    sec | polling_disable           | na
[0x26] P12V_ACCL4 Vol           : ina233     | access[O] | poll[X] 1    sec | polling_disable           | na
[0x37] P12V_ACCL4 Cur           : ina233     | access[O] | poll[X] 1    sec | polling_disable           | na
[0x48] P12V_ACCL4 PWR           : ina233     | access[O] | poll[X] 1    sec | polling_disable           | na
[0x27] P12V_ACCL5 Vol           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.157
[0x38] P12V_ACCL5 Cur           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.992
[0x49] P12V_ACCL5 PWR           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    36.400
[0x28] P12V_ACCL6 Vol           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.156
[0x39] P12V_ACCL6 Cur           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.472
[0x4a] P12V_ACCL6 PWR           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    30.049
[0x29] P12V_ACCL7 Vol           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.126
[0x3a] P12V_ACCL7 Cur           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.907
[0x4b] P12V_ACCL7 PWR           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    35.250
[0x2a] P12V_ACCL8 Vol           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.123
[0x3c] P12V_ACCL8 Cur           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.942
[0x4c] P12V_ACCL8 PWR           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    35.650
[0x2c] P12V_ACCL9 Vol           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.128
[0x3d] P12V_ACCL9 Cur           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.842
[0x4d] P12V_ACCL9 PWR           : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    34.474
[0x2d] P12V_ACCL10 Vol          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.127
[0x3e] P12V_ACCL10 Cur          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.932
[0x50] P12V_ACCL10 PWR          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    35.575
[0x2e] P12V_ACCL11 Vol          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.128
[0x3f] P12V_ACCL11 Cur          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.884
[0x51] P12V_ACCL11 PWR          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    34.974
[0x2f] P12V_ACCL12 Vol          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.130
[0x40] P12V_ACCL12 Cur          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.599
[0x52] P12V_ACCL12 PWR          : ina233     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    31.524
[0x70] ACCL_1_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0x73] ACCL_1_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    44.000
[0x71] ACCL_1_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.635
[0x72] ACCL_1_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.184
[0x74] ACCL_1_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.867
[0x75] ACCL_1_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.416
[0x76] ACCL_2_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x79] ACCL_2_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x77] ACCL_2_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x78] ACCL_2_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x7a] ACCL_2_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x7b] ACCL_2_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x7c] ACCL_3_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x7f] ACCL_3_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x7d] ACCL_3_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x7e] ACCL_3_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x80] ACCL_3_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x81] ACCL_3_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x82] ACCL_4_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x85] ACCL_4_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x83] ACCL_4_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x84] ACCL_4_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x86] ACCL_4_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x87] ACCL_4_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | sensor_not_present        | na
[0x88] ACCL_5_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    37.000
[0x8b] ACCL_5_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    41.000
[0x89] ACCL_5_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.611
[0x8a] ACCL_5_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     6.054
[0x8c] ACCL_5_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.843
[0x8d] ACCL_5_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.696
[0x8e] ACCL_6_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0x91] ACCL_6_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    41.000
[0x8f] ACCL_6_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.099
[0x90] ACCL_6_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.621
[0x92] ACCL_6_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.123
[0x93] ACCL_6_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.750
[0x94] ACCL_7_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    37.000
[0x97] ACCL_7_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    42.000
[0x95] ACCL_7_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.355
[0x96] ACCL_7_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.446
[0x98] ACCL_7_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.123
[0x99] ACCL_7_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.678
[0x9a] ACCL_8_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0x9d] ACCL_8_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0x9b] ACCL_8_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.611
[0x9c] ACCL_8_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.214
[0x9e] ACCL_8_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.379
[0x9f] ACCL_8_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.184
[0xa0] ACCL_9_Freya_1_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0xa3] ACCL_9_Freya_2_Temp      : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    41.000
[0xa1] ACCL_9_Freya_1_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.867
[0xa2] ACCL_9_Freya_1_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     6.464
[0xa4] ACCL_9_Freya_2_VOL_1     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.843
[0xa5] ACCL_9_Freya_2_VOL_2     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.880
[0xa6] ACCL_10_Freya_1_Temp     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    37.000
[0xa9] ACCL_10_Freya_2_Temp     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.000
[0xa7] ACCL_10_Freya_1_VOL_1    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.611
[0xa8] ACCL_10_Freya_1_VOL_2    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.696
[0xaa] ACCL_10_Freya_2_VOL_1    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.611
[0xab] ACCL_10_Freya_2_VOL_2    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.880
[0xac] ACCL_11_Freya_1_Temp     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    37.000
[0xaf] ACCL_11_Freya_2_Temp     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.000
[0xad] ACCL_11_Freya_1_VOL_1    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.355
[0xae] ACCL_11_Freya_1_VOL_2    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.416
[0xb0] ACCL_11_Freya_2_VOL_1    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.099
[0xb1] ACCL_11_Freya_2_VOL_2    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     6.464
[0xb2] ACCL_12_Freya_1_Temp     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0xb5] ACCL_12_Freya_2_Temp     : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    41.000
[0xb3] ACCL_12_Freya_1_VOL_1    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.635
[0xb4] ACCL_12_Freya_1_VOL_2    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.678
[0xb6] ACCL_12_Freya_2_VOL_1    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.123
[0xb7] ACCL_12_Freya_2_VOL_2    : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.750
[0x3 ] HSC 1 Temp               : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.309
[0x53] P51V_STBY_L Vol          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    50.886
[0xb ] P51V_AUX_L Vol           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    50.861
[0x5d] P51V_STBY_L Cur          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.425
[0x30] P51V_AUX_L Cur           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.417
[0x55] P51V_STBY_L PWR          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    72.520
[0x41] P51V_AUX_L PWR           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    72.111
[0x4 ] HSC 2 Temp               : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    27.119
[0x54] P51V_STBY_R Vol          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    50.861
[0xc ] P51V_AUX_R Vol           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    50.861
[0x5e] P51V_STBY_R Cur          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.778
[0x31] P51V_AUX_R Cur           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.784
[0x56] P51V_STBY_R PWR          : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.582
[0x42] P51V_AUX_R PWR           : adm1272    | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.891
[0x9 ] POWER_BRICK_1_TEMP       : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    32.000
[0xd ] P12V_AUX_1 Vol           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.129
[0x32] P12V_AUX_1 Cur           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    18.000
[0x43] P12V_AUX_1 PWR           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |   199.977
[0xa ] POWER_BRICK_2_TEMP       : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    31.000
[0xe ] P12V_AUX_2 Vol           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.139
[0x33] P12V_AUX_2 Cur           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    10.250
[0x44] P12V_AUX_2 PWR           : q50sn120a1 | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |   124.536
---------------------------------------------------------------------------------