### PR TITLE
fby35: gl: Modify MP5990 OCP setting

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_hook.c
@@ -61,11 +61,11 @@ adm1278_init_arg adm1278_init_args[] = {
 };
 mp5990_init_arg mp5990_init_args[] = { [0] = { .is_init = false,
 					       .iout_cal_gain = 0x01B3,
-					       .iout_oc_fault_limit = 0x0044,
+					       .iout_oc_fault_limit = 0x0050,
 					       .ocw_sc_ref = 0x0AE0 },
 				       [1] = { .is_init = false,
 					       .iout_cal_gain = 0x021A,
-					       .iout_oc_fault_limit = 0x0054,
+					       .iout_oc_fault_limit = 0x0058,
 					       .ocw_sc_ref = 0x0ADF } };
 mp2985_init_arg mp2985_init_args[] = { [0] = { .is_init = false } };
 


### PR DESCRIPTION
# Description
- Modify the MPS5990 HSC IOUT OC FAULT LIMIT.

# Motivation
- Increase the OCP value.

# Test Plan
- Build Code: Pass
- Read OCP register: Pass

# Log
1. Read HSC OCP register.
- Before
root@bmc-oob:~# bic-util slot1 0x18 0x52 0x3 0x16 2 0x46
44 00

- After
root@bmc-oob:~# bic-util slot1 0x18 0x52 0x3 0x16 2 0x46
50 00