### PR TITLE
common: ipmi: fix the mutex lock of ipmb read was not released

### DIFF
--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -442,7 +442,7 @@ void IPMI_handler(void *arug0, void *arug1, void *arug2)
 				      K_THREAD_STACK_SIZEOF(IPMI_handle_thread_stack),
 				      ipmi_cmd_handle, (void *)&msg_cfg, NULL, NULL,
 				      CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
-		if (k_thread_join(tid, K_SECONDS(3)) == -EAGAIN) { // timeout
+		if (k_thread_join(tid, K_SECONDS(5)) == -EAGAIN) { // timeout
 			k_thread_abort(tid);
 			LOG_ERR("%s(): abort the handler due to timeout. netfn: %x, cmd: %x",
 				__func__, msg_cfg.buffer.netfn, msg_cfg.buffer.cmd);


### PR DESCRIPTION
# Description
In our IPMI handler processing, we create a thread to handle operations and set a timeout of 3 seconds to prevent resource occupation. During this process, we may use IPMB read, however the timeout for waiting the IPMB response is also set to 3 seconds. This situation may result in the IPMI handler being kill due to exceeding the timeout, while the mutex lock for IPMB read has not been released.

# Motivation
To fix the mutex lock of ipmb read may not be released in some cases.

# Test Plan
1. Build and test pass on YV3.5 system. pass