### PR TITLE
fby35: gl: Support to reset BMC by IPMI command

### DIFF
--- a/meta-facebook/yv35-gl/src/lib/plat_sys.c
+++ b/meta-facebook/yv35-gl/src/lib/plat_sys.c
@@ -19,15 +19,20 @@
 #include "util_sys.h"
 #include "hal_gpio.h"
 #include "plat_gpio.h"
+#include "util_worker.h"
 
 /* BMC reset */
-
 void BMC_reset_handler()
 {
-	/*TODO :
-        1. set GPIO "RST_BMC_R_N" LOW
-        2. k_msleep(10)
-        3. set GPIO "RST_BMC_R_N" HIGH
-    */
-	return;
+    gpio_set(RST_BMC_R_N, GPIO_LOW);
+    k_msleep(10);
+    gpio_set(RST_BMC_R_N, GPIO_HIGH);
 }
+
+K_WORK_DELAYABLE_DEFINE(BMC_reset_work, BMC_reset_handler);
+int pal_submit_bmc_cold_reset()
+{
+    k_work_schedule_for_queue(&plat_work_q, &BMC_reset_work, K_MSEC(BMC_COLD_RESET_DELAY_MS));
+    return 0;
+}
+/* BMC reset */

--- a/meta-facebook/yv35-gl/src/lib/plat_sys.h
+++ b/meta-facebook/yv35-gl/src/lib/plat_sys.h
@@ -17,4 +17,6 @@
 #ifndef PLAT_SYS_H
 #define PLAT_SYS_H
 
+#define BMC_COLD_RESET_DELAY_MS 1000
+
 #endif


### PR DESCRIPTION
# Description:
    - If BMC get command of reseting BMC , it will pull RST_BMC_R_N.

# Motivation:
    - Support IPMI command of reseting BMC.

# Test plan:
    [root@localhost ~]# ipmitool mc reset cold
    Sent cold reset command to MC
    [root@localhost ~]#
    Broadcast message from root@bmc-oob. (Mon Aug 14 11:12:24 2023):

    The system is going down for reboot NOW!
    /*Reconnect to BMC*/
    root@bmc-oob:~# log-util all --print | grep reboot
    0    all      2023-08-14 11:13:22    healthd          BMC Reboot detected - caused by reboot command
    root@bmc-oob:~#