### PR TITLE
fby3.5: cl: Support to cache IFX VR crc

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_hook.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.h
@@ -35,6 +35,19 @@ typedef struct _dimm_post_proc_arg {
 	uint8_t dimm_number;
 } dimm_post_proc_arg;
 
+typedef struct _ifx_vr_fw_info {
+	uint8_t checksum[4];
+	uint8_t remaining_write;
+	uint8_t vendor;
+	bool is_init;
+} ifx_vr_fw_info;
+
+enum IFX_VR_ID {
+	IFX_VR_VCCIN = 0x0,
+	IFX_VR_VCCFA,
+	IFX_VR_VCCD,
+};
+
 /**************************************************************************************************
  * INIT ARGS
 **************************************************************************************************/
@@ -45,6 +58,8 @@ extern pmic_init_arg pmic_init_args[];
 extern max16550a_init_arg max16550a_init_args[];
 extern ltc4286_init_arg ltc4286_init_args[];
 extern ltc4282_init_arg ltc4282_init_args[];
+extern ifx_vr_fw_info ifx_vr_fw_info_table[];
+
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK ARGS
@@ -71,5 +86,6 @@ bool post_ltc4286_read(sensor_cfg *cfg, void *args, int *reading);
 bool post_ltc4282_read(sensor_cfg *cfg, void *args, int *reading);
 bool pre_intel_dimm_i3c_read(sensor_cfg *cfg, void *args);
 bool post_intel_dimm_i3c_read(sensor_cfg *cfg, void *args, int *reading);
+bool pre_ifx_vr_cache_crc(sensor_cfg *cfg, uint8_t index);
 
 #endif

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -463,6 +463,9 @@ void check_vr_type(uint8_t index)
 	} else if ((msg.data[0] == 0x02) && (msg.data[2] == 0x8A)) {
 		sensor_config[index].type = sensor_dev_xdpe15284;
 		if (sensor_config[index].offset == VR_VOL_CMD) {
+			if (pre_ifx_vr_cache_crc(sensor_config, index) == false) {
+				LOG_ERR("XDPE15284 fails to cache the crc");
+			}
 			set_vr_page(sensor_config[index].port, sensor_config[index].target_addr, 0);
 			xdpe15284_lock_reg(sensor_config[index].port,
 					   sensor_config[index].target_addr);


### PR DESCRIPTION
# Description:
Cache the CRC before starting to polling VR sensor.

# Motivation:
To fix the I2C transaction of get CRC between IFX VR and BIC been alternated, causing get abnormal CRC from VR.

# Test Plan:
1. Build and test pass on YV35 system pass

2. Get the FW version root@bmc-oob:~# fw-util slot1 --version
1OU Bridge-IC Version: oby35-vf-v2023.29.01
SB Bridge-IC Version: oby35-cl-v2023.38.e1
BIOS Version: Y35CLM02
BIOS Version after activation: Y35CLM02
SB CPLD Version: 00010A05
SB CPLD Version after activation: 00010A05
MP5990 HSC Checksum: 158B
ME Version: 6.0.5.46
VCCIN/VCCFA_EHV_FIVRA Version: Infineon 9F9524FE, Remaining Write: 20 VCCIN/VCCFA_EHV_FIVRA Version after activation: Infineon 9F9524FE, Remaining Write: 20 VCCINFAON/VCCFA_EHV Version: Infineon 031FA534, Remaining Write: 21 VCCINFAON/VCCFA_EHV Version after activation: Infineon 031FA534, Remaining Write: 21 VCCD Version: Infineon 02A2DA5E, Remaining Write: 21 VCCD Version after activation: Infineon 02A2DA5E, Remaining Write: 21