### PR TITLE
Artemis: cb: Accurate power monitor sensor reading

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -58,7 +58,7 @@ ltc4286_init_arg ltc4286_init_args[] = {
 };
 
 ina233_init_arg ina233_init_args[] = {
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -67,7 +67,7 @@ ina233_init_arg ina233_init_args[] = {
 		.rsvd = 0b0100,
 	},
 	},
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -76,7 +76,7 @@ ina233_init_arg ina233_init_args[] = {
 		.rsvd = 0b0100,
 	},
 	},
-	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -85,7 +85,7 @@ ina233_init_arg ina233_init_args[] = {
 		.rsvd = 0b0100,
 	},
 	},
-	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -94,7 +94,7 @@ ina233_init_arg ina233_init_args[] = {
 		.rsvd = 0b0100,
 	},
 	},
-	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -112,7 +112,7 @@ ina233_init_arg ina233_init_args[] = {
 		.rsvd = 0b0100,
 	},
 	},
-	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -121,7 +121,7 @@ ina233_init_arg ina233_init_args[] = {
 		.rsvd = 0b0100,
 	},
 	},
-	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -130,7 +130,7 @@ ina233_init_arg ina233_init_args[] = {
 		.rsvd = 0b0100,
 	},
 	},
-	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -139,7 +139,7 @@ ina233_init_arg ina233_init_args[] = {
 		.rsvd = 0b0100,
 	},
 	},
-	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -148,7 +148,7 @@ ina233_init_arg ina233_init_args[] = {
 		.rsvd = 0b0100,
 	},
 	},
-	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -174,7 +174,7 @@ pex89000_init_arg pex_sensor_init_args[] = {
 };
 
 sq52205_init_arg sq52205_init_args[] = {
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0010002,
 	.config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -184,7 +184,7 @@ sq52205_init_arg sq52205_init_args[] = {
 		.reset_bit = 0b0,
 	},
 	},
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0010002,
 	.config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,


### PR DESCRIPTION
# Description
- Modify INA233/SQ52205 initial initial setting to accurate sensor reading.

# Motivation
- Modify the initial setting of INA233/SQ52205 according to EE suggestions. Note:
  - JIRA link: https://metainfra.atlassian.net/browse/T17GTART-230
  - File name: 18_SDR_Accuracy_0710.xlsx

# Test Plan
- Build code: Pass
- Get INA233/SQ52205 sensor reading: Pass
- Check INA233/SQ52205 initial setting is match with the correct settings reported by EE: Pass

# Log
- Get INA233/SQ52205 sensor reading root@bmc-oob:~# sensor-util cb | grep P12V_ACCL
CB_P12V_ACCL1_V              (0x23) :   12.14 Volts | (ok)
CB_P12V_ACCL2_V              (0x24) :   12.14 Volts | (ok)
CB_P12V_ACCL3_V              (0x25) :   12.14 Volts | (ok)
CB_P12V_ACCL4_V              (0x26) :   12.14 Volts | (ok)
CB_P12V_ACCL5_V              (0x27) :   12.14 Volts | (ok)
CB_P12V_ACCL6_V              (0x28) :   12.14 Volts | (ok)
CB_P12V_ACCL7_V              (0x29) :   12.13 Volts | (ok)
CB_P12V_ACCL8_V              (0x2A) :   12.12 Volts | (ok)
CB_P12V_ACCL9_V              (0x2C) :   12.13 Volts | (ok)
CB_P12V_ACCL10_V             (0x2D) :   12.13 Volts | (ok)
CB_P12V_ACCL11_V             (0x2E) :   12.13 Volts | (ok)
CB_P12V_ACCL12_V             (0x2F) :   12.13 Volts | (ok)
CB_P12V_ACCL1_A              (0x34) :    2.55 Amps  | (ok)
CB_P12V_ACCL2_A              (0x35) :    2.52 Amps  | (ok)
CB_P12V_ACCL3_A              (0x36) :    2.58 Amps  | (ok)
CB_P12V_ACCL4_A              (0x37) :    2.50 Amps  | (ok)
CB_P12V_ACCL5_A              (0x38) :    2.54 Amps  | (ok)
CB_P12V_ACCL6_A              (0x39) :    1.45 Amps  | (ok)
CB_P12V_ACCL7_A              (0x3A) :    2.39 Amps  | (ok)
CB_P12V_ACCL8_A              (0x3C) :    2.49 Amps  | (ok)
CB_P12V_ACCL9_A              (0x3D) :    2.40 Amps  | (ok)
CB_P12V_ACCL10_A             (0x3E) :    2.51 Amps  | (ok)
CB_P12V_ACCL11_A             (0x3F) :    2.44 Amps  | (ok)
CB_P12V_ACCL12_A             (0x40) :    2.59 Amps  | (ok)
CB_P12V_ACCL1_W              (0x45) :   30.90 Watts | (ok)
CB_P12V_ACCL2_W              (0x46) :   30.58 Watts | (ok)
CB_P12V_ACCL3_W              (0x47) :   31.38 Watts | (ok)
CB_P12V_ACCL4_W              (0x48) :   30.33 Watts | (ok)
CB_P12V_ACCL5_W              (0x49) :   30.85 Watts | (ok)
CB_P12V_ACCL6_W              (0x4A) :   17.65 Watts | (ok)
CB_P12V_ACCL7_W              (0x4B) :   29.00 Watts | (ok)
CB_P12V_ACCL8_W              (0x4C) :   30.20 Watts | (ok)
CB_P12V_ACCL9_W              (0x4D) :   29.17 Watts | (ok)
CB_P12V_ACCL10_W             (0x50) :   30.42 Watts | (ok)
CB_P12V_ACCL11_W             (0x51) :   29.62 Watts | (ok)
CB_P12V_ACCL12_W             (0x52) :   31.48 Watts | (ok)
root@bmc-oob:~# sensor-util cb | grep M_AUX
CB_P1V25_1_VDD(P12V_1_M_AUX)_V (0x61) :   12.13 Volts | (ok)
CB_P1V25_2_VDD(P12V_2_M_AUX)_V (0x62) :   12.14 Volts | (ok)
CB_P1V25_1_VDD(P12V_1_M_AUX)_A (0x63) :    1.48 Amps  | (ok)
CB_P1V25_2_VDD(P12V_2_M_AUX)_A (0x64) :    1.73 Amps  | (ok)
CB_P1V25_1_VDD(P12V_1_M_AUX)_W (0x65) :   17.95 Watts | (ok)
CB_P1V25_2_VDD(P12V_2_M_AUX)_W (0x66) :   20.92 Watts | (ok)

