### PR TITLE
GTA: cb: Cache Artemis module firmware version after boot1 updating register

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -968,7 +968,7 @@ bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 
 	int ret = 0;
 	uint8_t nvme_temp = 0;
-	uint8_t drive_ready_bit = 0;
+	uint8_t drive_not_ready = 0;
 	uint8_t nvme_status[FREYA_STATUS_BLOCK_LENGTH] = { 0 };
 
 	ret = read_nvme_info(cfg->port, cfg->target_addr, FREYA_STATUS_BLOCK_OFFSET,
@@ -980,26 +980,22 @@ bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 	}
 
 	nvme_temp = nvme_status[NVME_TEMPERATURE_INDEX];
-	drive_ready_bit = (nvme_status[FREYA_READY_STATUS_OFFSET] & FREYA_READY_STATUS_BIT);
-	if ((nvme_temp == 0) || (drive_ready_bit != 0)) {
+	drive_not_ready = (nvme_status[FREYA_READY_STATUS_OFFSET] & FREYA_READY_STATUS_BIT);
+	if ((nvme_temp == 0) || (drive_not_ready != 0)) {
 		/* Freya not ready */
 		cfg->cache_status = SENSOR_POLLING_DISABLE;
 
 		switch (cfg->target_addr) {
 		case ACCL_FREYA_1_ADDR:
 		case ACCL_ARTEMIS_MODULE_1_ADDR:
-			if (accl_freya->is_cache_freya1_info) {
-				accl_freya->is_cache_freya1_info = false;
-				memset(&accl_freya->freya1_fw_info, 0, FREYA_FW_VERSION_LENGTH);
-			}
+			accl_freya->is_cache_freya1_info = false;
+			memset(&accl_freya->freya1_fw_info, 0, FREYA_FW_VERSION_LENGTH);
 			accl_freya->freya1_fw_info.is_freya_ready = FREYA_NOT_READY;
 			break;
 		case ACCL_FREYA_2_ADDR:
 		case ACCL_ARTEMIS_MODULE_2_ADDR:
-			if (accl_freya->is_cache_freya2_info) {
-				accl_freya->is_cache_freya2_info = false;
-				memset(&accl_freya->freya2_fw_info, 0, FREYA_FW_VERSION_LENGTH);
-			}
+			accl_freya->is_cache_freya2_info = false;
+			memset(&accl_freya->freya2_fw_info, 0, FREYA_FW_VERSION_LENGTH);
 			accl_freya->freya2_fw_info.is_freya_ready = FREYA_NOT_READY;
 			break;
 		default:
@@ -1013,6 +1009,14 @@ bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 	switch (cfg->target_addr) {
 	case ACCL_FREYA_1_ADDR:
 	case ACCL_ARTEMIS_MODULE_1_ADDR:
+		if (accl_freya->freya1_fw_info.is_freya_ready != FREYA_READY) {
+			// Workaround: Record ready flag at the last sensor of ASIC, and get firmware version in the next sensor polling for confirming version ready
+			if (cfg->offset == NVME_VOLTAGE_RAIL_2_OFFSET) {
+				accl_freya->freya1_fw_info.is_freya_ready = FREYA_READY;
+			}
+			return true;
+		}
+
 		if (accl_freya->is_cache_freya1_info != true) {
 			ret = get_freya_fw_info(cfg->port, cfg->target_addr,
 						&accl_freya->freya1_fw_info);
@@ -1024,6 +1028,14 @@ bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 		break;
 	case ACCL_FREYA_2_ADDR:
 	case ACCL_ARTEMIS_MODULE_2_ADDR:
+		if (accl_freya->freya2_fw_info.is_freya_ready != FREYA_READY) {
+			// Workaround: Record ready flag at the last sensor of ASIC, and get firmware version in the next sensor polling for confirming version ready
+			if (cfg->offset == NVME_VOLTAGE_RAIL_2_OFFSET) {
+				accl_freya->freya2_fw_info.is_freya_ready = FREYA_READY;
+			}
+			return true;
+		}
+
 		if (accl_freya->is_cache_freya2_info != true) {
 			ret = get_freya_fw_info(cfg->port, cfg->target_addr,
 						&accl_freya->freya2_fw_info);


### PR DESCRIPTION
…ng register

# Description
- Cache Artemis module firmware version after boot1 updating register.
  - It is possible that boot1 has not updated the register after checking the drive ready (drive ready bit and the temperature are not zero). We proceed in two stages to identify the correct Artemis module firmware version. The first stage：When BIC confirms that the drive is ready (drive ready bit and temperature not zero), it will get the firmware version at the next sensor polling. The second stage：(After passing the first stage, BIC will proceed to the second stage of checking.) Check the version of PSOC and QSPI. If it is “Unexpected data“ (0x00) or “Invalid data“ (0xFF), it will report that drive is not ready and take firmware again in the next round. After BRCM modifies the nvme ready bit, we will change back to the original method and confirm whether the problem is solved.
- Clear firmware version cache flag when drive not ready.
- Modify "drive ready"flag name to avoid confusion.

# Motivation
- Cache Artemis module firmware version after boot1 updating register.
- Clear firmware version cache flag when drive not ready.

# Test Plan
- Build code: Pass
- Get Artemis module firmware version: Pass

# Log
......
CB_ACCL1 DEV1 Version: v2.13.9.104.10
CB_ACCL1 DEV2 Version: v2.13.9.104.10
CB_ACCL2 DEV1 Version: v2.13.9.104.10
CB_ACCL2 DEV2 Version: v2.13.9.104.10
CB_ACCL3 DEV1 Version: v2.13.9.104.9
CB_ACCL3 DEV2 Version: v2.13.9.104.9
CB_ACCL4 DEV1 Version: v2.13.9.104.9
CB_ACCL4 DEV2 Version: v2.13.9.104.9
CB_ACCL5 DEV1 Version: v2.13.9.104.10
CB_ACCL5 DEV2 Version: v2.13.9.104.10
CB_ACCL6 DEV1 Version: v2.13.9.104.10
CB_ACCL6 DEV2 Version: v2.13.9.104.10
CB_ACCL7 DEV1 Version: v2.13.9.104.10
CB_ACCL7 DEV2 Version: v2.13.9.104.10
CB_ACCL8 DEV1 Version: v2.13.9.104.10
CB_ACCL8 DEV2 Version: v2.13.9.104.10
CB_ACCL9 DEV1 Version: v2.13.9.104.10
CB_ACCL9 DEV2 Version: v2.13.9.104.10
CB_ACCL10 DEV1 Version: v2.13.9.104.10
CB_ACCL10 DEV2 Version: v2.13.9.104.10
CB_ACCL11 DEV1 Version: v2.13.9.104.10
CB_ACCL11 DEV2 Version: v2.13.9.104.10
CB_ACCL12 DEV1 Version: v2.13.9.104.10
CB_ACCL12 DEV2 Version: v2.13.9.104.10
......