### PR TITLE
common: Support the PCC sending postcode to BMC though ipmi or pldm

### DIFF
--- a/common/service/pldm/pldm_oem.h
+++ b/common/service/pldm/pldm_oem.h
@@ -29,6 +29,12 @@ extern "C" {
 /* commands of pldm type 0x3F : PLDM_TYPE_OEM */
 #define PLDM_OEM_CMD_ECHO 0x00
 #define PLDM_OEM_IPMI_BRIDGE 0x01
+#define PLDM_OEM_WRITE_FILE_IO 0x02
+#define PLDM_OEM_READ_FILE_IO 0x03
+
+enum cmd_type {
+   POST_CODE = 0x00,
+};
 
 struct _cmd_echo_req {
 	uint8_t iana[IANA_LEN];
@@ -55,6 +61,16 @@ struct _ipmi_cmd_resp {
 	uint8_t cmd;
 	uint8_t ipmi_comp_code;
 	uint8_t first_data;
+} __attribute__((packed));
+
+struct pldm_oem_write_file_io_req {
+	uint8_t cmd_code;
+	uint32_t data_length;
+	uint8_t messages[];
+} __attribute__((packed));
+
+struct pldm_oem_write_file_io_resp {
+	uint8_t completion_code;
 } __attribute__((packed));
 
 uint8_t check_iana(const uint8_t *iana);


### PR DESCRIPTION
# Summary:
Because some of the platforms send postcode to BMC through pldm, both ipmi and pldm are supported.

# Test Plan:
-Build code: pass

# Test Log:
- Bmc gets postcode success

Aug 06 00:53:39 bmc pldmd[311]: Tx: 17 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 98 3f 02 00 04 00 00 00 93 e0 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 18 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 99 3f 02 00 04 00 00 00 96 e0 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 19 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 9a 3f 02 00 04 00 00 00 b7 e0 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 1a 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 9b 3f 02 00 04 00 00 00 0c e6 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 1b 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 9c 3f 02 00 04 00 00 00 00 ea 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 1c 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 9d 3f 02 00 04 00 00 00 90 e0 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 1d 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 9e 3f 02 00 04 00 00 00 92 e0 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 1e 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 9f 3f 02 00 04 00 00 00 91 e0 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 1f 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 80 3f 02 00 04 00 00 00 01 ea 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 00 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 81 3f 02 00 04 00 00 00 0c e6 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 01 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 82 3f 02 00 04 00 00 00 00 ea 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 02 3f 02 05
Aug 06 00:53:39 bmc pldmd[311]: Rx: 83 3f 02 00 04 00 00 00 d2 e0 00 ea
Aug 06 00:53:39 bmc pldmd[311]: Tx: 03 3f 02 05