- Check INA233/SQ52205 initial setting is match with the correct settings reported by EE

[ SQ52205 ]
uart:~$ i2c scan I2C_1
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: 40 41 -- -- -- -- -- -- 48 -- 4a -- -- -- -- --
50: -- -- -- -- -- -- 56 -- -- 59 -- -- -- -- 5e --
60: -- -- -- -- -- -- -- -- -- -- 6a -- 6c -- -- 6f
70: 70 -- -- -- -- -- -- --
11 devices found on I2C_1
uart:~$ i2c read I2C_1 0x40 0x05 0x02
00000000: 13 ff                                            |..               |
uart:~$ i2c read I2C_1 0x41 0x05 0x02
00000000: 13 ff                                            |..               |

[ INA233 ]
uart:~$ i2c scan I2C_3
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: 70 -- -- -- -- -- -- --
1 devices found on I2C_3
uart:~$ i2c write I2C_3 0x70 0x01 0x00 0x01
uart:~$ i2c scan I2C_3
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: 40 41 42 43 44 45 -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: 70 -- -- -- -- -- -- --
7 devices found on I2C_3
uart:~$ i2c read I2C_3 0x40 0xD4 0x02
00000000: ff 13                                            |..               |
uart:~$ i2c read I2C_3 0x41 0xD4 0x02
00000000: 00 11                                            |..               |
uart:~$ i2c read I2C_3 0x42 0xD4 0x02
00000000: 00 11                                            |..               |
uart:~$ i2c read I2C_3 0x43 0xD4 0x02
00000000: 00 11                                            |..               |
uart:~$ i2c read I2C_3 0x44 0xD4 0x02
00000000: 00 11                                            |..               |
uart:~$ i2c read I2C_3 0x45 0xD4 0x02
00000000: 00 11                                            |..               |
uart:~$ i2c write I2C_3 0x70 0x01 0x00 0x00
uart:~$ i2c scan I2C_3
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: 70 -- -- -- -- -- -- --
1 devices found on I2C_3
uart:~$ i2c write I2C_3 0x70 0x01 0x00 0x02
uart:~$ i2c scan I2C_3
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: 40 41 42 43 44 45 -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: 70 -- -- -- -- -- -- --
7 devices found on I2C_3
uart:~$ i2c read I2C_3 0x40 0xD4 0x02
00000000: ff 13                                            |..               |
uart:~$ i2c read I2C_3 0x41 0xD4 0x02
00000000: 00 11                                            |..               |
uart:~$ i2c read I2C_3 0x42 0xD4 0x02
00000000: 00 11                                            |..               |
uart:~$ i2c read I2C_3 0x43 0xD4 0x02
00000000: 00 11                                            |..               |
uart:~$ i2c read I2C_3 0x44 0xD4 0x02
00000000: 00 11                                            |..               |
uart:~$ i2c read I2C_3 0x45 0xD4 0x02
00000000: 00 11                                            |..               |