### PR TITLE
Artemis: Workaround for BIC PLDM firmware update fail

### DIFF
--- a/common/service/pldm/pldm.c
+++ b/common/service/pldm/pldm.c
@@ -25,6 +25,7 @@
 #include <zephyr.h>
 #include "libutil.h"
 #include "ipmi.h"
+#include "plat_def.h"
 
 LOG_MODULE_REGISTER(pldm);
 
@@ -195,6 +196,9 @@ uint16_t mctp_pldm_read(void *mctp_p, pldm_msg *msg, uint8_t *rbuf, uint16_t rbu
 	for (uint8_t retry_count = 0; retry_count < PLDM_MSG_MAX_RETRY; retry_count++) {
 		uint8_t event = 0;
 		if (mctp_pldm_send_msg(mctp_p, msg) == PLDM_ERROR) {
+#ifdef PLDM_SEND_FAIL_DELAY_MS
+			k_msleep(PLDM_SEND_FAIL_DELAY_MS);
+#endif
 			LOG_WRN("Send msg failed!");
 			continue;
 		}

--- a/meta-facebook/at-cb/src/platform/plat_def.h
+++ b/meta-facebook/at-cb/src/platform/plat_def.h
@@ -21,4 +21,7 @@
 #define KEYWORD_CPLD_LATTICE "LCMXO3-4300C"
 #define BIC_FW_VERSION_ADD_FRU_NAME
 
+#define PLDM_SEND_FAIL_DELAY_MS                                                                    \
+	20 // Workaround to avoid responding too frequently and being unable to reply
+
 #endif

--- a/meta-facebook/at-mc/src/platform/plat_def.h
+++ b/meta-facebook/at-mc/src/platform/plat_def.h
@@ -23,4 +23,7 @@
 #define KEYWORD_CPLD_LATTICE "LCMXO3-4300C"
 #define BIC_FW_VERSION_ADD_FRU_NAME
 
+#define PLDM_SEND_FAIL_DELAY_MS                                                                    \
+	20 // Workaround to avoid responding too frequently and being unable to reply
+
 #endif


### PR DESCRIPTION
# Description
- Workaround for BIC PLDM firmware update fail
  - Add delay to avoid responding too frequently and being unable to reply

# Motivation
- Workaround for BIC PLDM firmware update fail

# Test Plan
- Build code: Pass
- MEB BIC PLDM firmware update: 300 rounds Pass
- CPLD PLDM firmware update: 200 rounds Pass