### PR TITLE
Artemis: cb: Modify ACB 2nd source HSC initial setting

### DIFF
--- a/common/dev/ltc4286.c
+++ b/common/dev/ltc4286.c
@@ -246,13 +246,15 @@ uint8_t ltc4286_read(sensor_cfg *cfg, int *reading)
 	double val;
 	I2C_MSG msg;
 
-	msg.bus = cfg->port;
-	msg.target_addr = cfg->target_addr;
-	msg.tx_len = 1;
-	msg.rx_len = 2;
-	msg.data[0] = cfg->offset;
-	if (i2c_master_read(&msg, retry)) {
-		return SENSOR_FAIL_TO_ACCESS;
+	if ((cfg->offset != PMBUS_READ_IIN) && (cfg->offset != PMBUS_READ_POUT)) {
+		msg.bus = cfg->port;
+		msg.target_addr = cfg->target_addr;
+		msg.tx_len = 1;
+		msg.rx_len = 2;
+		msg.data[0] = cfg->offset;
+		if (i2c_master_read(&msg, retry)) {
+			return SENSOR_FAIL_TO_ACCESS;
+		}
 	}
 
 	sensor_val *sval = (sensor_val *)reading;

--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -53,8 +53,8 @@ adm1272_init_arg adm1272_init_args[] = {
 };
 
 ltc4286_init_arg ltc4286_init_args[] = {
-	[0] = { .is_init = false, .r_sense_mohm = 0.3, .mfr_config_1 = { 0x5572 } },
-	[1] = { .is_init = false, .r_sense_mohm = 0.3, .mfr_config_1 = { 0x5572 } }
+	[0] = { .is_init = false, .r_sense_mohm = 0.3, .mfr_config_1 = { 0x6D72 } },
+	[1] = { .is_init = false, .r_sense_mohm = 0.3, .mfr_config_1 = { 0x6D72 } }
 };
 
 ina233_init_arg ina233_init_args[] = {


### PR DESCRIPTION
# Description
- Modify ACB second source (LTC4286) MFR config according to vendor suggestions.
- Fix LTC4286 IIN/POUT reading fail issue.

# Motivation
- Modify ACB second source (LTC4286) MFR config according to vendor suggestions.

# Test Plan
- Build code: Pass
- ACB 2nd source power on: Pass