### PR TITLE
common: driver: patch: patch-fix-the-order-of-adc

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0054-adc-aspeed-Fix-the-order-of-adc-engine-init.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0054-adc-aspeed-Fix-the-order-of-adc-engine-init.patch
@@ -1,0 +1,67 @@
+From 1add7f55d29041bd078bd274a0ec5b5469b0bf05 Mon Sep 17 00:00:00 2001
+From: Yi-Shum <easonchen1@quantatw.com>
+Date: Thu, 13 Jul 2023 13:26:02 +0800
+Subject: [PATCH] adc: aspeed: Fix the order of adc engine init.
+
+The channel cannot be enabled before the engine is initiated.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I61b15a7f8c4d131be0e4bfe9cffe86be26cc3070
+---
+ drivers/adc/aspeed/adc_aspeed.c | 26 +++++++-------------------
+ 1 file changed, 7 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/adc/aspeed/adc_aspeed.c b/drivers/adc/aspeed/adc_aspeed.c
+index 2a4debbddb..a7e009d0ce 100644
+--- a/drivers/adc/aspeed/adc_aspeed.c
++++ b/drivers/adc/aspeed/adc_aspeed.c
+@@ -443,24 +443,6 @@ static void aspeed_acquisition_thread(struct adc_aspeed_data *data)
+ 	}
+ }
+ 
+-static void adc_aspeed_channel_config(const struct device *dev)
+-{
+-	const struct adc_aspeed_cfg *config = DEV_CFG(dev);
+-	struct adc_aspeed_data *priv = DEV_DATA(dev);
+-	struct adc_register_s *adc_register = config->base;
+-	union adc_engine_control_s engine_ctrl;
+-
+-	engine_ctrl.value = adc_register->engine_ctrl.value;
+-	engine_ctrl.fields.channel_enable = config->channels_used;
+-	adc_register->engine_ctrl.value = engine_ctrl.value;
+-
+-	priv->required_eoc_num = popcount(config->channels_used);
+-	if (config->channels_used & BIT(ASPEED_ADC_CH_NUMBER - 1))
+-		priv->required_eoc_num += 12;
+-
+-	return;
+-}
+-
+ static int adc_aspeed_engine_init(const struct device *dev,
+ 				  uint32_t timeout_ms)
+ {
+@@ -482,6 +464,10 @@ static int adc_aspeed_engine_init(const struct device *dev,
+ 		return ret;
+ 	}
+ 
++	engine_ctrl.value = adc_register->engine_ctrl.value;
++	engine_ctrl.fields.channel_enable = config->channels_used;
++	adc_register->engine_ctrl.value = engine_ctrl.value;
++
+ 	return 0;
+ }
+ 
+@@ -505,7 +491,9 @@ static int adc_aspeed_init(const struct device *dev)
+ 		return ret;
+ 	}
+ 
+-	adc_aspeed_channel_config(dev);
++	priv->required_eoc_num = popcount(config->channels_used);
++	if (config->channels_used & BIT(ASPEED_ADC_CH_NUMBER - 1))
++		priv->required_eoc_num += 12;
+ 	ret = adc_aspeed_set_rate(dev, ASPEED_SAMPLING_RATE_DEFAULT);
+ 	if (ret) {
+ 		return ret;
+-- 
+2.34.1
+


### PR DESCRIPTION
Summary:
- The patch is intended to fix the order of adc engine init

Test Plan:
- Build Code: PASS
- Apply patch: PASS