### PR TITLE
common: mctp: support MCTP set EID command handler

### DIFF
--- a/common/service/mctp/mctp.h
+++ b/common/service/mctp/mctp.h
@@ -188,6 +188,13 @@ typedef struct _mctp {
 	uint8_t cci_msg_tag;
 } mctp;
 
+typedef struct _mctp_port {
+	mctp *mctp_inst;
+	mctp_medium_conf conf;
+	uint8_t mctp_medium_type;
+	uint8_t user_idx;
+} mctp_port;
+
 /* public function */
 mctp *mctp_init(void);
 

--- a/common/service/mctp/mctp_ctrl.c
+++ b/common/service/mctp/mctp_ctrl.c
@@ -49,6 +49,56 @@ __weak int load_mctp_support_types(uint8_t *type_len, uint8_t *types)
 	return -1;
 }
 
+__weak uint8_t plat_get_mctp_port_count()
+{
+	return 0;
+}
+
+__weak mctp_port *plat_get_mctp_port(uint8_t index)
+{
+	return NULL;
+}
+
+uint8_t mctp_ctrl_cmd_set_endpoint_id(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t *resp,
+				      uint16_t *resp_len, void *ext_params)
+{
+	ARG_UNUSED(ext_params);
+	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(buf, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, MCTP_ERROR);
+
+	struct _set_eid_req *req = (struct _set_eid_req *)buf;
+	struct _set_eid_resp *p = (struct _set_eid_resp *)resp;
+
+	uint8_t plat_mctp_port_count = plat_get_mctp_port_count();
+	if (plat_mctp_port_count != 0) {
+		for (uint8_t i = 0; i < plat_mctp_port_count; i++) {
+			mctp_port *port = plat_get_mctp_port(i);
+			if (port != NULL) {
+				port->mctp_inst->endpoint = req->eid;
+			} else {
+				LOG_ERR("plat_get_mctp_port not implemented");
+				p->completion_code = MCTP_CTRL_CC_ERROR;
+				*resp_len = 1;
+				return MCTP_SUCCESS;
+			}
+		}
+		p->completion_code = MCTP_CTRL_CC_SUCCESS;
+	} else {
+		LOG_ERR("plat_get_mctp_port not implemented");
+		p->completion_code = MCTP_CTRL_CC_ERROR;
+	}
+
+	p->status = 0; // Assignment accepted. Device does not use an EID pool.
+	p->eid = req->eid;
+	p->eid_pool_size = 0;
+
+	*resp_len = (p->completion_code == MCTP_CTRL_CC_SUCCESS) ? sizeof(*p) : 1;
+
+	return MCTP_SUCCESS;
+}
+
 uint8_t mctp_ctrl_cmd_get_endpoint_id(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t *resp,
 				      uint16_t *resp_len, void *ext_params)
 {
@@ -202,6 +252,7 @@ static uint8_t mctp_ctrl_cmd_resp_process(mctp *mctp_inst, uint8_t *buf, uint32_
 }
 
 static mctp_ctrl_cmd_handler_t mctp_ctrl_cmd_tbl[] = {
+	{ MCTP_CTRL_CMD_SET_ENDPOINT_ID, mctp_ctrl_cmd_set_endpoint_id },
 	{ MCTP_CTRL_CMD_GET_ENDPOINT_ID, mctp_ctrl_cmd_get_endpoint_id },
 	{ MCTP_CTRL_CMD_GET_MESSAGE_TYPE_SUPPORT, mctp_ctrl_cmd_get_message_type_support }
 };

--- a/common/service/mctp/mctp_ctrl.h
+++ b/common/service/mctp/mctp_ctrl.h
@@ -147,6 +147,9 @@ uint8_t mctp_ctrl_cmd_handler(void *mctp_p, uint8_t *buf, uint32_t len, mctp_ext
 uint8_t mctp_ctrl_send_msg(void *mctp_p, mctp_ctrl_msg *msg);
 uint8_t mctp_ctrl_read(void *mctp_p, mctp_ctrl_msg *msg, uint8_t *read_buf, uint16_t read_len);
 
+uint8_t plat_get_mctp_port_count();
+mctp_port *plat_get_mctp_port(uint8_t index);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# Description
Support MCTP set EID command handler.

# Motivation
The BMC should be able to set EID to MCTP endpoints.

# Test Plan:
- BMC sets EID to BIC: Pass

# Log:
root@bmc:~# busctl call xyz.openbmc_project.MCTP /xyz/openbmc_project/mctp au.com.CodeConstruct.MCTP SetupEndpoint say "mctpi2c0" 1 0x20 yisb 8 1 "/xyz/openbmc_project/mctp/1/8" true
root@bmc:~# pldmtool base GetPLDMTypes
[
    {
        "PLDM Type": "base",
        "PLDM Type Code": 0
    },
    {
        "PLDM Type": "platform",
        "PLDM Type Code": 2
    }
]