### PR TITLE
Artemis: cb: Accurate power monitor sensor reading

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -58,7 +58,7 @@ ltc4286_init_arg ltc4286_init_args[] = {
 };
 
 ina233_init_arg ina233_init_args[] = {
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001151079, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -77,7 +77,7 @@ ina233_init_arg ina233_init_args[] = {
 		.ein_status = 0b0,
 	},
 	},
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0011523, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -96,7 +96,7 @@ ina233_init_arg ina233_init_args[] = {
 		.ein_status = 0b0,
 	},
 	},
-	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001149, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -115,7 +115,7 @@ ina233_init_arg ina233_init_args[] = {
 		.ein_status = 0b0,
 	},
 	},
-	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001148, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -134,7 +134,7 @@ ina233_init_arg ina233_init_args[] = {
 		.ein_status = 0b0,
 	},
 	},
-	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001147982, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -153,7 +153,7 @@ ina233_init_arg ina233_init_args[] = {
 		.ein_status = 0b0,
 	},
 	},
-	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0009859, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -172,7 +172,7 @@ ina233_init_arg ina233_init_args[] = {
 		.ein_status = 0b0,
 	},
 	},
-	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
+	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001147982, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -191,7 +191,7 @@ ina233_init_arg ina233_init_args[] = {
 		.ein_status = 0b0,
 	},
 	},
-	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
+	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001152115, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -210,7 +210,7 @@ ina233_init_arg ina233_init_args[] = {
 		.ein_status = 0b0,
 	},
 	},
-	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
+	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001114, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -229,7 +229,7 @@ ina233_init_arg ina233_init_args[] = {
 		.ein_status = 0b0,
 	},
 	},
-	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
+	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0011547, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -248,7 +248,7 @@ ina233_init_arg ina233_init_args[] = {
 		.ein_status = 0b0,
 	},
 	},
-	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00117647, .mfr_config_init = true,
+	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001135758, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -267,7 +267,7 @@ ina233_init_arg ina233_init_args[] = {
 		.ein_status = 0b0,
 	},
 	},
-	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0009848, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,


### PR DESCRIPTION
# Description
- Modify INA233 initial setting to accurate sensor reading.

# Motivation
- Modify the initial setting of INA233 according to EE suggestions.

# Note
- JIRA link: https://metainfra.atlassian.net/browse/T17GTART-230
- File name: SDR for 8 boards result_0731.xlsx

# Test Plan
- Build code: Pass
- Get INA233 sensor reading: Pass
- Check INA233 initial setting is match with the correct settings reported by EE: Pass

