### PR TITLE
common: snoop: Revise to use callback function

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0055-drivers-misc-aspeed-snoop-Replace-RX-handling-with-c.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0055-drivers-misc-aspeed-snoop-Replace-RX-handling-with-c.patch
@@ -1,0 +1,148 @@
+From 577e1bf77367b5ec41b89f0a15a6cb032de3321f Mon Sep 17 00:00:00 2001
+From: Chia-Wei Wang <chiawei_wang@aspeedtech.com>
+Date: Fri, 29 Jul 2022 13:04:13 +0800
+Subject: [PATCH] drivers: misc/aspeed-snoop: Replace RX handling with callback
+ function
+
+Replace the original snoop data read with RX callback function.
+
+Signed-off-by: Chia-Wei Wang <chiawei_wang@aspeedtech.com>
+Change-Id: Ibacf018d4b2ff8235c0ae2c0c7a3d4b6cef5625f
+---
+ drivers/misc/aspeed/snoop_aspeed.c         | 54 ++++++++--------------
+ include/drivers/misc/aspeed/snoop_aspeed.h |  9 +++-
+ 2 files changed, 27 insertions(+), 36 deletions(-)
+
+diff --git a/drivers/misc/aspeed/snoop_aspeed.c b/drivers/misc/aspeed/snoop_aspeed.c
+index 0f8fd912f4..dca5a39605 100644
+--- a/drivers/misc/aspeed/snoop_aspeed.c
++++ b/drivers/misc/aspeed/snoop_aspeed.c
+@@ -38,20 +38,12 @@ LOG_MODULE_REGISTER(snoop_aspeed, CONFIG_LOG_DEFAULT_LEVEL);
+ #define	  HICRB_ENSNP1D		BIT(15)
+ #define	  HICRB_ENSNP0D		BIT(14)
+ 
+-/* misc. constant */
+-#define SNOOP_CHANNEL_NUM	2
+-
+ static uintptr_t lpc_base;
+ #define LPC_RD(reg)             sys_read32(lpc_base + reg)
+ #define LPC_WR(val, reg)        sys_write32(val, lpc_base + reg)
+ 
+-struct snoop_aspeed_fifo {
+-	intptr_t reserved;
+-	uint32_t byte;
+-};
+-
+ struct snoop_aspeed_data {
+-	struct k_fifo fifo[SNOOP_CHANNEL_NUM];
++	snoop_aspeed_rx_callback_t *rx_cb;
+ };
+ 
+ struct snoop_aspeed_config {
+@@ -59,21 +51,16 @@ struct snoop_aspeed_config {
+ 	uint16_t port[SNOOP_CHANNEL_NUM];
+ };
+ 
+-int snoop_aspeed_read(const struct device *dev, uint32_t ch, uint8_t *out, bool blocking)
++int snoop_aspeed_register_rx_callback(const struct device *dev, snoop_aspeed_rx_callback_t cb)
+ {
+-	struct snoop_aspeed_fifo *node;
+ 	struct snoop_aspeed_data *data = (struct snoop_aspeed_data *)dev->data;
+ 
+-	if (ch >= SNOOP_CHANNEL_NUM)
+-		return -EINVAL;
+-
+-	node = k_fifo_get(&data->fifo[ch], (blocking) ? K_FOREVER : K_NO_WAIT);
+-	if (!node)
+-		return -ENODATA;
+-
+-	*out = (uint8_t)node->byte;
++	if (data->rx_cb) {
++		LOG_ERR("Snoop RX callback is registered\n");
++		return -EBUSY;
++	}
+ 
+-	k_free(node);
++	data->rx_cb = cb;
+ 
+ 	return 0;
+ }
+@@ -81,28 +68,27 @@ int snoop_aspeed_read(const struct device *dev, uint32_t ch, uint8_t *out, bool
+ static void snoop_aspeed_isr(const struct device *dev)
+ {
+ 	uint32_t hicr6, snpwdr;
+-	struct snoop_aspeed_fifo *node;
++	uint8_t snoop[SNOOP_CHANNEL_NUM];
++	uint8_t *snoop_ptr[SNOOP_CHANNEL_NUM];
+ 	struct snoop_aspeed_data *data = (struct snoop_aspeed_data *)dev->data;
+ 
+ 	hicr6 = LPC_RD(HICR6);
+ 	snpwdr = LPC_RD(SNPWDR);
+ 
++	memset(snoop_ptr, 0, sizeof(snoop_ptr));
++
+ 	if (hicr6 & HICR6_STR_SNP0W) {
+-		node = k_malloc(sizeof(struct snoop_aspeed_fifo));
+-		if (node) {
+-			node->byte = (snpwdr & SNPWDR_DATA0_MASK) >> SNPWDR_DATA0_SHIFT;
+-			k_fifo_put(&data->fifo[0], node);
+-		} else
+-			LOG_ERR("failed to allocate FIFO0, drop data\n");
++		snoop[0] = (snpwdr & SNPWDR_DATA0_MASK) >> SNPWDR_DATA0_SHIFT;
++		snoop_ptr[0] = &snoop[0];
+ 	}
+ 
+ 	if (hicr6 & HICR6_STR_SNP1W) {
+-		node = k_malloc(sizeof(struct snoop_aspeed_fifo));
+-		if (node) {
+-			node->byte = (snpwdr & SNPWDR_DATA1_MASK) >> SNPWDR_DATA1_SHIFT;
+-			k_fifo_put(&data->fifo[1], node);
+-		} else
+-			LOG_ERR("failed to allocate FIFO1, drop data\n");
++		snoop[1] = (snpwdr & SNPWDR_DATA1_MASK) >> SNPWDR_DATA1_SHIFT;
++		snoop_ptr[1] = &snoop[1];
++	}
++
++	if (data->rx_cb) {
++		data->rx_cb(snoop_ptr[0], snoop_ptr[1]);
+ 	}
+ 
+ 	LPC_WR(hicr6, HICR6);
+@@ -143,7 +129,6 @@ static void snoop_aspeed_enable(const struct device *dev, uint32_t ch)
+ static int snoop_aspeed_init(const struct device *dev)
+ {
+ 	int i;
+-	struct snoop_aspeed_data *data = (struct snoop_aspeed_data *)dev->data;
+ 	struct snoop_aspeed_config *cfg = (struct snoop_aspeed_config *)dev->config;
+ 
+ 	if (!lpc_base)
+@@ -160,7 +145,6 @@ static int snoop_aspeed_init(const struct device *dev)
+ 		if (!cfg->port[i])
+ 			continue;
+ 
+-		k_fifo_init(&data->fifo[i]);
+ 		snoop_aspeed_enable(dev, i);
+ 	}
+ 
+diff --git a/include/drivers/misc/aspeed/snoop_aspeed.h b/include/drivers/misc/aspeed/snoop_aspeed.h
+index 6fd31444b9..f97daf68f5 100644
+--- a/include/drivers/misc/aspeed/snoop_aspeed.h
++++ b/include/drivers/misc/aspeed/snoop_aspeed.h
+@@ -8,6 +8,13 @@
+ 
+ #define SNOOP_CHANNEL_NUM	2
+ 
+-int snoop_aspeed_read(const struct device *dev, uint32_t ch, uint8_t *out, bool blocking);
++/*
++ * callback to handle snoop RX data
++ * @snoop0: pointer to the byte snooped by channel 0, NULL if no data
++ * @snoop1: pointer to the byte snooped by channel 1, NULL if no data
++ */
++typedef void snoop_aspeed_rx_callback_t(const uint8_t *snoop0, const uint8_t *snoop1);
++
++int snoop_aspeed_register_rx_callback(const struct device *dev, snoop_aspeed_rx_callback_t cb);
+ 
+ #endif
+-- 
+2.25.1
+


### PR DESCRIPTION
# Description:
Replace RX handling with callback function

# Motivation:
To fix potential memory leak when using snoop RX handling.

# Test Plan:
1. Build and test pass on fby35 CL system. pass

2. Check post code. root@bmc-oob:~# bic-util slot1 --get_post_code
util_get_postcode: returns 240 bytes
7E D0 7E 7E EE ED EC EB E9 E7 E6 AF AF AF BF 7E
C6 CE BC BC BC BC BC CC 7E DC CA CA B7 7E 70 7E
D1 7E D1 7E D0 7E D0 7E D0 7E 7E BB BB BB BB BB
BB BB BB BB BB CB 7E 7E 70 7E 70 70 7E 70 70 B9
BA DB D9 DA C9 D7 B8 B8 B8 B8 B8 B8 B8 B7 B7 B7
B7 B7 B7 B7 B7 7E B9 70 D6 D2 7E D2 7E 7E BE BE
B7 B7 7E B7 7E 70 70 7E 70 70 70 7E B7 B7 B6 B6
B7 B7 7E 7E 7E 7E B6 B6 B7 B0 B6 B6 B6 B3 B3 B3
B3 B3 B3 B3 C6 B2 C5 B8 7E B4 7E B6 B1 B1 B1 7E
7E 70 7E C2 7E 7E B1 B1 70 C1 7E B0 CD 73 7E CF
7E B5 BF B0 AF AF E5 E3 E4 E1 E0 E0 E0 AE AA A8
A9 A9 A7 A7 A7 A2 A2 A9 A9 A7 A3 A3 A1 00 31 19
55 52 15 4D 4A 49 0E 48 7F 02 00 23 23 03 03 06
05 04 03 02 01 10 50 AF AF AF AF BF 7E C6 CE BC
BC BC BC BC CC 7E DC CA CA B7 7E 70 7E D0 7E D0