### PR TITLE
fby35: gl: Revise cpu power reading method

### DIFF
--- a/common/dev/include/intel_peci.h
+++ b/common/dev/include/intel_peci.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -60,6 +60,8 @@ typedef struct {
 bool check_dimm_present(uint8_t dimm_channel, uint8_t dimm_num, uint8_t *present_result);
 bool pal_get_power_sku_unit(uint8_t addr);
 bool pal_get_cpu_time(uint8_t addr, uint8_t cmd, uint8_t readlen, uint32_t *run_time);
-bool pal_get_cpu_energy(uint8_t addr, uint8_t cmd, uint8_t readlen, uint32_t *pkg_energy);
+bool pal_get_cpu_energy(uint8_t addr, uint32_t *pkg_energy, uint32_t *run_time);
+void pal_cal_cpu_power(intel_peci_unit unit_info, uint32_t diff_energy, uint32_t diff_time,
+		       int *reading);
 
 #endif

--- a/meta-facebook/yv35-gl/src/platform/plat_cpu.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_cpu.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_CPU_H
+#define PLAT_CPU_H
+
+#define CPU_TIME_UNIT 100000000
+
+#endif


### PR DESCRIPTION
# Description:
1. Revise the method to get CPU energy and time Before revision -
PCS 3 to get CPU accumulated energy
PCS 31 to get CPU total time
After revision -
PCS 3 to get both CPU total energy and total time
2. Revise the method to calculate CPU power

# Motivation:
Follow the latest BHS CPU method to get CPU power

# Test Plan:
Check CPU power sensor with and without stress - pass

# Test Log:
With stress
[root@FBK8_221107 ~]# ./mprime -t 13
[root@FBK8_221107 ~]# ./ptat -mon
...
Index Device Cor Thr CFreq UFreq  PState   Util  IPC     C0     C1     C6    PC2    PC6 MC Ch Sl  Temp DTS  Power  Volt UVolt TStat TLog #TL TMargin MCPMargin
     0   CPU0   -   -  1297     0       0 100.00 2.57 100.00   0.00   0.00   0.00   0.00  -  -  -    60  45 199.20 0.776 0.000   0x0  0x0   0  38.109    38.109
     0   MEM0   -   -     -     -      -    -      -      -      -      -      -  -  -  -   255   -   4.61     -     -     -  0x0   -       -         -
     1   CPU0   -   -  1297     0       0 100.00 2.57 100.00   0.00   0.00   0.00   0.00  -  -  -    59  46 199.14 0.776 0.000   0x0  0x0   0  38.031    38.031
     1   MEM0   -   -     -     -      -    -      -      -      -      -      -  -  -  -   255   -   4.59     -     -     -  0x0   -       -         -
     2   CPU0   -   -  1297     0       0 100.00 2.57 100.00   0.00   0.00   0.00   0.00  -  -  -    59  46 199.72 0.776 0.000   0x0  0x0   0  37.906

root@bmc-oob:~# sensor-util slot1|grep -i CPU
MB_SOC_CPU_TEMP_C            (0x4) :   63.00 C     | (ok)
CPU_PWR                      (0x3E) :  199.00 Watts | (ok)

Without stress
Index Device Cor Thr CFreq UFreq  PState   Util  IPC     C0     C1     C6    PC2    PC6 MC Ch Sl  Temp DTS  Power  Volt UVolt TStat TLog #TL TMargin MCPMargin
     0   CPU0   -   -  1312     0       0   0.14 0.50   0.30   0.27  99.43   0.00   0.00  -  -  -    48  57 122.68 0.786 0.000   0x0  0x0   0  49.281    49.281
     0   MEM0   -   -     -     -      -    -      -      -      -      -      -  -  -  -   255   -   0.00     -     -     -  0x0   -       -         -
     1   CPU0   -   -  1305     0       0   0.04 0.49   0.10   0.27  99.64   0.00   0.00  -  -  -    48  57 122.73 0.791 0.000   0x0  0x0   0  49.297    49.297
     1   MEM0   -   -     -     -      -    -      -      -      -      -      -  -  -  -   255   -   0.00     -     -     -  0x0   -       -         -
     2   CPU0   -   -  1319     0       0   0.05 0.61   0.11   0.35  99.54   0.00   0.00  -  -  -    48  57 122.78 0.793 0.000   0x0  0x0   0  49.250    49.250
root@bmc-oob:~# sensor-util slot1|grep -i CPU
MB_SOC_CPU_TEMP_C            (0x4) :   48.00 C     | (ok)
CPU_PWR                      (0x3E) :  122.00 Watts | (ok)