### PR TITLE
fby35: cl: Correct SDR sensor unit

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sdr_table.c
@@ -60,7 +60,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -121,7 +121,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -182,7 +182,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -792,7 +792,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -914,7 +914,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -975,7 +975,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1036,7 +1036,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1097,7 +1097,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1158,7 +1158,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2073,7 +2073,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2134,7 +2134,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2195,7 +2195,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2256,7 +2256,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2317,7 +2317,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2439,7 +2439,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2500,7 +2500,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2561,7 +2561,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2622,7 +2622,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2683,7 +2683,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -3113,7 +3113,7 @@ SDR_Full_sensor hotswap_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -3376,7 +3376,7 @@ SDR_Full_sensor dpv2_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UNCT_SETTABLE | IPMI_SDR_LNCT_SETTABLE | IPMI_SDR_UNCT_READABLE |
 			IPMI_SDR_LNCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -3437,7 +3437,7 @@ SDR_Full_sensor dpv2_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UNCT_SETTABLE | IPMI_SDR_LNCT_SETTABLE | IPMI_SDR_UNCT_READABLE |
 			IPMI_SDR_LNCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -3498,7 +3498,7 @@ SDR_Full_sensor dpv2_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UNCT_SETTABLE | IPMI_SDR_LNCT_SETTABLE | IPMI_SDR_UNCT_READABLE |
 			IPMI_SDR_LNCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -3559,7 +3559,7 @@ SDR_Full_sensor dpv2_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -3619,7 +3619,7 @@ SDR_Full_sensor dpv2_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UNCT_SETTABLE | IPMI_SDR_LNCT_SETTABLE | IPMI_SDR_UNCT_READABLE |
 			IPMI_SDR_LNCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization


### PR DESCRIPTION
# Description
- Correct the sensor unit of SDR table.

# Motivation
- BMC using sensor unit to decide method to convert threshold.

# Test plan
- Build Code: Pass
- Check threshold: Pass

