### PR TITLE
fby35 : gl: Remove switch mux to BIC right after POST complete

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_isr.c
@@ -489,11 +489,6 @@ void ISR_POST_COMPLETE(uint8_t gpio_value)
 	bool is_post_completed = (gpio_value == VW_GPIO_HIGH) ? true : false;
 	set_post_complete(is_post_completed);
 
-	if (is_post_completed) {
-		// Switch I3C mux to bic after post complete
-		switch_i3c_dimm_mux(I3C_MUX_TO_BIC);
-	}
-
 	post_complete.gpio_value = gpio_value;
 	k_work_init_delayable(&post_complete.work, post_complete_handler);
 	k_work_schedule(&post_complete.work, K_MSEC(10));


### PR DESCRIPTION
# Description:
Remove switch mux to BIC right after POST complete

# Motivation:
Mux would be switched to BIC when reading DIMM after POST complete

# Test Plan:
Check DIMM and PMIC sensors - pass

# Test Log:
root@bmc-oob:~# log-util slot1 --print|grep -i end
1    slot1    2023-09-07 10:00:29    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-09-07 10:00:29, Sensor: END_OF_POST (0x11), Event Data: (01FFFF) OEM System boot event Deassertion
1    slot1    2023-09-07 10:00:29    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-09-07 10:00:29, Sensor: END_OF_POST (0x11), Event Data: (01FFFF) OEM System boot event Deassertion
1    slot1    2023-09-07 10:00:51    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-09-07 10:00:51, Sensor: END_OF_POST (0x11), Event Data: (01FFFF) OEM System boot event Deassertion
1    slot1    2023-09-07 10:02:19    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-09-07 10:02:19, Sensor: END_OF_POST (0x11), Event Data: (01FFFF) OEM System boot event Assertion
root@bmc-oob:~# sensor-util slot1|grep -i DIMM
MB_DIMMA_TEMP_C              (0x5) :   31.75 C     | (ok)
MB_DIMMB_TEMP_C              (0x6) :   30.75 C     | (ok)
MB_DIMMC_TEMP_C              (0x7) :   31.00 C     | (ok)
MB_DIMMD_TEMP_C              (0x8) :   31.00 C     | (ok)
MB_DIMME_TEMP_C              (0x9) :   31.25 C     | (ok)
MB_DIMMF_TEMP_C              (0xA) :   31.00 C     | (ok)
MB_DIMMG_TEMP_C              (0xB) :   31.00 C     | (ok)
MB_DIMMH_TEMP_C              (0xC) :   30.75 C     | (ok)
MB_ADC_P12V_DIMM_VOLT_V      (0x25) :   12.36 Volts | (ok)
MB_VR_DIMMA_PMIC_PWR_W       (0x36) :    1.00 Watts | (ok)
MB_VR_DIMMB_PMIC_PWR_W       (0x37) :    0.50 Watts | (ok)
MB_VR_DIMMC_PMIC_PWR_W       (0x38) :    0.50 Watts | (ok)
MB_VR_DIMMD_PMIC_PWR_W       (0x39) :    0.50 Watts | (ok)
MB_VR_DIMME_PMIC_PWR_W       (0x3A) :    0.50 Watts | (ok)
MB_VR_DIMMF_PMIC_PWR_W       (0x3B) :    0.88 Watts | (ok)
MB_VR_DIMMG_PMIC_PWR_W       (0x3C) :    0.62 Watts | (ok)
MB_VR_DIMMH_PMIC_PWR_W       (0x3D) :    0.50 Watts | (ok)