### PR TITLE
Artemis: cb: enable the password function

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_class.c
+++ b/meta-facebook/at-cb/src/platform/plat_class.c
@@ -21,6 +21,7 @@
 
 #include "libutil.h"
 #include "hal_i2c.h"
+#include "pmbus.h"
 #include "plat_fru.h"
 #include "plat_class.h"
 #include "common_i2c_mux.h"
@@ -386,4 +387,69 @@ bool get_acb_power_status()
 bool get_acb_power_good_flag()
 {
 	return is_power_good;
+}
+
+void enable_xdpe15284_password()
+{
+	int ret = -1;
+	int retry = 3;
+	I2C_MSG msg = { 0 };
+
+	msg.bus = I2C_BUS1;
+	msg.target_addr = XDPE15284D_ADDR;
+	msg.tx_len = 2;
+	msg.data[0] = PMBUS_PAGE;
+	msg.data[1] = PMBUS_PAGE_0;
+
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Set xdpe15284 page 0 fail, ret: %d", ret);
+		return;
+	}
+
+	msg.bus = I2C_BUS1;
+	msg.target_addr = XDPE15284D_ADDR;
+	msg.tx_len = 6;
+	msg.data[0] = 0xCB;
+	msg.data[1] = 0x4;
+	msg.data[2] = 0x1;
+	msg.data[3] = 0x0;
+	msg.data[4] = 0x0;
+	msg.data[5] = 0x0;
+
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Enable xdpe15284 passwork fail, ret: %d", ret);
+		return;
+	}
+
+	msg.bus = I2C_BUS1;
+	msg.target_addr = XDPE15284D_ADDR;
+	msg.tx_len = 2;
+	msg.data[0] = PMBUS_PAGE;
+	msg.data[1] = PMBUS_PAGE_1;
+
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Set xdpe15284 page 1 fail, ret: %d", ret);
+		return;
+	}
+
+	msg.bus = I2C_BUS1;
+	msg.target_addr = XDPE15284D_ADDR;
+	msg.tx_len = 6;
+	msg.data[0] = 0xCB;
+	msg.data[1] = 0x4;
+	msg.data[2] = 0x1;
+	msg.data[3] = 0x0;
+	msg.data[4] = 0x0;
+	msg.data[5] = 0x0;
+
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Enable xdpe15284 passwork fail, ret: %d", ret);
+		return;
+	}
+
+	return;
 }

--- a/meta-facebook/at-cb/src/platform/plat_class.h
+++ b/meta-facebook/at-cb/src/platform/plat_class.h
@@ -145,5 +145,6 @@ uint8_t get_pwr_brick_module();
 uint8_t get_pwr_monitor_module();
 bool get_acb_power_status();
 bool get_acb_power_good_flag();
+void enable_xdpe15284_password();
 
 #endif

--- a/meta-facebook/at-cb/src/platform/plat_init.c
+++ b/meta-facebook/at-cb/src/platform/plat_init.c
@@ -42,6 +42,7 @@ void pal_pre_init()
 
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
 	check_accl_device_presence_status_via_ioexp();
+	enable_xdpe15284_password();
 	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
 }
 


### PR DESCRIPTION
# Description
To prevent unexpected write of VR register, which is suggested by VR vendor.

# Motivation
To prevent unexpected write of VR register, which is suggested by VR vendor. BIC lock the registers by default.

# Test Plan
Build and test pass on system.