# Log
1. Check sensor threshold.
- Before root@bmc-oob:~# sensor-util slot1 --thre | grep MB
MB_INLET_TEMP_C              (0x1) :   40.00 C     | (unr) | UCR: 52.00 | UNC: NA | UNR: -106.00 | LCR: NA | LNC: NA | LNR: NA
MB_OUTLET_TEMP_C             (0x2) :   52.00 C     | (unr) | UCR: 83.00 | UNC: NA | UNR: -106.00 | LCR: NA | LNC: NA | LNR: NA
MB_PCH_TEMP_C                (0x4) :   58.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_CPU_TEMP_C            (0x5) :   52.00 C     | (ok) | UCR: 77.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_THERMAL_MARGIN_C      (0x14) :  -25.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_TJMAX_C               (0x15) :   77.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA0_TEMP_C             (0x6) : NA | (na)
MB_DIMMA2_TEMP_C             (0x7) :   50.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA3_TEMP_C             (0x9) :   48.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA4_TEMP_C             (0xA) : NA | (na)
MB_DIMMA6_TEMP_C             (0xB) :   47.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA7_TEMP_C             (0xC) :   45.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SSD0_M2A_TEMP_C           (0xD) :   41.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_HSC_TEMP_C                (0xE) :   50.62 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_TEMP_C           (0xF) :   56.19 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_TEMP_C           (0x10) :   55.31 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_TEMP_C             (0x11) :   52.88 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_TEMP_C            (0x12) :   53.75 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_TEMP_C            (0x13) :   55.25 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_ADC_P12V_STBY_VOLT_V      (0x20) :   12.34 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
MB_ADC_P3V_BAT_VOLT_V        (0x21) :    3.08 Volts | (ok) | UCR: 3.51 | UNC: 3.46 | UNR: NA | LCR: 2.76 | LNC: 2.79 | LNR: NA
MB_ADC_P3V3_STBY_VOLT_V      (0x22) :    3.31 Volts | (ok) | UCR: 3.56 | UNC: 3.53 | UNR: 4.00 | LCR: 3.04 | LNC: 3.08 | LNR: 2.30
MB_ADC_P1V8_STBY_VOLT_V      (0x23) :    1.81 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.09 | LCR: 1.67 | LNC: 1.69 | LNR: 1.44
MB_ADC_P1V05_PCH_VOLT_V      (0x24) :    1.04 Volts | (ok) | UCR: 1.12 | UNC: 1.10 | UNR: 1.22 | LCR: 0.97 | LNC: 0.98 | LNR: 0.84
MB_ADC_P5V_STBY_VOLT_V       (0x25) :    5.01 Volts | (ok) | UCR: 5.40 | UNC: 5.35 | UNR: 5.80 | LCR: 4.59 | LNC: 4.64 | LNR: 4.00
MB_ADC_P12V_DIMM_VOLT_V      (0x26) :   12.32 Volts | (ok) | UCR: 14.21 | UNC: 14.07 | UNR: NA | LCR: 9.87 | LNC: 10.01 | LNR: NA
MB_ADC_P1V2_STBY_VOLT_V      (0x27) :    1.21 Volts | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.39 | LCR: 1.10 | LNC: 1.12 | LNR: 0.96
MB_ADC_P3V3_M2_VOLT_V        (0x28) :    3.32 Volts | (ok) | UCR: 3.71 | UNC: 3.67 | UNR: NA | LCR: 2.91 | LNC: 2.94 | LNR: NA
MB_HSC_INPUT_VOLT_V          (0x29) :   12.28 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
MB_VR_VCCIN_VOLT_V           (0x2A) :    1.79 Volts | (ok) | UCR: 1.93 | UNC: 1.91 | UNR: 2.20 | LCR: 1.46 | LNC: 1.48 | LNR: 0.40
MB_VR_FIVRA_VOLT_V           (0x2C) :    1.80 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.20 | LCR: 1.69 | LNC: 1.71 | LNR: 0.40
MB_VR_EHV_VOLT_V             (0x2D) :    1.80 Volts | (ok) | UCR: 1.90 | UNC: 1.88 | UNR: 2.20 | LCR: 1.70 | LNC: 1.72 | LNR: 0.40
MB_VR_VCCD_VOLT_V            (0x2E) :    1.14 Volts | (ok) | UCR: 1.23 | UNC: 1.21 | UNR: 1.50 | LCR: 1.05 | LNC: 1.06 | LNR: 0.40
MB_VR_FAON_VOLT_V            (0x2F) :    1.06 Volts | (ok) | UCR: 1.11 | UNC: 1.10 | UNR: 1.48 | LCR: 0.90 | LNC: 0.91 | LNR: 0.40
MB_HSC_OUTPUT_CURR_A         (0x30) :    4.39 Amps  | (ok) | UCR: 31.96 | UNC: 28.73 | UNR: 39.95 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_CURR_A           (0x31) :    7.16 Amps  | (unr) | UCR: -58.50 | UNC: -80.34 | UNR: -19.50 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_CURR_A           (0x32) :    2.88 Amps  | (unr) | UCR: -26.35 | UNC: -31.31 | UNR: -8.37 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_CURR_A             (0x33) :    0.50 Amps  | (unr) | UCR: 6.24 | UNC: 5.04 | UNR: -2.48 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_CURR_A            (0x34) :    2.34 Amps  | (unr) | UCR: -18.62 | UNC: -21.66 | UNR: -5.70 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_CURR_A            (0x35) :    7.70 Amps  | (unr) | UCR: -20.54 | UNC: -24.44 | UNR: -6.50 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_PACKAGE_PWR_W         (0x38) :   32.00 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_PWR_W           (0x39) :   53.65 Watts | (ok) | UCR: 399.28 | UNC: 360.22 | UNR: 499.10 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_PWR_W            (0x3A) :   26.81 Watts | (unr) | UCR: -107.16 | UNC: -146.64 | UNR: -36.66 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_PWR_W            (0x3C) :    5.01 Watts | (unr) | UCR: -50.73 | UNC: -59.28 | UNR: -18.24 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_PWR_W              (0x3D) :    0.95 Watts | (unr) | UCR: 11.25 | UNC: 8.97 | UNR: -6.54 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_PWR_W             (0x3E) :    0.56 Watts | (unr) | UCR: -22.00 | UNC: -25.30 | UNR: -7.04 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_PWR_W             (0x3F) :    8.17 Watts | (unr) | UCR: -22.40 | UNC: -26.60 | UNR: -7.56 | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA0_PMIC_PWR_W      (0x1E) : NA | (na)
MB_VR_DIMMA2_PMIC_PWR_W      (0x1F) :    0.38 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA3_PMIC_PWR_W      (0x36) :    0.50 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA4_PMIC_PWR_W      (0x37) : NA | (na)
MB_VR_DIMMA6_PMIC_PWR_W      (0x42) :    0.25 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA7_PMIC_PWR_W      (0x47) :    0.12 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA

