### PR TITLE
op2: op: Correct SDR sensor unit

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_sdr_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sdr_table.c
@@ -56,7 +56,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -117,7 +117,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -178,7 +178,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -239,7 +239,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -300,7 +300,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -361,7 +361,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -422,7 +422,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -483,7 +483,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -544,7 +544,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -605,7 +605,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -666,7 +666,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -727,7 +727,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -788,7 +788,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -849,7 +849,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -910,7 +910,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -971,7 +971,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1032,7 +1032,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1093,7 +1093,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1154,7 +1154,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1215,7 +1215,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1278,7 +1278,7 @@ SDR_Full_sensor plat_EXPA_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1339,7 +1339,7 @@ SDR_Full_sensor plat_EXPA_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1400,7 +1400,7 @@ SDR_Full_sensor plat_EXPA_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1461,7 +1461,7 @@ SDR_Full_sensor plat_EXPA_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1523,7 +1523,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1584,7 +1584,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1645,7 +1645,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1706,7 +1706,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1767,7 +1767,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1828,7 +1828,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1889,7 +1889,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1950,7 +1950,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2011,7 +2011,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2072,7 +2072,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2133,7 +2133,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -2194,7 +2194,7 @@ SDR_Full_sensor plat_EXPB_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization


### PR DESCRIPTION
# Description
- Correct the sensor unit of SDR table. 0x00 is unsigned, 0x40 is 1's complements, and 0x80 is 2's complements.

# Motivation
- BMC using sensor unit to decide method to convert threshold.

# Test plan
- Build Code: Pass
- Check threshold: Pass

# Log
1. Get sensor threshold.
- Before root@bmc-oob:~# sensor-util slot1 --thre | grep OU_
1OU_BIC_TEMP_C               (0x40) :   29.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
1OU_ADC_P3V3_STBY_VOLT_V     (0x4C) :    3.34 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
2OU_BIC_TEMP_C               (0x70) :   28.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
2OU_ADC_P3V3_STBY_VOLT_V     (0x7C) :    3.29 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
2OU_ADC_P1V8_VOLT_V          (0x7D) :    1.83 Volts | (unr) | UCR: -0.62 | UNC: -0.64 | UNR: -0.60 | LCR: -0.91 | LNC: -0.89 | LNR: -0.92
2OU_ADC_P1V2_VOLT_V          (0x7F) :    1.18 Volts | (unr) | UCR: -1.26 | UNC: -1.28 | UNR: -1.25 | LCR: 1.10 | LNC: 1.12 | LNR: 1.09
3OU_BIC_TEMP_C               (0xA0) :   29.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
3OU_ADC_P3V3_STBY_VOLT_V     (0xAC) :    3.31 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
4OU_BIC_TEMP_C               (0xD0) :   28.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
4OU_ADC_P3V3_STBY_VOLT_V     (0xDC) :    3.31 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
4OU_ADC_P1V8_VOLT_V          (0xDD) :    1.82 Volts | (unr) | UCR: -0.62 | UNC: -0.64 | UNR: -0.60 | LCR: -0.91 | LNC: -0.89 | LNR: -0.92
4OU_ADC_P1V2_VOLT_V          (0xDF) :    1.18 Volts | (unr) | UCR: -1.26 | UNC: -1.28 | UNR: -1.25 | LCR: 1.10 | LNC: 1.12 | LNR: 1.09

- After root@bmc-oob:~# sensor-util slot1 --thre | grep OU_
1OU_BIC_TEMP_C               (0x40) :   29.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
1OU_ADC_P3V3_STBY_VOLT_V     (0x4C) :    3.34 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
2OU_BIC_TEMP_C               (0x70) :   28.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
2OU_ADC_P3V3_STBY_VOLT_V     (0x7C) :    3.29 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
2OU_ADC_P1V8_VOLT_V          (0x7D) :    1.82 Volts | (ok) | UCR: 1.94 | UNC: 1.92 | UNR: 1.96 | LCR: 1.65 | LNC: 1.67 | LNR: 1.64
2OU_ADC_P1V2_VOLT_V          (0x7F) :    1.18 Volts | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.31 | LCR: 1.10 | LNC: 1.12 | LNR: 1.09
3OU_BIC_TEMP_C               (0xA0) :   29.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
3OU_ADC_P3V3_STBY_VOLT_V     (0xAC) :    3.31 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
4OU_BIC_TEMP_C               (0xD0) :   28.00 C     | (ok) | UCR: 55.00 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
4OU_ADC_P3V3_STBY_VOLT_V     (0xDC) :    3.31 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
4OU_ADC_P1V8_VOLT_V          (0xDD) :    1.82 Volts | (ok) | UCR: 1.94 | UNC: 1.92 | UNR: 1.96 | LCR: 1.65 | LNC: 1.67 | LNR: 1.64
4OU_ADC_P1V2_VOLT_V          (0xDF) :    1.19 Volts | (ok) | UCR: 1.30 | UNC: 1.28 | UNR: 1.31 | LCR: 1.10 | LNC: 1.12 | LNR: 1.09