### PR TITLE
fby3.5:gl:Enable ASD related functions

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_def.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_def.h
@@ -17,6 +17,7 @@
 #ifndef PLAT_DEF_H
 #define PLAT_DEF_H
 
+#define ENABLE_ASD
 #define BMC_USB_PORT "CDC_ACM_0"
 
 #endif

--- a/meta-facebook/yv35-gl/src/platform/plat_gpio.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_gpio.c
@@ -261,3 +261,13 @@ bool pal_load_gpio_config(void)
 	memcpy(&gpio_cfg[0], &plat_gpio_cfg[0], sizeof(plat_gpio_cfg));
 	return true;
 };
+
+void enable_PRDY_interrupt()
+{
+	gpio_interrupt_conf(H_BMC_PRDY_BUF_N, GPIO_INT_EDGE_FALLING);
+}
+
+void disable_PRDY_interrupt()
+{
+	gpio_interrupt_conf(H_BMC_PRDY_BUF_N, GPIO_INT_DISABLE);
+}

--- a/meta-facebook/yv35-gl/src/platform/plat_gpio.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_gpio.h
@@ -263,4 +263,7 @@ extern enum _GPIO_NUMS_ GPIO_NUMS;
 
 extern char *gpio_name[];
 
+void enable_PRDY_interrupt();
+void disable_PRDY_interrupt();
+
 #endif


### PR DESCRIPTION
# Description:
1. Enable ASD related functions to support ASD.
2. Change the End of Line Sequence of plat_gpio.c from CRLF to LF.

# Motivation:
Support ASD for remote debuging the Intel CPU.

# Test Log:
1. Built and tested pass on Great Lakes.

2. Run ASD successfully. (1) ASD daemon:
    root@bmc-oob:~# bic-util slot1 --set_gpio 40 1
    slot 1: setting [40]BMC_JTAG_SEL_R to 1

    root@bmc-oob:~# asd -f 1
    ASD ver: ASD_BMC_v1.5.1
    Setting Port: 5123, FRU: 1
    Msg Flow: 1
    Log level: Warning
    ASD is initializing...
    ASD is initialized.
    Client Connecting.
    target_get_fds, null or uninitialized state
    BMC_JTAG_SEL is set to 1 successfully
    fru1 gpio thread started
    Client disconnected
    BMC_JTAG_SEL is set to 0 successfully

(2) Cscript + OpenIPC
    Python 3.8.12 (default, Sep 29 2021, 05:01:09)
    [GCC 5.4.0 20160609] on linux
    PythonSv running in interactive mode
    Connecting to IPC API....
    IPC-CLI: 4.23.21420.100, OpenIPC:4c6b81805dc634aab81ad57 : 23.16.12965.200
    Initializing IPC API....

    Info - Detected relevant file modified (or added) after OpenIPC was installed: /usr/local/Intel_GNR/openipc/Config/GNR/GNR_ASD_RC-Pins.xml

    Info - OpenIPC configuration 'GNR_ASD_RC-Pins'; run control plug-in(s): 'OpenRC'; probe plug-in(s): 'ASD_JTAG'
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - ASD plugin connected to: 192.168.88.45:5123 payloadSize: 3000 maxNumBuffers: 20 securityProtocol: None
    Info - Chain 0: (Adjusted) JTAG Frequency Divisor: 8
    Info - ASD I2C Bus_Select: 0 Bus_Speed: 100000
    Info - ASD I2C Bus_Select: 1 Bus_Speed: 100000
    Info - ASD I2C Bus_Select: 2 Bus_Speed: 100000
    Info - ASD I2C Bus_Select: 3 Bus_Speed: 100000
    Info - Hardware GPIO config = 0
    Info - JTAG Mode = SOFTWARE
    Info - JTAG Chain Select Mode = SINGLE
    Info - ASD Probe plugin version: 1.5.4-ASD_BMC_v1.5.1_
    Info - Added debug port 0 for probe ASD_JTAGProbe

    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected IO_V1_CLTAP A0 on JTAG chain 0 at position 0
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:

    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:

    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Info - Detected relevant file modified (or added) after OpenIPC was installed:
    Target System: GNR - GraniteRapids
    Running Graniterapids
    Using ASD_JTAGProbe as the OpenIPC connection.
    Creating SOC CHA and Core logical view...

        *******************************************************************************
        Welcome to CScripts for Server & Micro-server platforms!
        These scripts are provided as-is as a courtesy to assist with platform
        debug. They are NOT intended for manufacturing or production line validation,
        and Intel makes no guarantee, implied or otherwise, that these scripts will
        function in a production environment. They are not fully validated by Intel
        nor guaranteed to execute as described. These scripts rely on (in some cases)
        unspecified features within our components which may or may not be functional
        from stepping to stepping, or from product to product. They are provided at
        no cost. Customers are free to modify these scripts as needed for their own
        platform debugging purposes. Defects should be reported to your Intel account
        representative.

        All log files will be placed in /root/Ricky/ASD/BHS_CScripts_GNR2322.4000/cscripts
        For help on functions or objects when in the shell type help(NAME)

        *******************************************************************************

    Cscripts version: BHS.2322
    IPC-CLI Version 4.23.21420.100
    Probe Information: 1.5.4-ASD_BMC_v1.5.1_
    Start Platform Stuff with access type ipc
    WARNING!!! ltssm_gnr should not be imported directly. Import pysvtools.pciedebug.ltssm instead
    Socket 0: detected Server-SP, 28 cores, A1, PCI Segment 0, Bus List = [0x00, 0x01, 0x02, 0x03, 0x05, 0x06, 0x07, 0x08, 0x0a, 0x47, 0x83, 0xbf, 0xfe, 0xff]
    >>> halt()

        [GPC core group] Halt on 56 devices -- 09:44:04.118867 2023-07-07
    >>> go()
    >>>
        [GPC core group] Resuming on 56 devices -- 09:44:15.351595 2023-07-07