### PR TITLE
fby3.5: hd: Clear PMIC error

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_pmic.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_pmic.h
@@ -29,6 +29,8 @@
 #define SYS_CPLD_BMC_CHANNEL_ADDR 0x1E // 8 bits
 #define PMIC_FAULT_STATUS_OFFSET 0x0B
 
+#define CLEAR_MTP_RETRY_MAX 5
+
 void start_monitor_pmic_error_thread();
 void pmic_error_check();
 void read_pmic_error_when_dc_off();


### PR DESCRIPTION
Summary:
- Clear PMIC error after detecting PMIC error and adding SEL event.

Test plan:
- Build code: PASS
- Inject PMIC error and check PMIC register value: PASS

Log:
```
root@bmc-oob:~# dimm-util slot3 --config
FRU: slot3
...
DIMM A2:
	Type: DDR5 SDRAM
	Size: 24576 MB
	Speed: 4800 MT/s
	Manufacturer: Micron
	Manufacturing Date: 2023 Week03
	Part Number: MTC10F108YS1RC48BB1
	Serial Number: 3DD4D5FE
	Register Vendor: Rambus
	PMIC Vendor: MPS
...

// Inject SWAout_OV error
root@bmc-oob:~# dimm-util slot3 --pmic --dimm A2 --err_inj SWAout_OV
Error inject successfully on DIMM A2
// Check log
root@bmc-oob:~# log-util slot3 --print
2018 Mar 23 07:47:41 log-util: User cleared FRU: 3 logs
3    slot3    2018-03-23 07:47:46    power-util       SERVER_12V_CYCLE successful for FRU: 3
3    slot3    2018-03-23 07:47:49    gpiod            FRU: 3, System powered ON
3    slot3    2018-03-23 07:47:50    power-util       SERVER_POWER_ON successful for FRU: 3
3    slot3    2018-03-23 07:48:16    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2018-03-23 07:48:16, Sensor: PSB_STS (0x46), Event Data: (EE00FF) PSB Pass Assertion
3    slot3    2018-03-23 07:51:50    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2018-03-23 07:51:50, Sensor: PMIC_ERR (0xB4), Event Data: (020000) DIMM A2 SWAout OV Assertion
3    slot3    2018-03-23 07:51:53    gpiod            FRU: 3, System powered OFF
// Read PMIC register(R04~R0B, R33 are 0x00)
root@bmc-oob:~# bic-util slot3 0x18 0x52 0x14 0x92 0x40 0x00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 BC 20 00 00 04 C2 45 90 90 90 90
FF 78 63 78 63 78 63 78 63 99 99 42 22 22 04 06
C8 40 20 00 0E 00 00 00 00 5A 00 14 0B 2A 00 00

// Inject SWCout_OV error
root@bmc-oob:~# dimm-util slot3 --pmic --dimm A2 --err_inj SWCout_OV
Error inject successfully on DIMM A2
// Check log
root@bmc-oob:~# log-util slot3 --print
2018 Mar 23 07:52:07 log-util: User cleared FRU: 3 logs
3    slot3    2018-03-23 07:52:12    power-util       SERVER_12V_CYCLE successful for FRU: 3
3    slot3    2018-03-23 07:52:14    gpiod            FRU: 3, System powered ON
3    slot3    2018-03-23 07:52:16    power-util       SERVER_POWER_ON successful for FRU: 3
3    slot3    2018-03-23 07:52:42    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2018-03-23 07:52:42, Sensor: PSB_STS (0x46), Event Data: (EE00FF) PSB Pass Assertion
3    slot3    2018-03-23 07:56:16    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2018-03-23 07:56:16, Sensor: PMIC_ERR (0xB4), Event Data: (020200) DIMM A2 SWCout OV Assertion
3    slot3    2018-03-23 07:56:19    gpiod            FRU: 3, System powered OFF
// Read PMIC register(R04~R0B, R33 are 0x00)
root@bmc-oob:~# bic-util slot3 0x18 0x52 0x14 0x92 0x40 0x00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 BC 20 00 00 04 C2 45 90 90 90 90
FF 78 63 78 63 78 63 78 63 99 99 42 22 22 04 06
C8 40 20 00 0E 00 00 00 00 5A 00 14 0B 2A 00 00

// Inject SWDout_OV error
root@bmc-oob:~# dimm-util slot3 --pmic --dimm A2 --err_inj SWDout_OV
Error inject successfully on DIMM A2
// Check log
root@bmc-oob:~# log-util slot3 --print
2018 Mar 23 07:56:33 log-util: User cleared FRU: 3 logs
3    slot3    2018-03-23 07:56:38    power-util       SERVER_12V_CYCLE successful for FRU: 3
3    slot3    2018-03-23 07:56:40    gpiod            FRU: 3, System powered ON
3    slot3    2018-03-23 07:56:42    power-util       SERVER_POWER_ON successful for FRU: 3
3    slot3    2018-03-23 07:57:08    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2018-03-23 07:57:08, Sensor: PSB_STS (0x46), Event Data: (EE00FF) PSB Pass Assertion
3    slot3    2018-03-23 08:00:42    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2018-03-23 08:00:42, Sensor: PMIC_ERR (0xB4), Event Data: (020300) DIMM A2 SWDout OV Assertion
3    slot3    2018-03-23 08:00:45    gpiod            FRU: 3, System powered OFF
// Read PMIC register(R04~R0B, R33 are 0x00)
root@bmc-oob:~# bic-util slot3 0x18 0x52 0x14 0x92 0x40 0x00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 BC 20 00 00 04 C2 45 90 90 90 90
FF 78 63 78 63 78 63 78 63 99 99 42 22 22 04 06
C8 40 20 00 0E 00 00 00 00 5A 00 14 0B 2A 00 00

// Inject VinB_OV error
root@bmc-oob:~# dimm-util slot3 --pmic --dimm A2 --err_inj VinB_OV
Error inject successfully on DIMM A2
// Check log
root@bmc-oob:~# log-util slot3 --print
2018 Mar 23 08:00:59 log-util: User cleared FRU: 3 logs
3    slot3    2018-03-23 08:01:04    power-util       SERVER_12V_CYCLE successful for FRU: 3
3    slot3    2018-03-23 08:01:07    gpiod            FRU: 3, System powered ON
3    slot3    2018-03-23 08:01:08    power-util       SERVER_POWER_ON successful for FRU: 3
3    slot3    2018-03-23 08:01:34    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2018-03-23 08:01:34, Sensor: PSB_STS (0x46), Event Data: (EE00FF) PSB Pass Assertion
3    slot3    2018-03-23 08:05:08    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2018-03-23 08:05:08, Sensor: PMIC_ERR (0xB4), Event Data: (020400) DIMM A2 Vin Bulk OV Assertion
3    slot3    2018-03-23 08:05:11    gpiod            FRU: 3, System powered OFF
// Read PMIC register(R04~R0B, R33 are 0x00)
root@bmc-oob:~# bic-util slot3 0x18 0x52 0x14 0x92 0x40 0x00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 BC 20 00 00 04 C2 45 90 90 90 90
FF 78 63 78 63 78 63 78 63 99 99 42 22 22 04 06
C8 40 20 00 0E 00 00 00 00 5A 00 14 0B 2A 00 00

// Inject VinM_OV error
root@bmc-oob:~# dimm-util slot3 --pmic --dimm A2 --err_inj VinM_OV
Error inject successfully on DIMM A2
// Check log
root@bmc-oob:~# log-util slot3 --print
2018 Mar 23 08:05:25 log-util: User cleared FRU: 3 logs
3    slot3    2018-03-23 08:05:30    power-util       SERVER_12V_CYCLE successful for FRU: 3
3    slot3    2018-03-23 08:05:32    gpiod            FRU: 3, System powered ON
3    slot3    2018-03-23 08:05:34    power-util       SERVER_POWER_ON successful for FRU: 3
3    slot3    2018-03-23 08:06:00    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2018-03-23 08:06:00, Sensor: PSB_STS (0x46), Event Data: (EE00FF) PSB Pass Assertion
3    slot3    2018-03-23 08:09:37    ipmid            SEL Entry: FRU: 3, Record: Standard (0x02), Time: 2018-03-23 08:09:37, Sensor: PMIC_ERR (0xB4), Event Data: (020500) DIMM A2 Vin Mgmt OV Assertion
// Read PMIC register(R04~R0B, R33 are 0x00)
root@bmc-oob:~# bic-util slot3 0x18 0x52 0x14 0x92 0x40 0x00
00 00 00 00 00 00 00 00 00 00 00 00 01 00 01 00
00 00 00 00 00 BC 20 00 00 04 C2 45 90 90 90 90
FF 78 63 78 63 78 63 78 63 99 99 42 22 22 04 7E
C8 40 A0 00 0E 00 00 00 00 5A 00 14 0B 2A 00 00
```
