### PR TITLE
fby35: gl: Support DIMM and PMIC reading via I3C

### DIFF
--- a/common/hal/hal_i3c.h
+++ b/common/hal/hal_i3c.h
@@ -110,6 +110,7 @@ void util_init_i3c(void);
 int i3c_smq_read(I3C_MSG *msg);
 int i3c_smq_write(I3C_MSG *msg);
 int i3c_attach(I3C_MSG *msg);
+int i3c_detach(I3C_MSG *msg);
 int i3c_transfer(I3C_MSG *msg);
 int i3c_brocast_ccc(I3C_MSG *msg, uint8_t ccc_id, uint8_t ccc_addr);
 int i3c_spd_reg_read(I3C_MSG *msg, bool is_nvm);

--- a/meta-facebook/yv35-gl/src/platform/plat_dimm.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_dimm.c
@@ -9,18 +9,214 @@
 #include "ipmb.h"
 #include "ipmi.h"
 #include "kcs.h"
+#include "sensor.h"
+#include "pmic.h"
+#include "power_status.h"
+#include "plat_i2c.h"
+#include "plat_isr.h"
+#include "libutil.h"
+#include "rg3mxxb12.h"
 
 LOG_MODULE_REGISTER(plat_dimm);
 
-bool dimm_presence[MAX_COUNT_DIMM];
-static bool dimm_inited = false;
+K_THREAD_STACK_DEFINE(get_dimm_info_stack, GET_DIMM_INFO_STACK_SIZE);
+struct k_thread get_dimm_info_thread;
+k_tid_t get_dimm_info_tid;
 
-bool is_dimm_inited()
+struct k_mutex i3c_dimm_mutex;
+
+uint8_t pmic_i3c_addr_list[MAX_COUNT_DIMM / 2] = { PMIC_A_E_ADDR, PMIC_B_F_ADDR, PMIC_C_G_ADDR,
+						   PMIC_D_H_ADDR };
+uint8_t spd_i3c_addr_list[MAX_COUNT_DIMM / 2] = { DIMM_SPD_A_E_ADDR, DIMM_SPD_B_F_ADDR,
+						  DIMM_SPD_C_G_ADDR, DIMM_SPD_D_H_ADDR };
+
+dimm_info dimm_data[MAX_COUNT_DIMM];
+
+static bool dimm_prsnt_inited = false;
+
+void start_get_dimm_info_thread()
 {
-	return dimm_inited;
+	LOG_INF("Start thread to get dimm information");
+
+	get_dimm_info_tid =
+		k_thread_create(&get_dimm_info_thread, get_dimm_info_stack,
+				K_THREAD_STACK_SIZEOF(get_dimm_info_stack), get_dimm_info_handler,
+				NULL, NULL, NULL, CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+	k_thread_name_set(&get_dimm_info_thread, "get_dimm_info_thread");
 }
 
-void init_dimm_status()
+bool is_dimm_prsnt_inited()
+{
+	return dimm_prsnt_inited;
+}
+
+void get_dimm_info_handler()
+{
+	I3C_MSG i3c_msg = { 0 };
+	int i;
+
+	i3c_msg.bus = I3C_BUS4;
+
+	// Attach PMIC addr
+	for (i = 0; i < (MAX_COUNT_DIMM / 2); i++) {
+		i3c_msg.target_addr = pmic_i3c_addr_list[i];
+		i3c_attach(&i3c_msg);
+	}
+
+	// Init mutex
+	if (k_mutex_init(&i3c_dimm_mutex)) {
+		LOG_ERR("i3c_dimm_mux_mutex mutex init fail");
+	}
+
+	// Switch I3C mux to BIC when host post complete but BIC reset
+	if (get_post_status()) {
+		if (k_mutex_lock(&i3c_dimm_mutex, K_MSEC(I3C_DIMM_MUTEX_TIMEOUT_MS))) {
+			LOG_ERR("Failed to lock I3C dimm MUX");
+			return;
+		}
+
+		switch_i3c_dimm_mux(I3C_MUX_TO_BIC);
+
+		if (k_mutex_unlock(&i3c_dimm_mutex)) {
+			LOG_ERR("Failed to unlock I3C dimm MUX");
+		}
+	}
+
+	while (1) {
+		int ret = 0, dimm_id;
+
+		// Avoid to get wrong thus only monitor after post complete
+		if (!get_post_status()) {
+			k_msleep(GET_DIMM_INFO_TIME_MS);
+			continue;
+		}
+
+		if (!is_dimm_prsnt_inited()) {
+			init_i3c_dimm_prsnt_status();
+		}
+
+		if (k_mutex_lock(&i3c_dimm_mutex, K_MSEC(I3C_DIMM_MUTEX_TIMEOUT_MS))) {
+			LOG_ERR("Failed to lock I3C dimm MUX");
+			k_msleep(GET_DIMM_INFO_TIME_MS);
+			continue;
+		}
+
+		for (dimm_id = 0; dimm_id < MAX_COUNT_DIMM; dimm_id++) {
+			if (!dimm_data[dimm_id].is_present) {
+				continue;
+			}
+
+			ret = switch_i3c_dimm_mux(I3C_MUX_TO_BIC);
+			if (ret != 0) {
+				clear_unaccessible_dimm_data(dimm_id);
+				continue;
+			}
+
+			uint8_t slave_port_setting = (dimm_id / (MAX_COUNT_DIMM / 2)) ?
+								   I3C_HUB_TO_DIMMEFGH :
+								   I3C_HUB_TO_DIMMABCD;
+
+			if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
+						      slave_port_setting)) {
+				clear_unaccessible_dimm_data(dimm_id);
+				LOG_ERR("Failed to set slave port to slave port: 0x%x",
+					slave_port_setting);
+				continue;
+			}
+
+			memset(&i3c_msg, 0, sizeof(I3C_MSG));
+			i3c_msg.bus = I3C_BUS4;
+			i3c_msg.target_addr = spd_i3c_addr_list[dimm_id % (MAX_COUNT_DIMM / 2)];
+			i3c_attach(&i3c_msg);
+
+			// I3C_CCC_RSTDAA: Reset dynamic address assignment
+			// I3C_CCC_SETAASA: Set all addresses to static address
+			ret = all_brocast_ccc(&i3c_msg);
+			if (ret != 0) {
+				clear_unaccessible_dimm_data(dimm_id);
+				i3c_detach(&i3c_msg);
+				continue;
+			}
+
+			if (!get_post_status()) {
+				i3c_detach(&i3c_msg);
+				break;
+			}
+
+			i3c_msg.tx_len = 1;
+			i3c_msg.rx_len = MAX_LEN_I3C_GET_SPD_TEMP;
+			i3c_msg.data[0] = DIMM_SPD_TEMP;
+
+			ret = i3c_spd_reg_read(&i3c_msg, false);
+			if (ret != 0) {
+				clear_unaccessible_dimm_data(dimm_id);
+				i3c_detach(&i3c_msg);
+				LOG_ERR("Failed to read DIMM %d SPD temperature via I3C, ret= %d",
+					dimm_id, ret);
+			} else {
+				memcpy(&dimm_data[dimm_id].spd_temp_data, &i3c_msg.data,
+				       sizeof(dimm_data[dimm_id].spd_temp_data));
+			}
+			i3c_detach(&i3c_msg);
+
+			// Double check before read each DIMM info
+			if (!get_post_status()) {
+				break;
+			}
+
+			// Read DIMM PMIC power
+			memset(&i3c_msg, 0, sizeof(I3C_MSG));
+			i3c_msg.bus = I3C_BUS4;
+			i3c_msg.target_addr = pmic_i3c_addr_list[dimm_id % (MAX_COUNT_DIMM / 2)];
+			i3c_msg.tx_len = 1;
+			i3c_msg.rx_len = MAX_LEN_I3C_GET_PMIC_PWR;
+			i3c_msg.data[0] = DIMM_PMIC_SWA_PWR;
+
+			ret = i3c_transfer(&i3c_msg);
+			if (ret != 0) {
+				clear_unaccessible_dimm_data(dimm_id);
+				LOG_ERR("Failed to read DIMM %d PMIC power via I3C, ret= %d",
+					dimm_id, ret);
+				continue;
+			} else {
+				memcpy(&dimm_data[dimm_id].pmic_pwr_data, &i3c_msg.data,
+				       sizeof(dimm_data[dimm_id].pmic_pwr_data));
+			}
+
+			// Double check before read each DIMM info
+			if (!get_post_status()) {
+				break;
+			}
+
+			// Read DIMM PMIC error
+			memset(&i3c_msg, 0, sizeof(I3C_MSG));
+			i3c_msg.bus = I3C_BUS4;
+			i3c_msg.target_addr = pmic_i3c_addr_list[dimm_id % (MAX_COUNT_DIMM / 2)];
+			i3c_msg.tx_len = 1;
+			i3c_msg.rx_len = MAX_LEN_I3C_GET_PMIC_ERR;
+			i3c_msg.data[0] = PMIC_POR_ERROR_LOG_ADDR_VAL;
+
+			ret = i3c_transfer(&i3c_msg);
+			if (ret != 0) {
+				clear_unaccessible_dimm_data(dimm_id);
+				LOG_ERR("Failed to read DIMM %d PMIC error via I3C, ret= %d",
+					dimm_id, ret);
+				continue;
+			} else {
+				memcpy(&dimm_data[dimm_id].pmic_error_data, &i3c_msg.data,
+				       sizeof(dimm_data[dimm_id].pmic_error_data));
+			}
+		}
+
+		if (k_mutex_unlock(&i3c_dimm_mutex)) {
+			LOG_ERR("Failed to unlock I3C dimm MUX");
+		}
+
+		k_msleep(GET_DIMM_INFO_TIME_MS);
+	}
+}
+
+void init_i3c_dimm_prsnt_status()
 {
 	int index;
 	for (index = DIMM_ID_A; index < MAX_COUNT_DIMM; index++) {
@@ -39,32 +235,32 @@ void init_dimm_status()
 
 		ipmb_error ret = ipmb_read(&msg, IPMB_inf_index_map[msg.InF_target]);
 		if (ret != IPMB_ERROR_SUCCESS) {
-			LOG_ERR("Failed to get DIMM status, ret %d", ret);
+			LOG_ERR("Failed to get DIMM status, ret= %d", ret);
 			return;
 		}
 
 		uint8_t status = msg.data[0];
 		if (status == DIMM_PRESENT) {
-			dimm_presence[index] = true;
+			dimm_data[index].is_present = true;
 		} else {
-			dimm_presence[index] = false;
+			dimm_data[index].is_present = false;
 		}
 	}
 
-	dimm_inited = true;
+	dimm_prsnt_inited = true;
 }
 
 bool get_dimm_presence_status(uint8_t dimm_id)
 {
-	return dimm_presence[dimm_id];
+	return dimm_data[dimm_id].is_present;
 }
 
 void set_dimm_presence_status(uint8_t index, uint8_t status)
 {
 	if (status == DIMM_PRESENT) {
-		dimm_presence[index] = true;
+		dimm_data[index].is_present = true;
 	} else {
-		dimm_presence[index] = false;
+		dimm_data[index].is_present = false;
 	}
 }
 
