### PR TITLE
artemis: support BIC pldm update

### DIFF
--- a/common/service/pldm/pldm_firmware_update.c
+++ b/common/service/pldm/pldm_firmware_update.c
@@ -420,12 +420,7 @@ void req_fw_update_handler(void *mctp_p, void *ext_params, void *arg)
 	pldm_fw_update_param_t update_param = { 0 };
 	update_param.comp_id = cur_update_comp_id;
 	update_param.comp_version_str = cur_update_comp_str;
-	if (cur_update_comp_id < comp_config_count)
-		update_param.inf = fw_info->inf;
-	else {
-		LOG_ERR("Given component id %d doesn't exist in config table", cur_update_comp_id);
-		return;
-	}
+	update_param.inf = fw_info->inf;
 
 	/* do pre-update */
 	if (fw_info->pre_update_func) {

--- a/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <logging/log.h>
+
+#include "libutil.h"
+#include "util_spi.h"
+#include "hal_jtag.h"
+#include "sensor.h"
+#include "pldm_firmware_update.h"
+#include "plat_pldm_fw_update.h"
+#include "plat_ipmi.h"
+#include "plat_gpio.h"
+#include "plat_i2c.h"
+#include "plat_sensor_table.h"
+#include "plat_hook.h"
+#include "plat_class.h"
+
+LOG_MODULE_REGISTER(plat_fwupdate);
+
+/* PLDM FW update table */
+pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = CB_COMPNT_BIC,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = pldm_bic_update,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_SPI,
+		.activate_method = COMP_ACT_SELF,
+		.self_act_func = pldm_bic_activate,
+		.get_fw_version_fn = NULL,
+	},
+};
+
+void load_pldmupdate_comp_config(void)
+{
+	if (comp_config) {
+		LOG_WRN("PLDM update component table has already been load");
+		return;
+	}
+
+	comp_config_count = ARRAY_SIZE(PLDMUPDATE_FW_CONFIG_TABLE);
+	comp_config = malloc(sizeof(pldm_fw_update_info_t) * comp_config_count);
+	if (!comp_config) {
+		LOG_ERR("comp_config malloc failed");
+		return;
+	}
+
+	memcpy(comp_config, PLDMUPDATE_FW_CONFIG_TABLE, sizeof(PLDMUPDATE_FW_CONFIG_TABLE));
+}
+
+void clear_pending_version(uint8_t activate_method)
+{
+	if (!comp_config || !comp_config_count) {
+		LOG_ERR("Component configuration is empty");
+		return;
+	}
+
+	for (uint8_t i = 0; i < comp_config_count; i++) {
+		if (comp_config[i].activate_method == activate_method)
+			SAFE_FREE(comp_config[i].pending_version_p);
+	}
+}

--- a/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.h
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _PLAT_FWUPDATE_H_
+#define _PLAT_FWUPDATE_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "pldm_firmware_update.h"
+
+void load_pldmupdate_comp_config(void);
+void clear_pending_version(uint8_t activate_method);
+
+#endif /* _PLAT_FWUPDATE_H_ */

--- a/meta-facebook/at-mc/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/at-mc/src/platform/plat_pldm_fw_update.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <logging/log.h>
+
+#include "libutil.h"
+#include "util_spi.h"
+#include "sensor.h"
+#include "pldm_firmware_update.h"
+#include "plat_pldm_fw_update.h"
+#include "plat_ipmi.h"
+#include "plat_gpio.h"
+#include "plat_i2c.h"
+#include "plat_sensor_table.h"
+#include "plat_hook.h"
+#include "plat_class.h"
+
+LOG_MODULE_REGISTER(plat_fwupdate);
+
+/* PLDM FW update table */
+pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = MC_COMPNT_BIC,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = pldm_bic_update,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_SPI,
+		.activate_method = COMP_ACT_SELF,
+		.self_act_func = pldm_bic_activate,
+		.get_fw_version_fn = NULL,
+	},
+};
+
+void load_pldmupdate_comp_config(void)
+{
+	if (comp_config) {
+		LOG_WRN("PLDM update component table has already been load");
+		return;
+	}
+
+	comp_config_count = ARRAY_SIZE(PLDMUPDATE_FW_CONFIG_TABLE);
+	comp_config = malloc(sizeof(pldm_fw_update_info_t) * comp_config_count);
+	if (!comp_config) {
+		LOG_ERR("comp_config malloc failed");
+		return;
+	}
+
+	memcpy(comp_config, PLDMUPDATE_FW_CONFIG_TABLE, sizeof(PLDMUPDATE_FW_CONFIG_TABLE));
+}
+
+void clear_pending_version(uint8_t activate_method)
+{
+	if (!comp_config || !comp_config_count) {
+		LOG_ERR("Component configuration is empty");
+		return;
+	}
+
+	for (uint8_t i = 0; i < comp_config_count; i++) {
+		if (comp_config[i].activate_method == activate_method)
+			SAFE_FREE(comp_config[i].pending_version_p);
+	}
+}

