### PR TITLE
GT: Add optics sensors for CX7 IB NIC

### DIFF
--- a/common/dev/cx7.c
+++ b/common/dev/cx7.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <logging/log.h>
+#include "libutil.h"
+#include "sensor.h"
+#include "pldm.h"
+#include "hal_i2c.h"
+
+LOG_MODULE_REGISTER(cx7);
+
+uint8_t cx7_read(sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(cfg->init_args, SENSOR_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("sensor num: 0x%x is invalid", cfg->num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	cx7_init_arg *init_arg = (cx7_init_arg *)cfg->init_args;
+
+	uint8_t mctp_dest_eid = init_arg->endpoint;
+
+	mctp *mctp_inst = NULL;
+	mctp_ext_params ext_params = { 0 };
+	if (get_mctp_info_by_eid(mctp_dest_eid, &mctp_inst, &ext_params) == false) {
+		LOG_ERR("Failed to get mctp info by eid 0x%x", mctp_dest_eid);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	uint8_t req_buf[10] = { 0 };
+	uint8_t resp_buf[10] = { 0 };
+	pldm_msg pmsg = { 0 };
+	pmsg.ext_params = ext_params;
+	pmsg.hdr.msg_type = MCTP_MSG_TYPE_PLDM;
+	pmsg.hdr.pldm_type = PLDM_TYPE_PLAT_MON_CTRL;
+	pmsg.hdr.cmd = 0x11;
+	pmsg.hdr.rq = PLDM_REQUEST;
+	pmsg.len = sizeof(struct pldm_get_sensor_reading_req);
+
+	pmsg.buf = req_buf;
+	struct pldm_get_sensor_reading_req *cmd_req =
+		(struct pldm_get_sensor_reading_req *)pmsg.buf;
+	cmd_req->sensor_id = init_arg->sensor_id;
+	cmd_req->rearm_event_state = 0;
+
+	uint16_t resp_len = mctp_pldm_read(mctp_inst, &pmsg, resp_buf, sizeof(resp_buf));
+	if (resp_len == 0) {
+		LOG_ERR("Failed to get mctp info by eid 0x%x", mctp_dest_eid);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	if (resp_buf[0] != PLDM_SUCCESS) {
+		LOG_ERR("Failed to get get sensor reading");
+		return SENSOR_FAIL_TO_ACCESS;
+	} else {
+		sensor_val *sval = (sensor_val *)reading;
+		sval->integer = (resp_buf[8] << 8) | resp_buf[7];
+		sval->fraction = 0;
+		return SENSOR_READ_SUCCESS;
+	}
+}
+
+uint8_t cx7_init(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	cfg->read = cx7_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -117,6 +117,7 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(m88rt51632)
 	sensor_name_to_num(mpro)
 	sensor_name_to_num(bmr351)
+	sensor_name_to_num(cx7)
 };
 // clang-format on
 
@@ -171,6 +172,7 @@ SENSOR_DRIVE_INIT_DECLARE(m88rt51632);
 SENSOR_DRIVE_INIT_DECLARE(mpro);
 #endif
 SENSOR_DRIVE_INIT_DECLARE(bmr351);
+SENSOR_DRIVE_INIT_DECLARE(cx7);
 
 struct sensor_drive_api {
 	enum SENSOR_DEV dev;
@@ -227,6 +229,7 @@ struct sensor_drive_api {
 	SENSOR_DRIVE_TYPE_INIT_MAP(mpro),
 #endif
 	SENSOR_DRIVE_TYPE_INIT_MAP(bmr351),
+	SENSOR_DRIVE_TYPE_INIT_MAP(cx7),
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -156,6 +156,7 @@ enum SENSOR_DEV {
 	sensor_dev_m88rt51632 = 0x2B,
 	sensor_dev_mpro = 0x2C,
 	sensor_dev_bmr351 = 0x2D,
+	sensor_dev_cx7 = 0x2E,
 	sensor_dev_max
 };
 
@@ -624,6 +625,12 @@ typedef struct _pt5161l_init_arg_ {
 typedef struct _mp2985_init_arg {
 	bool is_init;
 } mp2985_init_arg;
+
+typedef struct _cx7_init_arg {
+	bool is_init;
+	uint8_t endpoint;
+	uint16_t sensor_id;
+} cx7_init_arg;
 
 extern bool enable_sensor_poll_thread;
 extern sensor_cfg *sensor_config;

--- a/meta-facebook/gt-cc/src/platform/plat_fru.h
+++ b/meta-facebook/gt-cc/src/platform/plat_fru.h
@@ -21,8 +21,22 @@ enum {
 	SWB_FRU_ID,
 	FIO_FRU_ID,
 	HSC_MODULE_FRU_ID,
+	NIC0_FRU_ID,
+	NIC1_FRU_ID,
+	NIC2_FRU_ID,
+	NIC3_FRU_ID,
+	NIC4_FRU_ID,
+	NIC5_FRU_ID,
+	NIC6_FRU_ID,
+	NIC7_FRU_ID,
 	// OTHER_FRU_ID,
 	MAX_FRU_ID,
+};
+
+enum GT_NIC_CONFIG {
+	NIC_CONFIG_UNKNOWN = 0,
+	NIC_CONFIG_CX7 = 1,
+	NIC_CONFIG_IB_CX7 = 2,
 };
 
 #define FRU_CFG_NUM MAX_FRU_ID
@@ -37,5 +51,17 @@ enum {
 #define HSC_MODULE_FRU_ADDR (0xA2 >> 1)
 #define HSC_MODULE_FRU_MUX_ADDR (0xE0 >> 1)
 #define HSC_MODULE_FRU_MUX_CHAN 6
+
+#define NIC_FRU_ADDR (0xA0 >> 1)
+#define NIC0_FRU_PORT 0x00
+#define NIC1_FRU_PORT 0x01
+#define NIC2_FRU_PORT 0x02
+#define NIC3_FRU_PORT 0x03
+#define NIC4_FRU_PORT 0x0A
+#define NIC5_FRU_PORT 0x0B
+#define NIC6_FRU_PORT 0x0C
+#define NIC7_FRU_PORT 0x0D
+
+uint8_t check_nic_type_by_fru();
 
 #endif

--- a/meta-facebook/gt-cc/src/platform/plat_hook.c
+++ b/meta-facebook/gt-cc/src/platform/plat_hook.c
@@ -854,6 +854,17 @@ nct7718w_init_arg nct7718w_init_args[] = {
 		.lt_critical_temperature = 0x65 },
 };
 
+cx7_init_arg cx7_init_args[] = {
+	[0] = { .is_init = false, .endpoint = 0x10, .sensor_id = 0x0008 },
+	[1] = { .is_init = false, .endpoint = 0x11, .sensor_id = 0x0008 },
+	[2] = { .is_init = false, .endpoint = 0x12, .sensor_id = 0x0008 },
+	[3] = { .is_init = false, .endpoint = 0x13, .sensor_id = 0x0008 },
+	[4] = { .is_init = false, .endpoint = 0x14, .sensor_id = 0x0008 },
+	[5] = { .is_init = false, .endpoint = 0x15, .sensor_id = 0x0008 },
+	[6] = { .is_init = false, .endpoint = 0x16, .sensor_id = 0x0008 },
+	[7] = { .is_init = false, .endpoint = 0x17, .sensor_id = 0x0008 },
+};
+
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS
  **************************************************************************************************/

--- a/meta-facebook/gt-cc/src/platform/plat_hook.h
+++ b/meta-facebook/gt-cc/src/platform/plat_hook.h
@@ -47,6 +47,7 @@ extern pex89000_init_arg pex_sensor_init_args[];
 extern ltc4282_init_arg ltc4282_hsc_init_args[];
 extern ltc4286_init_arg ltc4286_hsc_init_args[];
 extern nct7718w_init_arg nct7718w_init_args[];
+extern cx7_init_arg cx7_init_args[];
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS
  **************************************************************************************************/

--- a/meta-facebook/gt-cc/src/platform/plat_mctp.c
+++ b/meta-facebook/gt-cc/src/platform/plat_mctp.c
@@ -126,6 +126,30 @@ static mctp *find_mctp_by_smbus(uint8_t bus)
 	return NULL;
 }
 
+uint8_t get_mctp_info(uint8_t dest_endpoint, mctp **mctp_inst, mctp_ext_params *ext_params)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(ext_params, MCTP_ERROR);
+
+	uint8_t rc = MCTP_ERROR;
+	uint32_t i;
+
+	for (i = 0; i < ARRAY_SIZE(mctp_route_tbl); i++) {
+		mctp_route_entry *p = mctp_route_tbl + i;
+		if (!p) {
+			return MCTP_ERROR;
+		}
+		if (p->endpoint == dest_endpoint) {
+			*mctp_inst = find_mctp_by_smbus(p->bus);
+			ext_params->type = MCTP_MEDIUM_TYPE_SMBUS;
+			ext_params->smbus_ext_params.addr = p->addr;
+			rc = MCTP_SUCCESS;
+			break;
+		}
+	}
+	return rc;
+}
+
 static void set_endpoint_resp_handler(void *args, uint8_t *buf, uint16_t len)
 {
 	if (!buf || !len)

--- a/meta-facebook/gt-cc/src/platform/plat_mctp.h
+++ b/meta-facebook/gt-cc/src/platform/plat_mctp.h
@@ -18,6 +18,7 @@
 #define _PLAT_MCTP_h
 
 #include "storage_handler.h"
+#include "pldm_oem.h"
 
 struct mctp_to_ipmi_header_req {
 	uint8_t iana[IANA_LEN];

--- a/meta-facebook/gt-cc/src/platform/plat_pldm_monitor.h
+++ b/meta-facebook/gt-cc/src/platform/plat_pldm_monitor.h
@@ -77,12 +77,20 @@ enum plat_pldm_device_state_set_offset {
 };
 
 #define PLDM_PLATFORM_OEM_LED_EFFECTER_STATE_FIELD_COUNT 1
+#define PLDM_PLATFORM_OEM_NIC_TYPE_EFFECTER_STATE_FIELD_COUNT 1
 
 enum plat_effecter_states_set_led_value {
 	EFFECTER_STATE_LED_VALUE_UNKNOWN = 0x00,
 	EFFECTER_STATE_LED_VALUE_ON = 0x01,
 	EFFECTER_STATE_LED_VALUE_OFF = 0x02,
 	EFFECTER_STATE_LED_VALUE_MAX,
+};
+
+enum plat_effecter_states_nic_type_value {
+	EFFECTER_STATE_NIC_TYPE_UNKNOWN = 0x00,
+	EFFECTER_STATE_NIC_TYPE_CX7 = 0x01,
+	EFFECTER_STATE_NIC_TYPE_CX7_IB = 0x02,
+	EFFECTER_STATE_NIC_TYPE_MAX,
 };
 
 enum plat_pldm_effecter_id {
@@ -104,6 +112,7 @@ enum plat_pldm_effecter_id {
 	PLAT_EFFECTER_ID_LED_E1S_13 = 0x1D,
 	PLAT_EFFECTER_ID_LED_E1S_14 = 0x1E,
 	PLAT_EFFECTER_ID_LED_E1S_15 = 0x1F,
+	PLAT_EFFECTER_ID_NIC_TYPE = 0x00,
 };
 
 void ssd_alert_check(uint8_t group);

--- a/meta-facebook/gt-cc/src/platform/plat_sdr_table.c
+++ b/meta-facebook/gt-cc/src/platform/plat_sdr_table.c
@@ -9296,6 +9296,494 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
 		"SWB HSC TYPE",
 	},
+	{
+		// NIC OPTICS 0 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_NIC_OPTICS_0, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x96, // UNRT
+		0x30, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"SWB NIC OPTICS 0 Temperature",
+	},
+	{
+		// NIC OPTICS 1 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_NIC_OPTICS_1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x96, // UNRT
+		0x30, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"SWB NIC OPTICS 1 Temperature",
+	},
+	{
+		// NIC OPTICS 2 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_NIC_OPTICS_2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x96, // UNRT
+		0x30, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"SWB NIC OPTICS 2 Temperature",
+	},
+	{
+		// NIC OPTICS 3 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_NIC_OPTICS_3, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x96, // UNRT
+		0x30, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"SWB NIC OPTICS 3 Temperature",
+	},
+	{
+		// NIC OPTICS 4 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_NIC_OPTICS_4, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x96, // UNRT
+		0x30, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"SWB NIC OPTICS 4 Temperature",
+	},
+	{
+		// NIC OPTICS 5 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_NIC_OPTICS_5, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x96, // UNRT
+		0x30, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"SWB NIC OPTICS 5 Temperature",
+	},
+	{
+		// NIC OPTICS 6 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_NIC_OPTICS_6, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x96, // UNRT
+		0x30, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"SWB NIC OPTICS 6 Temperature",
+	},
+	{
+		// NIC OPTICS 7 temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_NIC_OPTICS_7, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x80, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x96, // UNRT
+		0x30, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"SWB NIC OPTICS 7 Temperature",
+	},
 };
 
 const int SDR_TABLE_SIZE = ARRAY_SIZE(plat_sdr_table);

--- a/meta-facebook/gt-cc/src/platform/plat_sensor_table.c
+++ b/meta-facebook/gt-cc/src/platform/plat_sensor_table.c
@@ -79,6 +79,32 @@ sensor_cfg plat_sensor_config[] = {
 	  is_nic_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
+	/* NIC optics 0-7 temperature sensor */
+	{ SENSOR_NUM_TEMP_NIC_OPTICS_0, sensor_dev_cx7, I2C_BUS1, NIC_ADDR, NONE,
+	  is_nic_optics_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &cx7_init_args[0] },
+	{ SENSOR_NUM_TEMP_NIC_OPTICS_1, sensor_dev_cx7, I2C_BUS2, NIC_ADDR, NONE,
+	  is_nic_optics_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &cx7_init_args[1] },
+	{ SENSOR_NUM_TEMP_NIC_OPTICS_2, sensor_dev_cx7, I2C_BUS3, NIC_ADDR, NONE,
+	  is_nic_optics_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &cx7_init_args[2] },
+	{ SENSOR_NUM_TEMP_NIC_OPTICS_3, sensor_dev_cx7, I2C_BUS4, NIC_ADDR, NONE,
+	  is_nic_optics_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &cx7_init_args[3] },
+	{ SENSOR_NUM_TEMP_NIC_OPTICS_4, sensor_dev_cx7, I2C_BUS11, NIC_ADDR, NONE,
+	  is_nic_optics_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &cx7_init_args[4] },
+	{ SENSOR_NUM_TEMP_NIC_OPTICS_5, sensor_dev_cx7, I2C_BUS12, NIC_ADDR, NONE,
+	  is_nic_optics_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &cx7_init_args[5] },
+	{ SENSOR_NUM_TEMP_NIC_OPTICS_6, sensor_dev_cx7, I2C_BUS13, NIC_ADDR, NONE,
+	  is_nic_optics_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &cx7_init_args[6] },
+	{ SENSOR_NUM_TEMP_NIC_OPTICS_7, sensor_dev_cx7, I2C_BUS14, NIC_ADDR, NONE,
+	  is_nic_optics_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &cx7_init_args[7] },
+
 	/* ADC voltage */
 	{ SENSOR_NUM_BB_P12V_AUX, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE, stby_access, 1780, 200,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
@@ -1616,6 +1642,13 @@ bool is_e1s_access(uint8_t sensor_num)
 bool is_nic_access(uint8_t sensor_num)
 {
 	uint8_t pin_index = ((sensor_num >> 4) * 3) + ((sensor_num & BIT_MASK(4)) / 5);
+
+	return !gpio_get(nic_prsnt_pin[pin_index]) ? true : false;
+}
+
+bool is_nic_optics_access(uint8_t sensor_num)
+{
+	uint8_t pin_index = sensor_num & GENMASK(3, 0);
 
 	return !gpio_get(nic_prsnt_pin[pin_index]) ? true : false;
 }

--- a/meta-facebook/gt-cc/src/platform/plat_sensor_table.h
+++ b/meta-facebook/gt-cc/src/platform/plat_sensor_table.h
@@ -22,6 +22,7 @@
 
 /* Define configuration for sensors */
 #define NIC_TEMP_OFFSET 0x01
+#define NIC_OPTICS_TEMP_OFFSET 0x01
 #define TMP75_TEMP_OFFSET 0x00
 #define NIC_ADDR (0x3E >> 1)
 #define NIC_0_POWER_MONITOR_ADDR (0x80 >> 1)
@@ -268,6 +269,15 @@
 #define SENSOR_NUM_CURR_E1S_15 0xBE
 #define SENSOR_NUM_POUT_E1S_15 0xBF
 
+#define SENSOR_NUM_TEMP_NIC_OPTICS_0 0xC0
+#define SENSOR_NUM_TEMP_NIC_OPTICS_1 0xC1
+#define SENSOR_NUM_TEMP_NIC_OPTICS_2 0xC2
+#define SENSOR_NUM_TEMP_NIC_OPTICS_3 0xC3
+#define SENSOR_NUM_TEMP_NIC_OPTICS_4 0xC4
+#define SENSOR_NUM_TEMP_NIC_OPTICS_5 0xC5
+#define SENSOR_NUM_TEMP_NIC_OPTICS_6 0xC6
+#define SENSOR_NUM_TEMP_NIC_OPTICS_7 0xC7
+
 /* The sensors of different source components by ADC */
 #define SENSOR_NUM_HSC_TYPE 0xF0
 #define SENSOR_NUM_VR_TYPE 0xF1
@@ -277,6 +287,7 @@ uint8_t plat_get_config_size();
 void load_sensor_config(void);
 bool is_e1s_access(uint8_t sensor_num);
 bool is_nic_access(uint8_t sensor_num);
+bool is_nic_optics_access(uint8_t sensor_num);
 bool is_dc_access(uint8_t sensor_num);
 
 #endif


### PR DESCRIPTION
Summary:
- Add optics sensors for CX7 IB NIC
- Support get NIC type effecter state
- Add NIC FRU read to identify if NIC type is CX7 or CX7 IB

Test Plan:
- Build code: Pass