### PR TITLE
common: service: correct the data type in numeric sensor PDR structure

### DIFF
--- a/common/service/sensor/pdr.h
+++ b/common/service/sensor/pdr.h
@@ -7,6 +7,8 @@
 #define TIMESTAMP104_SIZE 13//A binary datetime type formatted as a series of 13 bytes
 #define NUMERIC_PDR_SIZE 108
 
+typedef float real32_t;
+
 uint8_t pdr_init(void);
 
 enum pdr_repository_state {
@@ -46,16 +48,16 @@ typedef struct __attribute__((packed)) {
 	uint8_t aux_oem_unit_handle;
 	uint8_t is_linear;
 	uint8_t sensor_data_size;
-	int32_t resolution;
-	int32_t offset;
+	real32_t resolution;
+	real32_t offset;
 	uint16_t accuracy;
 	uint8_t plus_tolerance;
 	uint8_t minus_tolerance;
-	uint8_t hysteresis;
+	uint32_t hysteresis;
 	uint8_t supported_thresholds;
 	uint8_t threshold_and_hysteresis_volatility;
-	int32_t state_transition_interval;
-	int32_t update_interval;
+	real32_t state_transition_interval;
+	real32_t update_interval;
 	uint32_t max_readable;
 	uint32_t min_readable;
 	uint8_t range_field_format;


### PR DESCRIPTION
# Description:
1. Correct the data type of hysteresis.
2. Defined real32_t which is float to match the spec: DSP0248.

# Motivation:
1. The data type of hysteresis should be same with max_readable and min_readable because the size of these fields are identified by sensor_data_size.
2. Correct the data type to real32_t for the following members:
  - resolution
  - offset
  - state_transition_interval
  - update_interval

# Test Plan:
- Build code: Pass
- Add some PDR samples on platform and BMC get pdr from BIC: Pass

# Test Log:
1. Get PDR: root@yosemitev4:~# pldmtool platform GetPDR -m 10 -a -v [ pldmtool: Tx: 92 02 51 00 00 00 00 00 00 00 00 01 ff ff 00 00 pldmtool: Rx: 12 02 51 00 00 00 00 00 00 00 00 00 05 6c 00 00 00 00 00 01 02 00 00 5f 00 00 00 01 00 89 00 01 00 00 00 00 00 02 00 00 00 00 00 00 00 00 00 04 00 00 44 c1 00 00 20 41 00 00 00 00 00 00 00 00 ff 00 00 00 00 00 00 00 00 00 ff 00 00 00 00 00 00 00 04 ff 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 3c 00 00 00 00 00 00 00 96 00 00 00 00 00 00 00 00 00 00 { "nextRecordHandle": 0, "responseCount": 108, "recordHandle": 0, "PDRHeaderVersion": 1, "PDRType": "Numeric Sensor PDR", "recordChangeNumber": 0, "dataLength": 95 }