### PR TITLE
fby35: gl: Revise serverboard sensors' threshold

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
@@ -74,8 +74,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x96, // UNRT
-		0x96, // UCT
-		0x3C, // UNCT
+		0x3C, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -134,8 +134,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x96, // UNRT
-		0x96, // UCT
-		0x50, // UNCT
+		0x50, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -194,8 +194,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x96, // UNRT
-		0x96, // UCT
-		0x28, // UNCT
+		0x28, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -254,8 +254,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x5B, // UNCT
+		0x5B, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -314,8 +314,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x55, // UNCT
+		0x55, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -374,8 +374,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x55, // UNCT
+		0x55, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -434,8 +434,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x55, // UNCT
+		0x55, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -494,8 +494,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x55, // UNCT
+		0x55, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -554,8 +554,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x55, // UNCT
+		0x55, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -614,8 +614,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x55, // UNCT
+		0x55, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -674,8 +674,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x55, // UNCT
+		0x55, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -734,8 +734,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x55, // UNCT
+		0x55, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -794,8 +794,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x5D, // UNRT
-		0x5D, // UCT
-		0x4D, // UNCT
+		0x4D, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -854,8 +854,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x7D, // UCT
-		0x64, // UNCT
+		0x64, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -914,8 +914,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x7D, // UCT
-		0x64, // UNCT
+		0x64, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -974,8 +974,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x7D, // UCT
-		0x64, // UNCT
+		0x64, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1034,8 +1034,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x7D, // UCT
-		0x64, // UNCT
+		0x64, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1094,8 +1094,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x7D, // UCT
-		0x64, // UNCT
+		0x64, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1154,8 +1154,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x7D, // UNRT
-		0x7D, // UCT
-		0x64, // UNCT
+		0x64, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -1214,8 +1214,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x00, // UCT
-		0x01, // UNCT
+		0x01, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2479,7 +2479,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor minimum reading
 		0xF4, // UNRT
 		0xE0, // UCT
-		0xDD, // UNCT
+		0xD6, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2887,21 +2887,21 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x11, // [7:0] M bits
+		0xB8, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] acPWRacy , [3:2] acPWRacy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x1A, // UNRT
-		0x14, // UCT
-		0x12, // UNCT
+		0xEF, // UNRT
+		0xB5, // UCT
+		0xAD, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -2947,21 +2947,21 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x11, // [7:0] M bits
+		0xB8, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] acPWRacy , [3:2] acPWRacy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
+		0xD0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x1A, // UNRT
-		0x14, // UCT
-		0x12, // UNCT
+		0xEF, // UNRT
+		0xB5, // UCT
+		0xAD, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT
@@ -3087,8 +3087,8 @@ SDR_Full_sensor hotswap_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0xAF, // UNRT
-		0xAF, // UCT
-		0x50, // UNCT
+		0x50, // UCT
+		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
 		0x00, // LNCT


### PR DESCRIPTION
# Description:
- Revise parts of sensors' threshold from "Great Lakes_BIC_GPIO_20230807.xlsx".

# Motivation:
- To correct parts of sensors' threshold.

# Test plan:
- Get sensors' threshold

# Test log:
    root@bmc-oob:~# sensor-util slot3 --threshold
    slot3:
    MB_INLET_TEMP_C              (0x1) :   26.00 C     | (ok) | UCR: 60.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
    MB_OUTLET_TEMP_C             (0x2) :   31.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
    FIO_FRONT_TEMP_C             (0x3) :   26.00 C     | (ok) | UCR: 40.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
    MB_SOC_CPU_TEMP_C            (0x4) :   39.00 C     | (ok) | UCR: 91.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
    MB_DIMMA_TEMP_C              (0x5) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
    MB_DIMMB_TEMP_C              (0x6) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
    MB_DIMMC_TEMP_C              (0x7) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
    MB_DIMMD_TEMP_C              (0x8) :   28.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
    MB_DIMME_TEMP_C              (0x9) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
    MB_DIMMF_TEMP_C              (0xA) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
    MB_DIMMG_TEMP_C              (0xB) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
    MB_DIMMH_TEMP_C              (0xC) :   29.00 C     | (ok) | UCR: 85.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
    MB_SSD0_TEMP_C               (0xD) :   28.00 C     | (ok) | UCR: 77.00 | UNC: NA | UNR: 93.00 | LCR: NA | LNC: NA | LNR: NA
    MB_HSC_TEMP_C                (0xE) :   27.14 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: 175.00 | LCR: NA | LNC: NA | LNR: NA
    MB_VR_VCCIN_TEMP_C           (0xF) :   38.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
    MB_VR_EHV_TEMP_C             (0x10) :   38.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
    MB_VR_FIVRA_TEMP_C           (0x11) :   34.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
    MB_VR_VCCINF_TEMP_C          (0x12) :   34.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
    MB_VR_VCCD0_TEMP_C           (0x13) :   26.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
    MB_VR_VCCD1_TEMP_C           (0x14) :   27.00 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
    MB_SOC_THERMAL_MARGIN_C      (0x15) :  -53.00 C     | (ok) | UCR: 0.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
    MB_SOC_TJMAX_C               (0x16) :   92.00 C     | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
    ```
    MB_VR_VCCINF_CURR_A          (0x2C) :    5.25 Amps  | (ok) | UCR: 60.48 | UNC: 57.78 | UNR: 65.88 | LCR: NA | LNC: NA | LNR: NA
    ```
    MB_VR_VCCD0_PWR_W            (0x34) :    0.25 Watts | (ok) | UCR: 33.30 | UNC: 31.83 | UNR: 43.98 | LCR: NA | LNC: NA | LNR: NA
    MB_VR_VCCD1_PWR_W            (0x35) :    0.00 Watts | (ok) | UCR: 33.30 | UNC: 31.83 | UNR: 43.98 | LCR: NA | LNC: NA | LNR: NA