### PR TITLE
Artemis: mc: Clear CXL card cache value after power off

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_dev.c
+++ b/meta-facebook/at-mc/src/platform/plat_dev.c
@@ -63,6 +63,8 @@ LOG_MODULE_REGISTER(plat_dev);
 
 #define PM8702_DEFAULT_SENSOR_NUM SENSOR_NUM_TEMP_CXL_DIMMA
 
+#define CXL_CARD_VR_COUNT 3
+
 pm8702_dev_info pm8702_table[] = {
 	{ .is_init = false }, { .is_init = false }, { .is_init = false }, { .is_init = false },
 	{ .is_init = false }, { .is_init = false }, { .is_init = false }, { .is_init = false },
@@ -76,6 +78,25 @@ cxl_vr_fw_info cxl_vr_info_table[] = {
 	{ .is_init = false }, { .is_init = false }, { .is_init = false }, { .is_init = false },
 	{ .is_init = false }, { .is_init = false }, { .is_init = false }, { .is_init = false },
 };
+
+void clear_cxl_card_cache_value(uint8_t cxl_id)
+{
+	if (cxl_id >= ARRAY_SIZE(pm8702_table)) {
+		LOG_ERR("Fail to clear CXL card cache by invalid cxl id: 0x%x", cxl_id);
+		return;
+	}
+
+	uint8_t index = 0;
+	uint8_t offset = 0;
+
+	pm8702_table[cxl_id].is_init = false;
+	memset(&pm8702_table[cxl_id].dev_info, 0, sizeof(cci_fw_info_resp));
+
+	for (index = 0; index < CXL_CARD_VR_COUNT; ++index) {
+		offset = cxl_id * CXL_CARD_VR_COUNT + index;
+		memset(&cxl_vr_info_table[offset], 0, sizeof(cxl_vr_fw_info));
+	}
+}
 
 void cxl_mb_status_init(uint8_t cxl_id)
 {

--- a/meta-facebook/at-mc/src/platform/plat_dev.h
+++ b/meta-facebook/at-mc/src/platform/plat_dev.h
@@ -48,5 +48,6 @@ bool pal_get_pm8702_hbo_status(uint8_t cxl_id, uint8_t *resp_buf, uint8_t *resp_
 bool pal_pm8702_transfer_fw(uint8_t cxl_id, uint8_t *req_buf, int req_len);
 bool pal_set_pm8702_active_slot(uint8_t cxl_id, uint8_t *req_buf, int req_len);
 void init_cxl_card_ioexp(uint8_t cxl_id);
+void clear_cxl_card_cache_value(uint8_t cxl_id);
 
 #endif

--- a/meta-facebook/at-mc/src/platform/plat_isr.c
+++ b/meta-facebook/at-mc/src/platform/plat_isr.c
@@ -502,6 +502,7 @@ void ISR_NORMAL_PWRGD()
 	if (gpio_get(MEB_NORMAL_PWRGD_BIC) == HIGH_INACTIVE) {
 		for (index = 0; index < CXL_CARD_8; ++index) {
 			set_cxl_eid_flag(index, CLEAR_EID_FLAG);
+			clear_cxl_card_cache_value(index);
 		}
 	} else {
 		for (index = 0; index < ARRAY_SIZE(cxl_work_item); ++index) {

--- a/meta-facebook/at-mc/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-mc/src/platform/plat_sensor_table.c
@@ -2052,6 +2052,7 @@ bool is_cxl_access(uint8_t cxl_id)
 				cfg->cache_status = SENSOR_NOT_ACCESSIBLE;
 			}
 
+			clear_cxl_card_cache_value(cxl_id);
 			pcie_card_init_status[pcie_card_id] = false;
 			return false;
 		}


### PR DESCRIPTION
# Description
- Clear CXL card VR/PM8702 firmware version after power off.

# Motivation
- Clear VR/PM8702 firmware version cache after CXL card power off to avoid BMC getting invalid version.

# Test Plan
- Build code: Pass
- Clear VR/PM8702 firmware version after CXL card power off: Pass
- Get firmware version NA when CXL card power off: Pass
- Get firmware version NA when DC off: Pass

# Log
- Get firmware version NA when CXL card power off root@bmc-oob:~# fw-util mc --version
MC BIC Version: mc2023.27.a3
MC CPLD Version: 00020E10
MC CXL1 Version: 02.000.011.00
MC CXL2 Version: 02.000.011.00
MC CXL3 Version: 02.000.011.00
MC CXL4 Version: 02.000.011.00
MC CXL5 Version: 02.000.011.00
MC CXL6 Version: 02.000.011.00
MC CXL7 Version: NA
MC CXL8 Version: NA
root@bmc-oob:~# fw-util mc_cxl1 --version
MC CXL1 VR_P0V89A Version: Infineon 3d981559, Remaining Write: 26 MC CXL1 VR_P0V8D_PVDDQ_AB Version: Infineon 356d1b1c, Remaining Write: 26 MC CXL1 VR_PVDDQ_CD Version: Infineon 6428bbd6, Remaining Write: 26 root@bmc-oob:~# power-util mc_cxl1 off
Powering fru 40 to OFF state...
root@bmc-oob:~# fw-util mc --version
MC BIC Version: mc2023.27.a3
MC CPLD Version: 00020E10
MC CXL1 Version: NA
MC CXL2 Version: 02.000.011.00
MC CXL3 Version: 02.000.011.00
MC CXL4 Version: 02.000.011.00
MC CXL5 Version: 02.000.011.00
MC CXL6 Version: 02.000.011.00
MC CXL7 Version: NA
MC CXL8 Version: NA
root@bmc-oob:~# fw-util mc_cxl1 --version
Error getting version of vr_p0v89a on fru: mc_cxl1 Error getting version of vr_p0v8d_pvddq_ab on fru: mc_cxl1 Error getting version of vr_pvddq_cd on fru: mc_cxl1

- Get firmware version NA when DC off root@bmc-oob:~# fw-util mc --version
MC BIC Version: mc2023.27.a3
MC CPLD Version: 00020E10
MC CXL1 Version: 02.000.011.00
MC CXL2 Version: 02.000.011.00
MC CXL3 Version: 02.000.011.00
MC CXL4 Version: 02.000.011.00
MC CXL5 Version: 02.000.011.00
MC CXL6 Version: 02.000.011.00
MC CXL7 Version: NA
MC CXL8 Version: NA
root@bmc-oob:~# fw-util mc_cxl1 --version
MC CXL1 VR_P0V89A Version: Infineon 3d981559, Remaining Write: 26 MC CXL1 VR_P0V8D_PVDDQ_AB Version: Infineon 356d1b1c, Remaining Write: 26 MC CXL1 VR_PVDDQ_CD Version: Infineon 6428bbd6, Remaining Write: 26 root@bmc-oob:~# fw-util mc_cxl2 --version
MC CXL2 VR_P0V89A Version: Infineon 3d981559, Remaining Write: 26 MC CXL2 VR_P0V8D_PVDDQ_AB Version: Infineon 356d1b1c, Remaining Write: 26 MC CXL2 VR_PVDDQ_CD Version: Infineon 6428bbd6, Remaining Write: 26 root@bmc-oob:~# fw-util mc_cxl3 --version
MC CXL3 VR_P0V89A Version: Infineon 3d981559, Remaining Write: 26 MC CXL3 VR_P0V8D_PVDDQ_AB Version: Infineon 356d1b1c, Remaining Write: 26 MC CXL3 VR_PVDDQ_CD Version: Infineon 6428bbd6, Remaining Write: 26 root@bmc-oob:~# fw-util mc_cxl4 --version
MC CXL4 VR_P0V89A Version: Infineon 3d981559, Remaining Write: 26 MC CXL4 VR_P0V8D_PVDDQ_AB Version: Infineon 356d1b1c, Remaining Write: 26 MC CXL4 VR_PVDDQ_CD Version: Infineon 6428bbd6, Remaining Write: 26 root@bmc-oob:~# fw-util mc_cxl5 --version
MC CXL5 VR_P0V89A Version: Infineon 3d981559, Remaining Write: 26 MC CXL5 VR_P0V8D_PVDDQ_AB Version: Infineon 356d1b1c, Remaining Write: 26 MC CXL5 VR_PVDDQ_CD Version: Infineon 6428bbd6, Remaining Write: 26 root@bmc-oob:~# fw-util mc_cxl6 --version
MC CXL6 VR_P0V89A Version: Infineon 3d981559, Remaining Write: 26 MC CXL6 VR_P0V8D_PVDDQ_AB Version: Infineon 356d1b1c, Remaining Write: 26 MC CXL6 VR_PVDDQ_CD Version: Infineon 6428bbd6, Remaining Write: 26

root@bmc-oob:~# power-util mb status
Power status for fru 1 : ON
root@bmc-oob:~# power-util mb off
Powering fru 1 to OFF state...
root@bmc-oob:~# power-util mb status
Power status for fru 1 : OFF

root@bmc-oob:~# fw-util mc --version
MC BIC Version: mc2023.27.a3
MC CPLD Version: 00020E10
MC CXL1 Version: NA
MC CXL2 Version: NA
MC CXL3 Version: NA
MC CXL4 Version: NA
MC CXL5 Version: NA
MC CXL6 Version: NA
MC CXL7 Version: NA
MC CXL8 Version: NA
root@bmc-oob:~# fw-util mc_cxl1 --version
Error getting version of vr_p0v89a on fru: mc_cxl1 Error getting version of vr_p0v8d_pvddq_ab on fru: mc_cxl1 Error getting version of vr_pvddq_cd on fru: mc_cxl1 root@bmc-oob:~#
root@bmc-oob:~# fw-util mc_cxl2 --version
Error getting version of vr_p0v89a on fru: mc_cxl2 Error getting version of vr_p0v8d_pvddq_ab on fru: mc_cxl2 Error getting version of vr_pvddq_cd on fru: mc_cxl2 root@bmc-oob:~# fw-util mc_cxl3 --version
Error getting version of vr_p0v89a on fru: mc_cxl3 Error getting version of vr_p0v8d_pvddq_ab on fru: mc_cxl3 Error getting version of vr_pvddq_cd on fru: mc_cxl3 root@bmc-oob:~# fw-util mc_cxl4 --version
Error getting version of vr_p0v89a on fru: mc_cxl4 Error getting version of vr_p0v8d_pvddq_ab on fru: mc_cxl4 Error getting version of vr_pvddq_cd on fru: mc_cxl4 root@bmc-oob:~# fw-util mc_cxl5 --version
Error getting version of vr_p0v89a on fru: mc_cxl5 Error getting version of vr_p0v8d_pvddq_ab on fru: mc_cxl5 Error getting version of vr_pvddq_cd on fru: mc_cxl5 root@bmc-oob:~# fw-util mc_cxl6 --version
Error getting version of vr_p0v89a on fru: mc_cxl6 Error getting version of vr_p0v8d_pvddq_ab on fru: mc_cxl6 Error getting version of vr_pvddq_cd on fru: mc_cxl6