- After root@bmc-oob:~# sensor-util slot1 --thre | grep MB
MB_INLET_TEMP_C              (0x1) :   40.00 C     | (ok) | UCR: 52.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
MB_OUTLET_TEMP_C             (0x2) :   52.00 C     | (ok) | UCR: 83.00 | UNC: NA | UNR: 150.00 | LCR: NA | LNC: NA | LNR: NA
MB_PCH_TEMP_C                (0x4) :   59.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_CPU_TEMP_C            (0x5) :   52.00 C     | (ok) | UCR: 77.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOC_THERMAL_MARGIN_C      (0x14) :  -25.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_TJMAX_C               (0x15) :   77.00 C     | (ok) | UCR: NA | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA0_TEMP_C             (0x6) : NA | (na)
MB_DIMMA2_TEMP_C             (0x7) :   50.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA3_TEMP_C             (0x9) :   48.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA4_TEMP_C             (0xA) : NA | (na)
MB_DIMMA6_TEMP_C             (0xB) :   47.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_DIMMA7_TEMP_C             (0xC) :   45.00 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SSD0_M2A_TEMP_C           (0xD) :   41.00 C     | (ok) | UCR: 75.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_HSC_TEMP_C                (0xE) :   50.62 C     | (ok) | UCR: 80.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_TEMP_C           (0xF) :   56.31 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_TEMP_C           (0x10) :   55.31 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_TEMP_C             (0x11) :   52.88 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_TEMP_C            (0x12) :   53.75 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_TEMP_C            (0x13) :   55.25 C     | (ok) | UCR: 100.00 | UNC: NA | UNR: 125.00 | LCR: NA | LNC: NA | LNR: NA
MB_ADC_P12V_STBY_VOLT_V      (0x20) :   12.32 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
MB_ADC_P3V_BAT_VOLT_V        (0x21) :    3.08 Volts | (ok) | UCR: 3.51 | UNC: 3.46 | UNR: NA | LCR: 2.76 | LNC: 2.79 | LNR: NA
MB_ADC_P3V3_STBY_VOLT_V      (0x22) :    3.31 Volts | (ok) | UCR: 3.56 | UNC: 3.53 | UNR: 4.00 | LCR: 3.04 | LNC: 3.08 | LNR: 2.30
MB_ADC_P1V8_STBY_VOLT_V      (0x23) :    1.81 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.09 | LCR: 1.67 | LNC: 1.69 | LNR: 1.44
MB_ADC_P1V05_PCH_VOLT_V      (0x24) :    1.04 Volts | (ok) | UCR: 1.12 | UNC: 1.10 | UNR: 1.22 | LCR: 0.97 | LNC: 0.98 | LNR: 0.84
MB_ADC_P5V_STBY_VOLT_V       (0x25) :    5.01 Volts | (ok) | UCR: 5.40 | UNC: 5.35 | UNR: 5.80 | LCR: 4.59 | LNC: 4.64 | LNR: 4.00
MB_ADC_P12V_DIMM_VOLT_V      (0x26) :   12.32 Volts | (ok) | UCR: 14.21 | UNC: 14.07 | UNR: NA | LCR: 9.87 | LNC: 10.01 | LNR: NA
MB_ADC_P1V2_STBY_VOLT_V      (0x27) :    1.21 Volts | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.39 | LCR: 1.10 | LNC: 1.12 | LNR: 0.96
MB_ADC_P3V3_M2_VOLT_V        (0x28) :    3.32 Volts | (ok) | UCR: 3.71 | UNC: 3.67 | UNR: NA | LCR: 2.91 | LNC: 2.94 | LNR: NA
MB_HSC_INPUT_VOLT_V          (0x29) :   12.28 Volts | (ok) | UCR: 13.36 | UNC: 13.23 | UNR: 14.36 | LCR: 10.71 | LNC: 10.84 | LNR: 10.08
MB_VR_VCCIN_VOLT_V           (0x2A) :    1.62 Volts | (ok) | UCR: 1.93 | UNC: 1.91 | UNR: 2.20 | LCR: 1.46 | LNC: 1.48 | LNR: 0.40
MB_VR_FIVRA_VOLT_V           (0x2C) :    1.80 Volts | (ok) | UCR: 1.92 | UNC: 1.90 | UNR: 2.20 | LCR: 1.69 | LNC: 1.71 | LNR: 0.40
MB_VR_EHV_VOLT_V             (0x2D) :    1.80 Volts | (ok) | UCR: 1.90 | UNC: 1.88 | UNR: 2.20 | LCR: 1.70 | LNC: 1.72 | LNR: 0.40
MB_VR_VCCD_VOLT_V            (0x2E) :    1.14 Volts | (ok) | UCR: 1.23 | UNC: 1.21 | UNR: 1.50 | LCR: 1.05 | LNC: 1.06 | LNR: 0.40
MB_VR_FAON_VOLT_V            (0x2F) :    1.06 Volts | (ok) | UCR: 1.11 | UNC: 1.10 | UNR: 1.48 | LCR: 0.90 | LNC: 0.91 | LNR: 0.40
MB_HSC_OUTPUT_CURR_A         (0x30) :    4.42 Amps  | (ok) | UCR: 31.96 | UNC: 28.73 | UNR: 39.95 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_CURR_A           (0x31) :    6.88 Amps  | (ok) | UCR: 141.18 | UNC: 119.34 | UNR: 180.18 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_CURR_A           (0x32) :    3.03 Amps  | (ok) | UCR: 53.01 | UNC: 48.05 | UNR: 70.99 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_CURR_A             (0x33) :    0.50 Amps  | (ok) | UCR: 6.24 | UNC: 5.04 | UNR: 18.00 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_CURR_A            (0x34) :    0.49 Amps  | (ok) | UCR: 30.02 | UNC: 26.98 | UNR: 42.94 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_CURR_A            (0x35) :    7.70 Amps  | (ok) | UCR: 46.02 | UNC: 42.12 | UNR: 60.06 | LCR: NA | LNC: NA | LNR: NA
MB_SOC_PACKAGE_PWR_W         (0x38) :   30.00 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_PWR_W           (0x39) :   54.13 Watts | (ok) | UCR: 399.28 | UNC: 360.22 | UNR: 499.10 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_PWR_W            (0x3A) :   11.41 Watts | (ok) | UCR: 253.80 | UNC: 214.32 | UNR: 324.30 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_PWR_W            (0x3C) :    4.83 Watts | (ok) | UCR: 95.19 | UNC: 86.64 | UNR: 127.68 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_PWR_W              (0x3D) :    0.90 Watts | (ok) | UCR: 11.25 | UNC: 8.97 | UNR: 32.38 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_PWR_W             (0x3E) :    0.50 Watts | (ok) | UCR: 34.32 | UNC: 31.02 | UNR: 49.28 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_PWR_W             (0x3F) :    8.09 Watts | (ok) | UCR: 49.28 | UNC: 45.08 | UNR: 64.12 | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA0_PMIC_PWR_W      (0x1E) : NA | (na)
MB_VR_DIMMA2_PMIC_PWR_W      (0x1F) :    0.62 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA3_PMIC_PWR_W      (0x36) :    0.50 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA4_PMIC_PWR_W      (0x37) : NA | (na)
MB_VR_DIMMA6_PMIC_PWR_W      (0x42) :    0.25 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_VR_DIMMA7_PMIC_PWR_W      (0x47) :    0.00 Watts | (ok) | UCR: 32.20 | UNC: 31.50 | UNR: NA | LCR: NA | LNC: NA | LNR: NA