### PR TITLE
yosemite4: sd: Version commit for 2023.37.01

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_version.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_version.h
@@ -32,7 +32,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x2
+#define FIRMWARE_REVISION_2 0x1
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -41,7 +41,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x23
-#define BIC_FW_WEEK 0x25
+#define BIC_FW_WEEK 0x37
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x73 // char: s
 #define BIC_FW_platform_1 0x64 // char: d


### PR DESCRIPTION
Description:
- Version commit for SentinelDome BIC 2023.37.01.

Motivation:
- Version commit for SentinelDome BIC 2023.37.01.

Test Plan:
- Build code: Pass
- Get firmware version: Pass

Log:
uart:~$ platform info
========================{SHELL COMMAND INFO}========================================
* NAME:          Platform command
* DESCRIPTION:   Commands that could be used to debug or validate.
* DATE/VERSION:  none
* CHIP/OS:       ast1030_evb - Zephyr
* Note:          none
------------------------------------------------------------------
* PLATFORM:      Yosemite V4-Sentinel Dome
* BOARD ID:      1
* STAGE:         0
* SYSTEM:        255
* FW VERSION:    1.1
* FW DATE:       2023.37.1
* FW IMAGE:      Y4BSD.bin
========================{SHELL COMMAND INFO}========================================