### PR TITLE
Artemis: mc: Add delay time to wait for PCIE card to be ready

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_hook.c
+++ b/meta-facebook/at-mc/src/platform/plat_hook.c
@@ -969,8 +969,8 @@ bool pre_sq52205_read(sensor_cfg *cfg, void *args)
 	// Select Channel
 	bool ret = true;
 	bool is_sensor_init_done = false;
+	bool is_time_to_polling = false;
 	int mutex_status = 0;
-	int power_status = 0;
 	uint8_t card_type;
 
 	pwr_monitor_pre_proc_arg *pre_args = (pwr_monitor_pre_proc_arg *)args;
@@ -986,16 +986,11 @@ bool pre_sq52205_read(sensor_cfg *cfg, void *args)
 		return false;
 	}
 
-	power_status = get_pcie_card_power_status(pre_args->jcn_number);
-	if (power_status < 0) {
-		LOG_ERR("Fail to get PCIE card power status, pcie card id: 0x%x",
-			pre_args->jcn_number);
-		return false;
-	}
-
 	is_sensor_init_done = get_sensor_init_done_flag();
+	is_time_to_polling = is_time_to_poll_card_sensor(pre_args->jcn_number);
+
 	if (is_sensor_init_done) {
-		if ((power_status & PCIE_CARD_POWER_GOOD_BIT) == 0) {
+		if (is_time_to_polling != true) {
 			cfg->cache_status = SENSOR_POLLING_DISABLE;
 			return true;
 		} else {

--- a/meta-facebook/at-mc/src/platform/plat_sensor_table.h
+++ b/meta-facebook/at-mc/src/platform/plat_sensor_table.h
@@ -165,6 +165,15 @@
 /**********************Event**********************/
 #define SENSOR_NUM_SYSTEM_STATUS 0x10
 
+#define PCIE_CARD_POWER_GOOD_TIME_DEFAULT 0
+#define PCIE_CARD_SENSOR_POLL_DELAY_MS 10000
+
+typedef struct _sensor_poll_delay_cfg {
+	uint8_t pcie_card_id;
+	bool is_last_time_power_good;
+	int64_t card_first_power_good_time;
+} sensor_poll_delay_cfg;
+
 extern const int CXL_SENSOR_CONFIG_SIZE;
 
 void load_sensor_config(void);
@@ -176,5 +185,6 @@ bool get_pcie_card_mux_config(uint8_t cxl_id, uint8_t sensor_num, mux_config *ca
 			      mux_config *cxl_mux_cfg);
 sensor_cfg *get_cxl_sensor_cfg_info(uint8_t cxl_id, uint8_t *cfg_count);
 sensor_cfg *get_common_sensor_cfg_info(uint8_t sensor_num);
+bool is_time_to_poll_card_sensor(uint8_t pcie_card_id);
 
 #endif


### PR DESCRIPTION
# Description
- Add delay time to wait for PCIE card to be ready

# Motivation
- Add delay time to wait for PCIE card sensor to be ready after PCIE card power on to avoid BMC getting invalid sensor reading. (The delay time is set to 10s)

# Test Plan
- Build code: Pass
- BIC doesn't monitor PCIE card sensor when PCIE card power off/power on less than 10s: Pass
- Get PCIE card sensor after PCIE card power on 10s: Pass

# Log
- SSD 1 root@bmc-oob:~# power-util mc_ssd1 status
Power status for fru 37 : ON
root@bmc-oob:~# sensor-util mc | grep MC_E1S
MC_E1S_0_TEMP_C              (0x34) :   29.00 C     | (ok)
MC_E1S_1_TEMP_C              (0x35) :   30.00 C     | (ok)
MC_E1S_2_TEMP_C              (0x36) :   32.00 C     | (ok)
MC_E1S_3_TEMP_C              (0x37) :   33.00 C     | (ok)
root@bmc-oob:~# sensor-util mc | grep MC_P12V_AUX_SSD
MC_P12V_AUX_SSD1_VOL_V       (0xF) :   12.17 Volts | (ok)
...
MC_P12V_AUX_SSD1_CUR_A       (0x1E) :    0.34 Amps  | (ok)
...
MC_P12V_AUX_SSD1_PWR_W       (0x2D) :    4.12 Watts | (ok)
...
root@bmc-oob:~# power-util mc_ssd1 off; sleep 2; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
Powering fru 37 to OFF state...
MC_E1S_0_TEMP_C              (0x34) : NA | (na)
...
root@bmc-oob:~# power-util mc_ssd1 on; sleep 5; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
Powering fru 37 to ON state...
MC_E1S_0_TEMP_C              (0x34) : NA | (na)
...
root@bmc-oob:~# sleep 5; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
MC_E1S_0_TEMP_C              (0x34) :   28.00 C     | (ok)
...

- SSD 2 root@bmc-oob:~# power-util mc_ssd2 status
Power status for fru 36 : ON
root@bmc-oob:~# sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
MC_E1S_0_TEMP_C              (0x34) :   29.00 C     | (ok)
...
root@bmc-oob:~# power-util mc_ssd2 off; sleep 2; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
Powering fru 36 to OFF state...
MC_E1S_0_TEMP_C              (0x34) :   30.00 C     | (ok)
...
root@bmc-oob:~# power-util mc_ssd2 on; sleep 5; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
Powering fru 36 to ON state...
MC_E1S_0_TEMP_C              (0x34) :   29.00 C     | (ok)
...
root@bmc-oob:~# sleep 5; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
MC_E1S_0_TEMP_C              (0x34) :   29.00 C     | (ok)
...

- SSD 3 root@bmc-oob:~# power-util mc_ssd3 status
Power status for fru 35 : ON
root@bmc-oob:~# sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
MC_E1S_0_TEMP_C              (0x34) :   30.00 C     | (ok)
...
root@bmc-oob:~# power-util mc_ssd3 off; sleep 2; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
Powering fru 35 to OFF state...
MC_E1S_0_TEMP_C              (0x34) :   30.00 C     | (ok)
...
root@bmc-oob:~# power-util mc_ssd3 on; sleep 5; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
Powering fru 35 to ON state...
MC_E1S_0_TEMP_C              (0x34) :   30.00 C     | (ok)
...
root@bmc-oob:~# sleep 5; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
MC_E1S_0_TEMP_C              (0x34) :   30.00 C     | (ok)
...

- SSD 4 root@bmc-oob:~# power-util mc_ssd4 status
Power status for fru 34 : ON
root@bmc-oob:~# sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
MC_E1S_0_TEMP_C              (0x34) :   30.00 C     | (ok)
...
root@bmc-oob:~# power-util mc_ssd4 off; sleep 2; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
Powering fru 34 to OFF state...
MC_E1S_0_TEMP_C              (0x34) :   30.00 C     | (ok)
...
root@bmc-oob:~# power-util mc_ssd4 on; sleep 5; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
Powering fru 34 to ON state...
MC_E1S_0_TEMP_C              (0x34) :   30.00 C     | (ok)
...
root@bmc-oob:~# sleep 5; sensor-util mc | grep MC_E1S; sensor-util mc | grep MC_P12V_AUX_SSD
MC_E1S_0_TEMP_C              (0x34) :   30.00 C     | (ok)
...

- CXL 3/4/5/6 test Pass