### PR TITLE
common: Extend timeout of IPMI handler thread

### DIFF
--- a/common/service/ipmb/ipmb.c
+++ b/common/service/ipmb/ipmb.c
@@ -1026,7 +1026,7 @@ ipmb_error ipmb_send_response(ipmi_msg *resp, uint8_t index)
 	LOG_HEXDUMP_DBG(resp_cfg.buffer.data, resp_cfg.buffer.data_len, "");
 
 	/* Blocks here until is able put message in tx queue */
-	if (k_msgq_put(&ipmb_txqueue[index], &resp_cfg, K_FOREVER) != osOK) {
+	if (k_msgq_put(&ipmb_txqueue[index], &resp_cfg, K_MSEC(1000)) != osOK) {
 		k_mutex_unlock(&mutex_send_res);
 		return IPMB_ERROR_FAILURE;
 	}

--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -442,7 +442,7 @@ void IPMI_handler(void *arug0, void *arug1, void *arug2)
 				      K_THREAD_STACK_SIZEOF(IPMI_handle_thread_stack),
 				      ipmi_cmd_handle, (void *)&msg_cfg, NULL, NULL,
 				      CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
-		if (k_thread_join(tid, K_SECONDS(5)) == -EAGAIN) { // timeout
+		if (k_thread_join(tid, K_SECONDS(10)) == -EAGAIN) { // timeout
 			k_thread_abort(tid);
 			LOG_ERR("%s(): abort the handler due to timeout. netfn: %x, cmd: %x",
 				__func__, msg_cfg.buffer.netfn, msg_cfg.buffer.cmd);


### PR DESCRIPTION
# Description:
Extend timeout of IPMI handler thread to 10s.

# Motivation:
In the functions executed by the IPMI handler, the maximum wait time for resources is 8 seconds. Therefore, it is necessary to extend the IPMI handler's timeout to prevent it from being killed before releasing the resources.

# Test Plan:
1. Build and test pass on YV3.5 system. pass

2. Do DC cycle stress test to ensure ipmb lock fail doesn't happen again.
pass