### PR TITLE
fby35: gl: Avoid to send uninitialized DIMM temperature after BIC reset

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_dimm.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_dimm.c
@@ -50,6 +50,11 @@ bool is_dimm_prsnt_inited()
 	return dimm_prsnt_inited;
 }
 
+bool is_dimm_ready_monitor(uint8_t dimm_id)
+{
+	return dimm_data[dimm_id].is_ready_monitor;
+}
+
 void get_dimm_info_handler()
 {
 	I3C_MSG i3c_msg = { 0 };
@@ -161,6 +166,7 @@ void get_dimm_info_handler()
 
 			// Double check before read each DIMM info
 			if (!get_post_status()) {
+				dimm_data[dimm_id].is_ready_monitor = false;
 				break;
 			}
 
@@ -185,6 +191,7 @@ void get_dimm_info_handler()
 
 			// Double check before read each DIMM info
 			if (!get_post_status()) {
+				dimm_data[dimm_id].is_ready_monitor = false;
 				break;
 			}
 
@@ -206,6 +213,8 @@ void get_dimm_info_handler()
 				memcpy(&dimm_data[dimm_id].pmic_error_data, &i3c_msg.data,
 				       sizeof(dimm_data[dimm_id].pmic_error_data));
 			}
+			// If the DIMM is ready for monitoring, BIC can send its temperature to CPU by PECI.
+			dimm_data[dimm_id].is_ready_monitor = true;
 		}
 
 		if (k_mutex_unlock(&i3c_dimm_mutex)) {

--- a/meta-facebook/yv35-gl/src/platform/plat_dimm.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_dimm.h
@@ -78,6 +78,7 @@ enum DIMM_DEVICE_TYPE {
 
 typedef struct dimm_info {
 	bool is_present;
+	bool is_ready_monitor;
 	uint8_t pmic_error_data[MAX_LEN_I3C_GET_PMIC_ERR];
 	uint8_t pmic_pwr_data[MAX_LEN_I3C_GET_PMIC_PWR];
 	uint8_t spd_temp_data[MAX_LEN_I3C_GET_SPD_TEMP];
@@ -92,6 +93,7 @@ extern dimm_info dimm_data[MAX_COUNT_DIMM];
 void start_get_dimm_info_thread();
 void get_dimm_info_handler();
 bool is_dimm_prsnt_inited();
+bool is_dimm_ready_monitor(uint8_t dimm_id);
 void init_i3c_dimm_prsnt_status();
 bool get_dimm_presence_status(uint8_t dimm_id);
 void set_dimm_presence_status(uint8_t index, uint8_t status);

--- a/meta-facebook/yv35-gl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_hook.c
@@ -203,6 +203,11 @@ bool post_intel_dimm_i3c_read(sensor_cfg *cfg, void *args, int *reading)
 	dimm_post_proc_arg *post_proc_args = (dimm_post_proc_arg *)args;
 	sensor_val *sval = (sensor_val *)reading;
 
+	// If DIMM information handler is not ready, BIC won't send the DIMM's temperature to CPU by PECI.
+	if (!is_dimm_ready_monitor(post_proc_args->dimm_channel)) {
+		return true;
+	}
+
 	uint8_t addr = 0, write_len = 0, read_len = 0, cmd = 0, read_buf = 0;
 	uint8_t write_buf[PECI_WR_PKG_LEN_DWORD] = { 0 };
 	int ret = 0;


### PR DESCRIPTION
# Description
- Add flag "is_dimm_ready". It will enable after DIMM information handler is running.
- BIC sends DIMM temperature to CPU when "is_dimm_ready" enable.

# Motivation
- After BIC reseting, to avoid it from sending uninitialized DIMM temperature data to CPU, which could trigger a thermal trip event. Resulting in CPLD activating the protective mechanism and causing a 12V power-off.

# Test Plan:
- Build code: Pass
- The status is normal after reseting
	1. Serverboard power status is normal: Pass
	2. BIC and Host is normal: Pass