@@ -74,27 +270,35 @@ uint8_t sensor_num_map_dimm_id(uint8_t sensor_num)
 
 	switch (sensor_num) {
 	case SENSOR_NUM_MB_DIMMA_TEMP_C:
+	case SENSOR_NUM_MB_VR_DIMMA_PMIC_PWR_W:
 		dimm_id = DIMM_ID_A;
 		break;
 	case SENSOR_NUM_MB_DIMMB_TEMP_C:
+	case SENSOR_NUM_MB_VR_DIMMB_PMIC_PWR_W:
 		dimm_id = DIMM_ID_B;
 		break;
 	case SENSOR_NUM_MB_DIMMC_TEMP_C:
+	case SENSOR_NUM_MB_VR_DIMMC_PMIC_PWR_W:
 		dimm_id = DIMM_ID_C;
 		break;
 	case SENSOR_NUM_MB_DIMMD_TEMP_C:
+	case SENSOR_NUM_MB_VR_DIMMD_PMIC_PWR_W:
 		dimm_id = DIMM_ID_D;
 		break;
 	case SENSOR_NUM_MB_DIMME_TEMP_C:
+	case SENSOR_NUM_MB_VR_DIMME_PMIC_PWR_W:
 		dimm_id = DIMM_ID_E;
 		break;
 	case SENSOR_NUM_MB_DIMMF_TEMP_C:
+	case SENSOR_NUM_MB_VR_DIMMF_PMIC_PWR_W:
 		dimm_id = DIMM_ID_F;
 		break;
 	case SENSOR_NUM_MB_DIMMG_TEMP_C:
+	case SENSOR_NUM_MB_VR_DIMMG_PMIC_PWR_W:
 		dimm_id = DIMM_ID_G;
 		break;
 	case SENSOR_NUM_MB_DIMMH_TEMP_C:
+	case SENSOR_NUM_MB_VR_DIMMH_PMIC_PWR_W:
 		dimm_id = DIMM_ID_H;
 		break;
 	default:
@@ -103,4 +307,137 @@ uint8_t sensor_num_map_dimm_id(uint8_t sensor_num)
 	}
 
 	return dimm_id;
