### PR TITLE
Artemis: cb: Support to read second source sensor

### DIFF
--- a/common/dev/include/mp2985.h
+++ b/common/dev/include/mp2985.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MP2985H_H
+#define MP2985H_H
+
+bool mp2985_get_checksum(uint8_t bus, uint8_t addr, uint8_t *checksum);
+
+#endif

--- a/meta-facebook/at-cb/src/platform/plat_class.c
+++ b/meta-facebook/at-cb/src/platform/plat_class.c
@@ -39,6 +39,8 @@ LOG_MODULE_REGISTER(plat_class);
 static uint8_t board_revision = UNKNOWN_STAGE;
 static uint8_t hsc_module = HSC_MODULE_UNKNOWN;
 static uint8_t pwr_brick_module = POWER_BRICK_UNKNOWN;
+static uint8_t pwr_monitor_module = POWER_MONITOR_UNKNOWN;
+static uint8_t vr_module = VR_UNKNOWN;
 static bool is_power_good = false;
 
 struct ASIC_CARD_INFO asic_card_info[ASIC_CARD_COUNT] = {
@@ -290,6 +292,18 @@ int init_platform_config()
 		pwr_brick_module = POWER_BRICK_Q50SN120A1;
 	}
 
+	if (gpio_pin_get(gpio_dev, (POWER_MONITOR_PIN_NUM % GPIO_GROUP_SIZE))) {
+		pwr_monitor_module = POWER_MONITOR_SQ52205_INA230;
+	} else {
+		pwr_monitor_module = POWER_MONITOR_INA233_SQ52205;
+	}
+
+	if (gpio_pin_get(gpio_dev, (VR_MODULE_PIN_NUM % GPIO_GROUP_SIZE))) {
+		vr_module = VR_MP2985H;
+	} else {
+		vr_module = VR_XDPE15284D;
+	}
+
 	return 0;
 }
 
@@ -306,6 +320,16 @@ uint8_t get_hsc_module()
 uint8_t get_pwr_brick_module()
 {
 	return pwr_brick_module;
+}
+
+uint8_t get_pwr_monitor_module()
+{
+	return pwr_monitor_module;
+}
+
+uint8_t get_vr_module()
+{
+	return vr_module;
 }
 
 bool get_acb_power_status()

--- a/meta-facebook/at-cb/src/platform/plat_class.h
+++ b/meta-facebook/at-cb/src/platform/plat_class.h
@@ -25,8 +25,10 @@
 
 #define ASIC_CARD_COUNT 12
 
+#define POWER_MONITOR_PIN_NUM BOARD_ID3
 #define HSC_MODULE_PIN_NUM BOARD_ID2
 #define POWER_BRICK_MODULE_PIN_NUM BOARD_ID1
+#define VR_MODULE_PIN_NUM BOARD_ID0
 
 #define CPLD_ADDR (0xA0 >> 1)
 #define CPLD_PWRGD_1_OFFSET 0x05
@@ -63,10 +65,22 @@ enum HSC_MODULE {
 	HSC_MODULE_UNKNOWN = 0xFF,
 };
 
