### PR TITLE
fby35: gl: Modify MPS HSC OCW_SC_REF default

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_hook.c
@@ -66,7 +66,7 @@ mp5990_init_arg mp5990_init_args[] = { [0] = { .is_init = false,
 				       [1] = { .is_init = false,
 					       .iout_cal_gain = 0x021A,
 					       .iout_oc_fault_limit = 0x0058,
-					       .ocw_sc_ref = 0x0ADF } };
+					       .ocw_sc_ref = 0x0AE0 } };
 mp2985_init_arg mp2985_init_args[] = { [0] = { .is_init = false } };
 
 struct tca9548 mux_conf_addr_0xe2[8] = {


### PR DESCRIPTION
# Description
- Modify the MPS5990 HSC OCWREF and SCREF.

# Motivation
- According to power team and vendor suggestions, modify the value.

# Test Plan:
- Build Code: Pass
- Read OCP register: Pass

# Log
1. Read value of HSC OCW_SC_REF register from dongle.
Register_Name   Address   Byte_Count   Value
OCW_SC_REF      0xC5      2            0x0AE0