+}
+
+int switch_i3c_dimm_mux(uint8_t i3c_mux_position)
+{
+	I2C_MSG i2c_msg = { 0 };
+	int ret = 0, retry = 3;
+
+	i2c_msg.bus = I2C_BUS1;
+	i2c_msg.target_addr = CPLD_ADDR;
+	i2c_msg.tx_len = 2;
+	i2c_msg.rx_len = 0;
+	i2c_msg.data[0] = DIMM_I3C_MUX_CONTROL_OFFSET;
+
+	// BIT 0: PD_SPD1_REMOTE_EN
+	// 0: switch I3C mux to CPU 1: switch I3C mux to BIC
+	i2c_msg.data[1] = i3c_mux_position;
+
+	ret = i2c_master_write(&i2c_msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Failed to switch I3C MUX: 0x%x, ret= %d", i3c_mux_position, ret);
+	}
+
+	return ret;
+}
+
+int all_brocast_ccc(I3C_MSG *i3c_msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(i3c_msg, -1);
+
+	int ret = 0;
+
+	ret = i3c_brocast_ccc(i3c_msg, I3C_CCC_RSTDAA, I3C_BROADCAST_ADDR);
+	if (ret != 0) {
+		return ret;
+	}
+
+	ret = i3c_brocast_ccc(i3c_msg, I3C_CCC_SETAASA, I3C_BROADCAST_ADDR);
+	if (ret != 0) {
+		return ret;
+	}
+
+	return ret;
+}
+
+int get_pmic_error_raw_data(int dimm_index, uint8_t *data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(data, -1);
+
+	int i = 0, fail_count = 0;
+
+	for (i = 0; i < sizeof(dimm_data[dimm_index].pmic_error_data); i++) {
+		if (dimm_data[dimm_index].pmic_error_data[i] == SENSOR_FAIL) {
+			fail_count++;
+		}
+	}
+
+	// PMIC error data read failed
+	if (fail_count == sizeof(dimm_data[dimm_index].pmic_error_data)) {
+		return -1;
+	}
+
+	memcpy(data, &dimm_data[dimm_index].pmic_error_data,
+	       sizeof(dimm_data[dimm_index].pmic_error_data));
+
+	return 0;
+}
+
+void get_pmic_power_raw_data(int dimm_index, uint8_t *data)
+{
+	CHECK_NULL_ARG(data);
+
+	memcpy(data, &dimm_data[dimm_index].pmic_pwr_data,
+	       sizeof(dimm_data[dimm_index].pmic_pwr_data));
+}
+
+void get_spd_temp_raw_data(int dimm_index, uint8_t *data)
+{
+	CHECK_NULL_ARG(data);
+
+	memcpy(data, &dimm_data[dimm_index].spd_temp_data,
+	       sizeof(dimm_data[dimm_index].spd_temp_data));
+}
+
+int pal_get_pmic_pwr(uint8_t sensor_num, uint8_t *data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(data, -1);
+
+	uint8_t dimm_id = DIMM_ID_UNKNOWN;
+
+	dimm_id = sensor_num_map_dimm_id(sensor_num);
+	if (dimm_id == DIMM_ID_UNKNOWN) {
+		return -1;
+	}
+
+	get_pmic_power_raw_data(dimm_id, (uint8_t *)data);
+
+	// If sensor data is SENSOR_FAIL, return failed
+	if (data[0] == SENSOR_FAIL) {
+		return -1;
+	}
+
+	return 0;
+}
+
+int pal_get_spd_temp(uint8_t sensor_num, uint8_t *data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(data, -1);
+
+	uint8_t dimm_id = DIMM_ID_UNKNOWN;
+
+	dimm_id = sensor_num_map_dimm_id(sensor_num);
+	if (dimm_id == DIMM_ID_UNKNOWN) {
+		return -1;
+	}
+
+	get_spd_temp_raw_data(dimm_id, (uint8_t *)data);
+
+	// If sensor data is SENSOR_FAIL, return failed
+	if (data[0] == SENSOR_FAIL) {
+		return -1;
+	}
+
+	return 0;
+}
+
+void clear_unaccessible_dimm_data(uint8_t dimm_id)
+{
+	memset(dimm_data[dimm_id].pmic_error_data, SENSOR_FAIL,
+	       sizeof(dimm_data[dimm_id].pmic_error_data));
+	memset(dimm_data[dimm_id].pmic_pwr_data, SENSOR_FAIL,
+	       sizeof(dimm_data[dimm_id].pmic_pwr_data));
+	memset(dimm_data[dimm_id].spd_temp_data, SENSOR_FAIL,
+	       sizeof(dimm_data[dimm_id].spd_temp_data));
 }

--- a/meta-facebook/yv35-gl/src/platform/plat_dimm.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_dimm.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "plat_i3c.h"
 
 #define MAX_COUNT_DIMM 8
 #define DIMM_INDEX_BYTE 5
@@ -26,6 +27,22 @@
 #define DIMM_INDEX_MIN 0
 #define DIMM_INDEX_MAX 7
 #define DIMM_PRESENT 0x1
+
+#define DIMM_I3C_MUX_CONTROL_OFFSET 0x0B
+
+#define GET_DIMM_INFO_TIME_MS 1000
+#define GET_DIMM_INFO_STACK_SIZE 2304
+
+#define I3C_MUX_TO_CPU 0x0
+#define I3C_MUX_TO_BIC 0x1
+#define I3C_DIMM_MUTEX_TIMEOUT_MS 1000
+
+#define I3C_HUB_TO_DIMMABCD 0x7F
+#define I3C_HUB_TO_DIMMEFGH 0xBF
+
+#define MAX_LEN_I3C_GET_PMIC_ERR 47
+#define MAX_LEN_I3C_GET_PMIC_PWR 1
+#define MAX_LEN_I3C_GET_SPD_TEMP 2
 
 enum DIMM_ID {
 	DIMM_ID_A = 0,
@@ -39,10 +56,45 @@ enum DIMM_ID {
 	DIMM_ID_UNKNOWN = 0xff,
 };
 
-bool is_dimm_inited();
-void init_dimm_status();
+enum I3C_PMIC_ADDR {
+	PMIC_A_E_ADDR = 0x48,
+	PMIC_B_F_ADDR = 0x4a,
+	PMIC_C_G_ADDR = 0x4c,
+	PMIC_D_H_ADDR = 0x4e,
+};
+
+enum I3C_DIMM_SPD_ADDR {
+	DIMM_SPD_A_E_ADDR = 0x50,
+	DIMM_SPD_B_F_ADDR = 0x52,
+	DIMM_SPD_C_G_ADDR = 0x54,
+	DIMM_SPD_D_H_ADDR = 0x56,
+};
+
+typedef struct dimm_info {
+	bool is_present;
+	uint8_t pmic_error_data[MAX_LEN_I3C_GET_PMIC_ERR];
+	uint8_t pmic_pwr_data[MAX_LEN_I3C_GET_PMIC_PWR];
+	uint8_t spd_temp_data[MAX_LEN_I3C_GET_SPD_TEMP];
+} dimm_info;
+
+extern struct k_mutex i3c_dimm_mutex;
+extern uint8_t pmic_i3c_addr_list[MAX_COUNT_DIMM / 2];
+extern uint8_t spd_i3c_addr_list[MAX_COUNT_DIMM / 2];
+
+extern dimm_info dimm_data[MAX_COUNT_DIMM];
+
+void start_get_dimm_info_thread();
+void get_dimm_info_handler();
+bool is_dimm_prsnt_inited();
+void init_i3c_dimm_prsnt_status();
 bool get_dimm_presence_status(uint8_t dimm_id);
 void set_dimm_presence_status(uint8_t index, uint8_t status);
 uint8_t sensor_num_map_dimm_id(uint8_t sensor_num);
+int switch_i3c_dimm_mux(uint8_t i3c_mux_position);
+int all_brocast_ccc(I3C_MSG *i3c_msg);
+int get_pmic_error_raw_data(int dimm_index, uint8_t *data);
+void get_pmic_power_raw_data(int dimm_index, uint8_t *data);
+void get_spd_temp_raw_data(int dimm_index, uint8_t *data);
+void clear_unaccessible_dimm_data(uint8_t dimm_id);
 
 #endif

--- a/meta-facebook/yv35-gl/src/platform/plat_hook.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_hook.h
@@ -26,6 +26,11 @@ typedef struct _dimm_pre_proc_arg {
 	bool is_present_checked;
 } dimm_pre_proc_arg;
 
+typedef struct _dimm_post_proc_arg {
+	uint8_t dimm_channel;
+	uint8_t dimm_number;
+} dimm_post_proc_arg;
+
 /**************************************************************************************************
  * INIT ARGS
 **************************************************************************************************/
@@ -39,6 +44,7 @@ extern mp2985_init_arg mp2985_init_args[];
  **************************************************************************************************/
 extern struct tca9548 mux_conf_addr_0xe2[];
 extern xdpe15284_pre_read_arg xdpe15284_pre_read_args[];
+extern dimm_post_proc_arg dimm_post_proc_args[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK FUNC
@@ -48,6 +54,7 @@ bool pre_vol_bat3v_read(sensor_cfg *cfg, void *args);
 bool post_vol_bat3v_read(sensor_cfg *cfg, void *args, int *reading);
 bool post_cpu_margin_read(sensor_cfg *cfg, void *args, int *reading);
 bool pre_nvme_read(sensor_cfg *cfg, void *args);
-bool pre_intel_peci_dimm_read(sensor_cfg *cfg, void *args);
+bool pre_intel_dimm_i3c_read(sensor_cfg *cfg, void *args);
+bool post_intel_dimm_i3c_read(sensor_cfg *cfg, void *args, int *reading);
 
 #endif

--- a/meta-facebook/yv35-gl/src/platform/plat_i3c.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_i3c.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <logging/log.h>
+#include "plat_i3c.h"
+#include "rg3mxxb12.h"
+#include <errno.h>
+
+LOG_MODULE_REGISTER(plat_i3c);
+
+void init_i3c_hub()
+{
+	I3C_MSG i3c_msg = { 0 };
+	i3c_msg.bus = I3C_BUS4;
+
+	int ret = 0;
+	int i;
+	for (i = 0; i < RSTDAA_COUNT; i++) {
+		ret = i3c_brocast_ccc(&i3c_msg, I3C_CCC_RSTDAA, I3C_BROADCAST_ADDR);
+		if (ret != 0) {
+			LOG_ERR("Error to reset daa. count = %d", i);
+		}
+	}
+
+	ret = i3c_brocast_ccc(&i3c_msg, I3C_CCC_SETAASA, I3C_BROADCAST_ADDR);
+	if (ret != 0) {
+		LOG_ERR("Error to set daa");
+	}
+
+	i3c_msg.target_addr = RG3MXXB12_DEFAULT_STATIC_ADDRESS;
+	i3c_attach(&i3c_msg);
+
+	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
+		LOG_ERR("Failed to initialize i3c hub");
+	}
+
+	if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
+				      DEFAULT_SLAVE_PORT_SETTING)) {
+		LOG_ERR("Error to set slave port");
+	}
+}

