### PR TITLE
common: dev: Support rg3mxxb12 i3c initial and set slave port function

### DIFF
--- a/common/dev/include/rg3mxxb12.h
+++ b/common/dev/include/rg3mxxb12.h
@@ -17,6 +17,9 @@
 #ifndef RG3MXXB12_H
 #define RG3MXXB12_H
 
+#include "hal_i2c.h"
+#include "hal_i3c.h"
+
 #define RG3MXXB12_DEFAULT_STATIC_ADDRESS 0x70
 
 #define RG3MXXB12_PROTECTION_REG 0x10
@@ -70,5 +73,7 @@ enum pull_up_resistor {
 bool rg3mxxb12_i2c_mode_only_init(uint8_t bus, uint8_t slave_port, uint8_t ldo_volt,
 				  uint8_t pullup_resistor);
 bool rg3mxxb12_select_slave_port_connect(uint8_t bus, uint8_t slave_port);
+bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt);
+bool rg3mxxb12_set_slave_port(uint8_t bus, uint8_t addr, uint8_t setting);
 
 #endif

--- a/common/dev/rg3mxxb12.c
+++ b/common/dev/rg3mxxb12.c
@@ -16,7 +16,6 @@
 #include <logging/log.h>
 
 #include "rg3mxxb12.h"
-#include "hal_i2c.h"
 #include "libutil.h"
 
 LOG_MODULE_REGISTER(dev_rg3mxxb12);
@@ -70,7 +69,6 @@ static bool rg3mxxb12_register_write(uint8_t bus, uint8_t offset, uint8_t value)
 			offset, bus);
 		return false;
 	}
-
 	return true;
 }
 
@@ -177,6 +175,96 @@ out:
 	// Lock protected register
 	if (!rg3mxxb12_protected_register(bus, true)) {
 		return false;
+	}
+
+	return ret;
+}
+
+bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt)
+{
+	bool ret = false;
+
+	uint8_t cmd_unprotect[2] = { RG3MXXB12_PROTECTION_REG, 0x69 };
+	uint8_t cmd_protect[2] = { RG3MXXB12_PROTECTION_REG, 0x00 };
+	uint8_t cmd_initial[][2] = {
+		/* 
+		 * Refer to RG3MxxB12 datasheet page 13, LDO voltage depends
+		 * on each project's hard design
+		 */
+		{ RG3MXXB12_VOLT_LDO_SETTING, ldo_volt },
+		{ RG3MXXB12_SSPORTS_AGENT_ENABLE, 0x0 },
+		{ RG3MXXB12_SSPORTS_GPIO_ENABLE, 0x0 },
+		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0x0 },
+		{ RG3MXXB12_SSPORTS_PULLUP_ENABLE, 0xFF },
+		{ RG3MXXB12_SSPORTS_OD_ONLY, 0x0 },
+		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0xFF },
+		{ RG3MXXB12_SSPORTS_HUB_NETWORK_CONNECTION, 0xFF },
+	};
+
+	i3c_msg->tx_len = 2;
+	memcpy(i3c_msg->data, cmd_unprotect, 2);
+	int initial_cmd_size = sizeof(cmd_initial) / sizeof(cmd_initial[0]);
+
+	// Unlock protected regsiter
+	if (!i3c_controller_write(i3c_msg)) {
+		goto out;
+	}
+
+	for (int cmd = 0; cmd < initial_cmd_size; cmd++) {
+		i3c_msg->tx_len = 2;
+		memcpy(i3c_msg->data, cmd_initial[cmd], 2);
+		if (!i3c_controller_write(i3c_msg)) {
+			LOG_ERR("Failed to initial i3c mode. offset = 0x%02x, value = 0x%02x",
+				cmd_initial[cmd][0], cmd_initial[cmd][1]);
+			goto out;
+		}
+		k_msleep(10);
+	}
+
+	ret = true;
+out:
+	memcpy(i3c_msg->data, cmd_protect, 2);
+	if (!i3c_controller_write(i3c_msg)) {
+		goto out;
+	}
+
+	return ret;
+}
+
+bool rg3mxxb12_set_slave_port(uint8_t bus, uint8_t addr, uint8_t setting)
+{
+	I3C_MSG i3c_msg = { 0 };
+	int ret = 0;
+	uint8_t cmd_unprotect[2] = { RG3MXXB12_PROTECTION_REG, 0x69 };
+	uint8_t cmd_protect[2] = { RG3MXXB12_PROTECTION_REG, 0x00 };
+
+	i3c_msg.bus = bus;
+	i3c_msg.target_addr = addr;
+	i3c_msg.tx_len = 2;
+	memcpy(&i3c_msg.data, cmd_unprotect, 2);
+	if (!i3c_controller_write(&i3c_msg)) {
+		LOG_ERR("Failed to unprotect slave port register");
+		ret = false;
+		goto out;
+	}
+
+	memset(&i3c_msg.data, 0, 2);
+	i3c_msg.tx_len = 2;
+	i3c_msg.data[0] = RG3MXXB12_SLAVE_PORT_ENABLE;
+	i3c_msg.data[1] = setting;
+	if (!i3c_controller_write(&i3c_msg)) {
+		LOG_ERR("Failed to set slave port settings");
+		ret = false;
+		goto out;
+	}
+
+	ret = true;
+out:
+	memset(&i3c_msg.data, 0, 2);
+	i3c_msg.tx_len = 2;
+	memcpy(&i3c_msg.data, cmd_protect, 2);
+	if (!i3c_controller_write(&i3c_msg)) {
+		goto out;
 	}
 
 	return ret;

--- a/common/hal/hal_i3c.h
+++ b/common/hal/hal_i3c.h
@@ -114,4 +114,6 @@ int i3c_transfer(I3C_MSG *msg);
 int i3c_brocast_ccc(I3C_MSG *msg, uint8_t ccc_id, uint8_t ccc_addr);
 int i3c_spd_reg_read(I3C_MSG *msg, bool is_nvm);
 
+int i3c_controller_write(I3C_MSG *msg);
+
 #endif


### PR DESCRIPTION
# Description:
- Add rg3mxxb12_i3c_mode_init function for rg3mxxb12 device to support i3c mode of Hub
- Add rg3mxxb12_set_slave_port function to enable and disable slave port
- Add i3c_controller_write function to send data to target device

# Motivation:
- To support i3c mode for rg3mxxb12 Hub
- For different project to set their own slave port

# Test Plan:
- According to the i3c circuit of GL, trasmit the message from the controller BIC to the DIMM

                                      --------------
                                   ---|DIMM A/D/C/D|
----------------      ---------    |  --------------
|Controller BIC|------|I3C Hub|----|
----------------      --------     |  --------------
                                   ---|DIMM E/F/G/H|
                                      --------------

# Test Log:
uart:~$ i3c xfer I3C_3 -a 0x70 -w 0x10,0x69
Private transfer to address 0x70

uart:~$ i3c xfer I3C_3 -a 0x70 -w 0x12,0x7F
Private transfer to address 0x70

uart:~$ i3c xfer I3C_3 -a 0x70 -w 0x12 -r 1
Private transfer to address 0x70

00000000: 7f                                               |.                |
uart:~$ i3c xfer I3C_3 -a 0x70 -w 0x10,0x00
Private transfer to address 0x70

uart:~$ i3c attach I3C_3 -a 0x48 -m 0
Attach address 0x48 to I3C_3

uart:~$ i3c xfer I3C_3 -a 0x48 -w 0x0C -r 1
Private transfer to address 0x48

00000000: 09