### PR TITLE
ol2: op: fix gpio persistance

### DIFF
--- a/meta-facebook/op2-op/boards/ast1030_evb.overlay
+++ b/meta-facebook/op2-op/boards/ast1030_evb.overlay
@@ -99,6 +99,10 @@
 	status = "okay";
 };
 
+&gpio0_q_t {
+	aspeed,persist-maps = <0x00000004>;
+};
+
 &fmc_cs0 {
 	status = "okay";
 	spi-max-buswidth = <4>;


### PR DESCRIPTION
# Description:
Add gpio persistence for GPIOQ2

# Motivation:
To avoid OPB_BIC_MAIN_PWR_EN_R been reset to input after BIC reset.

# Test Plan:
1. Build and test pass on OLP2.0 system. pass

2. Check power status after BIC reset. Check device status after bic reset..
root@bmc-oob:~# enclosure-util slot1 --drive-health slot1-1U-dev0 : Normal
slot1-1U-dev1 : Normal
slot1-1U-dev2 : Normal
slot1-2U-dev0 : Normal
slot1-2U-dev1 : Normal
slot1-2U-dev2 : Normal
slot1-2U-dev3 : Normal
slot1-2U-dev4 : Normal
slot1-3U-dev0 : Normal
slot1-3U-dev1 : Normal
slot1-3U-dev2 : Normal
slot1-4U-dev0 : Normal
slot1-4U-dev1 : Normal
slot1-4U-dev2 : Normal
slot1-4U-dev3 : Normal
slot1-4U-dev4 : Normal