--- a/meta-facebook/yv35-gl/src/platform/plat_i3c.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_i3c.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_I3C_H
+#define PLAT_I3C_H
+
+#include "hal_i3c.h"
+
+#define RSTDAA_COUNT 2
+#define LDO_VOLT 0x3A
+#define DEFAULT_SLAVE_PORT_SETTING 0x3F
+
+#define I3C_BUS4 3
+
+void init_i3c_hub();
+
+#endif

--- a/meta-facebook/yv35-gl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_init.c
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -22,9 +22,11 @@
 #include "plat_gpio.h"
 #include "plat_kcs.h"
 #include "plat_dimm.h"
+#include "plat_i3c.h"
+#include "plat_pmic.h"
 
 /*
- * The operating voltage of GPIO input pins are lower than actual voltage because the chip 
+ * The operating voltage of GPIO input pins are lower than actual voltage because the chip
  * internal pull-down is enabled.
  * BIC disables the internal GPIO pull-down for all input pins.
  *
@@ -49,6 +51,7 @@ SCU_CFG scu_cfg[] = {
 
 void pal_pre_init()
 {
+	init_i3c_hub();
 	init_platform_config();
 	scu_init(scu_cfg, ARRAY_SIZE(scu_cfg));
 	if (!pal_load_vw_gpio_config()) {
@@ -72,7 +75,9 @@ void pal_set_sys_status()
 
 void pal_device_init()
 {
-	init_dimm_status();
+	init_i3c_dimm_prsnt_status();
+	start_get_dimm_info_thread();
+	start_monitor_pmic_error_thread();
 }
 
 #define DEF_PROJ_GPIO_PRIORITY 78

--- a/meta-facebook/yv35-gl/src/platform/plat_pmic.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_pmic.c
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plat_pmic.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <zephyr.h>
+#include <logging/log.h>
+#include "ipmb.h"
+#include "ipmi.h"
+#include "pmic.h"
+#include "libipmi.h"
+#include "power_status.h"
+#include "libutil.h"
+#include "plat_i3c.h"
+#include "plat_sensor_table.h"
+#include "plat_dimm.h"
+#include "rg3mxxb12.h"
+
+LOG_MODULE_REGISTER(plat_pmic);
+
+K_THREAD_STACK_DEFINE(monitor_pmic_error_stack, MONITOR_PMIC_ERROR_STACK_SIZE);
+struct k_thread monitor_pmic_error_thread;
+k_tid_t monitor_pmic_error_tid;
+
+static const uint8_t pmic_i3c_err_data_index[MAX_COUNT_PMIC_ERROR_OFFSET] = { 0, 1, 3, 4, 5, 6, 46 };
+static const uint8_t pmic_err_pattern[MAX_COUNT_PMIC_ERROR_TYPE][MAX_COUNT_PMIC_ERROR_OFFSET] = {
+	// R05,  R06,  R08,  R09,  R0A,  R0B,  R33
+	{ 0x02, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00 }, // SWAOUT_OV
+	{ 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00 }, // SWBOUT_OV
+	{ 0x02, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00 }, // SWCOUT_OV
+	{ 0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00 }, // SWDOUT_OV
+	{ 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // VIN_BULK_OV
+	{ 0x00, 0x00, 0x02, 0x00, 0x02, 0x00, 0x00 }, // VIN_MGMT_OV
+	{ 0x02, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00 }, // SWAOUT_UV
+	{ 0x02, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00 }, // SWBOUT_UV
+	{ 0x02, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00 }, // SWCOUT_UV
+	{ 0x02, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00 }, // SWDOUT_UV
+	{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08 }, // VIN_BULK_UV
+	{ 0x00, 0x00, 0x00, 0x10, 0x02, 0x00, 0x00 }, // VIN_MGMT_TO_VIN_BUCK_SWITCHOVER
+	{ 0x00, 0x00, 0x00, 0x80, 0x02, 0x00, 0x00 }, // HIGH_TEMP_WARNING
+	{ 0x00, 0x00, 0x00, 0x20, 0x02, 0x00, 0x00 }, // VOUT_1V8_PG
+	{ 0x00, 0x00, 0x00, 0x0F, 0x02, 0x00, 0x00 }, // HIGH_CURRENT_WARNING
+	{ 0x00, 0x00, 0x00, 0x00, 0x02, 0xF0, 0x00 }, // CURRENT_LIMIT_WARNING
+	{ 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00 }, // CURRENT_TEMP_SHUTDOWN
+};
+
+static bool is_pmic_error_flag[MAX_COUNT_DIMM][MAX_COUNT_PMIC_ERROR_TYPE];
+
+void start_monitor_pmic_error_thread()
+{
+	LOG_INF("Start thread to monitor PMIC error");
+
+	monitor_pmic_error_tid =
+		k_thread_create(&monitor_pmic_error_thread, monitor_pmic_error_stack,
+				K_THREAD_STACK_SIZEOF(monitor_pmic_error_stack),
+				monitor_pmic_error_via_i3c_handler, NULL, NULL, NULL,
+				CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+	k_thread_name_set(&monitor_pmic_error_thread, "monitor_pmic_error_thread");
+}
+
+void monitor_pmic_error_via_i3c_handler()
+{
+	int ret = 0, dimm_id;
+	uint8_t error_data[MAX_LEN_I3C_GET_PMIC_ERR] = { 0 };
+
+	// initialize PMIC error flag array
+	memset(is_pmic_error_flag, false, sizeof(is_pmic_error_flag));
+
+	while (1) {
+		for (dimm_id = 0; dimm_id < MAX_COUNT_DIMM; dimm_id++) {
+			if (!get_post_status()) {
+				break;
+			}
+
+			if (!get_dimm_presence_status(dimm_id)) {
+				continue;
+			}
+
+			memset(&error_data, 0, sizeof(error_data));
+			ret = get_pmic_error_raw_data(dimm_id, error_data);
+			if (ret < 0) {
+				continue;
+			}
+
+			// Compare error pattern, add SEL to BMC and update record
+			ret = compare_pmic_error(dimm_id, error_data, sizeof(error_data));
+			if (ret != 0) {
+				continue;
+			}
+		}
+
+		k_msleep(MONITOR_PMIC_ERROR_TIME_MS);
+	}
+}
+
+int compare_pmic_error(uint8_t dimm_id, uint8_t *pmic_err_data, uint8_t pmic_err_data_len)
+{
+	uint8_t err_index = 0, reg_index = 0, data_index = 0;
+	uint8_t pattern = 0;
+
+	if (pmic_err_data == NULL) {
+		return -1;
+	}
+
+	for (err_index = 0; err_index < MAX_COUNT_PMIC_ERROR_TYPE; err_index++) {
+		for (reg_index = 0; reg_index < MAX_COUNT_PMIC_ERROR_OFFSET; reg_index++) {
+			data_index = pmic_i3c_err_data_index[reg_index];
+
+			// Not enough data
+			if (data_index >= pmic_err_data_len) {
+				break;
+			}
+
+			pattern = pmic_err_pattern[err_index][reg_index];
+
+			// Not match
+			if ((pmic_err_data[data_index] & pattern) != pattern) {
+				break;
+			}
+		}
+
+		// All bytes of error pattern are match
+		if (reg_index == MAX_COUNT_PMIC_ERROR_OFFSET) {
+			if (is_pmic_error_flag[dimm_id][err_index] == false) {
+				add_pmic_error_sel(dimm_id, err_index);
+				is_pmic_error_flag[dimm_id][err_index] = true;
+			}
+
+			// One byte of error pattern is not match
+		} else {
+			is_pmic_error_flag[dimm_id][err_index] = false;
+		}
+	}
+
+	return 0;
+}
+
+void add_pmic_error_sel(uint8_t dimm_id, uint8_t error_type)
+{
+	common_addsel_msg_t sel_msg;
+
+	memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
+	sel_msg.InF_target = BMC_IPMB;
+	sel_msg.sensor_type = IPMI_SENSOR_TYPE_PROCESSOR;
+	sel_msg.sensor_number = SENSOR_NUM_PMIC_ERROR;
+	sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
+	sel_msg.event_data1 = dimm_id;
+	sel_msg.event_data2 = error_type;
+	sel_msg.event_data3 = 0x00;
+	if (!common_add_sel_evt_record(&sel_msg)) {
+		LOG_ERR("Fail to add PMIC error event log: dimm: 0x%x error: 0x%x", dimm_id,
+			error_type);
+	}
+}
+
+int get_pmic_fault_status()
+{
+	uint8_t cpld_bus = 0;
+	int ret = -1;
+	ipmb_error status;
+	ipmi_msg ipmi_msg = { 0 };
+
+	// Get slot ID
+	ipmi_msg.InF_source = SELF;
+	ipmi_msg.InF_target = BMC_IPMB;
+	ipmi_msg.netfn = NETFN_OEM_REQ;
+	ipmi_msg.cmd = CMD_OEM_GET_BOARD_ID;
+	ipmi_msg.data_len = 0;
+
+	status = ipmb_read(&ipmi_msg, IPMB_inf_index_map[ipmi_msg.InF_target]);
+	if (status != IPMB_ERROR_SUCCESS) {
+		LOG_ERR("Failed to get slot ID status(%d)", status);
+		return ret;
+	}
+
+	// slot1 SB CPLD BUS is 4
+	// slot2 SB CPLD BUS is 5
+	// slot3 SB CPLD BUS is 6
+	// slot4 SB CPLD BUS is 7
+	cpld_bus = ipmi_msg.data[2] + 3;
+
+	// Read SB CPLD (BMC channel) to know which PMIC happen critical error
+	ipmi_msg.InF_source = SELF;
+	ipmi_msg.InF_target = BMC_IPMB;
+	ipmi_msg.netfn = NETFN_APP_REQ;
+	ipmi_msg.cmd = CMD_APP_MASTER_WRITE_READ;
+	ipmi_msg.data_len = 4;
+	ipmi_msg.data[0] = (cpld_bus << 1) + 1; // bus
+	ipmi_msg.data[1] = GL_CPLD_BMC_CHANNEL_ADDR; // addr
+	ipmi_msg.data[2] = 1; // read len
+	ipmi_msg.data[3] = PMIC_FAULT_STATUS_OFFSET; // offset
+
+	status = ipmb_read(&ipmi_msg, IPMB_inf_index_map[ipmi_msg.InF_target]);
+	if (status != IPMB_ERROR_SUCCESS) {
+		LOG_ERR("Failed to read PMIC fault status(%d) via IPMB", status);
+		return ret;
+	}
+
+	return ipmi_msg.data[0];
+}
+
+void read_pmic_error_when_dc_off()
+{
+	int ret = 0;
+	uint8_t dimm_id;
+	int pmic_fault_status = 0;
+	I3C_MSG i3c_msg = { 0 };
+	bool is_pmic_fault[MAX_COUNT_DIMM] = { false, false, false, false,
+					       false, false, false, false };
+
+	// Check PMIC fault status from SB CPLD (BMC channel)
+	pmic_fault_status = get_pmic_fault_status();
+	if (pmic_fault_status < 0) {
+		LOG_ERR("Failed to read PMIC fault status.");
+		return;
+	} else if (pmic_fault_status == 0) {
+		// No PMIC critical error, doesn't need to read register
+		return;
+	}
+
+	// Check which PMIC is error
+	// DIMM PMIC Fault (1: Fault 0: Normal)
+	// bit 0: DIMM GH Fault
+	// bit 1: DIMM EF Fault
+	// bit 2: DIMM CD Fault
+	// bit 3: DIMM AB Fault
+	if (GETBIT(pmic_fault_status, 0)) {
+		is_pmic_fault[DIMM_ID_G] = true;
+		is_pmic_fault[DIMM_ID_H] = true;
+	}
+	if (GETBIT(pmic_fault_status, 1)) {
+		is_pmic_fault[DIMM_ID_E] = true;
+		is_pmic_fault[DIMM_ID_F] = true;
+	}
+	if (GETBIT(pmic_fault_status, 2)) {
+		is_pmic_fault[DIMM_ID_C] = true;
+		is_pmic_fault[DIMM_ID_D] = true;
+	}
+	if (GETBIT(pmic_fault_status, 3)) {
+		is_pmic_fault[DIMM_ID_A] = true;
+		is_pmic_fault[DIMM_ID_B] = true;
+	}
+
+	if (k_mutex_lock(&i3c_dimm_mutex, K_MSEC(I3C_DIMM_MUTEX_TIMEOUT_MS))) {
+		LOG_ERR("Failed to lock I3C dimm MUX");
+		return;
+	}
+
+	for (dimm_id = 0; dimm_id < MAX_COUNT_DIMM; dimm_id++) {
+		// If no PMIC critical error doesn't need to read
+		if (!is_pmic_fault[dimm_id]) {
+			continue;
+		}
+
+		// Switch I3C mux to BIC and switch DIMM mux
+		ret = switch_i3c_dimm_mux(I3C_MUX_TO_BIC);
+		if (ret != 0) {
+			continue;
+		}
+
+		uint8_t slave_port_setting = (dimm_id / (MAX_COUNT_DIMM / 2)) ?
+							   I3C_HUB_TO_DIMMEFGH :
+							   I3C_HUB_TO_DIMMABCD;
+
+		if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
+					      slave_port_setting)) {
+			LOG_ERR("Failed to set slave port to slave port: 0x%x", slave_port_setting);
+			continue;
+		}
+
+		// Broadcast CCC after switch DIMM mux
+		// I3C_CCC_RSTDAA: Reset dynamic address assignment
+		// I3C_CCC_SETAASA: Set all addresses to static address
+		memset(&i3c_msg, 0, sizeof(i3c_msg));
+		i3c_msg.bus = I3C_BUS4;
+		ret = all_brocast_ccc(&i3c_msg);
+		if (ret != 0) {
+			LOG_ERR("Failed to brocast CCC, ret%d bus%d", ret, i3c_msg.bus);
+			continue;
+		}
+
+		// Read PMIC error via I3C
+		i3c_msg.target_addr = pmic_i3c_addr_list[dimm_id % (MAX_COUNT_DIMM / 2)];
+		i3c_msg.tx_len = 1;
+		i3c_msg.rx_len = MAX_LEN_I3C_GET_PMIC_ERR;
+		memset(&i3c_msg.data, 0, MAX_LEN_I3C_GET_PMIC_ERR);
+		i3c_msg.data[0] = PMIC_POR_ERROR_LOG_ADDR_VAL;
+
+		ret = i3c_transfer(&i3c_msg);
+		if (ret != 0) {
+			LOG_ERR("Failed to read PMIC error via I3C");
+			continue;
+		}
+
+		LOG_HEXDUMP_DBG(i3c_msg.data, i3c_msg.rx_len, "PMIC error data");
+		// Compare error pattern, add SEL to BMC and update record
+		ret = compare_pmic_error(dimm_id, i3c_msg.data, i3c_msg.rx_len);
+		if (ret < 0) {
+			continue;
+		}
+	}
+
+	if (k_mutex_unlock(&i3c_dimm_mutex)) {
+		LOG_ERR("Failed to unlock I3C dimm MUX");
+	}
+
+	// Switch I3C MUX to CPU after read finish
+	switch_i3c_dimm_mux(I3C_MUX_TO_CPU);
+	return;
+}
+
+void clear_pmic_error()
+{
+	int dimm_id, ret = 0;
+	uint8_t dimm_status = SENSOR_INIT_STATUS;
+	I3C_MSG i3c_msg = { 0 };
+
+	if (k_mutex_lock(&i3c_dimm_mutex, K_MSEC(I3C_DIMM_MUTEX_TIMEOUT_MS))) {
+		LOG_ERR("Failed to lock I3C dimm MUX");
+		return;
+	}
+
+	for (dimm_id = 0; dimm_id < MAX_COUNT_DIMM; dimm_id++) {
+		dimm_status = get_dimm_status(dimm_id);
+		if ((dimm_status == SENSOR_INIT_STATUS) || (dimm_status == SENSOR_NOT_PRESENT) ||
+		    (dimm_status == SENSOR_POLLING_DISABLE)) {
+			continue;
+		}
+
+		ret = switch_i3c_dimm_mux(I3C_MUX_TO_BIC);
+		if (ret != 0) {
+			continue;
+		}
+
+		uint8_t slave_port_setting = (dimm_id / (MAX_COUNT_DIMM / 2)) ?
+							   I3C_HUB_TO_DIMMEFGH :
+							   I3C_HUB_TO_DIMMABCD;
+
+		if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
+					      slave_port_setting)) {
+			LOG_ERR("Failed to set slave port to slave port: 0x%x", slave_port_setting);
+			continue;
+		}
+
+		// Broadcast CCC after switch DIMM mux
+		// I3C_CCC_RSTDAA: Reset dynamic address assignment
+		// I3C_CCC_SETAASA: Set all addresses to static address
+		memset(&i3c_msg, 0, sizeof(i3c_msg));
+		i3c_msg.bus = I3C_BUS4;
+		ret = all_brocast_ccc(&i3c_msg);
+		if (ret != 0) {
+			LOG_ERR("Failed to brocast CCC, ret%d bus%d", ret, i3c_msg.bus);
+			continue;
+		}
+
+		i3c_msg.target_addr = pmic_i3c_addr_list[dimm_id % (MAX_COUNT_DIMM / 2)];
+		i3c_msg.tx_len = 2;
+		i3c_msg.rx_len = 1;
+		memset(&i3c_msg.data, 0, 2);
+
+		// Set R39 to clear registers R04 ~ R07
+		// Host Region Codes: 0x74
+		// Clear Registers R04 to R07, Erase MTP memory for R04 Register
+		i3c_msg.data[0] = PMIC_VENDOR_PASSWORD_CONTROL_OFFSET;
+		i3c_msg.data[1] = 0x74;
+		ret = i3c_controller_write(&i3c_msg);
+		if (ret != 0) {
+			continue;
+		}
+
+		// Set R14 to clear registers R08 ~ R0B, R33
+		// R14[0]: GLOBAL_CLEAR_STATUS, Clear all status bits
+		i3c_msg.data[0] = PMIC_CLEAR_STATUS_BITS4_OFFSET;
+		i3c_msg.data[1] = 0x01;
+		ret = i3c_controller_write(&i3c_msg);
+		if (ret != 0) {
+			continue;
+		}
+	}
+
+	if (k_mutex_unlock(&i3c_dimm_mutex)) {
+		LOG_ERR("Failed to unlock I3C dimm MUX");
+	}
+
+	// Switch I3C MUX to CPU after clear finish
+	switch_i3c_dimm_mux(I3C_MUX_TO_CPU);
+
+	return;
+}

--- a/meta-facebook/yv35-gl/src/platform/plat_pmic.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_pmic.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_PMIC_H
+#define PLAT_PMIC_H
+
+#include <stdint.h>
+
+#define MONITOR_PMIC_ERROR_STACK_SIZE 4096
+#define MONITOR_PMIC_ERROR_TIME_MS (3 * 1000) // 3s
+
+#define MAX_COUNT_PMIC_ERROR_OFFSET 7
+#define MAX_COUNT_PMIC_ERROR_TYPE 17
+
+#define GL_CPLD_BMC_CHANNEL_ADDR 0x1E // 8 bits
+#define PMIC_FAULT_STATUS_OFFSET 0x0B
+#define PMIC_CLEAR_STATUS_BITS4_OFFSET 0x14
+#define PMIC_VENDOR_PASSWORD_CONTROL_OFFSET 0x39
+
+void start_monitor_pmic_error_thread();
+void monitor_pmic_error_via_i3c_handler();
+int compare_pmic_error(uint8_t dimm_id, uint8_t *pmic_err_data, uint8_t pmic_err_data_len);
+void add_pmic_error_sel(uint8_t dimm_id, uint8_t error_type);
+int get_pmic_fault_status();
+void read_pmic_error_when_dc_off();
+void clear_pmic_error();
+
+#endif

--- a/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -2974,6 +2974,492 @@ SDR_Full_sensor plat_sdr_table[] = {
 		"MB_VR_VCCD1_PWR_W",
 	},
 	{
+		// DIMMA power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_VR_DIMMA_PMIC_PWR_W, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x0E, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xE0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0xE6, // UCT
+		0xE1, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_VR_DIMMA_PMIC_PWR_W",
+	},
+	{
+		// DIMMB power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_VR_DIMMB_PMIC_PWR_W, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x0E, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xE0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0xE6, // UCT
+		0xE1, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_VR_DIMMB_PMIC_PWR_W",
+	},
+	{
+		// DIMMC power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_VR_DIMMC_PMIC_PWR_W, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x0E, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xE0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0xE6, // UCT
+		0xE1, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_VR_DIMMC_PMIC_PWR_W",
+	},
+	{
+		// DIMMD power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_VR_DIMMD_PMIC_PWR_W, // sensor number
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x0E, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xE0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0xE6, // UCT
+		0xE1, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_VR_DIMMD_PMIC_PWR_W",
+	},
+	{
+		// DIMME power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_VR_DIMME_PMIC_PWR_W, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x0E, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xE0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0xE6, // UCT
+		0xE1, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_VR_DIMME_PMIC_PWR_W",
+	},
+	{
+		// DIMMF power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_VR_DIMMF_PMIC_PWR_W, // sensor number
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x0E, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xE0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0xE6, // UCT
+		0xE1, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_VR_DIMMF_PMIC_PWR_W",
+	},
+	{
+		// DIMMG power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_VR_DIMMG_PMIC_PWR_W, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x0E, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xE0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0xE6, // UCT
+		0xE1, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_VR_DIMMG_PMIC_PWR_W",
+	},
+	{
+		// DIMMH power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_MB_VR_DIMMH_PMIC_PWR_W, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x0E, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0xE0, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0xE6, // UCT
+		0xE1, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_VR_DIMMH_PMIC_PWR_W",
+	},
+	{
 		0x00,
 		0x00, // record ID
 		IPMI_SDR_VER_15, // SDR ver
@@ -3033,10 +3519,6 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
 		"CPU_PWR",
 	},
-
-	/* TODO:
-	 * DIMM power sensors are pending because I3C hasn't be ready yet.
-	 */
 };
 
 SDR_Full_sensor hotswap_sdr_table[] = {

--- a/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -24,12 +24,26 @@
 #include "plat_class.h"
 #include "plat_gpio.h"
 #include "plat_i2c.h"
+#include "plat_i3c.h"
+#include "plat_dimm.h"
 #include "plat_sensor_table.h"
 #include "plat_hook.h"
 
 #include <logging/log.h>
 
 LOG_MODULE_REGISTER(plat_sensor_table);
+
+dimm_pmic_mapping_cfg dimm_pmic_map_table[] = {
+	// dimm_sensor_num, mapping_pmic_sensor_num
+	{ SENSOR_NUM_MB_DIMMA_TEMP_C, SENSOR_NUM_MB_VR_DIMMA_PMIC_PWR_W },
+	{ SENSOR_NUM_MB_DIMMB_TEMP_C, SENSOR_NUM_MB_VR_DIMMB_PMIC_PWR_W },
+	{ SENSOR_NUM_MB_DIMMC_TEMP_C, SENSOR_NUM_MB_VR_DIMMC_PMIC_PWR_W },
+	{ SENSOR_NUM_MB_DIMMD_TEMP_C, SENSOR_NUM_MB_VR_DIMMD_PMIC_PWR_W },
+	{ SENSOR_NUM_MB_DIMME_TEMP_C, SENSOR_NUM_MB_VR_DIMME_PMIC_PWR_W },
+	{ SENSOR_NUM_MB_DIMMF_TEMP_C, SENSOR_NUM_MB_VR_DIMMF_PMIC_PWR_W },
+	{ SENSOR_NUM_MB_DIMMG_TEMP_C, SENSOR_NUM_MB_VR_DIMMG_PMIC_PWR_W },
+	{ SENSOR_NUM_MB_DIMMH_TEMP_C, SENSOR_NUM_MB_VR_DIMMH_PMIC_PWR_W },
+};
 
 sensor_cfg plat_sensor_config[] = {
 	/*  number,
@@ -66,38 +80,38 @@ sensor_cfg plat_sensor_config[] = {
 	  post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
-	{ SENSOR_NUM_MB_DIMMA_TEMP_C, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
-	  PECI_TEMP_CHANNEL0_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read, NULL, NULL, NULL,
-	  NULL },
-	{ SENSOR_NUM_MB_DIMMB_TEMP_C, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
-	  PECI_TEMP_CHANNEL1_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read, NULL, NULL, NULL,
-	  NULL },
-	{ SENSOR_NUM_MB_DIMMC_TEMP_C, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
-	  PECI_TEMP_CHANNEL2_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read, NULL, NULL, NULL,
-	  NULL },
-	{ SENSOR_NUM_MB_DIMMD_TEMP_C, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
-	  PECI_TEMP_CHANNEL3_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read, NULL, NULL, NULL,
-	  NULL },
-	{ SENSOR_NUM_MB_DIMME_TEMP_C, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
-	  PECI_TEMP_CHANNEL4_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read, NULL, NULL, NULL,
-	  NULL },
-	{ SENSOR_NUM_MB_DIMMF_TEMP_C, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
-	  PECI_TEMP_CHANNEL5_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read, NULL, NULL, NULL,
-	  NULL },
-	{ SENSOR_NUM_MB_DIMMG_TEMP_C, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
-	  PECI_TEMP_CHANNEL6_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read, NULL, NULL, NULL,
-	  NULL },
-	{ SENSOR_NUM_MB_DIMMH_TEMP_C, sensor_dev_intel_peci, NONE, CPU_PECI_ADDR,
-	  PECI_TEMP_CHANNEL7_DIMM0, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_peci_dimm_read, NULL, NULL, NULL,
-	  NULL },
+	{ SENSOR_NUM_MB_DIMMA_TEMP_C, sensor_dev_i3c_dimm, I3C_BUS4, DIMM_SPD_A_E_ADDR,
+	  DIMM_SPD_TEMP, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL,
+	  post_intel_dimm_i3c_read, &dimm_post_proc_args[0], NULL },
+	{ SENSOR_NUM_MB_DIMMB_TEMP_C, sensor_dev_i3c_dimm, I3C_BUS4, DIMM_SPD_B_F_ADDR,
+	  DIMM_SPD_TEMP, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL,
+	  post_intel_dimm_i3c_read, &dimm_post_proc_args[1], NULL },
+	{ SENSOR_NUM_MB_DIMMC_TEMP_C, sensor_dev_i3c_dimm, I3C_BUS4, DIMM_SPD_C_G_ADDR,
+	  DIMM_SPD_TEMP, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL,
+	  post_intel_dimm_i3c_read, &dimm_post_proc_args[2], NULL },
+	{ SENSOR_NUM_MB_DIMMD_TEMP_C, sensor_dev_i3c_dimm, I3C_BUS4, DIMM_SPD_D_H_ADDR,
+	  DIMM_SPD_TEMP, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL,
+	  post_intel_dimm_i3c_read, &dimm_post_proc_args[3], NULL },
+	{ SENSOR_NUM_MB_DIMME_TEMP_C, sensor_dev_i3c_dimm, I3C_BUS4, DIMM_SPD_A_E_ADDR,
+	  DIMM_SPD_TEMP, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL,
+	  post_intel_dimm_i3c_read, &dimm_post_proc_args[4], NULL },
+	{ SENSOR_NUM_MB_DIMMF_TEMP_C, sensor_dev_i3c_dimm, I3C_BUS4, DIMM_SPD_B_F_ADDR,
+	  DIMM_SPD_TEMP, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL,
+	  post_intel_dimm_i3c_read, &dimm_post_proc_args[5], NULL },
+	{ SENSOR_NUM_MB_DIMMG_TEMP_C, sensor_dev_i3c_dimm, I3C_BUS4, DIMM_SPD_C_G_ADDR,
+	  DIMM_SPD_TEMP, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL,
+	  post_intel_dimm_i3c_read, &dimm_post_proc_args[6], NULL },
+	{ SENSOR_NUM_MB_DIMMH_TEMP_C, sensor_dev_i3c_dimm, I3C_BUS4, DIMM_SPD_D_H_ADDR,
+	  DIMM_SPD_TEMP, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL,
+	  post_intel_dimm_i3c_read, &dimm_post_proc_args[7], NULL },
 
 	{ SENSOR_NUM_MB_SSD0_TEMP_C, sensor_dev_nvme, I2C_BUS2, SSD0_ADDR, SSD0_OFFSET, post_access,
 	  0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
@@ -228,9 +242,39 @@ sensor_cfg plat_sensor_config[] = {
 	  post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
-	/* TODO:
-	 * DIMM power sensors are pending because I3C hasn't be ready yet.
-	 */
+	// DIMM PMIC power
+	{ SENSOR_NUM_MB_VR_DIMMA_PMIC_PWR_W, sensor_dev_i3c_dimm, I3C_BUS4, PMIC_A_E_ADDR,
+	  DIMM_PMIC_SWA_PWR, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL, NULL, NULL,
+	  NULL },
+	{ SENSOR_NUM_MB_VR_DIMMB_PMIC_PWR_W, sensor_dev_i3c_dimm, I3C_BUS4, PMIC_B_F_ADDR,
+	  DIMM_PMIC_SWA_PWR, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL, NULL, NULL,
+	  NULL },
+	{ SENSOR_NUM_MB_VR_DIMMC_PMIC_PWR_W, sensor_dev_i3c_dimm, I3C_BUS4, PMIC_C_G_ADDR,
+	  DIMM_PMIC_SWA_PWR, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL, NULL, NULL,
+	  NULL },
+	{ SENSOR_NUM_MB_VR_DIMMD_PMIC_PWR_W, sensor_dev_i3c_dimm, I3C_BUS4, PMIC_D_H_ADDR,
+	  DIMM_PMIC_SWA_PWR, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL, NULL, NULL,
+	  NULL },
+	{ SENSOR_NUM_MB_VR_DIMME_PMIC_PWR_W, sensor_dev_i3c_dimm, I3C_BUS4, PMIC_A_E_ADDR,
+	  DIMM_PMIC_SWA_PWR, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL, NULL, NULL,
+	  NULL },
+	{ SENSOR_NUM_MB_VR_DIMMF_PMIC_PWR_W, sensor_dev_i3c_dimm, I3C_BUS4, PMIC_B_F_ADDR,
+	  DIMM_PMIC_SWA_PWR, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL, NULL, NULL,
+	  NULL },
+	{ SENSOR_NUM_MB_VR_DIMMG_PMIC_PWR_W, sensor_dev_i3c_dimm, I3C_BUS4, PMIC_C_G_ADDR,
+	  DIMM_PMIC_SWA_PWR, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL, NULL, NULL,
+	  NULL },
+	{ SENSOR_NUM_MB_VR_DIMMH_PMIC_PWR_W, sensor_dev_i3c_dimm, I3C_BUS4, PMIC_D_H_ADDR,
+	  DIMM_PMIC_SWA_PWR, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_intel_dimm_i3c_read, NULL, NULL, NULL,
+	  NULL },
 };
 
 sensor_cfg adm1278_sensor_config_table[] = {
@@ -392,4 +436,26 @@ void pal_extend_sensor_config()
 			check_vr_type(index);
 		}
 	}
