### PR TITLE
fby3.5: hd: modify CPU temp UCR

### DIFF
--- a/meta-facebook/yv35-hd/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_sdr_table.c
@@ -253,7 +253,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x69, // UNRT
-		0x5F, // UCT
+		0x5A, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT


### PR DESCRIPTION
Summary:
- Modify CPU temperature UCR from 95 to 90 degree C.

Test Plan:
- Build code: PASS
- Check CPU temperature UCR: PASS

Log:
```
root@bmc-oob:~# sensor-util slot1 -t | grep -i CPU_TEMP
MB_SOC_CPU_TEMP_C            (0x4) :   39.75 C     | (ok) | UCR: 90.00 | UNC: NA | UNR: 105.00 | LCR: NA | LNC: NA | LNR: NA
```