### PR TITLE
Artemis: cb: Fix switch sensor/fw version NA after mb reset

### DIFF
--- a/meta-facebook/at-cb/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/at-cb/src/ipmi/plat_ipmi.c
@@ -145,10 +145,12 @@ void OEM_1S_GET_FW_VERSION(ipmi_msg *msg)
 
 		if (pex_access_engine(cfg->port, cfg->target_addr, p->idx, pex_access_sbr_ver,
 				      &reading)) {
-			if (cfg->post_sensor_read_hook(cfg, cfg->post_sensor_read_args, NULL) ==
-			    false) {
-				LOG_ERR("PEX%d post-read failed!",
-					component - CB_COMPNT_PCIE_SWITCH0);
+			if (cfg->post_sensor_read_hook) {
+				if (cfg->post_sensor_read_hook(cfg, cfg->post_sensor_read_args,
+							       NULL) == false) {
+					LOG_ERR("PEX%d post-read failed!",
+						component - CB_COMPNT_PCIE_SWITCH0);
+				}
 			}
 			msg->completion_code = CC_PEX_ACCESS_FAIL;
 			return;


### PR DESCRIPTION
# Description
- Fix switch sensor/fw version NA after mb reset
  - Add checked function to avoid execution to the NULL function

# Motivation
- Fix switch sensor/fw version NA after mb reset

# Test Plan
- Build code: Pass
- Simultaneous request for switch sensor/firmware version during mb reset: 150 rounds Pass
- Get switch sensor/sensor/firmware version after mb reset: 150 rounds Pass