### PR TITLE
Artemis: cb: Clear freya version after PCIE card power off

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_class.c
+++ b/meta-facebook/at-cb/src/platform/plat_class.c
@@ -312,7 +312,10 @@ bool get_acb_power_status()
 
 	if (is_power_good == true && current_power_status == false) {
 		// DC drop
-		clear_freya_cache_flag();
+		uint8_t index = 0;
+		for (index = 0; index < ASIC_CARD_COUNT; ++index) {
+			clear_freya_cache_flag(index);
+		}
 	}
 
 	is_power_good = current_power_status;

--- a/meta-facebook/at-cb/src/platform/plat_dev.c
+++ b/meta-facebook/at-cb/src/platform/plat_dev.c
@@ -46,16 +46,20 @@ freya_info accl_freya_info[] = {
 	[11] = { .is_cache_freya1_info = false, .is_cache_freya2_info = false },
 };
 
-void clear_freya_cache_flag()
+void clear_freya_cache_flag(uint8_t card_id)
 {
-	uint8_t index = 0;
-
-	for (index = 0; index < ARRAY_SIZE(accl_freya_info); ++index) {
-		accl_freya_info[index].is_cache_freya1_info = false;
-		accl_freya_info[index].is_cache_freya2_info = false;
-		memset(&accl_freya_info[index].freya1_fw_info, 0, FREYA_FW_VERSION_LENGTH);
-		memset(&accl_freya_info[index].freya2_fw_info, 0, FREYA_FW_VERSION_LENGTH);
+	if (card_id >= ARRAY_SIZE(accl_freya_info)) {
+		LOG_ERR("Invalid card id to clear freya cache flag, card id: 0x%x", card_id);
+		return;
 	}
+
+	accl_freya_info[card_id].is_cache_freya1_info = false;
+	accl_freya_info[card_id].is_cache_freya2_info = false;
+	memset(&accl_freya_info[card_id].freya1_fw_info, 0, FREYA_FW_VERSION_LENGTH);
+	memset(&accl_freya_info[card_id].freya2_fw_info, 0, FREYA_FW_VERSION_LENGTH);
+
+	accl_freya_info[card_id].freya1_fw_info.is_freya_ready = FREYA_NOT_READY;
+	accl_freya_info[card_id].freya2_fw_info.is_freya_ready = FREYA_NOT_READY;
 }
 
 int get_freya_fw_info(uint8_t bus, uint8_t addr, freya_fw_info *fw_info)

--- a/meta-facebook/at-cb/src/platform/plat_dev.h
+++ b/meta-facebook/at-cb/src/platform/plat_dev.h
@@ -65,7 +65,7 @@ enum FREYA_ID {
 
 extern freya_info accl_freya_info[];
 
-void clear_freya_cache_flag();
+void clear_freya_cache_flag(uint8_t card_id);
 int get_freya_fw_info(uint8_t bus, uint8_t addr, freya_fw_info *fw_info);
 
 #endif

--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -514,6 +514,7 @@ bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 	if (is_power_good != true) {
 		cfg->cache_status = SENSOR_POLLING_DISABLE;
 		accl_sensor_info_args[card_id].is_sensor_init = false;
+		clear_freya_cache_flag(card_id);
 		return true;
 	}
 
@@ -552,7 +553,7 @@ bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 			sensor_cfg *accl_sensor_cfg = get_common_sensor_cfg_info(sensor_num);
 			if (accl_sensor_cfg == NULL) {
 				LOG_ERR("Fail to get sensor cfg info, card id: 0x%x, sensor num: 0x%x",
-					card_id, accl_sensor_cfg->num);
+					card_id, sensor_num);
 				goto error_exit;
 			}
 


### PR DESCRIPTION
# Description
- Clear freya version cache after PCIE card power off.

# Motivation
- Clear freya version cache after PCIE card power off to avoid BMC getting invalid version.

# Test Plan
- Build code: Pass
- Clear freya version after PCIE card power off: Pass
- Get drive not ready status when PCIE card power off: Pass

# Log
root@bmc-oob:~# fw-util cb_accl1 --version
CB_ACCL1 DEV1 Version: v3.23.7.0.2
CB_ACCL1 DEV2 Version: v3.23.7.0.2
root@bmc-oob:~# fw-util cb_accl2 --version
CB_ACCL2 DEV1 Version: v3.23.7.0.2
CB_ACCL2 DEV2 Version: v3.23.7.0.2
root@bmc-oob:~# power-util cb_accl1 status
Power status for fru 18 : ON
root@bmc-oob:~# power-util cb_accl2 status
Power status for fru 19 : ON
root@bmc-oob:~# power-util cb_accl1 off
Powering fru 18 to OFF state...
root@bmc-oob:~# power-util cb_accl2 off
Powering fru 19 to OFF state...
root@bmc-oob:~# fw-util cb_accl1 --version
CB_ACCL1 DEV1 Version: NA (NVME NOT READY)
CB_ACCL1 DEV2 Version: NA (NVME NOT READY)
root@bmc-oob:~# fw-util cb_accl2 --version
CB_ACCL2 DEV1 Version: NA (NVME NOT READY)
CB_ACCL2 DEV2 Version: NA (NVME NOT READY)