+}
+
+static int sensor_get_idx_by_sensor_num(uint16_t sensor_num)
+{
+	int sensor_idx = 0;
+	for (sensor_idx = 0; sensor_idx < sensor_config_count; sensor_idx++) {
+		if (sensor_num == sensor_config[sensor_idx].num)
+			return sensor_idx;
+	}
+
+	return -1;
+}
+
+uint8_t get_dimm_status(uint8_t dimm_index)
+{
+	int sensor_index =
+		sensor_get_idx_by_sensor_num(dimm_pmic_map_table[dimm_index].dimm_sensor_num);
+	if (sensor_index < 0) {
+		return SENSOR_NOT_SUPPORT;
+	}
+
+	return sensor_config[sensor_index].cache_status;
 }

--- a/meta-facebook/yv35-gl/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_sensor_table.h
@@ -116,6 +116,14 @@
 #define SENSOR_NUM_PROC_FAIL 0x65
 #define SENSOR_NUM_VR_HOT 0xB2
 #define SENSOR_NUM_CPUDIMM_HOT 0xB3
+#define SENSOR_NUM_PMIC_ERROR 0xB4
 #define SENSOR_NUM_CATERR 0xEB
+
+typedef struct _dimm_pmic_mapping_cfg {
+	uint8_t dimm_sensor_num;
+	uint8_t mapping_pmic_sensor_num;
+} dimm_pmic_mapping_cfg;
+
+uint8_t get_dimm_status(uint8_t dimm_index);
 
 #endif


