### PR TITLE
common: mctp: support platform set its own EID

### DIFF
--- a/common/service/mctp/mctp.c
+++ b/common/service/mctp/mctp.c
@@ -390,6 +390,11 @@ static void mctp_tx_task(void *arg, void *dummy0, void *dummy1)
 	}
 }
 
+__weak uint8_t plat_get_eid()
+{
+	return MCTP_DEFAULT_ENDPOINT;
+}
+
 /* mctp handle initial */
 mctp *mctp_init(void)
 {
@@ -401,7 +406,7 @@ mctp *mctp_init(void)
 	memset(mctp_inst, 0, sizeof(*mctp_inst));
 	mctp_inst->medium_type = MCTP_MEDIUM_TYPE_UNKNOWN;
 	mctp_inst->max_msg_size = MCTP_DEFAULT_MSG_MAX_SIZE;
-	mctp_inst->endpoint = MCTP_DEFAULT_ENDPOINT;
+	mctp_inst->endpoint = plat_get_eid();
 
 	LOG_DBG("mctp_inst = %p", mctp_inst);
 	return mctp_inst;

--- a/common/service/mctp/mctp.h
+++ b/common/service/mctp/mctp.h
@@ -230,6 +230,7 @@ uint8_t mctp_reg_msg_rx_func(mctp *mctp_inst, mctp_fn_cb rx_cb);
 mctp *pal_get_mctp(uint8_t mctp_medium_type, uint8_t bus);
 int pal_get_target(uint8_t interface);
 int pal_get_medium_type(uint8_t interface);
+uint8_t plat_get_eid();
 
 #ifdef __cplusplus
 }

--- a/common/service/mctp/mctp_ctrl.c
+++ b/common/service/mctp/mctp_ctrl.c
@@ -60,7 +60,7 @@ uint8_t mctp_ctrl_cmd_get_endpoint_id(void *mctp_inst, uint8_t *buf, uint16_t le
 
 	struct _get_eid_resp *p = (struct _get_eid_resp *)resp;
 
-	p->eid = MCTP_DEFAULT_ENDPOINT;
+	p->eid = plat_get_eid();
 	p->eid_type = STATIC_EID;
 	p->endpoint_type = BRIDGE;
 	/* Not support fairness arbitration */


### PR DESCRIPTION
# Description
Support for platform setting its own EID instead of using default value.

# Motivation
The EID is set as 0x0A for default. However, the EIDs should be vary between different slots.

# Test Plan:
- Build code: Pass
- Test with platform commit: Pass

# Log:
root@bmc:~# busctl call xyz.openbmc_project.MCTP /xyz/openbmc_project/mctp au.com.CodeConstruct.MCTP LearnEndpoint say "mctpi2c0" 1 0x20 yisb 50 1 "/xyz/openbmc_project/mctp/1/50" true