### PR TITLE
Artemis: cb: Send present SEL of Artemis modules through PLDM

### DIFF
--- a/meta-facebook/at-cb/CMakeLists.txt
+++ b/meta-facebook/at-cb/CMakeLists.txt
@@ -47,3 +47,6 @@ target_include_directories(app PRIVATE src/platform)
 
 # Fail build if there are any warnings 
 target_compile_options(app PRIVATE -Werror)
+
+add_compile_definitions(PLDM_MONITOR_EVENT_QUEUE_MSG_NUM_MAX=30)
+add_compile_definitions(PLDM_MAX_DATA_SIZE=1024)

--- a/meta-facebook/at-cb/src/platform/plat_class.h
+++ b/meta-facebook/at-cb/src/platform/plat_class.h
@@ -35,6 +35,8 @@
 #define CPLD_PWRGD_2_OFFSET 0x06
 #define CPLD_ACCLA_PWRGD_OFFSET 0x24
 #define CPLD_ACCLB_PWRGD_OFFSET 0x25
+#define CPLD_ACCL_7_12_POWER_CABLE_PRESENT_OFFSET 0x26
+#define CPLD_ACCL_1_6_POWER_CABLE_PRESENT_OFFSET 0x27
 #define CPLD_ACCL_1_6_PRESENT_OFFSET 0x3F
 #define CPLD_ACCL_7_12_PRESENT_OFFSET 0x3E
 #define CPLD_PWRGD_BIT BIT(0)