### PR DESCRIPTION
# Description:
Read DIMM related data (DIMM's temperature, PMIC power, and PMIC error) by I3C

# Motivation:
Currently, BIC read DIMM by using PECI command

# Test Plan:
1. Check DIMM temperature and PMIC power sensors - pass
2. Inject PMIC error and check SEL - pass

# Test Log:
1. Check DIMM temperature and PMIC power sensors root@bmc-oob:~# sensor-util slot1|grep -i DIMM
MB_DIMMA_TEMP_C              (0x5) :   34.50 C     | (ok)
MB_DIMMB_TEMP_C              (0x6) :   33.00 C     | (ok)
MB_DIMMC_TEMP_C              (0x7) :   33.25 C     | (ok)
MB_DIMMD_TEMP_C              (0x8) :   33.25 C     | (ok)
MB_DIMME_TEMP_C              (0x9) :   33.50 C     | (ok)
MB_DIMMF_TEMP_C              (0xA) :   33.00 C     | (ok)
MB_DIMMG_TEMP_C              (0xB) :   33.25 C     | (ok)
MB_DIMMH_TEMP_C              (0xC) :   33.00 C     | (ok)
MB_ADC_P12V_DIMM_VOLT_V      (0x25) :   12.36 Volts | (ok)
MB_VR_DIMMA_PMIC_PWR_W       (0x36) :    1.12 Watts | (ok)
MB_VR_DIMMB_PMIC_PWR_W       (0x37) :    0.62 Watts | (ok)
MB_VR_DIMMC_PMIC_PWR_W       (0x38) :    0.75 Watts | (ok)
MB_VR_DIMMD_PMIC_PWR_W       (0x39) :    0.50 Watts | (ok)
MB_VR_DIMME_PMIC_PWR_W       (0x3A) :    0.62 Watts | (ok)
MB_VR_DIMMF_PMIC_PWR_W       (0x3B) :    1.00 Watts | (ok)
MB_VR_DIMMG_PMIC_PWR_W       (0x3C) :    0.75 Watts | (ok)
MB_VR_DIMMH_PMIC_PWR_W       (0x3D) :    0.50 Watts | (ok)

2. Inject PMIC error and check SEL
- Inject DIMM warning error high_temp on DIMM A root@bmc-oob:~# log-util slot1 --print|grep -i ipmid
1    slot1    2023-08-15 14:02:15    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-08-15 14:02:14, Sensor: PMIC_ERR (0xB4), Event Data: (000C00) DIMM A High Temp Warning Assertion