### PR TITLE
fby3: dl: align sdr to TI BIC

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_sdr_table.c
@@ -1335,7 +1335,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1396,7 +1396,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1457,7 +1457,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1518,7 +1518,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1579,7 +1579,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1640,7 +1640,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1701,7 +1701,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x80, // sensor unit
+		0x00, // sensor unit
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization


### PR DESCRIPTION
# Description
Align sdr to TI BIC

# Motivation
BMC support negative threshold from fby3-v2023.39.1. Some UCR will become negative value with wrong SDR setting.

# Test plan
1. Update BMC to v2023.39.1

root@bmc-oob:~# fw-util bmc --version
BMC Version: fby3-v2023.39.1
BMC Version After Activated: fby3-v2023.39.1
BMC CPLD Version: 00030A09
Fan Speed Controller Version: FSC6.5
ROM Version: fby3-v2023.39.1
ROM Version After Activated: fby3-v2023.39.1
TPM Version: 7.85

2. Check threshold is correct

root@bmc-oob:~# sensor-util slot3 --thr
slot3:
MB Inlet Temp                (0x1) :  36.000 C     | (ok) | UCR: 50.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB Outlet Temp               (0x2) :  40.000 C     | (ok) | UCR: 90.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
FRONT IO Temp                (0x3) :  36.000 C     | (ok) | UCR: 40.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
PCH Temp                     (0x4) : NA | (na)
SOC CPU Temp                 (0x5) :  37.000 C     | (ok) | UCR: 76.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC Therm Margin             (0xD) : -39.000 C     | (ok) | UCR: -3.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC CPU TjMax                (0x25) :  76.000 C     | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
CPU Package Pwr              (0x1E) :  15.000 Watts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC DIMMA Temp               (0x6) :  37.000 C     | (ok) | UCR: 85.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC DIMMB Temp               (0x7) : NA | (na)
SOC DIMMC Temp               (0x9) :  37.000 C     | (ok) | UCR: 85.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC DIMMD Temp               (0xA) :  39.000 C     | (ok) | UCR: 85.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SOC DIMME Temp               (0xB) : NA | (na)
SOC DIMMF Temp               (0xC) :  38.000 C     | (ok) | UCR: 85.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
SSD0 Temp                    (0xE) : 0/NA | (na)
HSC Temp                     (0xF) :  39.000 C     | (ok) | UCR: 85.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCIN VR Temp                (0x10) :  39.000 C     | (ok) | UCR: 100.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCSA VR Temp                (0x11) :  40.000 C     | (ok) | UCR: 100.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCIO VR Temp                (0x12) :  39.000 C     | (ok) | UCR: 100.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
3V3_STBY VR Temp             (0x13) :  41.000 C     | (ok) | UCR: 100.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VDDQ_ABC VR Temp             (0x14) :  41.000 C     | (ok) | UCR: 100.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VDDQ_DEF VR Temp             (0x15) :  40.000 C     | (ok) | UCR: 100.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
P12V_STBY Vol                (0x20) :  11.842 Volts | (ok) | UCR: 13.206 | UNC: NA | UNR: NA | LCR: 11.284 | LNC: NA | LNR: NA
P3V_BAT Vol                  (0x21) :   3.072 Volts | (ok) | UCR: 3.728 | UNC: NA | UNR: NA | LCR: 2.736 | LNC: NA | LNR: NA
P3V3_STBY Vol                (0x22) :   3.315 Volts | (ok) | UCR: 3.621 | UNC: NA | UNR: NA | LCR: 2.975 | LNC: NA | LNR: NA
P1V05_PCH Vol                (0x23) :   1.051 Volts | (ok) | UCR: 1.199 | UNC: NA | UNR: NA | LCR: 0.941 | LNC: NA | LNR: NA
PVNN_PCH Vol                 (0x24) :   1.007 Volts | (ok) | UCR: 1.100 | UNC: NA | UNR: NA | LCR: 0.765 | LNC: NA | LNR: NA
HSC Input Vol                (0x26) :  11.820 Volts | (ok) | UCR: 13.200 | UNC: NA | UNR: NA | LCR: 10.800 | LNC: NA | LNR: NA
VCCIN VR Vol                 (0x27) :   1.700 Volts | (ok) | UCR: 2.050 | UNC: NA | UNR: NA | LCR: 1.450 | LNC: NA | LNR: NA
VCCSA VR Vol                 (0x28) :   0.820 Volts | (ok) | UCR: 1.250 | UNC: NA | UNR: NA | LCR: 0.360 | LNC: NA | LNR: NA
VCCIO VR Vol                 (0x29) :   1.010 Volts | (ok) | UCR: 1.150 | UNC: NA | UNR: NA | LCR: 0.850 | LNC: NA | LNR: NA
P3V3_STBY VR Vol             (0x2A) :   3.298 Volts | (ok) | UCR: 3.621 | UNC: NA | UNR: NA | LCR: 2.975 | LNC: NA | LNR: NA
VDDQ_ABC VR Vol              (0x2C) :   1.236 Volts | (ok) | UCR: 1.320 | UNC: NA | UNR: NA | LCR: 1.080 | LNC: NA | LNR: NA
VDDQ_DEF VR Vol              (0x2D) :   1.236 Volts | (ok) | UCR: 1.320 | UNC: NA | UNR: NA | LCR: 1.080 | LNC: NA | LNR: NA
HSC Output Cur               (0x30) :   2.000 Amps  | (ok) | UCR: 37.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCIN VR Cur                 (0x31) :   8.000 Amps  | (ok) | UCR: 140.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCSA VR Cur                 (0x32) :   2.000 Amps  | (ok) | UCR: 16.900 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCIO VR Cur                 (0x33) :   3.000 Amps  | (ok) | UCR: 35.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
P3V3_STBY VR Cur             (0x34) :   0.000 Amps  | (ok) | UCR: 20.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VDDQ_ABC VR Cur              (0x35) :   0.000 Amps  | (ok) | UCR: 47.500 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VDDQ_DEF VR Cur              (0x36) :   1.000 Amps  | (ok) | UCR: 47.500 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Input Pwr                (0x2E) :  24.000 Watts | (ok) | UCR: 480.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
HSC Input AvgPwr             (0x39) :  24.000 Watts | (ok) | UCR: 480.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCIN VR Pout                (0x3A) :  14.000 Watts | (ok) | UCR: 252.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCSA VR Pout                (0x3C) :   1.000 Watts | (ok) | UCR: 16.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VCCIO VR Pout                (0x3D) :   2.000 Watts | (ok) | UCR: 35.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
P3V3_STBY VRPout             (0x3E) :   0.000 Watts | (ok) | UCR: 66.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VDDQ_ABC VRPout              (0x3F) :   0.000 Watts | (ok) | UCR: 56.430 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
VDDQ_DEF VRPout              (0x42) :   0.000 Watts | (ok) | UCR: 56.430 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA