### PR TITLE
Artemis: cb: Clear freya version cache when freya drive not ready

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -736,9 +736,17 @@ bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 
 		switch (cfg->target_addr) {
 		case ACCL_FREYA_1_ADDR:
+			if (accl_freya->is_cache_freya1_info) {
+				accl_freya->is_cache_freya1_info = false;
+				memset(&accl_freya->freya1_fw_info, 0, FREYA_FW_VERSION_LENGTH);
+			}
 			accl_freya->freya1_fw_info.is_freya_ready = FREYA_NOT_READY;
 			break;
 		case ACCL_FREYA_2_ADDR:
+			if (accl_freya->is_cache_freya2_info) {
+				accl_freya->is_cache_freya2_info = false;
+				memset(&accl_freya->freya2_fw_info, 0, FREYA_FW_VERSION_LENGTH);
+			}
 			accl_freya->freya2_fw_info.is_freya_ready = FREYA_NOT_READY;
 			break;
 		default:


### PR DESCRIPTION
# Description
- Clear freya version cache when freya drive not ready.

# Motivation
- Clear freya version cache when freya drive not ready to avoid BMC getting error status when system power reset.

# Test Plan
- Build code: Pass
- Get freya version after power reset: 168 rounds Pass

# Log
CB_ACCL1 DEV1 Version: v3.23.7.0.2
CB_ACCL1 DEV2 Version: v3.23.7.0.2
CB_ACCL2 DEV1 Version: v3.23.7.0.2
CB_ACCL2 DEV2 Version: v3.23.7.0.2
CB_ACCL3 DEV1 Version: v3.23.7.0.2
CB_ACCL3 DEV2 Version: v3.23.7.0.2
CB_ACCL4 DEV1 Version: v3.23.7.0.2
CB_ACCL4 DEV2 Version: v3.23.7.0.2
CB_ACCL5 DEV1 Version: v3.23.7.0.2
CB_ACCL5 DEV2 Version: v3.23.7.0.2
CB_ACCL6 DEV1 Version: v3.23.7.0.2
CB_ACCL6 DEV2 Version: v3.23.7.0.2
CB_ACCL7 DEV1 Version: v3.23.7.0.2
CB_ACCL7 DEV2 Version: v3.23.7.0.2
CB_ACCL8 DEV1 Version: v3.23.7.0.2
CB_ACCL8 DEV2 Version: v3.23.7.0.2
CB_ACCL9 DEV1 Version: v3.23.7.0.2
CB_ACCL9 DEV2 Version: v3.23.7.0.2
CB_ACCL10 DEV1 Version: v3.23.7.0.2
CB_ACCL10 DEV2 Version: v3.23.7.0.2
CB_ACCL11 DEV1 Version: v3.23.7.0.2
CB_ACCL11 DEV2 Version: v3.23.7.0.2
CB_ACCL12 DEV1 Version: v3.23.7.0.2
CB_ACCL12 DEV2 Version: v3.23.7.0.2