### PR TITLE
Artemis: mc: Get CXL firmware version after setting EID

### DIFF
--- a/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
@@ -311,6 +311,11 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 			return;
 		}
 
+		if (is_cxl_access(cxl_id) != true) {
+			msg->completion_code = CC_NOT_SUPP_IN_CURR_STATE;
+			return;
+		}
+
 		if (pm8702_table[cxl_id].is_init != true) {
 			ret = pal_init_pm8702_info(cxl_id);
 			if (ret == false) {

--- a/meta-facebook/at-mc/src/platform/plat_dev.c
+++ b/meta-facebook/at-mc/src/platform/plat_dev.c
@@ -162,6 +162,13 @@ void cxl_mb_status_init(uint8_t cxl_id)
 
 		if (get_set_cxl_endpoint(cxl_id, MCTP_EID_CXL) != true) {
 			LOG_ERR("Fail to set eid, cxl id: 0x%x", cxl_id);
+		} else {
+			if (pm8702_table[cxl_id].is_init != true) {
+				ret = pal_init_pm8702_info(cxl_id);
+				if (ret != true) {
+					LOG_ERR("Initial cxl id: 0x%x info fail", cxl_id);
+				}
+			}
 		}
 	}
 

--- a/meta-facebook/at-mc/src/platform/plat_isr.c
+++ b/meta-facebook/at-mc/src/platform/plat_isr.c
@@ -141,6 +141,15 @@ void cxl_set_eid_work_handler(struct k_work *work_item)
 			k_mutex_unlock(meb_mutex);
 			continue;
 		}
+
+		if (pm8702_table[work_info->cxl_card_id].is_init != true) {
+			ret = pal_init_pm8702_info(work_info->cxl_card_id);
+			if (ret != true) {
+				LOG_ERR("Initial cxl id: 0x%x info fail", work_info->cxl_card_id);
+				continue;
+			}
+		}
+
 		/** mutex unlock bus **/
 		k_mutex_unlock(meb_mutex);
 		break;


### PR DESCRIPTION
# Description
- Because the CXL bus mutex lock fails, BMC may not be able to get CXL firmware version. Modify the time to cache CXL firmware version to after setting the EID to avoid i2c bus mutex lock fail.

# Motivation
- Modify the time to cache CXL firmware version to after setting the EID to avoid i2c bus mutex lock fail.

# Test Plan
- Build code: Pass
- Get CXL firmware version after AC-cycle: Pass
- Get CXL firmware version after DC-cycle: 110 rounds Pass
- Get CXL firmware version after BIC reset: Pass

# Log
root@bmc-oob:~# fw-util mc --version
MC BIC Version: mc2023.29.e1
MC CPLD Version: 00020E11
MC CXL1 Version: 02.000.011.00
MC CXL2 Version: 02.000.011.00
MC CXL3 Version: 02.000.011.00
MC CXL4 Version: 02.000.011.00
MC CXL5 Version: NA
MC CXL6 Version: NA
MC CXL7 Version: 02.000.011.00
MC CXL8 Version: 02.000.011.00