### PR TITLE
fby35: vf: add E1S clk/rst handle when 12V fault

### DIFF
--- a/common/hal/hal_gpio.c
+++ b/common/hal/hal_gpio.c
@@ -72,6 +72,12 @@ uint32_t GPIO_MULTI_FUNC_PIN_CTL_REG_ACCESS[] = {
 };
 const int GPIO_MULTI_FUNC_CFG_SIZE = ARRAY_SIZE(GPIO_MULTI_FUNC_PIN_CTL_REG_ACCESS);
 
+/* If you want to process the callback function immediately, return true */
+__weak bool plat_gpio_immediate_int_cb(uint8_t gpio_num)
+{
+	return false;
+}
+
 void irq_callback(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
 {
 	uint8_t group, index, gpio_num;
@@ -110,7 +116,10 @@ void irq_callback(const struct device *dev, struct gpio_callback *cb, uint32_t p
 		return;
 	}
 
-	k_work_submit_to_queue(&gpio_work_queue, &gpio_work[gpio_num]);
+	if (plat_gpio_immediate_int_cb(gpio_num))
+		gpio_cfg[gpio_num].int_cb();
+	else
+		k_work_submit_to_queue(&gpio_work_queue, &gpio_work[gpio_num]);
 }
 
 static void gpio_init_cb(uint8_t gpio_num)


### PR DESCRIPTION
Summary:
- add platform gpio immediate interrupt callback
- when IRQ_P12V_E1S_X_FLT_N -> 0, CLKBUF_E1S_X_OE_N -> 1
- when IRQ_P12V_E1S_X_FLT_N -> 0, RST_BIC_E1S_X_N -> 0

Test plan:
- Build code : Pass