### PR TITLE
ol2: op: Enable ADC's deglitch and set upper bound

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_hook.c
+++ b/meta-facebook/op2-op/src/platform/plat_hook.c
@@ -35,7 +35,38 @@ K_MUTEX_DEFINE(i2c_hub_mutex);
 /**************************************************************************************************
  * INIT ARGS
 **************************************************************************************************/
-adc_asd_init_arg adc_asd_init_args[] = { [0] = { .is_init = false } };
+adc_asd_init_arg adc_expa_asd_init_args[] = {
+	[0] = { 
+		.is_init = false,
+		.deglitch[0] = { .deglitch_en = true, .upper_bound = 0x2DB },
+		.deglitch[1] = { .deglitch_en = true, .upper_bound = 0x2DB },
+		.deglitch[2] = { .deglitch_en = true, .upper_bound = 0x2DB },
+		.deglitch[5] = { .deglitch_en = true, .upper_bound = 0x2DB },
+		.deglitch[6] = { .deglitch_en = true, .upper_bound = 0x31A },
+		.deglitch[7] = { .deglitch_en = true, .upper_bound = 0X18D },
+	},
+	[1] = {
+		.is_init = false,
+		.deglitch[0] = { .deglitch_en = true, .upper_bound = 0x214 },
+	}
+};
+
+adc_asd_init_arg adc_expb_asd_init_args[] = {
+	[0] = { 
+		.is_init = false,
+		.deglitch[0] = { .deglitch_en = true, .upper_bound = 0x2DB },
+		.deglitch[1] = { .deglitch_en = true, .upper_bound = 0x2DB },
+		.deglitch[2] = { .deglitch_en = true, .upper_bound = 0x2DB },
+		.deglitch[3] = { .deglitch_en = true, .upper_bound = 0x2DB },
+		.deglitch[4] = { .deglitch_en = true, .upper_bound = 0x2DB },
+		.deglitch[5] = { .deglitch_en = true, .upper_bound = 0x2DB },
+	},
+	[1] = {
+		.is_init = false,
+		.deglitch[3] = { .deglitch_en = true, .upper_bound = 0x31A },
+		.deglitch[6] = { .deglitch_en = true, .upper_bound = 0x214 },
+	}
+};
 
 ina233_init_arg ina233_init_args[] = {
 	[0] = { .is_init = false,

--- a/meta-facebook/op2-op/src/platform/plat_hook.h
+++ b/meta-facebook/op2-op/src/platform/plat_hook.h
@@ -25,7 +25,8 @@ typedef struct _i2c_proc_arg {
 /**************************************************************************************************
  * INIT ARGS
 **************************************************************************************************/
-extern adc_asd_init_arg adc_asd_init_args[];
+extern adc_asd_init_arg adc_expa_asd_init_args[];
+extern adc_asd_init_arg adc_expb_asd_init_args[];
 extern ina233_init_arg ina233_init_args[];
 extern sq52205_init_arg sq52205_init_args[];
 extern i2c_proc_arg i2c_proc_args[];

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.c
@@ -103,31 +103,31 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 	//adc
 	{ SENSOR_NUM_1OU_P3V3_STBY_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT5, NONE, NONE, stby_access,
 	  2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expa_asd_init_args[0] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expa_asd_init_args[0] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD1_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expa_asd_init_args[0] },
 
 	{ SENSOR_NUM_1OU_E1S_SSD2_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expa_asd_init_args[0] },
 
 	{ SENSOR_NUM_1OU_P1V8_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, dc_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
-	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  NULL, NULL, NULL, NULL, &adc_expa_asd_init_args[0] },
 
 	{ SENSOR_NUM_1OU_P0V9_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT7, NONE, NONE, dc_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
-	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  NULL, NULL, NULL, NULL, &adc_expa_asd_init_args[0] },
 
 	{ SENSOR_NUM_1OU_P1V2_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT8, NONE, NONE, dc_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
-	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  NULL, NULL, NULL, NULL, &adc_expa_asd_init_args[1] },
 
 	//INA233 VOL
 	{ SENSOR_NUM_1OU_E1S_SSD0_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_E1S_0_ADDR,
@@ -215,35 +215,35 @@ sensor_cfg plat_expansion_B_sensor_config[] = {
 	//adc
 	{ SENSOR_NUM_2OU_E1S_SSD0_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT4, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expb_asd_init_args[0] },
 
 	{ SENSOR_NUM_2OU_E1S_SSD1_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT3, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expb_asd_init_args[0] },
 
 	{ SENSOR_NUM_2OU_E1S_SSD2_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expb_asd_init_args[0] },
 
 	{ SENSOR_NUM_2OU_E1S_SSD3_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expb_asd_init_args[0] },
 
 	{ SENSOR_NUM_2OU_E1S_SSD4_P3V3_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE,
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expb_asd_init_args[0] },
 
 	{ SENSOR_NUM_2OU_P3V3_STBY_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT5, NONE, NONE, stby_access,
 	  2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expb_asd_init_args[0] },
 
 	{ SENSOR_NUM_2OU_P1V8_STBY_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT11, NONE, NONE,
 	  stby_access, 1, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expb_asd_init_args[1] },
 
 	{ SENSOR_NUM_2OU_P1V2_STBY_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT14, NONE, NONE,
 	  stby_access, 1, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expb_asd_init_args[1] },
 
 	//INA233 VOL
 	{ SENSOR_NUM_2OU_E1S_SSD0_P12V_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPB_E1S_0_ADDR,


### PR DESCRIPTION
# Description:
    - Enable ADC's deglitch and set upper bound.
        - ADC Table "adc_expa_asd_init_args" is for 1OU/3OU.
        - ADC Table "adc_expb_asd_init_args" is for 2OU/4OU.
    - Revise ADC sensors' init_args to correspond the ADC table.

# Motivation:
    - Set the maximum readable value for the ADC. If the ADC sensor exceeds it, the BIC will read the ADC again.

# Test Plan:
1. build code: Pass
2. Check ADC's sensors: Pass

# Test Log:
2. Check ADC's sesnors root@bmc-oob:~# sensor-util all --t | grep ADC
```
1OU_E1S_ADC_SSD0_P3V3_VOLT_V (0x47) :    3.32 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
1OU_E1S_ADC_SSD1_P3V3_VOLT_V (0x48) :    3.32 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
1OU_E1S_ADC_SSD2_P3V3_VOLT_V (0x49) :    3.32 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.
```
2OU_E1S_ADC_SSD0_P3V3_VOLT_V (0x77) :    3.35 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
2OU_E1S_ADC_SSD1_P3V3_VOLT_V (0x78) :    3.35 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
2OU_E1S_ADC_SSD2_P3V3_VOLT_V (0x79) :    3.35 Volts | (ok) | UCR: 3.57 | UNC: 3.54 | UNR: 3.81 | LCR: 3.03 | LNC: 3.06 | LNR: 2.79
```