### PR TITLE
fby3.5: hd: Modify VR voltage UCR

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_sdr_table.c
@@ -2571,7 +2571,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0xAB, // UCT
+		0xAA, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x25, // LCT
@@ -2632,7 +2632,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x88, // UCT
+		0x87, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x3B, // LCT
@@ -2693,7 +2693,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0xAB, // UCT
+		0xAA, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x25, // LCT
@@ -2754,7 +2754,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x81, // UCT
+		0x80, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x51, // LCT


### PR DESCRIPTION
Summary:
- Modify the UCR of MB_VR_CPU0_VOLT_V from 1.71 to 1.7.
- Modify the UCR of MB_VR_SOC_VOLT_V from 1.36 to 1.35.
- Modify the UCR of MB_VR_CPU1_VOLT_V from 1.71 to 1.7.
- Modify the UCR of MB_VR_PVDDIO_VOLT_V from 1.29 to 1.28.

Test Plan:
- Build code: PASS
- Check UCR: PASS

Log:

```
Before
root@bmc-oob:~# sensor-util slot1 -t | grep -i VR | grep -i vol
MB_VR_CPU0_VOLT_V            (0x21) :    0.86 Volts  | (ok) | UCR: 1.71 | UNC: NA | UNR: NA | LCR: 0.37 | LNC: NA | LNR: NA
MB_VR_SOC_VOLT_V             (0x22) :    0.99 Volts  | (ok) | UCR: 1.36 | UNC: NA | UNR: NA | LCR: 0.59 | LNC: NA | LNR: NA
MB_VR_CPU1_VOLT_V            (0x23) :    0.86 Volts  | (ok) | UCR: 1.71 | UNC: NA | UNR: NA | LCR: 0.37 | LNC: NA | LNR: NA
MB_VR_PVDDIO_VOLT_V          (0x24) :    1.10 Volts  | (ok) | UCR: 1.29 | UNC: NA | UNR: NA | LCR: 0.81 | LNC: NA | LNR: NA
MB_VR_PVDD11_VOLT_V          (0x25) :    1.10 Volts  | (ok) | UCR: 1.17 | UNC: NA | UNR: NA | LCR: 1.04 | LNC: NA | LNR: NA

After
root@bmc-oob:~# sensor-util slot1 -t | grep -i VR | grep -i vol
MB_VR_CPU0_VOLT_V            (0x21) :    0.86 Volts  | (ok) | UCR: 1.70 | UNC: NA | UNR: NA | LCR: 0.37 | LNC: NA | LNR: NA
MB_VR_SOC_VOLT_V             (0x22) :    0.99 Volts  | (ok) | UCR: 1.35 | UNC: NA | UNR: NA | LCR: 0.59 | LNC: NA | LNR: NA
MB_VR_CPU1_VOLT_V            (0x23) :    0.86 Volts  | (ok) | UCR: 1.70 | UNC: NA | UNR: NA | LCR: 0.37 | LNC: NA | LNR: NA
MB_VR_PVDDIO_VOLT_V          (0x24) :    1.10 Volts  | (ok) | UCR: 1.28 | UNC: NA | UNR: NA | LCR: 0.81 | LNC: NA | LNR: NA
MB_VR_PVDD11_VOLT_V          (0x25) :    1.10 Volts  | (ok) | UCR: 1.17 | UNC: NA | UNR: NA | LCR: 1.04 | LNC: NA | LNR: NA
```