@@ -129,6 +131,7 @@ enum PCIE_CARD_INDEX {
 
 struct ASIC_CARD_INFO {
 	bool card_status;
+	bool pwr_cbl_status;
 	uint8_t card_type;
 	bool asic_1_status;
 	bool asic_2_status;

--- a/meta-facebook/at-cb/src/platform/plat_init.c
+++ b/meta-facebook/at-cb/src/platform/plat_init.c
@@ -23,6 +23,7 @@
 #include "plat_class.h"
 #include "plat_i2c_target.h"
 #include "util_worker.h"
+#include "plat_pldm_monitor.h"
 
 SCU_CFG scu_cfg[] = {
 	//register    value
@@ -47,7 +48,15 @@ void pal_pre_init()
 
 void pal_post_init()
 {
+	uint8_t board_revision = get_board_revision();
 	plat_mctp_init();
+	/* Send device presence log when the BIC is AC on */
+	if (is_ac_lost()) {
+		plat_accl_present_check();
+		if (board_revision > EVT2_STAGE) {
+			plat_accl_power_cable_present_check();
+		}
+	}
 }
 
 void pal_device_init()

--- a/meta-facebook/at-cb/src/platform/plat_pldm_monitor.c
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_monitor.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <logging/log.h>
+
+#include "sensor.h"
+#include "hal_gpio.h"
+#include "pldm.h"
+#include "pmbus.h"
+#include "plat_fru.h"
+#include "plat_gpio.h"
+#include "plat_sensor_table.h"
+#include "plat_pldm_monitor.h"
+#include "plat_class.h"
+
+LOG_MODULE_REGISTER(plat_pldm_monitor);
+
+void plat_accl_present_check()
+{
+	bool is_present = ASIC_CARD_NOT_PRESENT;
+	struct pldm_sensor_event_state_sensor_state event;
+	for (uint8_t i = 0; i < ASIC_CARD_COUNT; i++) {
+		is_present = asic_card_info[i].card_status;
+		event.sensor_offset = PLDM_STATE_SET_OFFSET_DEVICE_PRESENCE;
+		event.event_state =
+			is_present ? PLDM_STATE_SET_PRESENT : PLDM_STATE_SET_NOT_PRESENT;
+		event.previous_event_state = PLDM_STATE_SET_NOT_PRESENT;
+		if (pldm_send_platform_event(PLDM_SENSOR_EVENT, PLDM_EVENT_ACCL_1 + i,
+					     PLDM_STATE_SENSOR_STATE, (uint8_t *)&event,
+					     sizeof(struct pldm_sensor_event_state_sensor_state))) {
+			LOG_ERR("Send ACCL%d presence event log failed", PLDM_EVENT_ACCL_1 + i);
+		}
+	}
+}
+
+void plat_accl_power_cable_present_check()
+{
+	bool is_present = ASIC_CARD_NOT_PRESENT;
+	struct pldm_sensor_event_state_sensor_state event;
+	for (uint8_t i = 0; i < ASIC_CARD_COUNT; i++) {
+		is_present = asic_card_info[i].pwr_cbl_status;
+		event.sensor_offset = PLDM_STATE_SET_OFFSET_DEVICE_PRESENCE;
+		event.event_state =
+			is_present ? PLDM_STATE_SET_PRESENT : PLDM_STATE_SET_NOT_PRESENT;
+		event.previous_event_state = PLDM_STATE_SET_NOT_PRESENT;
+		if (pldm_send_platform_event(PLDM_SENSOR_EVENT, PLDM_EVENT_ACCL_PWR_CBL_1 + i,
+					     PLDM_STATE_SENSOR_STATE, (uint8_t *)&event,
+					     sizeof(struct pldm_sensor_event_state_sensor_state))) {
+			LOG_ERR("Send ACCL%d power cable presence event log failed",
+				PLDM_EVENT_ACCL_PWR_CBL_1 + i);
+		}
+	}
+}

--- a/meta-facebook/at-cb/src/platform/plat_pldm_monitor.h
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_monitor.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_PLDM_MONITOR_H
+#define PLAT_PLDM_MONITOR_H
+
+enum plat_pldm_event_sensor_num {
+	// ACCL1 - ACCL12
+	PLDM_EVENT_ACCL_1 = 0x01,
+	PLDM_EVENT_ACCL_2,
+	PLDM_EVENT_ACCL_3,
+	PLDM_EVENT_ACCL_4,
+	PLDM_EVENT_ACCL_5,
+	PLDM_EVENT_ACCL_6,
+	PLDM_EVENT_ACCL_7,
+	PLDM_EVENT_ACCL_8,
+	PLDM_EVENT_ACCL_9,
+	PLDM_EVENT_ACCL_10,
+	PLDM_EVENT_ACCL_11,
+	PLDM_EVENT_ACCL_12,
+	PLDM_EVENT_ACCL_PWR_CBL_1,
+	PLDM_EVENT_ACCL_PWR_CBL_2,
+	PLDM_EVENT_ACCL_PWR_CBL_3,
+	PLDM_EVENT_ACCL_PWR_CBL_4,
+	PLDM_EVENT_ACCL_PWR_CBL_5,
+	PLDM_EVENT_ACCL_PWR_CBL_6,
+	PLDM_EVENT_ACCL_PWR_CBL_7,
+	PLDM_EVENT_ACCL_PWR_CBL_8,
+	PLDM_EVENT_ACCL_PWR_CBL_9,
+	PLDM_EVENT_ACCL_PWR_CBL_10,
+	PLDM_EVENT_ACCL_PWR_CBL_11,
+	PLDM_EVENT_ACCL_PWR_CBL_12,
+};
+
+enum plat_pldm_device_state_set_offset {
+	PLDM_STATE_SET_OFFSET_DEVICE_PRESENCE = 0,
+	PLDM_STATE_SET_OFFSET_DEVICE_STATUS = 1,
+};
+
+void plat_accl_present_check();
+void plat_accl_power_cable_present_check();
+
+#endif


### PR DESCRIPTION
 # Description
 - Support PLDM event log

 # Motivation
 - To send present SEL of Artemis modules through PLDM

 # Test Plan:
 - Check BMC logs present of Artemis module

 # Log:
 ```
 root@bmc-oob:~# log-util --print all | grep ACCL
 0    all      2018-03-09 04:35:57    pldmd            State Sensor: CB_SENSOR_ACCL_1, present
 0    all      2018-03-09 04:35:58    pldmd            State Sensor: CB_SENSOR_ACCL_2, not present
 0    all      2018-03-09 04:35:59    pldmd            State Sensor: CB_SENSOR_ACCL_3, present
 0    all      2018-03-09 04:36:00    pldmd            State Sensor: CB_SENSOR_ACCL_4, present
 0    all      2018-03-09 04:36:01    pldmd            State Sensor: CB_SENSOR_ACCL_5, present
 0    all      2018-03-09 04:36:02    pldmd            State Sensor: CB_SENSOR_ACCL_6, present
 0    all      2018-03-09 04:36:03    pldmd            State Sensor: CB_SENSOR_ACCL_7, present
 0    all      2018-03-09 04:36:04    pldmd            State Sensor: CB_SENSOR_ACCL_8, present
 0    all      2018-03-09 04:36:05    pldmd            State Sensor: CB_SENSOR_ACCL_9, not present
 0    all      2018-03-09 04:36:06    pldmd            State Sensor: CB_SENSOR_ACCL_10, not present
 0    all      2018-03-09 04:36:07    pldmd            State Sensor: CB_SENSOR_ACCL_11, present
 0    all      2018-03-09 04:36:08    pldmd            State Sensor: CB_SENSOR_ACCL_12, present
 ```