# Log
root@bmc-oob:~# sensor-util cb | grep CB_P12V_ACCL
CB_P12V_ACCL1_V              (0x23) :   12.14 Volts | (ok)
CB_P12V_ACCL2_V              (0x24) :   12.14 Volts | (ok)
CB_P12V_ACCL3_V              (0x25) :   12.13 Volts | (ok)
CB_P12V_ACCL4_V              (0x26) :   12.13 Volts | (ok)
CB_P12V_ACCL5_V              (0x27) :   12.13 Volts | (ok)
CB_P12V_ACCL6_V              (0x28) :   12.13 Volts | (ok)
CB_P12V_ACCL7_V              (0x29) :   12.13 Volts | (ok)
CB_P12V_ACCL8_V              (0x2A) :   12.12 Volts | (ok)
CB_P12V_ACCL9_V              (0x2C) :   12.13 Volts | (ok)
CB_P12V_ACCL10_V             (0x2D) :   12.13 Volts | (ok)
CB_P12V_ACCL11_V             (0x2E) :   12.13 Volts | (ok)
CB_P12V_ACCL12_V             (0x2F) :   12.13 Volts | (ok)
CB_P12V_ACCL1_A              (0x34) :    2.60 Amps  | (ok)
CB_P12V_ACCL2_A              (0x35) :    2.60 Amps  | (ok)
CB_P12V_ACCL3_A              (0x36) :    2.64 Amps  | (ok)
CB_P12V_ACCL4_A              (0x37) :    2.56 Amps  | (ok)
CB_P12V_ACCL5_A              (0x38) :    2.56 Amps  | (ok)
CB_P12V_ACCL6_A              (0x39) :    2.50 Amps  | (ok)
CB_P12V_ACCL7_A              (0x3A) :    2.56 Amps  | (ok)
CB_P12V_ACCL8_A              (0x3C) :    2.65 Amps  | (ok)
CB_P12V_ACCL9_A              (0x3D) :    2.59 Amps  | (ok)
CB_P12V_ACCL10_A             (0x3E) :    2.61 Amps  | (ok)
CB_P12V_ACCL11_A             (0x3F) :    2.49 Amps  | (ok)
CB_P12V_ACCL12_A             (0x40) :    2.59 Amps  | (ok)
CB_P12V_ACCL1_W              (0x45) :   31.58 Watts | (ok)
CB_P12V_ACCL2_W              (0x46) :   31.55 Watts | (ok)
CB_P12V_ACCL3_W              (0x47) :   32.05 Watts | (ok)
CB_P12V_ACCL4_W              (0x48) :   30.98 Watts | (ok)
CB_P12V_ACCL5_W              (0x49) :   31.05 Watts | (ok)
CB_P12V_ACCL6_W              (0x4A) :   30.30 Watts | (ok)
CB_P12V_ACCL7_W              (0x4B) :   31.05 Watts | (ok)
CB_P12V_ACCL8_W              (0x4C) :   32.15 Watts | (ok)
CB_P12V_ACCL9_W              (0x4D) :   31.35 Watts | (ok)
CB_P12V_ACCL10_W             (0x50) :   31.58 Watts | (ok)
CB_P12V_ACCL11_W             (0x51) :   30.15 Watts | (ok)
CB_P12V_ACCL12_W             (0x52) :   31.42 Watts | (ok)

uart:~$ i2c write I2C_3 0x70 0x02 0x00 0x00
uart:~$ i2c scan I2C_3
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: 70 -- -- -- -- -- -- --
1 devices found on I2C_3
uart:~$ i2c write I2C_3 0x70 0x02 0x00 0x01
uart:~$i2c scan I2C_3
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: 40 41 42 43 44 45 -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: 70 -- -- -- -- -- -- --
7 devices found on I2C_3
uart:~$ i2c read I2C_3 0x40 0xD4 0x02
00000000: 4f 14                                            |O.               |
uart:~$ i2c read I2C_3 0x41 0xD4 0x02
00000000: 9c 11                                            |..               |
uart:~$ i2c read I2C_3 0x42 0xD4 0x02
00000000: 52 11                                            |R.               |
uart:~$ i2c read I2C_3 0x43 0xD4 0x02
00000000: f4 11                                            |..               |
uart:~$ i2c read I2C_3 0x44 0xD4 0x02
00000000: 5c 11                                            |\.               |
uart:~$ i2c read I2C_3 0x45 0xD4 0x02
00000000: 6c 11                                            |l.               |
uart:~$ i2c write I2C_3 0x70 0x02 0x00 0x02
uart:~$i2c scan I2C_3
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: 40 41 42 43 44 45 -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
70: 70 -- -- -- -- -- -- --
7 devices found on I2C_3
uart:~$ i2c read I2C_3 0x40 0xD4 0x02
00000000: 49 14                                            |I.               |
uart:~$ i2c read I2C_3 0x41 0xD4 0x02
00000000: 6c 11                                            |l.               |
uart:~$ i2c read I2C_3 0x42 0xD4 0x02
00000000: 6b 11                                            |k.               |
uart:~$ i2c read I2C_3 0x43 0xD4 0x02
00000000: 68 11                                            |h.               |
uart:~$ i2c read I2C_3 0x44 0xD4 0x02
00000000: 5b 11                                            |[.               |
uart:~$ i2c read I2C_3 0x45 0xD4 0x02
00000000: 60 11                                            |`.               |