### PR TITLE
Artemis: cb: Support FIO Present LOG

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_init.c
+++ b/meta-facebook/at-cb/src/platform/plat_init.c
@@ -52,6 +52,7 @@ void pal_post_init()
 	plat_mctp_init();
 	/* Send device presence log when the BIC is AC on */
 	if (is_ac_lost()) {
+		plat_fio_present_check();
 		plat_accl_present_check();
 		if (board_revision > EVT2_STAGE) {
 			plat_accl_power_cable_present_check();

--- a/meta-facebook/at-cb/src/platform/plat_pldm_monitor.c
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_monitor.c
@@ -64,3 +64,17 @@ void plat_accl_power_cable_present_check()
 		}
 	}
 }
+
+void plat_fio_present_check()
+{
+	struct pldm_sensor_event_state_sensor_state event;
+	event.sensor_offset = PLDM_STATE_SET_OFFSET_DEVICE_PRESENCE;
+	event.event_state = gpio_get(PRSNT_FIO_N) == LOW_ACTIVE ? PLDM_STATE_SET_PRESENT :
+								  PLDM_STATE_SET_NOT_PRESENT;
+	event.previous_event_state = PLDM_STATE_SET_NOT_PRESENT;
+	if (pldm_send_platform_event(PLDM_SENSOR_EVENT, PLDM_EVENT_FIO, PLDM_STATE_SENSOR_STATE,
+				     (uint8_t *)&event,
+				     sizeof(struct pldm_sensor_event_state_sensor_state))) {
+		LOG_ERR("Send FIO cable presence event log failed");
+	}
+}

--- a/meta-facebook/at-cb/src/platform/plat_pldm_monitor.h
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_monitor.h
@@ -43,6 +43,7 @@ enum plat_pldm_event_sensor_num {
 	PLDM_EVENT_ACCL_PWR_CBL_10,
 	PLDM_EVENT_ACCL_PWR_CBL_11,
 	PLDM_EVENT_ACCL_PWR_CBL_12,
+	PLDM_EVENT_FIO,
 };
 
 enum plat_pldm_device_state_set_offset {
@@ -52,5 +53,6 @@ enum plat_pldm_device_state_set_offset {
 
 void plat_accl_present_check();
 void plat_accl_power_cable_present_check();
+void plat_fio_present_check();
 
 #endif


### PR DESCRIPTION
 # Description:
  - As title.

 # Motivation:
 - To Support FIO present LOG

 # Test Plan:
 - Builr pass and FIO present/not Present LOG can be logged. - pass

 # Log:
 - Present ``` root@bmc-oob:~# log-util --print all | grep FIO
0    all      2018-03-09 04:35:58    pldmd            State Sensor: CB_SENSOR_FIO, present
root@bmc-oob:~#
 ```
 - Not Present
 ```
 root@bmc-oob:~# log-util --print all | grep FIO
0    all      2018-03-09 04:35:58    pldmd            State Sensor: CB_SENSOR_FIO, not present
root@bmc-oob:~#