### PR TITLE
fby35: gl: Use kwork to do clear pmic error when host DC on

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_isr.c
@@ -152,6 +152,7 @@ static void PROC_FAIL_handler(struct k_work *work)
 
 K_WORK_DELAYABLE_DEFINE(PROC_FAIL_work, PROC_FAIL_handler);
 K_WORK_DELAYABLE_DEFINE(read_pmic_critical_work, read_pmic_error_when_dc_off);
+K_WORK_DEFINE(clear_pmic_error_work, clear_pmic_error);
 
 // The PMIC needs a total of 100ms from CAMP signal assertion to complete the write operation
 #define READ_PMIC_CRITICAL_ERROR_MS 100
@@ -165,7 +166,7 @@ void Initialize_CPU()
 		/* start thread proc_fail_handler after 10 seconds */
 		k_work_schedule(&PROC_FAIL_work, K_SECONDS(PROC_FAIL_START_DELAY_SECOND));
 
-		clear_pmic_error();
+		k_work_submit(&clear_pmic_error_work);
 	} else {
 		ISR_POST_COMPLETE(VW_GPIO_LOW);
 		abort_snoop_thread();


### PR DESCRIPTION
# Description:
Use kwork to do clear pmic error when host DC on

# Motivation:
Since there is a mutex lock in clear pmic error function, BIC must use kwork in interrupt handler to avoid system hang

# Test Plan:
1. Check host can power on successfully - pass
2. Check PMIC error clear successfully - pass

# Test Log:
1. Check host can power on successfully root@bmc-oob:~# power-util slot1 cycle
Power cycling fru 1...
[  807.584805] reboot: Power down
[root@FBK8_221107 ~]

2. Check PMIC error clear successfully root@bmc-oob:~# dimm-util slot1 --pmic --err_inj high_temp --dimm A Error inject successfully on DIMM A
Before DC cycle:
root@bmc-oob:~# dimm-util slot1 --pmic --err_list
DIMM A PMIC Error: high_temp
DIMM B PMIC Error: No Error
DIMM C PMIC Error: No Error
DIMM D PMIC Error: No Error
DIMM E PMIC Error: No Error
DIMM F PMIC Error: No Error
DIMM G PMIC Error: No Error
DIMM H PMIC Error: No Error
After DC cycle:
root@bmc-oob:~# dimm-util slot1 --pmic --err_list
DIMM A PMIC Error: No Error
DIMM B PMIC Error: No Error
DIMM C PMIC Error: No Error
DIMM D PMIC Error: No Error
DIMM E PMIC Error: No Error
DIMM F PMIC Error: No Error
DIMM G PMIC Error: No Error
DIMM H PMIC Error: No Error