### PR TITLE
common: dev : Fix intel peci without free dynamic memory

### DIFF
--- a/common/dev/intel_peci.c
+++ b/common/dev/intel_peci.c
@@ -240,6 +240,7 @@ __weak bool pal_get_cpu_time(uint8_t addr, uint8_t cmd, uint8_t readlen, uint32_
 	*run_time = (*run_time << 8) | readbuf[2];
 	*run_time = (*run_time << 8) | readbuf[1];
 
+	SAFE_FREE(readbuf);
 	return true;
 cleanup:
 	SAFE_FREE(readbuf);
@@ -277,6 +278,7 @@ __weak bool pal_get_cpu_energy(uint8_t addr, uint8_t cmd, uint8_t readlen, uint3
 	*pkg_energy = (*pkg_energy << 8) | readbuf[2];
 	*pkg_energy = (*pkg_energy << 8) | readbuf[1];
 
+	SAFE_FREE(readbuf);
 	return true;
 cleanup:
 	SAFE_FREE(readbuf);


### PR DESCRIPTION
Description:
Fix intel peci without free dynamic memory

Motivation:
BIC allocates memory each time when running those function, then will cause memory leek

Test Plan:
Update BIC FW after idle about 10 minutes - pass

Test Log:
Before fix:
root@bmc-oob:~# fw-util slot1 --force --update bic Y35BCL.bin uart:~$ [00:17:33.603,000] <err> util_spi: SPI index 0, failed to allocate txbuf. [00:17:33.603,000] <err> ipmi: firmware (0x02) update failed cc: c8 [00:17:33.807,000] <err> util_spi: SPI index 0, failed to allocate txbuf. [00:17:33.807,000] <err> ipmi: firmware (0x02) update failed cc: c8 [00:17:34.011,000] <err> util_spi: SPI index 0, failed to allocate txbuf. [00:17:34.011,000] <err> ipmi: firmware (0x02) update failed cc: c8 [00:17:33.603,000] <err> util_spi: SPI index 0, failed to allocate txbuf. [00:17:33.603,000] <err> ipmi: firmware (0x02) update failed cc: c8 After fix:
root@bmc-oob:~# fw-util slot1 --force --update bic Y35BCL.bin uart:~$ [00:13:19.180,000] <inf> util_spi: Update success [00:13:20.211,000] <inf> util_spi: Update success
[00:13:21.260,000] <inf> util_spi: Update success
[00:13:22.290,000] <inf> util_spi: Update success
[00:13:22.934,000] <inf> util_spi: Update success