### PR TITLE
common: Increase IPMI timeout

### DIFF
--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -442,7 +442,7 @@ void IPMI_handler(void *arug0, void *arug1, void *arug2)
 				      K_THREAD_STACK_SIZEOF(IPMI_handle_thread_stack),
 				      ipmi_cmd_handle, (void *)&msg_cfg, NULL, NULL,
 				      CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
-		if (k_thread_join(tid, K_SECONDS(1)) == -EAGAIN) { // timeout
+		if (k_thread_join(tid, K_SECONDS(3)) == -EAGAIN) { // timeout
 			k_thread_abort(tid);
 			LOG_ERR("%s(): abort the handler due to timeout. netfn: %x, cmd: %x",
 				__func__, msg_cfg.buffer.netfn, msg_cfg.buffer.cmd);


### PR DESCRIPTION
# Description
- Increase the waiting time of IPMI handler.

# Motivation
- Due to erasing 64K flash taking at least two seconds. Currently, the timeout setting of IPMI causes updates BIOS timeout usually.

# Test Plan
- Build code: Pass
- Update BIOS: Pass
- Update BIC: Pass

# Log
1. Update BIC. root@bmc-oob:~# fw-util slot1 --force --update bic Y35BCL.bin There is no valid platform signature in image.
slot_id: 1, comp: 2, intf: 0, img: Y35BCL.bin, force: 1 file size = 299572 bytes, slot = 1, intf = 0xff
updating fw on slot 1:
updated bic: 100 %
Elapsed time:  5   sec.

get new SDR cache from BIC
Force upgrade of slot1 : bic succeeded

2. Update BIOS.
- Before modify root@bmc-oob:~# fw-util slot1 --force --update bios Y35CLM01.BIN Checking if the server is ready...
There is no valid platform signature in image.
Force powering off the server
Putting ME into recovery mode...
slot_id: 1, comp: c, intf: 0, img: Y35CLM01.BIN, force: 1 Init libusb Successful!
1d6b:0104 (bus 1, device 52) path: 1.1.4
Manufactured : ZEPHYR
Product : Zephyr CDC ACM
----------------------------------------
Device Descriptors:
Vendor ID : 1d6b
Product ID : 104
Serial Number : 3
Size of Device Descriptor : 18
Type of Descriptor : 1
USB Specification Release Number : 512
Device Release Number : 518
Device Class : 0
Device Sub-Class : 0
Device Protocol : 0
Max. Packet Size : 64
No. of Configuraions : 1
Configured value : 1
Claimed Interface: 1, EP addr: 0x03
-----------------------------------

Interface Descriptors:
  Number of Interfaces : 0x2
  Length : 0x9
  Desc_Type : 0x2
  Config_index : 0x0
  Total length : 75
  Configuration Value  : 0x1
  Configuration Attributes : 0xc0
  MaxPower(mA) : 50
    Interface:
      bInterfaceNumber:   0
      bAlternateSetting:  0
      bNumEndpoints:      1
      bInterfaceClass:    2
      bInterfaceSubClass: 2
      bInterfaceProtocol: 0
      iInterface:         0

      EndPoint Descriptors:
        bLength: 7
        bDescriptorType: 0x5
        bEndpointAddress: 0x81
        Maximum Packet Size: 0x10
        bmAttributes: 0x3
        bInterval: 0xa
-----------------------------------
    Interface:
      bInterfaceNumber:   1
      bAlternateSetting:  0
      bNumEndpoints:      2
      bInterfaceClass:    10
      bInterfaceSubClass: 0
      bInterfaceProtocol: 0
      iInterface:         0

      EndPoint Descriptors:
        bLength: 7
        bDescriptorType: 0x5
        bEndpointAddress: 0x82
        Maximum Packet Size: 0x40
        bmAttributes: 0x2
        bInterval: 0x0
      EndPoint Descriptors:
        bLength: 7
        bDescriptorType: 0x5
        bEndpointAddress: 0x3
        Maximum Packet Size: 0x40
        bmAttributes: 0x2
        bInterval: 0x0
-----------------------------------
Checksum function is unavailable, disabling deduplication and verification. Updating BIOS, dedup is off, verification is off.
1024 blocks (1024 written, 0 skipped)...finished.
Elapsed time:  1636   sec.
Doing ME Reset...
Power-cycling the server...
Force upgrade of slot1 : bios succeeded

root@bmc-oob:~# log-util --print
...
0 all 2023-06-29 23:09:34 fw-util Updating BIOS on slot1. File: /tmp/Y35CLM01A.BIN 0 all 2023-06-29 23:36:50 fw-util Updated BIOS on slot1. File: /tmp/Y35CLM01A.BIN. Result: Success ...

- After modify root@bmc-oob:~# fw-util slot1 --force --update bios Y35CLM01.BIN Checking if the server is ready...
There is no valid platform signature in image.
Force powering off the server
Putting ME into recovery mode...
slot_id: 1, comp: c, intf: 0, img: Y35CLM01.BIN, force: 1 Init libusb Successful!
1d6b:0104 (bus 1, device 52) path: 1.1.4
Manufactured : ZEPHYR
Product : Zephyr CDC ACM
----------------------------------------
Device Descriptors:
Vendor ID : 1d6b
Product ID : 104
Serial Number : 3
Size of Device Descriptor : 18
Type of Descriptor : 1
USB Specification Release Number : 512
Device Release Number : 518
Device Class : 0
Device Sub-Class : 0
Device Protocol : 0
Max. Packet Size : 64
No. of Configuraions : 1
Configured value : 1
Claimed Interface: 1, EP addr: 0x03
-----------------------------------

Interface Descriptors:
  Number of Interfaces : 0x2
  Length : 0x9
  Desc_Type : 0x2
  Config_index : 0x0
  Total length : 75
  Configuration Value  : 0x1
  Configuration Attributes : 0xc0
  MaxPower(mA) : 50
    Interface:
      bInterfaceNumber:   0
      bAlternateSetting:  0
      bNumEndpoints:      1
      bInterfaceClass:    2
      bInterfaceSubClass: 2
      bInterfaceProtocol: 0
      iInterface:         0

      EndPoint Descriptors:
        bLength: 7
        bDescriptorType: 0x5
        bEndpointAddress: 0x81
        Maximum Packet Size: 0x10
        bmAttributes: 0x3
        bInterval: 0xa
-----------------------------------
    Interface:
      bInterfaceNumber:   1
      bAlternateSetting:  0
      bNumEndpoints:      2
      bInterfaceClass:    10
      bInterfaceSubClass: 0
      bInterfaceProtocol: 0
      iInterface:         0

      EndPoint Descriptors:
        bLength: 7
        bDescriptorType: 0x5
        bEndpointAddress: 0x82
        Maximum Packet Size: 0x40
        bmAttributes: 0x2
        bInterval: 0x0
      EndPoint Descriptors:
        bLength: 7
        bDescriptorType: 0x5
        bEndpointAddress: 0x3
        Maximum Packet Size: 0x40
        bmAttributes: 0x2
        bInterval: 0x0
-----------------------------------
Checksum function is unavailable, disabling deduplication and verification. Updating BIOS, dedup is off, verification is off.
1024 blocks (1024 written, 0 skipped)...finished.
Elapsed time:  213   sec.
Doing ME Reset...
Power-cycling the server...
Force upgrade of slot1 : bios succeeded

root@bmc-oob:~# log-util --print all
...
0    all      2023-07-06 19:26:48    fw-util          Updating BIOS on slot1. File: Y35CLM01.BIN
0    all      2023-07-06 19:30:21    fw-util          Updated BIOS on slot1. File: Y35CLM01.BIN. Result: Success
...