### PR TITLE
fby3.5: hd: Disable BIC JTAG to CPU

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_init.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_init.c
@@ -77,7 +77,6 @@ void pal_set_sys_status()
 		set_tsi_threshold();
 		read_cpuid();
 	}
-	gpio_set(BIC_JTAG_SEL_R, gpio_get(FM_DBP_PRESENT_N));
 	set_sys_ready_pin(BIC_READY);
 }
 

--- a/meta-facebook/yv35-hd/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_isr.c
@@ -144,7 +144,6 @@ void ISR_SLP3()
 void ISR_DBP_PRSNT()
 {
 	common_addsel_msg_t sel_msg;
-	gpio_set(BIC_JTAG_SEL_R, gpio_get(FM_DBP_PRESENT_N));
 	if ((gpio_get(FM_DBP_PRESENT_N) == GPIO_HIGH)) {
 		sel_msg.event_type = IPMI_OEM_EVENT_TYPE_DEASSERT;
 	} else {


### PR DESCRIPTION
Summary:
- In previous design, 
  if HDT is present(FM_DBP_PRESENT_N low), BIC_JTAG_SEL_R will be set low to disable BIC JTAG to CPU; 
  if HDT is not present(FM_DBP_PRESENT_N high), BIC_JTAG_SEL_R will be set high to enable BIC JTAG to CPU.
- Remove the gpio set of BIC_JTAG_SEL_R to keep it output low to disable BIC JTAG to CPU.

Test Plan:
- Build code: Pass
