### PR TITLE
fby35: hda1: Support BSD version read

### DIFF
--- a/meta-facebook/yv35-hda1/src/platform/plat_fru.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_fru.c
@@ -16,11 +16,19 @@
 
 #include <string.h>
 #include <logging/log.h>
+#include <sys/crc.h>
 #include "fru.h"
+#include "hal_gpio.h"
+#include "power_status.h"
 #include "plat_fru.h"
+#include "plat_gpio.h"
 #include "libutil.h"
 
 LOG_MODULE_REGISTER(plat_fru);
+
+#define BSD_IMG_SIZE_OFST 40
+#define BSD_IMG_SIZE_BYTE_CNT 2
+#define MAX_BSD_IMG_SIZE 1024
 
 const EEPROM_CFG plat_fru_config[] = {
 	{
@@ -54,35 +62,21 @@ const EEPROM_CFG plat_bios_version_area_config = {
 	BIOS_FW_VERSION_MAX_SIZE,
 };
 
-/* PSB error information */
-const EEPROM_CFG plat_psb_error_area_config = {
-	NV_ATMEL_24C128,
-	MB_FRU_ID,
-	MB_FRU_PORT,
-	MB_CPU_EEPROM_ADDR,
-	FRU_DEV_ACCESS_BYTE,
-	PSB_ERROR_START,
-	PSB_ERROR_MAX_SIZE,
+/* CPU eeprom - BSD image */
+const EEPROM_CFG plat_bsd_area_config = {
+	NV_ATMEL_24C128,     MB_FRU_ID,       MB_CPU_FRU_PORT,  MB_CPU_FRU_ADDR,
+	FRU_DEV_ACCESS_BYTE, BSD_IMAGE_START, MAX_BSD_IMG_SIZE,
+};
+
+/* MB eeprom - BSD version(crc32) */
+const EEPROM_CFG plat_bsd_version_area_config = {
+	NV_ATMEL_24C128,     MB_FRU_ID,		MB_FRU_PORT,	  MB_FRU_ADDR,
+	FRU_DEV_ACCESS_BYTE, BSD_VERSION_START, BSD_VERSION_MAX_SIZE,
 };
 
 void pal_load_fru_config(void)
 {
 	memcpy(fru_config, plat_fru_config, sizeof(plat_fru_config));
-}
-
-bool write_psb_inform(EEPROM_ENTRY *entry)
-{
-	CHECK_NULL_ARG_WITH_RETURN(entry, false);
-
-	bool ret = false;
-	entry->config = plat_psb_error_area_config;
-	ret = eeprom_write(entry);
-	if (ret == false) {
-		LOG_ERR("eeprom_write fail");
-		return ret;
-	}
-
-	return ret;
 }
 
 int set_bios_version(EEPROM_ENTRY *entry, uint8_t block_index)
@@ -127,4 +121,91 @@ int get_bios_version(EEPROM_ENTRY *entry, uint8_t block_index)
 	}
 
 	return 0;
+}
+
+bool write_bsd_version()
+{
+	bool ret = false;
+
+	/* Access CPU eeprom only if CPU off */
+	if (get_DC_status() == true)
+		goto exit;
+
+	gpio_set(BMC_GPIOT6_SPI0_PROGRAM_SEL, GPIO_HIGH);
+	k_msleep(100);
+
+	uint16_t bsd_img_size = 0;
+	uint8_t bsd_img_buff[MAX_BSD_IMG_SIZE] = { 0 };
+
+	EEPROM_ENTRY entry = { 0 };
+	entry.config = plat_bsd_area_config;
+	entry.config.start_offset = 0x0000;
+	entry.data_len = EEPROM_WRITE_SIZE;
+
+	while (entry.config.start_offset + EEPROM_WRITE_SIZE <= MAX_BSD_IMG_SIZE) {
+		ret = eeprom_read(&entry);
+		if (ret == false) {
+			LOG_ERR("eeprom_read fail");
+			goto exit;
+		}
+
+		if (!bsd_img_size &&
+		    (entry.config.start_offset + EEPROM_WRITE_SIZE) > BSD_IMG_SIZE_OFST) {
+			bsd_img_size =
+				entry.data[BSD_IMG_SIZE_OFST - entry.config.start_offset] |
+				(entry.data[BSD_IMG_SIZE_OFST - entry.config.start_offset + 1]
+				 << 8);
+		}
+
+		if (bsd_img_size &&
+		    (entry.config.start_offset + EEPROM_WRITE_SIZE > bsd_img_size)) {
+			memcpy(&bsd_img_buff[entry.config.start_offset], entry.data,
+			       bsd_img_size - entry.config.start_offset);
+			break;
+		} else {
+			memcpy(&bsd_img_buff[entry.config.start_offset], entry.data,
+			       EEPROM_WRITE_SIZE);
+			entry.config.start_offset += EEPROM_WRITE_SIZE;
+			entry.data_len = EEPROM_WRITE_SIZE;
+		}
+	}
+
+	LOG_HEXDUMP_DBG(bsd_img_buff, bsd_img_size, "BSD image:");
+
+	uint32_t digest = crc32_ieee(bsd_img_buff, bsd_img_size);
+	LOG_INF("BSD crc32: 0x%x", digest);
+
+	entry.config = plat_bsd_version_area_config;
+	entry.data_len = sizeof(digest);
+	memcpy(entry.data, &digest, entry.data_len);
+
+	ret = eeprom_write(&entry);
+	if (ret == false) {
+		LOG_ERR("eeprom_write fail");
+		goto exit;
+	}
+
+	ret = true;
+exit:
+	gpio_set(BMC_GPIOT6_SPI0_PROGRAM_SEL, GPIO_LOW);
+
+	return ret;
+}
+
+uint32_t read_bsd_version()
+{
+	EEPROM_ENTRY entry = { 0 };
+	entry.config = plat_bsd_version_area_config;
+	entry.data_len = sizeof(uint32_t);
+
+	if (eeprom_read(&entry) == false) {
+		LOG_ERR("eeprom_read fail");
+		return 0;
+	}
+
+	uint32_t bsd_ver = 0;
+	for (int i = 0; i < entry.data_len; i++)
+		bsd_ver |= (entry.data[i] << (8 * i));
+
+	return bsd_ver;
 }

--- a/meta-facebook/yv35-hda1/src/platform/plat_fru.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_fru.c
@@ -27,7 +27,6 @@
 LOG_MODULE_REGISTER(plat_fru);
 
 #define BSD_IMG_SIZE_OFST 40
-#define BSD_IMG_SIZE_BYTE_CNT 2
 #define MAX_BSD_IMG_SIZE 1024
 
 const EEPROM_CFG plat_fru_config[] = {
@@ -64,14 +63,24 @@ const EEPROM_CFG plat_bios_version_area_config = {
 
 /* CPU eeprom - BSD image */
 const EEPROM_CFG plat_bsd_area_config = {
-	NV_ATMEL_24C128,     MB_FRU_ID,       MB_CPU_FRU_PORT,  MB_CPU_FRU_ADDR,
-	FRU_DEV_ACCESS_BYTE, BSD_IMAGE_START, MAX_BSD_IMG_SIZE,
+	NV_ATMEL_24C128,
+	MB_FRU_ID,
+	MB_CPU_FRU_PORT,
+	MB_CPU_FRU_ADDR,
+	FRU_DEV_ACCESS_BYTE,
+	BSD_IMAGE_START,
+	MAX_BSD_IMG_SIZE,
 };
 
 /* MB eeprom - BSD version(crc32) */
 const EEPROM_CFG plat_bsd_version_area_config = {
-	NV_ATMEL_24C128,     MB_FRU_ID,		MB_FRU_PORT,	  MB_FRU_ADDR,
-	FRU_DEV_ACCESS_BYTE, BSD_VERSION_START, BSD_VERSION_MAX_SIZE,
+	NV_ATMEL_24C128,
+	MB_FRU_ID,
+	MB_FRU_PORT,
+	MB_FRU_ADDR,
+	FRU_DEV_ACCESS_BYTE,
+	BSD_VERSION_START,
+	BSD_VERSION_MAX_SIZE,
 };
 
 void pal_load_fru_config(void)

--- a/meta-facebook/yv35-hda1/src/platform/plat_fru.h
+++ b/meta-facebook/yv35-hda1/src/platform/plat_fru.h
@@ -20,21 +20,22 @@
 #include "eeprom.h"
 #include "fru.h"
 
-enum {
-	MB_FRU_ID,
-	DPV2_FRU_ID,
-	// OTHER_FRU_ID,
-	MAX_FRU_ID,
+enum { MB_FRU_ID,
+       DPV2_FRU_ID,
+       // OTHER_FRU_ID,
+       MAX_FRU_ID,
 };
 
 #define FRU_CFG_NUM MAX_FRU_ID
 
 #define MB_FRU_PORT 0x01
 #define MB_FRU_ADDR 0x54
-#define MB_CPU_EEPROM_ADDR 0x50
 
 #define DPV2_FRU_PORT 0x08
 #define DPV2_FRU_ADDR 0x51
+
+#define MB_CPU_FRU_PORT 0x0C
+#define MB_CPU_FRU_ADDR 0x50
 
 #define BIOS_FW_VERSION_START 0x0A00
 #define BIOS_FW_VERSION_MAX_SIZE 34
@@ -42,11 +43,14 @@ enum {
 #define BIOS_FW_VERSION_SECOND_BLOCK_OFFSET 17
 #define BIOS_FW_VERSION_BLOCK_MAX_SIZE 17
 
-#define PSB_ERROR_START 0x0002
-#define PSB_ERROR_MAX_SIZE 9
+#define BSD_IMAGE_START 0x0000
+#define BSD_VERSION_START 0x0A40
+#define BSD_VERSION_MAX_SIZE 4
 
 bool get_bios_version_area_config(EEPROM_CFG *config);
 int set_bios_version(EEPROM_ENTRY *entry, uint8_t block_index);
 int get_bios_version(EEPROM_ENTRY *entry, uint8_t block_index);
+bool write_bsd_version();
+uint32_t read_bsd_version();
 
 #endif

--- a/meta-facebook/yv35-hda1/src/platform/plat_fru.h
+++ b/meta-facebook/yv35-hda1/src/platform/plat_fru.h
@@ -20,10 +20,11 @@
 #include "eeprom.h"
 #include "fru.h"
 
-enum { MB_FRU_ID,
-       DPV2_FRU_ID,
-       // OTHER_FRU_ID,
-       MAX_FRU_ID,
+enum {
+	MB_FRU_ID,
+	DPV2_FRU_ID,
+	// OTHER_FRU_ID,
+	MAX_FRU_ID,
 };
 
 #define FRU_CFG_NUM MAX_FRU_ID

--- a/meta-facebook/yv35-hda1/src/platform/plat_init.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_init.c
@@ -25,6 +25,7 @@
 #include "plat_mctp.h"
 #include "plat_ssif.h"
 #include "plat_power_status.h"
+#include "plat_fru.h"
 #include "util_worker.h"
 
 SCU_CFG scu_cfg[] = {
@@ -63,6 +64,8 @@ void pal_post_init()
 	plat_mctp_init();
 
 	ssif_init();
+
+	write_bsd_version();
 }
 
 void pal_set_sys_status()

--- a/meta-facebook/yv35-hda1/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-hda1/src/platform/plat_sdr_table.c
@@ -265,7 +265,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // reserved
 		0x00, // OEM
 		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
-		"MB_CPU_TEMP_C",
+		"MB_SOC_CPU_TEMP_C",
 	},
 	{
 		// SSD temperature


### PR DESCRIPTION
Summary:
- Support BSD version get oem command.
- BIC would access CPU eeprom for BSD version while CPU power off.

TestPlan:
- BuildCode: PASS
- Get BSD version with OEM command: PASS

Log:
- BMC console:
  ```
  root@bmc-oob:~# bic-util slot1 0xe0 0x0b 0x15 0xa0 0x00 0x04
  15 A0 00 56 B3 83 66
  ```