--- a/meta-facebook/at-mc/src/platform/plat_pldm_fw_update.h
+++ b/meta-facebook/at-mc/src/platform/plat_pldm_fw_update.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _PLAT_FWUPDATE_H_
+#define _PLAT_FWUPDATE_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "pldm_firmware_update.h"
+
+void load_pldmupdate_comp_config(void);
+void clear_pending_version(uint8_t activate_method);
+
+#endif /* _PLAT_FWUPDATE_H_ */

--- a/scripts/signing/pldm_fw_package/platform/cfg_at_cb.json
+++ b/scripts/signing/pldm_fw_package/platform/cfg_at_cb.json
@@ -1,0 +1,33 @@
+{
+    "PlatformDescriptor": [
+        {
+            "DescriptorType" : 1,
+            "DescriptorData" : "0000A015"
+        },
+        {
+            "DescriptorType" : 65535,
+            "VendorDefinedDescriptorTitleString" : "Platform",
+            "VendorDefinedDescriptorData" : "Artemis"
+    
+        },
+        {
+            "DescriptorType" : 65535,
+            "VendorDefinedDescriptorTitleString" : "BoardID",
+            "VendorDefinedDescriptorData" : "ColterBay"
+        },
+        {
+            "DescriptorType" : 65535,
+            "VendorDefinedDescriptorTitleString" : "Stage",
+            "VendorDefinedDescriptorData" : "na"
+        }
+    ],
+    "SupportDevice" : [
+        {
+            "CompID" : [2],
+            "Vendor" : "aspeed",
+            "Device" : "ast1030",
+            "CheckSum" : "n",
+            "pkg_suffix" : ".pldm"
+        }
+    ]
+}

--- a/scripts/signing/pldm_fw_package/platform/cfg_at_mc.json
+++ b/scripts/signing/pldm_fw_package/platform/cfg_at_mc.json
@@ -1,0 +1,34 @@
+{
+    "PlatformDescriptor": [
+        {
+            "DescriptorType" : 1,
+            "DescriptorData" : "0000A015"
+        },
+        {
+            "DescriptorType" : 65535,
+            "VendorDefinedDescriptorTitleString" : "Platform",
+            "VendorDefinedDescriptorData" : "Artemis"
+    
+        },
+        {
+            "DescriptorType" : 65535,
+            "VendorDefinedDescriptorTitleString" : "BoardID",
+            "VendorDefinedDescriptorData" : "MooseCreek"
+        },
+        {
+            "DescriptorType" : 65535,
+            "VendorDefinedDescriptorTitleString" : "Stage",
+            "VendorDefinedDescriptorData" : "na"
+        }
+    ],
+    "SupportDevice" : [
+        {
+            "CompID" : [2],
+            "Vendor" : "aspeed",
+            "Device" : "ast1030",
+            "CheckSum" : "n",
+            "pkg_suffix" : ".pldm"
+        }
+    ]
+}
+

--- a/scripts/signing/pldm_fw_package/pldm_update_pkg_gen.py
+++ b/scripts/signing/pldm_fw_package/pldm_update_pkg_gen.py
@@ -199,7 +199,7 @@ if __name__ == '__main__':
         msg_hdr_print("n", "Using package file name [" + pkg_file_name + "].")
 
     if DBG_EN == True:
-        cmd_line = ["python", command_prefix, pkg_file_name, CONFIG_FILE]
+        cmd_line = ["python3", command_prefix, pkg_file_name, CONFIG_FILE]
     else:
         cmd_line = [command_prefix, pkg_file_name, CONFIG_FILE]
 


### PR DESCRIPTION
# Description
- Support ACB/MEB BIC pldm update to avoid use force for normal update.
- Modify the python command to python3 in pldm_update_pkg_gen.py.

# Motivation
- Support ACB/MEB BIC pldm update to avoid use force for normal update.

Note
Jira link: https://metainfra.atlassian.net/browse/T17GTART-156

# Test Plan
Build code: Pass

Update acb bic:
root@bmc-oob:~# fw-util cb --update bic at_cb_ast1030_v2023.31.a1.pldm RequestUpdate Success.
PassComponentTable Success.
UpdateComponent Success.
Download offset : 0x00045700/0x00045720, size : 0x00000020 TransferComplete.
VerifyComplete.
ApplyComplete.
ActivateFirmwareComplete.
Upgrade of cb : bic succeeded

Update meb bic:
root@bmc-oob:~# fw-util mc --update bic at_mc_ast1030_v2023.31.01.pldm RequestUpdate Success.
PassComponentTable Success.
UpdateComponent Success.
Download offset : 0x00045200/0x000452d8, size : 0x000000d8 TransferComplete.
VerifyComplete.
ApplyComplete.
ActivateFirmwareComplete.
Upgrade of mc : bic succeeded