### PR TITLE
Artemis : cb: Add PCIE switch init retry times

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -35,7 +35,7 @@
 
 LOG_MODULE_REGISTER(plat_hook);
 
-#define PEX_SWITCH_INIT_RETRY_COUNT 3
+#define PEX_SWITCH_INIT_RETRY_COUNT 20
 #define ACCL_SENSOR_COUNT 6
 
 struct k_mutex xdpe15284_mutex;


### PR DESCRIPTION
# Description
- Short term solution, ACB BIC add retry timer after BIC receive the normal power good.
- Prevent BIC reach max retry times when system boot up.

# Motivation
- Prevent to reach max retry times after system AC cycle.

# Test Plan
- Build code: Pass

Log:
Get PEX firmware version:
Every 1.0s: fw-util cb --version    2018-03-09 04:54:35

CB BIC Version: cb2023.22.01
CB CPLD Version: 00040E10
CB PESW0 Version: 52.d7.00.07
CB PESW1 Version: 52.d7.01.07
VR_PESW_VCC Version: Infineon 49f0fe5c, Remaining Write: 22

Get PEX sensor after AC cycle:
root@bmc-oob:~# sensor-util cb | grep -i pex
CB_PEX0_TEMP_C               (0x5) :   57.57 C     | (ok)
CB_PEX1_TEMP_C               (0x6) :   59.71 C     | (ok)
CB_P1V8_PEX_V                (0x13) :    1.82 Volts | (ok)