### PR TITLE
Artemis: cb: Set channel before switch temperature sensor reading

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_class.c
+++ b/meta-facebook/at-cb/src/platform/plat_class.c
@@ -30,7 +30,6 @@
 #include "plat_gpio.h"
 #include "ioexp_pca9555.h"
 #include "plat_dev.h"
-#include "i2c-mux-tca9543a.h"
 
 LOG_MODULE_REGISTER(plat_class);
 
@@ -335,38 +334,4 @@ bool get_acb_power_status()
 bool get_acb_power_good_flag()
 {
 	return is_power_good;
-}
-
-void init_i2c_bus_mux()
-{
-	bool ret;
-	static bool is_pex0_init_mux = false;
-	static bool is_pex1_init_mux = false;
-
-	mux_config mux_cfg = { 0 };
-
-	// Enable i2c mux channel 1
-	if (is_pex0_init_mux != true) {
-		mux_cfg.bus = PEX_0_BUS;
-		mux_cfg.target_addr = PEX89144_0_MUX_ADDR;
-		mux_cfg.channel = TCA9543A_CHANNEL_1;
-		ret = set_mux_channel(mux_cfg, MUTEX_LOCK_ENABLE);
-		if (ret) {
-			is_pex0_init_mux = true;
-		} else {
-			LOG_ERR("Enable i2c bus 2 mux fail");
-		}
-	}
-
-	if (is_pex1_init_mux != true) {
-		mux_cfg.bus = PEX_1_BUS;
-		mux_cfg.target_addr = PEX89144_1_MUX_ADDR;
-		mux_cfg.channel = TCA9543A_CHANNEL_1;
-		ret = set_mux_channel(mux_cfg, MUTEX_LOCK_ENABLE);
-		if (ret) {
-			is_pex1_init_mux = true;
-		} else {
-			LOG_ERR("Enable i2c bus 3 mux fail");
-		}
-	}
 }

--- a/meta-facebook/at-cb/src/platform/plat_class.h
+++ b/meta-facebook/at-cb/src/platform/plat_class.h
@@ -147,6 +147,5 @@ uint8_t get_hsc_module();
 uint8_t get_pwr_brick_module();
 bool get_acb_power_status();
 bool get_acb_power_good_flag();
-void init_i2c_bus_mux();
 
 #endif

--- a/meta-facebook/at-cb/src/platform/plat_hook.h
+++ b/meta-facebook/at-cb/src/platform/plat_hook.h
@@ -50,6 +50,7 @@ extern sq52205_init_arg sq52205_init_args[];
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS
  **************************************************************************************************/
+extern mux_config tca9543_configs[];
 extern vr_page_cfg xdpe15284_page[];
 extern mux_config pca9548_configs[];
 extern mux_config pca9546_configs[];

--- a/meta-facebook/at-cb/src/platform/plat_init.c
+++ b/meta-facebook/at-cb/src/platform/plat_init.c
@@ -38,7 +38,6 @@ void pal_pre_init()
 				1);
 	}
 
-	init_i2c_bus_mux();
 	check_accl_device_presence_status_via_ioexp();
 	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
 }

--- a/meta-facebook/at-cb/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-cb/src/platform/plat_sensor_table.c
@@ -121,10 +121,12 @@ sensor_cfg plat_sensor_config[] = {
 	/** PEX temp **/
 	{ SENSOR_NUM_TEMP_PEX_0, sensor_dev_pex89000, I2C_BUS2, PEX89144_I2CS_ADDR, PEX_TEMP,
 	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, pre_pex89000_read, NULL, NULL, NULL, &pex_sensor_init_args[0] },
+	  SENSOR_INIT_STATUS, pre_pex89000_read, &tca9543_configs[0], NULL, NULL,
+	  &pex_sensor_init_args[0] },
 	{ SENSOR_NUM_TEMP_PEX_1, sensor_dev_pex89000, I2C_BUS3, PEX89144_I2CS_ADDR, PEX_TEMP,
 	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, pre_pex89000_read, NULL, NULL, NULL, &pex_sensor_init_args[1] },
+	  SENSOR_INIT_STATUS, pre_pex89000_read, &tca9543_configs[1], NULL, NULL,
+	  &pex_sensor_init_args[1] },
 
 	/** SQ52205 **/
 	{ SENSOR_NUM_VOL_P12V_1_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_1_ADDR,


### PR DESCRIPTION
# Description
- Set i2c mux channel before switch temperature sensor reading to avoid channel being swithced, because i2c mux channel will reset by interrupt pin after power cycle.

# Motivation
- Set i2c mux channel before switch temperature sensor reading to avoid channel being swithced, because i2c mux channel will reset by interrupt pin after power cycle.

# Test Plan
- Build code: Pass
- Get switch temperature after MB power cycle: Pass

# Log
root@bmc-oob:~# sensor-util cb | grep CB_PEX
CB_PEX0_TEMP_C               (0x5) :   49.02 C     | (ok)
CB_PEX1_TEMP_C               (0x6) :   49.26 C     | (ok)
root@bmc-oob:~# power-util mb cycle
Power cycling fru 1...
root@bmc-oob:~# sensor-util cb | grep CB_PEX
CB_PEX0_TEMP_C               (0x5) :   49.26 C     | (ok)
CB_PEX1_TEMP_C               (0x6) :   48.55 C     | (ok)