### PR TITLE
common: Support commands for bic fw update

### DIFF
--- a/common/service/mctp/mctp_ctrl.c
+++ b/common/service/mctp/mctp_ctrl.c
@@ -44,6 +44,11 @@ static K_MUTEX_DEFINE(wait_recv_resp_mutex);
 
 static sys_slist_t wait_recv_resp_list = SYS_SLIST_STATIC_INIT(&wait_recv_resp_list);
 
+__weak int load_mctp_support_types(uint8_t *type_len, uint8_t *types)
+{
+	return -1;
+}
+
 uint8_t mctp_ctrl_cmd_get_endpoint_id(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t *resp,
 				      uint16_t *resp_len, void *ext_params)
 {
@@ -64,6 +69,38 @@ uint8_t mctp_ctrl_cmd_get_endpoint_id(void *mctp_inst, uint8_t *buf, uint16_t le
 	p->completion_code = (len != 0) ? MCTP_CTRL_CC_ERROR_INVALID_LENGTH : MCTP_CTRL_CC_SUCCESS;
 
 	*resp_len = (p->completion_code == MCTP_CTRL_CC_SUCCESS) ? sizeof(*p) : 1;
+
+	return MCTP_SUCCESS;
+}
+
+uint8_t mctp_ctrl_cmd_get_message_type_support(void *mctp_inst, uint8_t *buf, uint16_t len,
+					       uint8_t *resp, uint16_t *resp_len, void *ext_params)
+{
+	ARG_UNUSED(ext_params);
+	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(buf, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, MCTP_ERROR);
+
+	struct _get_message_type_resp *p = (struct _get_message_type_resp *)resp;
+
+	uint8_t type_len = 0;
+	uint8_t *types = malloc(sizeof(TYPE_MAX_SIZE));
+	int ret = 0;
+
+	ret = load_mctp_support_types(&type_len, types);
+
+	if (ret < 0) {
+		LOG_ERR("Command not supported, %d", ret);
+		p->completion_code = MCTP_ERROR;
+	} else {
+		p->completion_code = MCTP_CTRL_CC_SUCCESS;
+		p->type_count = type_len;
+		memcpy(p->type_number, types, type_len);
+	}
+
+	free(types);
+	*resp_len = (p->completion_code == MCTP_CTRL_CC_SUCCESS) ? (sizeof(*p) + type_len) : 1;
 
 	return MCTP_SUCCESS;
 }
@@ -166,6 +203,7 @@ static uint8_t mctp_ctrl_cmd_resp_process(mctp *mctp_inst, uint8_t *buf, uint32_
 
 static mctp_ctrl_cmd_handler_t mctp_ctrl_cmd_tbl[] = {
 	{ MCTP_CTRL_CMD_GET_ENDPOINT_ID, mctp_ctrl_cmd_get_endpoint_id },
+	{ MCTP_CTRL_CMD_GET_MESSAGE_TYPE_SUPPORT, mctp_ctrl_cmd_get_message_type_support }
 };
 
 uint8_t mctp_ctrl_cmd_handler(void *mctp_p, uint8_t *buf, uint32_t len, mctp_ext_params ext_params)

--- a/common/service/mctp/mctp_ctrl.h
+++ b/common/service/mctp/mctp_ctrl.h
@@ -37,6 +37,8 @@ typedef struct _mctp_ctrl_cmd_handler {
 #define MCTP_CTRL_CMD_SET_ENDPOINT_ID 0x01
 #define MCTP_CTRL_CMD_GET_ENDPOINT_ID 0x02
 
+#define MCTP_CTRL_CMD_GET_MESSAGE_TYPE_SUPPORT 0x05
+
 #define MCTP_CTRL_CMD_GET_ENDPOINT_ID_REQ_LEN 0x00
 
 #define MCTP_CTRL_READ_STATUS_SUCCESS 0x00
@@ -78,6 +80,21 @@ enum eid_type {
 	DYNAMIC_EID,
 	STATIC_EID,
 };
+
+/*
+Reference from DSP0239_1.3.0 Table 1
+*/
+enum message_type {
+	TYPE_MCTP_CONTROL,
+	TYPE_PLDM,
+	TYPE_MAX_SIZE,
+};
+
+struct _get_message_type_resp {
+	uint8_t completion_code;
+	uint8_t type_count;
+	uint8_t type_number[0];
+} __attribute__((packed));
 
 struct _get_eid_resp {
 	uint8_t completion_code;

--- a/common/service/pldm/pldm_firmware_update.c
+++ b/common/service/pldm/pldm_firmware_update.c
@@ -1056,7 +1056,37 @@ static uint8_t get_firmware_parameter(void *mctp_inst, uint8_t *buf, uint16_t le
 	return PLDM_SUCCESS;
 }
 
+static uint8_t query_device_identifiers(void *mctp_inst, uint8_t *buf, uint16_t len,
+					uint8_t instance_id, uint8_t *resp, uint16_t *resp_len,
+					void *ext_params)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(buf, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(ext_params, PLDM_ERROR);
+
+	return plat_pldm_query_device_identifiers(buf, len, resp, resp_len);
+}
+
+__weak uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uint8_t *resp,
+						  uint16_t *resp_len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, PLDM_ERROR);
+
+	uint8_t *completion_code_p = resp;
+
+	*completion_code_p = PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+	*resp_len = 1;
+	LOG_WRN("Not supported command");
+
+	return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+}
+
 static pldm_cmd_handler pldm_fw_update_cmd_tbl[] = {
+	{ PLDM_FW_UPDATE_CMD_CODE_QUERY_DEVICE_IDENTIFIERS, query_device_identifiers },
 	{ PLDM_FW_UPDATE_CMD_CODE_GET_FIRMWARE_PARAMETERS, get_firmware_parameter },
 	{ PLDM_FW_UPDATE_CMD_CODE_REQUEST_UPDATE, request_update },
 	{ PLDM_FW_UPDATE_CMD_CODE_PASS_COMPONENT_TABLE, pass_component_table },

--- a/common/service/pldm/pldm_firmware_update.h
+++ b/common/service/pldm/pldm_firmware_update.h
@@ -204,6 +204,19 @@ enum pldm_component_classification_values {
 	PLDM_COMP_DOWNSTREAM_DEVICE = 0xFFFF
 };
 
+/** @brief Descriptor types defined in PLDM firmware update specification
+ *  DSP0267 Table 7 – Descriptor identifier table
+ */
+enum pldm_firmware_update_descriptor_types {
+	PLDM_FWUP_IANA_ENTERPRISE_ID = 0x0001,
+	PLDM_FWUP_VENDOR_DEFINED = 0xFFFF
+};
+
+/** @brief Descriptor types length defined in PLDM firmware update specification
+ *  DSP0267 Table 7 – Descriptor identifier table
+ */
+enum pldm_firmware_update_descriptor_types_length { PLDM_FWUP_IANA_ENTERPRISE_ID_LENGTH = 4 };
+
 /**
  * Component response for PassComponentTable and UpdateComponent commands
  */
@@ -415,6 +428,24 @@ struct pldm_apply_complete_req {
 	uint16_t compActivationMethodsModification;
 } __attribute__((packed));
 
+/**
+ * Structure representing QueryDeviceIdentifiers request
+ */
+struct pldm_query_device_identifiers_resp {
+	uint8_t completion_code;
+	uint32_t device_identifiers_len;
+	uint8_t descriptor_count;
+} __attribute__((packed));
+
+/**
+ *  Structure representing descriptor type, length and value
+ */
+struct pldm_descriptor_tlv {
+	uint16_t descriptor_type;
+	uint16_t descriptor_length;
+	uint8_t descriptor_data[1];
+} __attribute__((packed));
+
 struct pldm_get_firmware_parameters_resp {
 	uint8_t completion_code;
 	union {
@@ -460,6 +491,9 @@ uint8_t pldm_bic_update(void *fw_update_param);
 uint8_t pldm_vr_update(void *fw_update_param);
 uint8_t pldm_cpld_update(void *fw_update_param);
 uint8_t pldm_bic_activate(void *arg);
+
+uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uint8_t *resp,
+					   uint16_t *resp_len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Description:
  Support MCTP "Get Support Type" command and PLDM "Query Device Identifiers" command
  to follow PLDM fw update spec.

- Cmd1 MCTP Get Support Type: Description : Get a list of the MCTP message types that are supported by the bic. Example: Request: none Response: Byte 0: 0x00 Byte 1: 0x02 Byte 2-3: 0x01 0x00

- Cmd2 PLDM Query Device Identifiers: Description : This command is used by bmc to obtain the fw identifiers for the bic. Example: Request: none Response: Byte 0: 0x00 Byte 1-4: 0x08 0x00 0x00 0x00 Byte 5: 0x01 Byte 6-7: 0x01 0x00 Byte 8-9: 0x04 0x00 Byte 10-13: 0x00 0x00 0xa0 0x15

Test Plan:
- Build code : pass

Test Log:

- Get Mctp supported message types:

root@greatlakes:/tmp#  busctl introspect xyz.openbmc_project.MCTP /xyz/openbmc_project/mctp/1/8
NAME                                TYPE      SIGNATURE RESULT/VALUE FLAGS
au.com.CodeConstruct.MCTP.Endpoint  interface -         -            -
.Remove                             method    -         -            -
.SetMTU                             method    u         -            -
org.freedesktop.DBus.Introspectable interface -         -            -
.Introspect                         method    -         s            -
org.freedesktop.DBus.Peer           interface -         -            -
.GetMachineId                       method    -         s            -
.Ping                               method    -         -            -
org.freedesktop.DBus.Properties     interface -         -            -
.Get                                method    ss        v            -
.GetAll                             method    s         a{sv}        -
.Set                                method    ssv       -            -
.PropertiesChanged                  signal    sa{sv}as  -            -
xyz.openbmc_project.MCTP.Endpoint   interface -         -            -
.EID                                property  y         8            const
.NetworkId                          property  i         1            const
.SupportedMessageTypes              property  ay        2 0 1        const
root@greatlakes:/tmp#

- PLDM Query Device Identifiers

root@greatlakes:/tmp# pldmtool fw_update QueryDeviceIdentifiers {
    "EID": 8,
    "Descriptors": [
        {
            "Type": "IANA Enterprise ID",
            "Value": [
                "0000a015"
            ]
        }
    ]
}

- Get current bic version by "get fw paramter" command:

root@greatlakes:/tmp# pldmtool fw_update GetFwParams {
    "CapabilitiesDuringUpdate": {
        "Component Update Failure Recovery Capability": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer.",
        "Component Update Failure Retry Capability": " Device can have component updated again without exiting update mode and restarting transfer via RequestUpdate command.",
        "Firmware Device Partial Updates": "Firmware Device cannot accept a partial update and all components present on the FD shall be updated.",
        "Firmware Device Host Functionality during Firmware Update": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer",
        "Firmware Device Update Mode Restrictions": "No host OS environment restriction for update mode"
    },
    "ComponentCount": 0,
    "ActiveComponentImageSetVersionString": "2023.25.01",
    "PendingComponentImageSetVersionString": "",
    "ComponentParameterEntries": null
}

- Updating: ....
Aug 05 19:17:06 greatlakes pldmd[2043]: Component Transfer complete, EID=0x8, COMPONENT_VERSION=ast1030 v2023.29.a1 Aug 05 19:17:06 greatlakes pldmd[2043]: Tx: 02 05 16 00 Aug 05 19:17:06 greatlakes pldmd[2043]: Rx: 83 05 17 00 Aug 05 19:17:06 greatlakes pldmd[2043]: Component verification complete, EID=0x8, COMPONENT_VERSION=ast1030 v2023.29.a1 Aug 05 19:17:06 greatlakes pldmd[2043]: Tx: 03 05 17 00 Aug 05 19:17:06 greatlakes pldmd[2043]: Rx: 84 05 18 00 00 00 Aug 05 19:17:06 greatlakes pldmd[2043]: Component apply complete, EID=0x8, COMPONENT_VERSION=ast1030 v2023.29.a1 Aug 05 19:17:06 greatlakes pldmd[2043]: Tx: 04 05 18 00 Aug 05 19:17:06 greatlakes pldmd[2043]: Tx: 80 05 1a 00 Aug 05 19:17:06 greatlakes pldmd[2043]: Rx: 00 05 1a 00 00 00 Aug 05 19:17:06 greatlakes pldmd[2043]: Firmware update time: 30970.2 ms

- After update, check bic version changed

root@greatlakes:/tmp# pldmtool fw_update GetFwParams {
    "CapabilitiesDuringUpdate": {
        "Component Update Failure Recovery Capability": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer.",
        "Component Update Failure Retry Capability": " Device can have component updated again without exiting update mode and restarting transfer via RequestUpdate command.",
        "Firmware Device Partial Updates": "Firmware Device cannot accept a partial update and all components present on the FD shall be updated.",
        "Firmware Device Host Functionality during Firmware Update": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer",
        "Firmware Device Update Mode Restrictions": "No host OS environment restriction for update mode"
    },
    "ComponentCount": 0,
    "ActiveComponentImageSetVersionString": "2023.26.02",
    "PendingComponentImageSetVersionString": "",
    "ComponentParameterEntries": null
}