### PR TITLE
ol2: op: Modify ADC port in DVT

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.c
@@ -519,12 +519,27 @@ void pal_extend_sensor_config()
 {
 	uint8_t sensor_count = 0;
 	uint8_t card_type = get_card_type();
+	uint8_t board_revision = get_board_revision();
+	uint8_t card_position = get_card_position();
+	uint8_t sensor_number_p1v8_adc = SENSOR_NUM_1OU_P1V8_ADC_VOLT;
+	uint8_t sensor_number_p1v2_adc = SENSOR_NUM_1OU_P1V2_ADC_VOLT;
+	if (card_position == CARD_POSITION_3OU) {
+		sensor_number_p1v8_adc += ((CARD_POSITION_3OU - CARD_POSITION_1OU) * SENSOR_NUMBER_INTERVAL);
+		sensor_number_p1v2_adc += ((CARD_POSITION_3OU - CARD_POSITION_1OU) * SENSOR_NUMBER_INTERVAL);
+	}
 
 	switch (card_type) {
 	case CARD_TYPE_OPA:
-
 		sensor_count = ARRAY_SIZE(plat_expansion_A_sensor_config);
 		for (int index = 0; index < sensor_count; index++) {
+			if (board_revision != EVT_STAGE) {
+				if (sensor_config[index].num == sensor_number_p1v8_adc) {
+					sensor_config[index].port = ADC_PORT11;
+				}
+				if (sensor_config[index].num == sensor_number_p1v2_adc) {
+					sensor_config[index].port = ADC_PORT14;
+				}
+			}
 			add_sensor_config(plat_expansion_A_sensor_config[index]);
 		}
 		break;


### PR DESCRIPTION
# Description:
Modify ADC port of P1V2 and P1V8.

# Motivation:
P1V2 and P1V8 ADC ports are changed since DVT.

# Test Plan:
1. Build and test pass on OLP2.0 system. pass

2. Get sensor reading root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :   28.00 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :   31.00 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :   24.20 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) : NA | (na)
MB_DIMMA0_TEMP_C             (0x5) : NA | (na)
MB_DIMMA1_TEMP_C             (0x6) : NA | (na)
MB_DIMMA2_TEMP_C             (0x7) : NA | (na)
MB_DIMMA4_TEMP_C             (0x8) : NA | (na)
MB_DIMMA6_TEMP_C             (0x9) : NA | (na)
MB_DIMMA7_TEMP_C             (0xA) : NA | (na)
MB_DIMMA8_TEMP_C             (0xB) : NA | (na)
MB_DIMMA10_TEMP_C            (0xC) : NA | (na)
MB_SSD0_M2A_TEMP_C           (0xD) : NA | (na)
MB_HSC_TEMP_C                (0xE) :   30.00 C     | (ok)
MB_VR_CPU0_TEMP_C            (0xF) :   37.00 C     | (ok)
MB_VR_SOC_TEMP_C             (0x10) :   39.00 C     | (ok)
MB_VR_CPU1_TEMP_C            (0x11) :   35.00 C     | (ok)
MB_VR_PVDDIO_TEMP_C          (0x12) :   35.00 C     | (ok)
MB_VR_PVDD11_TEMP_C          (0x13) :   34.00 C     | (ok)
MB_ADC_P12V_STBY_VOLT_V      (0x14) :   12.35 Volts | (ok)
MB_ADC_PVDD18_S5_VOLT_V      (0x15) :    1.82 Volts | (ok)
MB_ADC_P3V3_STBY_VOLT_V      (0x16) :    3.30 Volts | (ok)
MB_ADC_PVDD11_S3_VOLT_V      (0x17) :    1.10 Volts | (ok)
MB_ADC_P3V_BAT_VOLT_V        (0x18) :    2.99 Volts | (ok)
MB_ADC_PVDD33_S5_VOLT_V      (0x19) :    3.31 Volts | (ok)
MB_ADC_P5V_STBY_VOLT_V       (0x1A) :    4.98 Volts | (ok)
MB_ADC_P12V_MEM_1_VOLT_V     (0x1B) :   12.29 Volts | (ok)
MB_ADC_P12V_MEM_0_VOLT_V     (0x1C) :   12.29 Volts | (ok)
MB_ADC_P1V2_STBY_VOLT_V      (0x1D) :    1.20 Volts | (ok)
MB_ADC_P3V3_M2_VOLT_V        (0x1E) :    3.28 Volts | (ok)
MB_ADC_P1V8_STBY_VOLT_V      (0x1F) :    1.80 Volts | (ok)
MB_HSC_INPUT_VOLT_V          (0x20) :   12.38 Volts | (ok)
MB_VR_CPU0_VOLT_V            (0x21) :    0.90 Volts | (ok)
MB_VR_SOC_VOLT_V             (0x22) :    1.01 Volts | (ok)
MB_VR_CPU1_VOLT_V            (0x23) :    0.90 Volts | (ok)
MB_VR_PVDDIO_VOLT_V          (0x24) :    1.10 Volts | (ok)
MB_VR_PVDD11_VOLT_V          (0x25) :    1.10 Volts | (ok)
HSC_OUTPUT_CURR_A            (0x26) :    8.20 Amps  | (ok)
MB_VR_CPU0_CURR_A            (0x27) :    2.10 Amps  | (ok)
MB_VR_SOC_CURR_A             (0x28) :   35.60 Amps  | (ok)
MB_VR_CPU1_CURR_A            (0x29) :    4.70 Amps  | (ok)
MB_VR_PVDDIO_CURR_A          (0x2A) :   18.70 Amps  | (ok)
MB_VR_PVDD11_CURR_A          (0x2B) :    1.90 Amps  | (ok)
MB_HSC_INPUT_PWR_W           (0x2C) :  102.92 Watts | (ok)
MB_VR_CPU0_PWR_W             (0x2D) :    2.00 Watts | (ok)
MB_VR_SOC_PWR_W              (0x2E) :   35.00 Watts | (ok)
MB_VR_CPU1_PWR_W             (0x2F) :    4.00 Watts | (ok)
MB_VR_PVDDIO_PWR_W           (0x30) :   20.00 Watts | (ok)
MB_VR_PVDD11_PWR_W           (0x31) :    1.00 Watts | (ok)
MB_SOC_PACKAGE_PWR_W         (0x32) : NA | (na)
MB_VR_DIMMA0_PMIC_PWR_W      (0x33) : NA | (na)
MB_VR_DIMMA1_PMIC_PWR_W      (0x34) : NA | (na)
MB_VR_DIMMA2_PMIC_PWR_W      (0x35) : NA | (na)
MB_VR_DIMMA4_PMIC_PWR_W      (0x36) : NA | (na)
MB_VR_DIMMA6_PMIC_PWR_W      (0x37) : NA | (na)
MB_VR_DIMMA7_PMIC_PWR_W      (0x38) : NA | (na)
MB_VR_DIMMA8_PMIC_PWR_W      (0x39) : NA | (na)
MB_VR_DIMMA10_PMIC_PWR_W     (0x3A) : NA | (na)
1OU_BIC_TEMP_C               (0x40) :   25.00 C     | (ok)
1OU_E1S_SSD0_P12V_VOLT_V     (0x41) :   12.34 Volts | (ok)
1OU_E1S_SSD1_P12V_VOLT_V     (0x42) :   12.34 Volts | (ok)
1OU_E1S_SSD2_P12V_VOLT_V     (0x43) :   12.34 Volts | (ok)
1OU_BIC_P12V_EDGE_VOLT_V     (0x46) :   12.34 Volts | (ok)
1OU_E1S_ADC_SSD0_P3V3_VOLT_V (0x47) :    3.29 Volts | (ok)
1OU_E1S_ADC_SSD1_P3V3_VOLT_V (0x48) :    3.29 Volts | (ok)
1OU_E1S_ADC_SSD2_P3V3_VOLT_V (0x49) :    3.29 Volts | (ok)
1OU_ADC_P3V3_STBY_VOLT_V     (0x4C) :    3.29 Volts | (ok)
1OU_ADC_P1V8_VOLT_V          (0x4D) :    1.82 Volts | (ok)
1OU_ADC_P0V9_VOLT_V          (0x4E) :    0.90 Volts | (ok)
1OU_ADC_P1V2_VOLT_V          (0x4F) :    1.20 Volts | (ok)
1OU_E1S_SSD0_P12V_CURR_A     (0x50) :    0.31 Amps  | (ok)
1OU_E1S_SSD1_P12V_CURR_A     (0x51) :    0.31 Amps  | (ok)
1OU_E1S_SSD2_P12V_CURR_A     (0x52) :    0.32 Amps  | (ok)
1OU_E1S_P12V_EDGE_CURR_A     (0x55) :    1.65 Amps  | (ok)
1OU_E1S_SSD0_P12V_PWR_W      (0x56) :    3.78 Watts | (ok)
1OU_E1S_SSD1_P12V_PWR_W      (0x57) :    3.90 Watts | (ok)
1OU_E1S_SSD2_P12V_PWR_W      (0x58) :    3.97 Watts | (ok)
1OU_E1S_P12V_EDGE_PWR_W      (0x5B) :   20.33 Watts | (ok)
1OU_RETIMER_TEMP_C           (0x61) :   43.76 C     | (ok)
1OU_E1S_SSD0_TEMP_C          (0x5C) :   24.00 C     | (ok)
1OU_E1S_SSD1_TEMP_C          (0x5D) :   24.00 C     | (ok)
1OU_E1S_SSD2_TEMP_C          (0x5E) :   24.00 C     | (ok)
2OU_BIC_TEMP_C               (0x70) :   25.00 C     | (ok)
2OU_E1S_SSD0_P12V_VOLT_V     (0x71) :   12.36 Volts | (ok)
2OU_E1S_SSD1_P12V_VOLT_V     (0x72) :   12.35 Volts | (ok)
2OU_E1S_SSD2_P12V_VOLT_V     (0x73) :   12.35 Volts | (ok)
2OU_E1S_SSD3_P12V_VOLT_V     (0x74) :   12.36 Volts | (ok)
2OU_E1S_SSD4_P12V_VOLT_V     (0x75) :   12.36 Volts | (ok)
2OU_BIC_MAIN_P12V_VOLT_V     (0x76) :   12.36 Volts | (ok)
2OU_E1S_ADC_SSD0_P3V3_VOLT_V (0x77) :    3.33 Volts | (ok)
2OU_E1S_ADC_SSD1_P3V3_VOLT_V (0x78) :    3.34 Volts | (ok)
2OU_E1S_ADC_SSD2_P3V3_VOLT_V (0x79) :    3.34 Volts | (ok)
2OU_E1S_ADC_SSD3_P3V3_VOLT_V (0x7A) :    3.33 Volts | (ok)
2OU_E1S_ADC_SSD4_P3V3_VOLT_V (0x7B) :    3.33 Volts | (ok)
2OU_ADC_P3V3_STBY_VOLT_V     (0x7C) :    3.33 Volts | (ok)
2OU_ADC_P1V8_VOLT_V          (0x7D) :    1.81 Volts | (ok)
2OU_ADC_P1V2_VOLT_V          (0x7F) :    1.18 Volts | (ok)
2OU_E1S_SSD0_P12V_CURR_A     (0x80) :    0.30 Amps  | (ok)
2OU_E1S_SSD1_P12V_CURR_A     (0x81) :    0.30 Amps  | (ok)
2OU_E1S_SSD2_P12V_CURR_A     (0x82) :    0.30 Amps  | (ok)
2OU_E1S_SSD3_P12V_CURR_A     (0x83) :    0.31 Amps  | (ok)
2OU_E1S_SSD4_P12V_CURR_A     (0x84) :    0.31 Amps  | (ok)
2OU_BIC_MAIN_P12V_CURR_A     (0x85) :    2.65 Amps  | (ok)
2OU_E1S_SSD0_P12V_PWR_W      (0x86) :    3.67 Watts | (ok)
2OU_E1S_SSD1_P12V_PWR_W      (0x87) :    3.67 Watts | (ok)
2OU_E1S_SSD2_P12V_PWR_W      (0x88) :    3.80 Watts | (ok)
2OU_E1S_SSD3_P12V_PWR_W      (0x89) :    3.85 Watts | (ok)
2OU_E1S_SSD4_P12V_PWR_W      (0x8A) :    3.85 Watts | (ok)
2OU_BIC_MAIN_P12V_PWR_W      (0x8B) :   32.80 Watts | (ok)
2OU_E1S_SSD0_TEMP_C          (0x8C) :   24.00 C     | (ok)
2OU_E1S_SSD1_TEMP_C          (0x8D) :   26.00 C     | (ok)
2OU_E1S_SSD2_TEMP_C          (0x8E) :   24.00 C     | (ok)
2OU_E1S_SSD3_TEMP_C          (0x8F) :   25.00 C     | (ok)
2OU_E1S_SSD4_TEMP_C          (0x90) :   24.00 C     | (ok)