### PR TITLE
Artemis: mc: Unlock mutex when initial CXL information fails

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_isr.c
+++ b/meta-facebook/at-mc/src/platform/plat_isr.c
@@ -146,6 +146,7 @@ void cxl_set_eid_work_handler(struct k_work *work_item)
 			ret = pal_init_pm8702_info(work_info->cxl_card_id);
 			if (ret != true) {
 				LOG_ERR("Initial cxl id: 0x%x info fail", work_info->cxl_card_id);
+				k_mutex_unlock(meb_mutex);
 				continue;
 			}
 		}


### PR DESCRIPTION
# Description
- Unlock mutex when initial CXL information fails, avoiding it permanent occupation.

# Motivation
- Unlock mutex when initial CXL information fails, avoiding it permanent occupation.

# Test Plan
- Build code: Pass
- Get CXL card sensor reading: Pass