### PR TITLE
GT: Add VR status mfr specific check

### DIFF
--- a/meta-facebook/gt-cc/src/platform/plat_pldm_monitor.c
+++ b/meta-facebook/gt-cc/src/platform/plat_pldm_monitor.c
@@ -480,12 +480,6 @@ void vr_status_mfr_specific_check_handler(struct k_work *work)
 			if (!cfg->pre_sensor_read_hook(cfg, cfg->pre_sensor_read_args)) {
 				LOG_ERR("Pre-sensor reading hook function failed, VR%d status mfr specific check failed",
 					i);
-				if (cfg->post_sensor_read_hook) {
-					if (!cfg->post_sensor_read_hook(
-						    cfg, cfg->post_sensor_read_args, NULL)) {
-						LOG_ERR("Post-sensor reading hook function failed");
-					}
-				}
 				continue;
 			}
 		}
@@ -582,12 +576,6 @@ void vr_alert_check()
 			if (!cfg->pre_sensor_read_hook(cfg, cfg->pre_sensor_read_args)) {
 				LOG_ERR("Pre-sensor reading hook function failed, VR%d alert check failed",
 					i);
-				if (cfg->post_sensor_read_hook) {
-					if (!cfg->post_sensor_read_hook(
-						    cfg, cfg->post_sensor_read_args, NULL)) {
-						LOG_ERR("Post-sensor reading hook function failed");
-					}
-				}
 				continue;
 			}
 		}

--- a/meta-facebook/gt-cc/src/platform/plat_pldm_monitor.h
+++ b/meta-facebook/gt-cc/src/platform/plat_pldm_monitor.h
@@ -121,5 +121,6 @@ void nic_present_check();
 void pal_load_pldm_effcter_table();
 void plat_pldm_assign_gpio_effecter_id();
 void vr_alert_check();
+void vr_status_mfr_specific_check_handler();
 
 #endif


### PR DESCRIPTION
Summary:
- Check VR status mfr specific when ISR_VR_PMBUS_ALERT triggered, clear VR faults if bit ADCUNLOCK or BBEVENT is high.

Test Plan:
- Build code: Pass