### PR TITLE
fby3.5: hd: Add SRAM size in overlay

### DIFF
--- a/meta-facebook/yv35-hd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-hd/boards/ast1030_evb.overlay
@@ -226,5 +226,5 @@
 };
 
 &sram0 {
-    reg = <0 DT_SIZE_K(512)>, <0x80000 DT_SIZE_K(256)>;
+    reg = <0 DT_SIZE_K(576)>, <0x90000 DT_SIZE_K(192)>;
 };


### PR DESCRIPTION
Summary:
- Set the SRAM size in overlay file(SRAM NC 192 KB and SRAM 576 KB).

Test Plan:
- Build code: PASS

Log:
```
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:      172416 B       192 KB     87.70%
           FLASH:          0 GB         0 GB
            SRAM:      524888 B       576 KB     88.99%
        IDT_LIST:          0 GB         2 KB      0.00%
```