### PR TITLE
common: Fix process postcode to avoid unnecessary getting semaphore

### DIFF
--- a/common/dev/pcc.c
+++ b/common/dev/pcc.c
@@ -298,6 +298,7 @@ static void process_postcode(void *arvg0, void *arvg1, void *arvg2)
 {
 	uint16_t send_index = 0;
 	while (1) {
+		k_sem_take(&get_postcode_sem, K_FOREVER);
 		uint16_t current_read_index = pcc_read_index;
 		for (; send_index != current_read_index;
 		     send_index = (send_index + 1) % PCC_BUFFER_LEN) {
@@ -307,8 +308,6 @@ static void process_postcode(void *arvg0, void *arvg1, void *arvg2)
 				   ABL_POSTCODE_PREFIX) {
 				check_ABL_error(pcc_read_buffer[send_index]);
 			}
-
-			k_sem_take(&get_postcode_sem, K_FOREVER);
 
 			send_post_code_to_bmc(send_index);
 


### PR DESCRIPTION
# Summary:
k_sem_take put into for loop might cause bic cannot open.

# Test plan:
- Build code: pass

# Test log:
- Bmc get post code success

Jul 28 02:00:17 bmc pldmd[1021]: Tx: 10 3f 02 05
Jul 28 02:00:17 bmc pldmd[1021]: Rx: 91 3f 02 00 04 00 00 00 00 ea 00 ea
Jul 28 02:00:18 bmc pldmd[1021]: Tx: 11 3f 02 05
Jul 28 02:00:18 bmc pldmd[1021]: Rx: 92 3f 02 00 04 00 00 00 d2 e0 00 ea
Jul 28 02:00:18 bmc pldmd[1021]: Tx: 12 3f 02 05
Jul 28 02:00:18 bmc pldmd[1021]: Rx: 93 3f 02 00 04 00 00 00 50 e0 00 ea
Jul 28 02:00:18 bmc pldmd[1021]: Tx: 13 3f 02 05
Jul 28 02:00:18 bmc pldmd[1021]: Rx: 94 3f 02 00 04 00 00 00 01 ea 00 ea
Jul 28 02:00:18 bmc pldmd[1021]: Tx: 14 3f 02 05
Jul 28 02:00:18 bmc pldmd[1021]: Rx: 95 3f 02 00 04 00 00 00 0c e6 00 ea
Jul 28 02:00:18 bmc pldmd[1021]: Tx: 15 3f 02 05
Jul 28 02:00:18 bmc pldmd[1021]: Rx: 96 3f 02 00 04 00 00 00 00 ea 00 ea
Jul 28 02:00:18 bmc pldmd[1021]: Tx: 16 3f 02 05
Jul 28 02:00:18 bmc pldmd[1021]: Rx: 97 3f 02 00 04 00 00 00 00 55 00 ea
Jul 28 02:00:18 bmc pldmd[1021]: Tx: 17 3f 02 05
Jul 28 02:00:18 bmc pldmd[1021]: Rx: 98 3f 02 00 04 00 00 00 14 e0 00 ea
Jul 28 02:00:18 bmc pldmd[1021]: Tx: 18 3f 02 05
Jul 28 02:00:18 bmc pldmd[1021]: Rx: 99 3f 02 00 04 00 00 00 15 e0 00 ea
Jul 28 02:00:18 bmc pldmd[1021]: Tx: 19 3f 02 05