### PR TITLE
ol2: op: Version commit for op-v2023.32.01

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_version.h
+++ b/meta-facebook/op2-op/src/platform/plat_version.h
@@ -21,7 +21,7 @@
 
 #define PLATFORM_NAME "Olympic 2.0"
 #define PROJECT_NAME "Olmsted Point"
-#define PROJECT_STAGE EVT
+#define PROJECT_STAGE DVT
 
 /*
  * 0x01 mother board
@@ -32,7 +32,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x09
+#define FIRMWARE_REVISION_2 0x01
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -41,7 +41,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x23
-#define BIC_FW_WEEK 0x30
+#define BIC_FW_WEEK 0x32
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x6f // char: o
 #define BIC_FW_platform_1 0x70 // char: p


### PR DESCRIPTION
# Description
- Version commit for op-v2023.32.01

# Motivation
- Version commit for op-v2023.32.01

# Test Plan:
1. Build and test pass on OLP2.0 system Pass

2. Get version
1. Get all expansion card fw version. root@bmc-oob:~# fw-util slot1 --version 1ou_bic
1OU Bridge-IC Version: oby35-op-v2023.32.01
root@bmc-oob:~# fw-util slot1 --version 2ou_bic
2OU Bridge-IC Version: oby35-op-v2023.32.01
root@bmc-oob:~# fw-util slot1 --version 3ou_bic
3OU Bridge-IC Version: oby35-op-v2023.32.01
root@bmc-oob:~# fw-util slot1 --version 4ou_bic
4OU Bridge-IC Version: oby35-op-v2023.32.01