+enum VR_MODULE {
+	VR_XDPE15284D,
+	VR_MP2985H,
+	VR_UNKNOWN = 0xFF,
+};
+
 enum POWER_BRICK_MODULE {
 	POWER_BRICK_Q50SN120A1,
 	POWER_BRICK_BMR3512202,
 	POWER_BRICK_UNKNOWN = 0xFF,
+};
+
+enum POWER_MONITOR_MODULE {
+	POWER_MONITOR_INA233_SQ52205,
+	POWER_MONITOR_SQ52205_INA230,
+	POWER_MONITOR_UNKNOWN = 0xFF,
 };
 
 enum ASIC_CARD_STATUS {
@@ -126,7 +140,9 @@ void check_accl_device_presence_status_via_ioexp();
 int init_platform_config();
 uint8_t get_board_revision();
 uint8_t get_hsc_module();
+uint8_t get_vr_module();
 uint8_t get_pwr_brick_module();
+uint8_t get_pwr_monitor_module();
 bool get_acb_power_status();
 bool get_acb_power_good_flag();
 

--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -53,11 +53,11 @@ adm1272_init_arg adm1272_init_args[] = {
 };
 
 ltc4286_init_arg ltc4286_init_args[] = {
-	[0] = { .is_init = false, .r_sense_mohm = 0.3, .mfr_config_1 = { 0x6D72 } },
-	[1] = { .is_init = false, .r_sense_mohm = 0.3, .mfr_config_1 = { 0x6D72 } }
+	[0] = { .is_init = false, .r_sense_mohm = 0.3, .mfr_config_1 = { 0xFFFF } },
+	[1] = { .is_init = false, .r_sense_mohm = 0.3, .mfr_config_1 = { 0xFFFF } }
 };
 
-ina233_init_arg ina233_init_args[] = {
+ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001151079, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
@@ -288,12 +288,135 @@ ina233_init_arg ina233_init_args[] = {
 	},
 };
 
+sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
+        [0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+        [1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+        [2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+        [3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+        [4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+        [5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+        [6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+        [7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+        [8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+        [9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+        [10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+        [11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        .config = {
+                .operating_mode =0b111,
+                .shunt_volt_time = 0b100,
+                .bus_volt_time = 0b100,
+                .aver_mode = 0b111, //set 1024 average times
+                .rsvd = 0b000,
+                .reset_bit = 0b0,
+        },
+        },
+};
+
 pex89000_init_arg pex_sensor_init_args[] = {
 	[0] = { .idx = 0, .is_init = false },
 	[1] = { .idx = 1, .is_init = false },
 };
 
-sq52205_init_arg sq52205_init_args[] = {
+sq52205_init_arg u178_179_sq52205_init_args[] = {
 	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0010002,
 	.config = {
 		.operating_mode =0b111,
@@ -315,6 +438,33 @@ sq52205_init_arg sq52205_init_args[] = {
 	},
 	},
 };
+
+ina230_init_arg u178_179_ina230_init_args[] = {
+	[0] = { .is_init = false,
+	.config = {
+		.MODE = 0b111,
+                .VSH_CT = 0b100,
+                .VBUS_CT = 0b100,
+                .AVG = 0b111,
+        },
+        .alt_cfg.value = 0,
+        .r_shunt = 0.001,
+        .i_max = 32.768,
+	},
+	[1] = { .is_init = false,
+        .config = {
+                .MODE = 0b111,
+                .VSH_CT = 0b100,
+                .VBUS_CT = 0b100,
+                .AVG = 0b111,
+        },
+        .alt_cfg.value = 0,
+        .r_shunt = 0.001,
+        .i_max = 32.768,
+        },
+};
+
+mp2985_init_arg mp2985_init_args[] = { [0] = { .is_init = false } };
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS
@@ -460,13 +610,15 @@ bool pre_ina233_read(sensor_cfg *cfg, void *args)
 		struct k_mutex *mutex = get_i2c_mux_mutex(mux_cfg->bus);
 		mutex_status = k_mutex_lock(mutex, K_MSEC(MUTEX_LOCK_INTERVAL_MS));
 		if (mutex_status != 0) {
-			LOG_ERR("Mutex lock fail, status: %d", mutex_status);
+			LOG_ERR("Mutex lock fail, status: %d, card id: 0x%x", mutex_status,
+				pre_args->card_id);
 			return false;
 		}
 
 		ret = set_mux_channel(*mux_cfg, MUTEX_LOCK_ENABLE);
 		if (ret == false) {
-			LOG_ERR("ina233 switch mux fail");
+			LOG_ERR("Switch mux fail, card id: 0x%x, sensor num: 0x%x",
+				pre_args->card_id, cfg->num);
 			k_mutex_unlock(mutex);
 		}
 
@@ -527,6 +679,7 @@ bool pre_xdpe15284_read(sensor_cfg *cfg, void *args)
 	ret = i2c_master_write(&msg, retry);
 	if (ret != 0) {
 		LOG_ERR("Set xdpe15284 page fail, ret: %d", ret);
+		k_mutex_unlock(&xdpe15284_mutex);
 		return false;
 	}
 

--- a/meta-facebook/at-cb/src/platform/plat_hook.h
+++ b/meta-facebook/at-cb/src/platform/plat_hook.h
@@ -43,9 +43,12 @@ typedef struct _accl_card_sensor_info {
 extern adc_asd_init_arg adc_asd_init_args[];
 extern adm1272_init_arg adm1272_init_args[];
 extern ltc4286_init_arg ltc4286_init_args[];
-extern ina233_init_arg ina233_init_args[];
+extern ina233_init_arg accl_pwr_monitor_ina233_init_args[];
+extern sq52205_init_arg accl_pwr_monitor_sq52205_init_args[];
 extern pex89000_init_arg pex_sensor_init_args[];
-extern sq52205_init_arg sq52205_init_args[];
+extern sq52205_init_arg u178_179_sq52205_init_args[];
+extern ina230_init_arg u178_179_ina230_init_args[];
+extern mp2985_init_arg mp2985_init_args[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS

--- a/meta-facebook/at-cb/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-cb/src/platform/plat_sensor_table.c
@@ -83,41 +83,6 @@ sensor_cfg plat_sensor_config[] = {
 	  1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 
-	/** VR **/
-	{ SENSOR_NUM_TEMP_P0V8_VDD_1, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
-	  PMBUS_READ_TEMPERATURE_1, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0],
-	  post_xdpe15284_read, NULL, NULL },
-	{ SENSOR_NUM_VOL_P0V8_VDD_1, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0],
-	  post_xdpe15284_read, NULL, NULL },
-	{ SENSOR_NUM_CUR_P0V8_VDD_1, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0],
-	  post_xdpe15284_read, NULL, NULL },
-	{ SENSOR_NUM_PWR_P0V8_VDD_1, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
-	  PMBUS_READ_POUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0],
-	  post_xdpe15284_read, NULL, NULL },
-
-	{ SENSOR_NUM_TEMP_P0V8_VDD_2, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
-	  PMBUS_READ_TEMPERATURE_1, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1],
-	  post_xdpe15284_read, NULL, NULL },
-	{ SENSOR_NUM_VOL_P0V8_VDD_2, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1],
-	  post_xdpe15284_read, NULL, NULL },
-	{ SENSOR_NUM_CUR_P0V8_VDD_2, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1],
-	  post_xdpe15284_read, NULL, NULL },
-	{ SENSOR_NUM_PWR_P0V8_VDD_2, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
-	  PMBUS_READ_POUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1],
-	  post_xdpe15284_read, NULL, NULL },
-
 	/** PEX temp **/
 	{ SENSOR_NUM_TEMP_PEX_0, sensor_dev_pex89000, I2C_BUS2, PEX89144_I2CS_ADDR, PEX_TEMP,
 	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
@@ -127,200 +92,6 @@ sensor_cfg plat_sensor_config[] = {
 	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_pex89000_read, &tca9543_configs[1], NULL, NULL,
 	  &pex_sensor_init_args[1] },
-
-	/** SQ52205 **/
-	{ SENSOR_NUM_VOL_P12V_1_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_1_ADDR,
-	  SQ52205_READ_VOL_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &sq52205_init_args[0] },
-	{ SENSOR_NUM_CUR_P12V_1_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_1_ADDR,
-	  SQ52205_READ_CUR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &sq52205_init_args[0] },
-	{ SENSOR_NUM_PWR_P12V_1_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_1_ADDR,
-	  SQ52205_READ_PWR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &sq52205_init_args[0] },
-	{ SENSOR_NUM_VOL_P12V_2_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_2_ADDR,
-	  SQ52205_READ_VOL_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &sq52205_init_args[1] },
-	{ SENSOR_NUM_CUR_P12V_2_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_2_ADDR,
-	  SQ52205_READ_CUR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &sq52205_init_args[1] },
-	{ SENSOR_NUM_PWR_P12V_2_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_2_ADDR,
-	  SQ52205_READ_PWR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
-	  &sq52205_init_args[1] },
-
-	/** INA233 12V 1 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_1, sensor_dev_ina233, I2C_BUS4, INA233_12V_1_7_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[0],
-	  post_ina233_read, &pwr_monitor_args[0], &ina233_init_args[0] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_1, sensor_dev_ina233, I2C_BUS4, INA233_12V_1_7_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[0],
-	  post_ina233_read, &pwr_monitor_args[0], &ina233_init_args[0] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_1, sensor_dev_ina233, I2C_BUS4, INA233_12V_1_7_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[0],
-	  post_ina233_read, &pwr_monitor_args[0], &ina233_init_args[0] },
-
-	/** INA233 12V 2 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_2, sensor_dev_ina233, I2C_BUS4, INA233_12V_2_8_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[1],
-	  post_ina233_read, &pwr_monitor_args[1], &ina233_init_args[1] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_2, sensor_dev_ina233, I2C_BUS4, INA233_12V_2_8_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[1],
-	  post_ina233_read, &pwr_monitor_args[1], &ina233_init_args[1] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_2, sensor_dev_ina233, I2C_BUS4, INA233_12V_2_8_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[1],
-	  post_ina233_read, &pwr_monitor_args[1], &ina233_init_args[1] },
-
-	/** INA233 12V 3 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_3, sensor_dev_ina233, I2C_BUS4, INA233_12V_3_9_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[2],
-	  post_ina233_read, &pwr_monitor_args[2], &ina233_init_args[2] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_3, sensor_dev_ina233, I2C_BUS4, INA233_12V_3_9_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[2],
-	  post_ina233_read, &pwr_monitor_args[2], &ina233_init_args[2] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_3, sensor_dev_ina233, I2C_BUS4, INA233_12V_3_9_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[2],
-	  post_ina233_read, &pwr_monitor_args[2], &ina233_init_args[2] },
-
-	/** INA233 12V 4 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_4, sensor_dev_ina233, I2C_BUS4, INA233_12V_4_10_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[3],
-	  post_ina233_read, &pwr_monitor_args[3], &ina233_init_args[3] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_4, sensor_dev_ina233, I2C_BUS4, INA233_12V_4_10_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[3],
-	  post_ina233_read, &pwr_monitor_args[3], &ina233_init_args[3] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_4, sensor_dev_ina233, I2C_BUS4, INA233_12V_4_10_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[3],
-	  post_ina233_read, &pwr_monitor_args[3], &ina233_init_args[3] },
-
-	/** INA233 12V 5 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_5, sensor_dev_ina233, I2C_BUS4, INA233_12V_5_11_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[4],
-	  post_ina233_read, &pwr_monitor_args[4], &ina233_init_args[4] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_5, sensor_dev_ina233, I2C_BUS4, INA233_12V_5_11_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[4],
-	  post_ina233_read, &pwr_monitor_args[4], &ina233_init_args[4] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_5, sensor_dev_ina233, I2C_BUS4, INA233_12V_5_11_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[4],
-	  post_ina233_read, &pwr_monitor_args[4], &ina233_init_args[4] },
-
-	/** INA233 12V 6 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_6, sensor_dev_ina233, I2C_BUS4, INA233_12V_12_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[5],
-	  post_ina233_read, &pwr_monitor_args[5], &ina233_init_args[5] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_6, sensor_dev_ina233, I2C_BUS4, INA233_12V_12_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[5],
-	  post_ina233_read, &pwr_monitor_args[5], &ina233_init_args[5] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_6, sensor_dev_ina233, I2C_BUS4, INA233_12V_12_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[5],
-	  post_ina233_read, &pwr_monitor_args[5], &ina233_init_args[5] },
-
-	/** INA233 12V 7 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_7, sensor_dev_ina233, I2C_BUS9, INA233_12V_1_7_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[6],
-	  post_ina233_read, &pwr_monitor_args[6], &ina233_init_args[6] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_7, sensor_dev_ina233, I2C_BUS9, INA233_12V_1_7_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[6],
-	  post_ina233_read, &pwr_monitor_args[6], &ina233_init_args[6] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_7, sensor_dev_ina233, I2C_BUS9, INA233_12V_1_7_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[6],
-	  post_ina233_read, &pwr_monitor_args[6], &ina233_init_args[6] },
-
-	/** INA233 12V 8 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_8, sensor_dev_ina233, I2C_BUS9, INA233_12V_2_8_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[7],
-	  post_ina233_read, &pwr_monitor_args[7], &ina233_init_args[7] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_8, sensor_dev_ina233, I2C_BUS9, INA233_12V_2_8_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[7],
-	  post_ina233_read, &pwr_monitor_args[7], &ina233_init_args[7] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_8, sensor_dev_ina233, I2C_BUS9, INA233_12V_2_8_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[7],
-	  post_ina233_read, &pwr_monitor_args[7], &ina233_init_args[7] },
-
-	/** INA233 12V 9 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_9, sensor_dev_ina233, I2C_BUS9, INA233_12V_3_9_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[8],
-	  post_ina233_read, &pwr_monitor_args[8], &ina233_init_args[8] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_9, sensor_dev_ina233, I2C_BUS9, INA233_12V_3_9_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[8],
-	  post_ina233_read, &pwr_monitor_args[8], &ina233_init_args[8] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_9, sensor_dev_ina233, I2C_BUS9, INA233_12V_3_9_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[8],
-	  post_ina233_read, &pwr_monitor_args[8], &ina233_init_args[8] },
-
-	/** INA233 12V 10 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_10, sensor_dev_ina233, I2C_BUS9, INA233_12V_4_10_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[9],
-	  post_ina233_read, &pwr_monitor_args[9], &ina233_init_args[9] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_10, sensor_dev_ina233, I2C_BUS9, INA233_12V_4_10_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[9],
-	  post_ina233_read, &pwr_monitor_args[9], &ina233_init_args[9] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_10, sensor_dev_ina233, I2C_BUS9, INA233_12V_4_10_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[9],
-	  post_ina233_read, &pwr_monitor_args[9], &ina233_init_args[9] },
-
-	/** INA233 12V 11 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_11, sensor_dev_ina233, I2C_BUS9, INA233_12V_5_11_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[10],
-	  post_ina233_read, &pwr_monitor_args[10], &ina233_init_args[10] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_11, sensor_dev_ina233, I2C_BUS9, INA233_12V_5_11_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[10],
-	  post_ina233_read, &pwr_monitor_args[10], &ina233_init_args[10] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_11, sensor_dev_ina233, I2C_BUS9, INA233_12V_5_11_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[10],
-	  post_ina233_read, &pwr_monitor_args[10], &ina233_init_args[10] },
-
-	/** INA233 12V 12 **/
-	{ SENSOR_NUM_VOL_P12V_ACCL_12, sensor_dev_ina233, I2C_BUS9, INA233_12V_12_ADDR,
-	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[11],
-	  post_ina233_read, &pwr_monitor_args[11], &ina233_init_args[11] },
-	{ SENSOR_NUM_CUR_P12V_ACCL_12, sensor_dev_ina233, I2C_BUS9, INA233_12V_12_ADDR,
-	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[11],
-	  post_ina233_read, &pwr_monitor_args[11], &ina233_init_args[11] },
-	{ SENSOR_NUM_PWR_P12V_ACCL_12, sensor_dev_ina233, I2C_BUS9, INA233_12V_12_ADDR,
-	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[11],
-	  post_ina233_read, &pwr_monitor_args[11], &ina233_init_args[11] },
 
 	/** ACCL card 1 **/
 	{ SENSOR_NUM_TEMP_ACCL_1_FREYA_1, sensor_dev_nvme, I2C_BUS8, ACCL_FREYA_1_ADDR,
@@ -785,6 +556,470 @@ sensor_cfg bmr351_sensor_config_table[] = {
 	{ SENSOR_NUM_PWR_P12V_AUX_2, sensor_dev_bmr351, I2C_BUS1, POWER_BRICK_2_ADDR,
 	  PMBUS_READ_POUT, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+};
+
+sensor_cfg vr_xdpe15284_sensor_config_table[] = {
+	{ SENSOR_NUM_TEMP_P0V8_VDD_1, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0],
+	  post_xdpe15284_read, NULL, NULL },
+	{ SENSOR_NUM_VOL_P0V8_VDD_1, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0],
+	  post_xdpe15284_read, NULL, NULL },
+	{ SENSOR_NUM_CUR_P0V8_VDD_1, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0],
+	  post_xdpe15284_read, NULL, NULL },
+	{ SENSOR_NUM_PWR_P0V8_VDD_1, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
+	  PMBUS_READ_POUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0],
+	  post_xdpe15284_read, NULL, NULL },
+
+	{ SENSOR_NUM_TEMP_P0V8_VDD_2, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1],
+	  post_xdpe15284_read, NULL, NULL },
+	{ SENSOR_NUM_VOL_P0V8_VDD_2, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1],
+	  post_xdpe15284_read, NULL, NULL },
+	{ SENSOR_NUM_CUR_P0V8_VDD_2, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1],
+	  post_xdpe15284_read, NULL, NULL },
+	{ SENSOR_NUM_PWR_P0V8_VDD_2, sensor_dev_xdpe15284, I2C_BUS1, XDPE15284D_ADDR,
+	  PMBUS_READ_POUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1],
+	  post_xdpe15284_read, NULL, NULL },
+};
+
+sensor_cfg vr_mp2985h_sensor_config_table[] = {
+	{ SENSOR_NUM_TEMP_P0V8_VDD_1, sensor_dev_mp2985, I2C_BUS1, XDPE15284D_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0],
+	  post_xdpe15284_read, NULL, &mp2985_init_args[0] },
+	{ SENSOR_NUM_VOL_P0V8_VDD_1, sensor_dev_mp2985, I2C_BUS1, XDPE15284D_ADDR, PMBUS_READ_VOUT,
+	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0], post_xdpe15284_read, NULL,
+	  &mp2985_init_args[0] },
+	{ SENSOR_NUM_CUR_P0V8_VDD_1, sensor_dev_mp2985, I2C_BUS1, XDPE15284D_ADDR, PMBUS_READ_IOUT,
+	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0], post_xdpe15284_read, NULL,
+	  &mp2985_init_args[0] },
+	{ SENSOR_NUM_PWR_P0V8_VDD_1, sensor_dev_mp2985, I2C_BUS1, XDPE15284D_ADDR, PMBUS_READ_POUT,
+	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[0], post_xdpe15284_read, NULL,
+	  &mp2985_init_args[0] },
+
+	{ SENSOR_NUM_TEMP_P0V8_VDD_2, sensor_dev_mp2985, I2C_BUS1, XDPE15284D_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1],
+	  post_xdpe15284_read, NULL, &mp2985_init_args[0] },
+	{ SENSOR_NUM_VOL_P0V8_VDD_2, sensor_dev_mp2985, I2C_BUS1, XDPE15284D_ADDR, PMBUS_READ_VOUT,
+	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1], post_xdpe15284_read, NULL,
+	  &mp2985_init_args[0] },
+	{ SENSOR_NUM_CUR_P0V8_VDD_2, sensor_dev_mp2985, I2C_BUS1, XDPE15284D_ADDR, PMBUS_READ_IOUT,
+	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1], post_xdpe15284_read, NULL,
+	  &mp2985_init_args[0] },
+	{ SENSOR_NUM_PWR_P0V8_VDD_2, sensor_dev_mp2985, I2C_BUS1, XDPE15284D_ADDR, PMBUS_READ_POUT,
+	  is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_page[1], post_xdpe15284_read, NULL,
+	  &mp2985_init_args[0] },
+};
+
+sensor_cfg power_monitor_ina233_sq52205_sensor_config_table[] = {
+	/** INA233 12V 1 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_1, sensor_dev_ina233, I2C_BUS4, INA233_12V_1_7_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[0],
+	  post_ina233_read, &pwr_monitor_args[0], &accl_pwr_monitor_ina233_init_args[0] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_1, sensor_dev_ina233, I2C_BUS4, INA233_12V_1_7_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[0],
+	  post_ina233_read, &pwr_monitor_args[0], &accl_pwr_monitor_ina233_init_args[0] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_1, sensor_dev_ina233, I2C_BUS4, INA233_12V_1_7_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[0],
+	  post_ina233_read, &pwr_monitor_args[0], &accl_pwr_monitor_ina233_init_args[0] },
+
+	/** INA233 12V 2 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_2, sensor_dev_ina233, I2C_BUS4, INA233_12V_2_8_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[1],
+	  post_ina233_read, &pwr_monitor_args[1], &accl_pwr_monitor_ina233_init_args[1] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_2, sensor_dev_ina233, I2C_BUS4, INA233_12V_2_8_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[1],
+	  post_ina233_read, &pwr_monitor_args[1], &accl_pwr_monitor_ina233_init_args[1] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_2, sensor_dev_ina233, I2C_BUS4, INA233_12V_2_8_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[1],
+	  post_ina233_read, &pwr_monitor_args[1], &accl_pwr_monitor_ina233_init_args[1] },
+
+	/** INA233 12V 3 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_3, sensor_dev_ina233, I2C_BUS4, INA233_12V_3_9_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[2],
+	  post_ina233_read, &pwr_monitor_args[2], &accl_pwr_monitor_ina233_init_args[2] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_3, sensor_dev_ina233, I2C_BUS4, INA233_12V_3_9_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[2],
+	  post_ina233_read, &pwr_monitor_args[2], &accl_pwr_monitor_ina233_init_args[2] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_3, sensor_dev_ina233, I2C_BUS4, INA233_12V_3_9_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[2],
+	  post_ina233_read, &pwr_monitor_args[2], &accl_pwr_monitor_ina233_init_args[2] },
+
+	/** INA233 12V 4 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_4, sensor_dev_ina233, I2C_BUS4, INA233_12V_4_10_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[3],
+	  post_ina233_read, &pwr_monitor_args[3], &accl_pwr_monitor_ina233_init_args[3] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_4, sensor_dev_ina233, I2C_BUS4, INA233_12V_4_10_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[3],
+	  post_ina233_read, &pwr_monitor_args[3], &accl_pwr_monitor_ina233_init_args[3] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_4, sensor_dev_ina233, I2C_BUS4, INA233_12V_4_10_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[3],
+	  post_ina233_read, &pwr_monitor_args[3], &accl_pwr_monitor_ina233_init_args[3] },
+
+	/** INA233 12V 5 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_5, sensor_dev_ina233, I2C_BUS4, INA233_12V_5_11_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[4],
+	  post_ina233_read, &pwr_monitor_args[4], &accl_pwr_monitor_ina233_init_args[4] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_5, sensor_dev_ina233, I2C_BUS4, INA233_12V_5_11_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[4],
+	  post_ina233_read, &pwr_monitor_args[4], &accl_pwr_monitor_ina233_init_args[4] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_5, sensor_dev_ina233, I2C_BUS4, INA233_12V_5_11_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[4],
+	  post_ina233_read, &pwr_monitor_args[4], &accl_pwr_monitor_ina233_init_args[4] },
+
+	/** INA233 12V 6 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_6, sensor_dev_ina233, I2C_BUS4, INA233_12V_12_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[5],
+	  post_ina233_read, &pwr_monitor_args[5], &accl_pwr_monitor_ina233_init_args[5] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_6, sensor_dev_ina233, I2C_BUS4, INA233_12V_12_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[5],
+	  post_ina233_read, &pwr_monitor_args[5], &accl_pwr_monitor_ina233_init_args[5] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_6, sensor_dev_ina233, I2C_BUS4, INA233_12V_12_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[5],
+	  post_ina233_read, &pwr_monitor_args[5], &accl_pwr_monitor_ina233_init_args[5] },
+
+	/** INA233 12V 7 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_7, sensor_dev_ina233, I2C_BUS9, INA233_12V_1_7_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[6],
+	  post_ina233_read, &pwr_monitor_args[6], &accl_pwr_monitor_ina233_init_args[6] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_7, sensor_dev_ina233, I2C_BUS9, INA233_12V_1_7_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[6],
+	  post_ina233_read, &pwr_monitor_args[6], &accl_pwr_monitor_ina233_init_args[6] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_7, sensor_dev_ina233, I2C_BUS9, INA233_12V_1_7_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[6],
+	  post_ina233_read, &pwr_monitor_args[6], &accl_pwr_monitor_ina233_init_args[6] },
+
+	/** INA233 12V 8 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_8, sensor_dev_ina233, I2C_BUS9, INA233_12V_2_8_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[7],
+	  post_ina233_read, &pwr_monitor_args[7], &accl_pwr_monitor_ina233_init_args[7] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_8, sensor_dev_ina233, I2C_BUS9, INA233_12V_2_8_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[7],
+	  post_ina233_read, &pwr_monitor_args[7], &accl_pwr_monitor_ina233_init_args[7] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_8, sensor_dev_ina233, I2C_BUS9, INA233_12V_2_8_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[7],
+	  post_ina233_read, &pwr_monitor_args[7], &accl_pwr_monitor_ina233_init_args[7] },
+
+	/** INA233 12V 9 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_9, sensor_dev_ina233, I2C_BUS9, INA233_12V_3_9_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[8],
+	  post_ina233_read, &pwr_monitor_args[8], &accl_pwr_monitor_ina233_init_args[8] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_9, sensor_dev_ina233, I2C_BUS9, INA233_12V_3_9_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[8],
+	  post_ina233_read, &pwr_monitor_args[8], &accl_pwr_monitor_ina233_init_args[8] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_9, sensor_dev_ina233, I2C_BUS9, INA233_12V_3_9_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[8],
+	  post_ina233_read, &pwr_monitor_args[8], &accl_pwr_monitor_ina233_init_args[8] },
+
+	/** INA233 12V 10 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_10, sensor_dev_ina233, I2C_BUS9, INA233_12V_4_10_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[9],
+	  post_ina233_read, &pwr_monitor_args[9], &accl_pwr_monitor_ina233_init_args[9] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_10, sensor_dev_ina233, I2C_BUS9, INA233_12V_4_10_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[9],
+	  post_ina233_read, &pwr_monitor_args[9], &accl_pwr_monitor_ina233_init_args[9] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_10, sensor_dev_ina233, I2C_BUS9, INA233_12V_4_10_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[9],
+	  post_ina233_read, &pwr_monitor_args[9], &accl_pwr_monitor_ina233_init_args[9] },
+
+	/** INA233 12V 11 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_11, sensor_dev_ina233, I2C_BUS9, INA233_12V_5_11_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[10],
+	  post_ina233_read, &pwr_monitor_args[10], &accl_pwr_monitor_ina233_init_args[10] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_11, sensor_dev_ina233, I2C_BUS9, INA233_12V_5_11_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[10],
+	  post_ina233_read, &pwr_monitor_args[10], &accl_pwr_monitor_ina233_init_args[10] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_11, sensor_dev_ina233, I2C_BUS9, INA233_12V_5_11_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[10],
+	  post_ina233_read, &pwr_monitor_args[10], &accl_pwr_monitor_ina233_init_args[10] },
+
+	/** INA233 12V 12 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_12, sensor_dev_ina233, I2C_BUS9, INA233_12V_12_ADDR,
+	  PMBUS_READ_VOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[11],
+	  post_ina233_read, &pwr_monitor_args[11], &accl_pwr_monitor_ina233_init_args[11] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_12, sensor_dev_ina233, I2C_BUS9, INA233_12V_12_ADDR,
+	  PMBUS_READ_IOUT, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[11],
+	  post_ina233_read, &pwr_monitor_args[11], &accl_pwr_monitor_ina233_init_args[11] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_12, sensor_dev_ina233, I2C_BUS9, INA233_12V_12_ADDR,
+	  PMBUS_READ_EIN, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[11],
+	  post_ina233_read, &pwr_monitor_args[11], &accl_pwr_monitor_ina233_init_args[11] },
+
+	/** SQ52205 **/
+	{ SENSOR_NUM_VOL_P12V_1_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_1_ADDR,
+	  SQ52205_READ_VOL_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_sq52205_init_args[0] },
+	{ SENSOR_NUM_CUR_P12V_1_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_1_ADDR,
+	  SQ52205_READ_CUR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_sq52205_init_args[0] },
+	{ SENSOR_NUM_PWR_P12V_1_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_1_ADDR,
+	  SQ52205_READ_PWR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_sq52205_init_args[0] },
+	{ SENSOR_NUM_VOL_P12V_2_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_2_ADDR,
+	  SQ52205_READ_VOL_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_sq52205_init_args[1] },
+	{ SENSOR_NUM_CUR_P12V_2_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_2_ADDR,
+	  SQ52205_READ_CUR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_sq52205_init_args[1] },
+	{ SENSOR_NUM_PWR_P12V_2_M_AUX, sensor_dev_sq52205, I2C_BUS2, SQ52205_P1V25_2_ADDR,
+	  SQ52205_READ_PWR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_sq52205_init_args[1] },
+};
+
+sensor_cfg power_monitor_sq52205_ina230_sensor_config_table[] = {
+	/** SQ52205 12V 1 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_1, sensor_dev_sq52205, I2C_BUS4, INA233_12V_1_7_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[0],
+	  post_ina233_read, &pwr_monitor_args[0], &accl_pwr_monitor_sq52205_init_args[0] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_1, sensor_dev_sq52205, I2C_BUS4, INA233_12V_1_7_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[0],
+	  post_ina233_read, &pwr_monitor_args[0], &accl_pwr_monitor_sq52205_init_args[0] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_1, sensor_dev_sq52205, I2C_BUS4, INA233_12V_1_7_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[0],
+	  post_ina233_read, &pwr_monitor_args[0], &accl_pwr_monitor_sq52205_init_args[0] },
+
+	/** SQ52205 12V 2 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_2, sensor_dev_sq52205, I2C_BUS4, INA233_12V_2_8_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[1],
+	  post_ina233_read, &pwr_monitor_args[1], &accl_pwr_monitor_sq52205_init_args[1] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_2, sensor_dev_sq52205, I2C_BUS4, INA233_12V_2_8_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[1],
+	  post_ina233_read, &pwr_monitor_args[1], &accl_pwr_monitor_sq52205_init_args[1] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_2, sensor_dev_sq52205, I2C_BUS4, INA233_12V_2_8_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[1],
+	  post_ina233_read, &pwr_monitor_args[1], &accl_pwr_monitor_sq52205_init_args[1] },
+
+	/** SQ52205 12V 3 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_3, sensor_dev_sq52205, I2C_BUS4, INA233_12V_3_9_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[2],
+	  post_ina233_read, &pwr_monitor_args[2], &accl_pwr_monitor_sq52205_init_args[2] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_3, sensor_dev_sq52205, I2C_BUS4, INA233_12V_3_9_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[2],
+	  post_ina233_read, &pwr_monitor_args[2], &accl_pwr_monitor_sq52205_init_args[2] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_3, sensor_dev_sq52205, I2C_BUS4, INA233_12V_3_9_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[2],
+	  post_ina233_read, &pwr_monitor_args[2], &accl_pwr_monitor_sq52205_init_args[2] },
+
+	/** SQ52205 12V 4 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_4, sensor_dev_sq52205, I2C_BUS4, INA233_12V_4_10_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[3],
+	  post_ina233_read, &pwr_monitor_args[3], &accl_pwr_monitor_sq52205_init_args[3] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_4, sensor_dev_sq52205, I2C_BUS4, INA233_12V_4_10_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[3],
+	  post_ina233_read, &pwr_monitor_args[3], &accl_pwr_monitor_sq52205_init_args[3] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_4, sensor_dev_sq52205, I2C_BUS4, INA233_12V_4_10_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[3],
+	  post_ina233_read, &pwr_monitor_args[3], &accl_pwr_monitor_sq52205_init_args[3] },
+
+	/** SQ52205 12V 5 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_5, sensor_dev_sq52205, I2C_BUS4, INA233_12V_5_11_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[4],
+	  post_ina233_read, &pwr_monitor_args[4], &accl_pwr_monitor_sq52205_init_args[4] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_5, sensor_dev_sq52205, I2C_BUS4, INA233_12V_5_11_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[4],
+	  post_ina233_read, &pwr_monitor_args[4], &accl_pwr_monitor_sq52205_init_args[4] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_5, sensor_dev_sq52205, I2C_BUS4, INA233_12V_5_11_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[4],
+	  post_ina233_read, &pwr_monitor_args[4], &accl_pwr_monitor_sq52205_init_args[4] },
+
+	/** SQ52205 12V 6 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_6, sensor_dev_sq52205, I2C_BUS4, INA233_12V_12_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[5],
+	  post_ina233_read, &pwr_monitor_args[5], &accl_pwr_monitor_sq52205_init_args[5] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_6, sensor_dev_sq52205, I2C_BUS4, INA233_12V_12_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[5],
+	  post_ina233_read, &pwr_monitor_args[5], &accl_pwr_monitor_sq52205_init_args[5] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_6, sensor_dev_sq52205, I2C_BUS4, INA233_12V_12_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[5],
+	  post_ina233_read, &pwr_monitor_args[5], &accl_pwr_monitor_sq52205_init_args[5] },
+
+	/** SQ52205 12V 7 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_7, sensor_dev_sq52205, I2C_BUS9, INA233_12V_1_7_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[6],
+	  post_ina233_read, &pwr_monitor_args[6], &accl_pwr_monitor_sq52205_init_args[6] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_7, sensor_dev_sq52205, I2C_BUS9, INA233_12V_1_7_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[6],
+	  post_ina233_read, &pwr_monitor_args[6], &accl_pwr_monitor_sq52205_init_args[6] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_7, sensor_dev_sq52205, I2C_BUS9, INA233_12V_1_7_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[6],
+	  post_ina233_read, &pwr_monitor_args[6], &accl_pwr_monitor_sq52205_init_args[6] },
+
+	/** SQ52205 12V 8 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_8, sensor_dev_sq52205, I2C_BUS9, INA233_12V_2_8_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[7],
+	  post_ina233_read, &pwr_monitor_args[7], &accl_pwr_monitor_sq52205_init_args[7] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_8, sensor_dev_sq52205, I2C_BUS9, INA233_12V_2_8_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[7],
+	  post_ina233_read, &pwr_monitor_args[7], &accl_pwr_monitor_sq52205_init_args[7] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_8, sensor_dev_sq52205, I2C_BUS9, INA233_12V_2_8_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[7],
+	  post_ina233_read, &pwr_monitor_args[7], &accl_pwr_monitor_sq52205_init_args[7] },
+
+	/** SQ52205 12V 9 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_9, sensor_dev_sq52205, I2C_BUS9, INA233_12V_3_9_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[8],
+	  post_ina233_read, &pwr_monitor_args[8], &accl_pwr_monitor_sq52205_init_args[8] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_9, sensor_dev_sq52205, I2C_BUS9, INA233_12V_3_9_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[8],
+	  post_ina233_read, &pwr_monitor_args[8], &accl_pwr_monitor_sq52205_init_args[8] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_9, sensor_dev_sq52205, I2C_BUS9, INA233_12V_3_9_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[8],
+	  post_ina233_read, &pwr_monitor_args[8], &accl_pwr_monitor_sq52205_init_args[8] },
+
+	/** SQ52205 12V 10 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_10, sensor_dev_sq52205, I2C_BUS9, INA233_12V_4_10_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[9],
+	  post_ina233_read, &pwr_monitor_args[9], &accl_pwr_monitor_sq52205_init_args[9] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_10, sensor_dev_sq52205, I2C_BUS9, INA233_12V_4_10_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[9],
+	  post_ina233_read, &pwr_monitor_args[9], &accl_pwr_monitor_sq52205_init_args[9] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_10, sensor_dev_sq52205, I2C_BUS9, INA233_12V_4_10_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[9],
+	  post_ina233_read, &pwr_monitor_args[9], &accl_pwr_monitor_sq52205_init_args[9] },
+
+	/** SQ52205 12V 11 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_11, sensor_dev_sq52205, I2C_BUS9, INA233_12V_5_11_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[10],
+	  post_ina233_read, &pwr_monitor_args[10], &accl_pwr_monitor_sq52205_init_args[10] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_11, sensor_dev_sq52205, I2C_BUS9, INA233_12V_5_11_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[10],
+	  post_ina233_read, &pwr_monitor_args[10], &accl_pwr_monitor_sq52205_init_args[10] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_11, sensor_dev_sq52205, I2C_BUS9, INA233_12V_5_11_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[10],
+	  post_ina233_read, &pwr_monitor_args[10], &accl_pwr_monitor_sq52205_init_args[10] },
+
+	/** SQ52205 12V 12 **/
+	{ SENSOR_NUM_VOL_P12V_ACCL_12, sensor_dev_sq52205, I2C_BUS9, INA233_12V_12_ADDR,
+	  SQ52205_READ_VOL_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[11],
+	  post_ina233_read, &pwr_monitor_args[11], &accl_pwr_monitor_sq52205_init_args[11] },
+	{ SENSOR_NUM_CUR_P12V_ACCL_12, sensor_dev_sq52205, I2C_BUS9, INA233_12V_12_ADDR,
+	  SQ52205_READ_CUR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[11],
+	  post_ina233_read, &pwr_monitor_args[11], &accl_pwr_monitor_sq52205_init_args[11] },
+	{ SENSOR_NUM_PWR_P12V_ACCL_12, sensor_dev_sq52205, I2C_BUS9, INA233_12V_12_ADDR,
+	  SQ52205_READ_PWR_OFFSET, is_dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ina233_read, &pwr_monitor_args[11],
+	  post_ina233_read, &pwr_monitor_args[11], &accl_pwr_monitor_sq52205_init_args[11] },
+
+	/** INA230 **/
+	{ SENSOR_NUM_VOL_P12V_1_M_AUX, sensor_dev_ina230, I2C_BUS2, SQ52205_P1V25_1_ADDR,
+	  SQ52205_READ_VOL_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_ina230_init_args[0] },
+	{ SENSOR_NUM_CUR_P12V_1_M_AUX, sensor_dev_ina230, I2C_BUS2, SQ52205_P1V25_1_ADDR,
+	  SQ52205_READ_CUR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_ina230_init_args[0] },
+	{ SENSOR_NUM_PWR_P12V_1_M_AUX, sensor_dev_ina230, I2C_BUS2, SQ52205_P1V25_1_ADDR,
+	  SQ52205_READ_PWR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_ina230_init_args[0] },
+	{ SENSOR_NUM_VOL_P12V_2_M_AUX, sensor_dev_ina230, I2C_BUS2, SQ52205_P1V25_2_ADDR,
+	  SQ52205_READ_VOL_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_ina230_init_args[1] },
+	{ SENSOR_NUM_CUR_P12V_2_M_AUX, sensor_dev_ina230, I2C_BUS2, SQ52205_P1V25_2_ADDR,
+	  SQ52205_READ_CUR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_ina230_init_args[1] },
+	{ SENSOR_NUM_PWR_P12V_2_M_AUX, sensor_dev_ina230, I2C_BUS2, SQ52205_P1V25_2_ADDR,
+	  SQ52205_READ_PWR_OFFSET, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &u178_179_ina230_init_args[1] },
 };
 
 sensor_cfg artemis_module_1_sensor_cfg[] = {
@@ -1349,7 +1584,9 @@ uint8_t pal_get_extend_sensor_config()
 	uint8_t index = 0;
 	uint8_t extend_sensor_config_size = 0;
 	uint8_t hsc_module = get_hsc_module();
+	uint8_t vr_module = get_vr_module();
 	uint8_t power_brick_module = get_pwr_brick_module();
+	uint8_t power_monitor_module = get_pwr_monitor_module();
 
 	switch (hsc_module) {
 	case HSC_MODULE_ADM1272:
@@ -1375,6 +1612,32 @@ uint8_t pal_get_extend_sensor_config()
 		break;
 	}
 
+	switch (power_monitor_module) {
+	case POWER_MONITOR_INA233_SQ52205:
+		extend_sensor_config_size +=
+			ARRAY_SIZE(power_monitor_ina233_sq52205_sensor_config_table);
+		break;
+	case POWER_MONITOR_SQ52205_INA230:
+		extend_sensor_config_size +=
+			ARRAY_SIZE(power_monitor_sq52205_ina230_sensor_config_table);
+		break;
+	default:
+		LOG_ERR("Invalid power monitor module: 0x%x", power_monitor_module);
+		break;
+	}
+
+	switch (vr_module) {
+	case VR_XDPE15284D:
+		extend_sensor_config_size += ARRAY_SIZE(vr_xdpe15284_sensor_config_table);
+		break;
+	case VR_MP2985H:
+		extend_sensor_config_size += ARRAY_SIZE(vr_mp2985h_sensor_config_table);
+		break;
+	default:
+		LOG_ERR("Invalid vr module: 0x%x", vr_module);
+		break;
+	}
+
 	for (index = 0; index < ASIC_CARD_COUNT; ++index) {
 		if (asic_card_info[index].card_type == ASIC_CARD_WITH_ARTEMIS_MODULE) {
 			extend_sensor_config_size +=
@@ -1391,7 +1654,9 @@ void pal_extend_sensor_config()
 	uint8_t card_index = 0;
 	uint8_t sensor_count = 0;
 	uint8_t hsc_module = get_hsc_module();
+	uint8_t vr_module = get_vr_module();
 	uint8_t power_brick_module = get_pwr_brick_module();
+	uint8_t power_monitor_module = get_pwr_monitor_module();
 
 	switch (hsc_module) {
 	case HSC_MODULE_ADM1272:
@@ -1426,6 +1691,42 @@ void pal_extend_sensor_config()
 		break;
 	default:
 		LOG_ERR("Invalid power brick module: 0x%x", power_brick_module);
+		break;
+	}
+
+	switch (power_monitor_module) {
+	case POWER_MONITOR_INA233_SQ52205:
+		sensor_count = ARRAY_SIZE(power_monitor_ina233_sq52205_sensor_config_table);
+		for (index = 0; index < sensor_count; index++) {
+			add_sensor_config(power_monitor_ina233_sq52205_sensor_config_table[index]);
+		}
+		break;
+	case POWER_MONITOR_SQ52205_INA230:
+		sensor_count = ARRAY_SIZE(power_monitor_sq52205_ina230_sensor_config_table);
+		for (index = 0; index < sensor_count; index++) {
+			add_sensor_config(power_monitor_sq52205_ina230_sensor_config_table[index]);
+		}
+		break;
+	default:
+		LOG_ERR("Invalid power monitor module: 0x%x", power_monitor_module);
+		break;
+	}
+
+	switch (vr_module) {
+	case VR_XDPE15284D:
+		sensor_count = ARRAY_SIZE(vr_xdpe15284_sensor_config_table);
+		for (index = 0; index < sensor_count; index++) {
+			add_sensor_config(vr_xdpe15284_sensor_config_table[index]);
+		}
+		break;
+	case VR_MP2985H:
+		sensor_count = ARRAY_SIZE(vr_mp2985h_sensor_config_table);
+		for (index = 0; index < sensor_count; index++) {
+			add_sensor_config(vr_mp2985h_sensor_config_table[index]);
+		}
+		break;
+	default:
+		LOG_ERR("Invalid vr module: 0x%x", vr_module);
 		break;
 	}
 


### PR DESCRIPTION
# Description
- Support to read ACB second source sensor.
- Support to read VR (MP2985H) checksum.

# Motivation
- Support to read ACB second source sensor.
- Support to read VR (MP2985H) checksum.

# Test Plan
- Build code: Pass
- Get ACB sensor reading on ACB 2nd source board: Pass
- Get ACB VR firmware version on ACB 2nd source board: Pass

# Log
- Get ACB sensor reading on ACB 2nd source board Note: HSC2 sensor NA because of i2c address missing root@bmc-oob:~# sensor-util cb
cb:
CB_INLET_TEMP_C              (0x67) :   26.50 C     | (ok)
CB_OUTLET_1_TEMP_C           (0x1) :   30.00 C     | (ok)
CB_OUTLET_2_TEMP_C           (0x2) :   27.00 C     | (ok)
CB_HSC1_TEMP _C              (0x3) :   24.85 C     | (ok)
CB_HSC2_TEMP_C               (0x4) : NA | (na)
CB_PEX0_TEMP_C               (0x5) :   53.77 C     | (ok)
CB_PEX1_TEMP_C               (0x6) :   53.77 C     | (ok)
CB_POWER_BRICK_1_TEMP_C      (0x9) :   34.00 C     | (ok)
CB_POWER_BRICK_2_TEMP_C      (0xA) :   34.00 C     | (ok)
CB_P51V_AUX_L_V              (0xB) :   51.06 Volts | (ok)
CB_P51V_AUX_R_V              (0xC) : NA | (na)
CB_P12V_AUX_1_V              (0xD) :   12.14 Volts | (ok)
CB_P12V_AUX_2_V              (0xE) :   12.15 Volts | (ok)
CB_P5V_AUX_V                 (0x10) :    5.13 Volts | (ok)
CB_P3V3_AUX_V                (0x11) :    3.34 Volts | (ok)
CB_P1V2_AUX_V                (0x12) :    1.21 Volts | (ok)
CB_P1V8_PEX_V                (0x13) :    1.82 Volts | (ok)
CB_P1V8_1_VDD_V              (0x1E) :    1.83 Volts | (ok)
CB_P1V8_2_VDD_V              (0x1F) :    1.82 Volts | (ok)
CB_P1V25_1_VDD_V             (0x20) :    1.27 Volts | (ok)
CB_P1V25_2_VDD_V             (0x21) :    1.27 Volts | (ok)
CB_P12V_ACCL1_V              (0x23) :   12.15 Volts | (ok)
CB_P12V_ACCL2_V              (0x24) :   12.15 Volts | (ok)
CB_P12V_ACCL3_V              (0x25) :   12.15 Volts | (ok)
CB_P12V_ACCL4_V              (0x26) :   12.15 Volts | (ok)
CB_P12V_ACCL5_V              (0x27) :   12.14 Volts | (ok)
CB_P12V_ACCL6_V              (0x28) :   12.15 Volts | (ok)
CB_P12V_ACCL7_V              (0x29) :   12.12 Volts | (ok)
CB_P12V_ACCL8_V              (0x2A) :   12.11 Volts | (ok)
CB_P12V_ACCL9_V              (0x2C) :   12.12 Volts | (ok)
CB_P12V_ACCL10_V             (0x2D) :   12.11 Volts | (ok)
CB_P12V_ACCL11_V             (0x2E) :   12.12 Volts | (ok)
CB_P12V_ACCL12_V             (0x2F) :   12.12 Volts | (ok)
CB_P51V_AUX_L_A              (0x30) :    4.49 Amps  | (ok)
CB_P51V_AUX_R_A              (0x31) : NA | (na)
CB_P12V_AUX_1_A              (0x32) :   20.00 Amps  | (ok)
CB_P12V_AUX_2_A              (0x33) :   18.50 Amps  | (ok)
CB_P12V_ACCL1_A              (0x34) :    2.91 Amps  | (ok)
CB_P12V_ACCL2_A              (0x35) :    2.91 Amps  | (ok)
CB_P12V_ACCL3_A              (0x36) :    2.85 Amps  | (ok)
CB_P12V_ACCL4_A              (0x37) :    2.88 Amps  | (ok)
CB_P12V_ACCL5_A              (0x38) :    2.86 Amps  | (ok)
CB_P12V_ACCL6_A              (0x39) :    2.49 Amps  | (ok)
CB_P12V_ACCL7_A              (0x3A) :    2.84 Amps  | (ok)
CB_P12V_ACCL8_A              (0x3C) :    2.90 Amps  | (ok)
CB_P12V_ACCL9_A              (0x3D) :    2.89 Amps  | (ok)
CB_P12V_ACCL10_A             (0x3E) :    2.81 Amps  | (ok)
CB_P12V_ACCL11_A             (0x3F) :    2.81 Amps  | (ok)
CB_P12V_ACCL12_A             (0x40) :    2.56 Amps  | (ok)
CB_P51V_AUX_L_W              (0x41) :  229.22 Watts | (ok)
CB_P51V_AUX_R_W              (0x42) : NA | (na)
CB_P12V_AUX_1_W              (0x43) :  242.86 Watts | (ok)
CB_P12V_AUX_2_W              (0x44) :  224.71 Watts | (ok)
CB_P12V_ACCL1_W              (0x45) :   35.35 Watts | (ok)
CB_P12V_ACCL2_W              (0x46) :   35.33 Watts | (ok)
CB_P12V_ACCL3_W              (0x47) :   34.67 Watts | (ok)
CB_P12V_ACCL4_W              (0x48) :   34.90 Watts | (ok)
CB_P12V_ACCL5_W              (0x49) :   34.70 Watts | (ok)
CB_P12V_ACCL6_W              (0x4A) :   30.23 Watts | (ok)
CB_P12V_ACCL7_W              (0x4B) :   34.42 Watts | (ok)
CB_P12V_ACCL8_W              (0x4C) :   35.10 Watts | (ok)
CB_P12V_ACCL9_W              (0x4D) :   35.00 Watts | (ok)
CB_P12V_ACCL10_W             (0x50) :   34.05 Watts | (ok)
CB_P12V_ACCL11_W             (0x51) :   34.10 Watts | (ok)
CB_P12V_ACCL12_W             (0x52) :   31.02 Watts | (ok)
CB_P51V_STBY_L_V             (0x53) :   50.98 Volts | (ok)
CB_P51V_STBY_R_V             (0x54) : NA | (na)
CB_P51V_STBY_L_W             (0x55) :  228.33 Watts | (ok)
CB_P51V_STBY_R_W             (0x56) : NA | (na)
CB_P0V8_VDD_1_V              (0x57) :    0.80 Volts | (ok)
CB_P0V8_VDD_2_V              (0x58) :    0.80 Volts | (ok)
CB_P0V8_VDD_1_A              (0x59) :   30.75 Amps  | (ok)
CB_P0V8_VDD_2_A              (0x5A) :   30.75 Amps  | (ok)
CB_P0V8_VDD_1_W              (0x5B) :   24.75 Watts | (ok)
CB_P0V8_VDD_2_W              (0x5C) :   24.75 Watts | (ok)
CB_P51V_STBY_L_A             (0x5D) :    4.48 Amps  | (ok)
CB_P51V_STBY_R_A             (0x5E) : NA | (na)
CB_P0V8_1_VDD_TEMP_C         (0x5F) :   34.00 C     | (ok)
CB_P0V8_2_VDD_TEMP_C         (0x60) :   34.00 C     | (ok)
CB_P1V25_1_VDD(P12V_1_M_AUX)_V (0x61) :   12.12 Volts | (ok)
CB_P1V25_2_VDD(P12V_2_M_AUX)_V (0x62) :   12.15 Volts | (ok)
CB_P1V25_1_VDD(P12V_1_M_AUX)_A (0x63) :    1.52 Amps  | (ok)
CB_P1V25_2_VDD(P12V_2_M_AUX)_A (0x64) :    1.72 Amps  | (ok)
CB_P1V25_1_VDD(P12V_1_M_AUX)_W (0x65) :   18.45 Watts | (ok)
CB_P1V25_2_VDD(P12V_2_M_AUX)_W (0x66) :   20.85 Watts | (ok)
CB_ACCL1_Freya_1_Temp_C      (0x70) :   37.00 C     | (ok)
CB_ACCL1_Freya_1_VOL_1_V     (0x71) :    4.10 Volts | (ok)
CB_ACCL1_Freya_1_VOL_2_V     (0x72) :    1.45 Volts | (ok)
CB_ACCL1_Freya_2_Temp_C      (0x73) :   40.00 C     | (ok)
CB_ACCL1_Freya_2_VOL_1_V     (0x74) :    5.38 Volts | (ok)
CB_ACCL1_Freya_2_VOL_2_V     (0x75) :    0.42 Volts | (ok)
CB_ACCL2_Freya_1_Temp_C      (0x76) :   36.00 C     | (ok)
CB_ACCL2_Freya_1_VOL_1_V     (0x77) :    4.36 Volts | (ok)
CB_ACCL2_Freya_1_VOL_2_V     (0x78) :    0.68 Volts | (ok)
CB_ACCL2_Freya_2_Temp_C      (0x79) :   40.00 C     | (ok)
CB_ACCL2_Freya_2_VOL_1_V     (0x7A) :    4.36 Volts | (ok)
CB_ACCL2_Freya_2_VOL_2_V     (0x7B) :    0.27 Volts | (ok)
CB_ACCL3_Freya_1_Temp_C      (0x7C) :   47.00 C     | (ok)
CB_ACCL3_Freya_1_VOL_1_V     (0x7D) :    4.10 Volts | (ok)
CB_ACCL3_Freya_1_VOL_2_V     (0x7E) :    0.68 Volts | (ok)
CB_ACCL3_Freya_2_Temp_C      (0x7F) :   39.00 C     | (ok)
CB_ACCL3_Freya_2_VOL_1_V     (0x80) :    4.87 Volts | (ok)
CB_ACCL3_Freya_2_VOL_2_V     (0x81) :    2.21 Volts | (ok)
CB_ACCL4_Freya_1_Temp_C      (0x82) :   37.00 C     | (ok)
CB_ACCL4_Freya_1_VOL_1_V     (0x83) :    3.84 Volts | (ok)
CB_ACCL4_Freya_1_VOL_2_V     (0x84) :    5.70 Volts | (ok)
CB_ACCL4_Freya_2_Temp_C      (0x85) :   39.00 C     | (ok)
CB_ACCL4_Freya_2_VOL_1_V     (0x86) :    5.38 Volts | (ok)
CB_ACCL4_Freya_2_VOL_2_V     (0x87) :    5.18 Volts | (ok)
CB_ACCL5_Freya_1_Temp_C      (0x88) :   35.00 C     | (ok)
CB_ACCL5_Freya_1_VOL_1_V     (0x89) :    4.87 Volts | (ok)
CB_ACCL5_Freya_1_VOL_2_V     (0x8A) :    1.45 Volts | (ok)
CB_ACCL5_Freya_2_Temp_C      (0x8B) :   38.00 C     | (ok)
CB_ACCL5_Freya_2_VOL_1_V     (0x8C) :    5.12 Volts | (ok)
CB_ACCL5_Freya_2_VOL_2_V     (0x8D) :    1.45 Volts | (ok)
CB_ACCL6_Freya_1_Temp_C      (0x8E) :   34.00 C     | (ok)
CB_ACCL6_Freya_1_VOL_1_V     (0x8F) :    4.61 Volts | (ok)
CB_ACCL6_Freya_1_VOL_2_V     (0x90) :    6.46 Volts | (ok)
CB_ACCL6_Freya_2_Temp_C      (0x91) :   38.00 C     | (ok)
CB_ACCL6_Freya_2_VOL_1_V     (0x92) :    5.12 Volts | (ok)
CB_ACCL6_Freya_2_VOL_2_V     (0x93) :    2.21 Volts | (ok)
CB_ACCL7_Freya_1_Temp_C      (0x94) :   35.00 C     | (ok)
CB_ACCL7_Freya_1_VOL_1_V     (0x95) :    4.61 Volts | (ok)
CB_ACCL7_Freya_1_VOL_2_V     (0x96) :    3.65 Volts | (ok)
CB_ACCL7_Freya_2_Temp_C      (0x97) :   37.00 C     | (ok)
CB_ACCL7_Freya_2_VOL_1_V     (0x98) :    4.61 Volts | (ok)
CB_ACCL7_Freya_2_VOL_2_V     (0x99) :    3.75 Volts | (ok)
CB_ACCL8_Freya_1_Temp_C      (0x9A) :   34.00 C     | (ok)
CB_ACCL8_Freya_1_VOL_1_V     (0x9B) :    5.12 Volts | (ok)
CB_ACCL8_Freya_1_VOL_2_V     (0x9C) :    2.88 Volts | (ok)
CB_ACCL8_Freya_2_Temp_C      (0x9D) :   37.00 C     | (ok)
CB_ACCL8_Freya_2_VOL_1_V     (0x9E) :    4.10 Volts | (ok)
CB_ACCL8_Freya_2_VOL_2_V     (0x9F) :    4.52 Volts | (ok)
CB_ACCL9_Freya_1_Temp_C      (0xA0) :   36.00 C     | (ok)
CB_ACCL9_Freya_1_VOL_1_V     (0xA1) :    5.12 Volts | (ok)
CB_ACCL9_Freya_1_VOL_2_V     (0xA2) :    1.45 Volts | (ok)
CB_ACCL9_Freya_2_Temp_C      (0xA3) :   39.00 C     | (ok)
CB_ACCL9_Freya_2_VOL_1_V     (0xA4) :    3.59 Volts | (ok)
CB_ACCL9_Freya_2_VOL_2_V     (0xA5) :    6.46 Volts | (ok)
CB_ACCL10_Freya_1_Temp_C     (0xA6) :   36.00 C     | (ok)
CB_ACCL10_Freya_1_VOL_1_V    (0xA7) :    4.61 Volts | (ok)
CB_ACCL10_Freya_1_VOL_2_V    (0xA8) :    5.18 Volts | (ok)
CB_ACCL10_Freya_2_Temp_C     (0xA9) :   38.00 C     | (ok)
CB_ACCL10_Freya_2_VOL_1_V    (0xAA) :    5.12 Volts | (ok)
CB_ACCL10_Freya_2_VOL_2_V    (0xAB) :    3.75 Volts | (ok)
CB_ACCL11_Freya_1_Temp_C     (0xAC) :   35.00 C     | (ok)
CB_ACCL11_Freya_1_VOL_1_V    (0xAD) :    5.12 Volts | (ok)
CB_ACCL11_Freya_1_VOL_2_V    (0xAE) :    5.29 Volts | (ok)
CB_ACCL11_Freya_2_Temp_C     (0xAF) :   38.00 C     | (ok)
CB_ACCL11_Freya_2_VOL_1_V    (0xB0) :    4.36 Volts | (ok)
CB_ACCL11_Freya_2_VOL_2_V    (0xB1) :    3.65 Volts | (ok)
CB_ACCL12_Freya_1_Temp_C     (0xB2) :   36.00 C     | (ok)
CB_ACCL12_Freya_1_VOL_1_V    (0xB3) :    4.61 Volts | (ok)
CB_ACCL12_Freya_1_VOL_2_V    (0xB4) :    1.45 Volts | (ok)
CB_ACCL12_Freya_2_Temp_C     (0xB5) :   40.00 C     | (ok)
CB_ACCL12_Freya_2_VOL_1_V    (0xB6) :    5.64 Volts | (ok)
CB_ACCL12_Freya_2_VOL_2_V    (0xB7) :    5.18 Volts | (ok)

- Get ACB VR firmware version on ACB 2nd source board root@bmc-oob:~# pldmd-util -b 3 -e 0x0a raw 0x3f 0x01 0x15 0xA0 0x00 0xE0 0x0B 0x15 0xA0 0x00 0x00 Request :
  Bus = 3
  Eid = 10
  Data = 0x3f 0x01 0x15 0xa0 0x00 0xe0 0x0b 0x15 0xa0 0x00 0x00
Response:
  Return Code: 0
  PLDM Request Bit     : 0x00
  PLDM Instance ID     : 0x16
  PLDM Type            : 0x3f
  PLDM Command         : 0x01
  PLDM Completion Code : 0x00
  PLDM Data : 0x15 0xa0 0x00 0xe4 0x0b 0x00 0x15 0xa0 0x00 0x00 0x04 0xaf 0x53 0x63 0xe4