### PR TITLE
fby35: cl: Modify SOC thermal margin threshold

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
@@ -243,7 +243,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x00, // sensor unit
+		0x80, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -259,8 +259,8 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x7D, // UNRT
-		0x00, // UCT
+		0x00, // UNRT
+		-0x03, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -381,7 +381,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // normal minimum
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
-		0x7D, // UNRT
+		0x00, // UNRT
 		0x00, // UCT
 		0x00, // UNCT
 		0x00, // LNRT


### PR DESCRIPTION
# Description
- Support negative sensor threshold.
- Modify SOC thermal margin threshold.
- Remove useless threshold of SOC TJMAX.

# Motivation
- BMC Fan table using SOC thermal margin as a basis for judging fan speed. But BIC didn't set any threshold about SOC thermal margin.

# Log:
- Before modify root@bmc-oob:~# sensor-util slot1 --thre | grep SOC
MB_SOC_CPU_TEMP_C            (0x5) :   47.00 C     | (ok) | UCR: 77.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_THERMAL_MARGIN_C      (0x14) :  -30.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_TJMAX_C               (0x15) :   77.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_PACKAGE_PWR_W         (0x38) :   31.00 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA

- After modify root@bmc-oob:~# sensor-util slot4 --thre | grep SOC
MB_SOC_CPU_TEMP_C            (0x5) :   49.00 C     | (ok) | UCR: 77.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_THERMAL_MARGIN_C      (0x14) :  -28.00 C     | (ok) | UCR: -3.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_TJMAX_C               (0x15) :   77.00 C     | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_PACKAGE_PWR_W         (0x38) :   36.00 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA