### PR TITLE
common: Change sensor message log type

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -653,7 +653,7 @@ void add_sensor_config(sensor_cfg config)
 	uint8_t index = get_sensor_config_index(config.num);
 	if (index != SENSOR_NUM_MAX) {
 		memcpy(&sensor_config[index], &config, sizeof(sensor_cfg));
-		LOG_ERR("Replace the sensor[0x%02x] configuration", config.num);
+		LOG_INF("Change the sensor[0x%02x] configuration", config.num);
 		return;
 	}
 	// Check config table size before adding sensor config


### PR DESCRIPTION
# Description
- Change sensor message log type when using different sensor config.

# Motivation
- This is a reminder message, because different materials are used. Change the message type of LOG to avoid user confusion.

# Test plan
- Build code: Pass
- Chcek BIC message: Pass

# Log
- Before change ...
[00:00:00.066,000] <err> sensor: Replace the sensor[0x21] configuration [00:00:00.066,000] <err> sensor: Replace the sensor[0x22] configuration [00:00:00.066,000] <err> sensor: Replace the sensor[0x23] configuration [00:00:00.066,000] <err> sensor: Replace the sensor[0x24] configuration [00:00:00.066,000] <err> sensor: Replace the sensor[0x25] configuration [00:00:00.066,000] <err> sensor: Replace the sensor[0x27] configuration [00:00:00.067,000] <err> sensor: Replace the sensor[0x28] configuration ...

- After change ...
[00:00:00.066,000] <inf> sensor: Change the sensor[0x21] configuration [00:00:00.066,000] <inf> sensor: Change the sensor[0x22] configuration [00:00:00.066,000] <inf> sensor: Change the sensor[0x23] configuration [00:00:00.066,000] <inf> sensor: Change the sensor[0x24] configuration [00:00:00.066,000] <inf> sensor: Change the sensor[0x25] configuration [00:00:00.066,000] <inf> sensor: Change the sensor[0x27] configuration [00:00:00.066,000] <inf> sensor: Change the sensor[0x28] configuration ...