### PR TITLE
fby3: vf: modify E1S_Outlet_Temp UCR from 70 to 52

### DIFF
--- a/meta-facebook/yv3-vf/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv3-vf/src/platform/plat_sdr_table.c
@@ -79,7 +79,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xFF, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x46, // UCT
+		0x34, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT


### PR DESCRIPTION
Summary:
- modify E1S Outlet Temp(0x50) UCR from 70 to 52

Test plan:
- Build code : Pass

root@bmc-oob:~# sensor-util slot1 -t 0x50
slot1:
E1S Outlet Temp              (0x50) :   27.00 C     | (ok) | UCR: 52.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA