### PR TITLE
fby4: sd: Support MP2856/MP2857 fw update through pldm

### DIFF
--- a/common/service/pldm/pldm_firmware_update.c
+++ b/common/service/pldm/pldm_firmware_update.c
@@ -153,8 +153,12 @@ uint8_t pldm_vr_update(void *fw_update_param)
 		if (xdpe12284c_fwupdate(p->bus, p->addr, hex_buff, fw_update_cfg.image_size) ==
 		    false)
 			goto exit;
-	} else if (!strncmp(p->comp_version_str, KEYWORD_VR_MP2971,
-			    ARRAY_SIZE(KEYWORD_VR_MP2971) - 1)) {
+	} else if ((!strncmp(p->comp_version_str, KEYWORD_VR_MP2971,
+				ARRAY_SIZE(KEYWORD_VR_MP2971) - 1)) ||
+				(!strncmp(p->comp_version_str, KEYWORD_VR_MP2856,
+			    ARRAY_SIZE(KEYWORD_VR_MP2856) - 1)) ||
+				(!strncmp(p->comp_version_str, KEYWORD_VR_MP2857,
+			    ARRAY_SIZE(KEYWORD_VR_MP2857) - 1))) {
 		if (mp2971_fwupdate(p->bus, p->addr, hex_buff, fw_update_cfg.image_size) == false)
 			goto exit;
 	} else {

--- a/common/service/pldm/pldm_firmware_update.h
+++ b/common/service/pldm/pldm_firmware_update.h
@@ -29,6 +29,8 @@ extern "C" {
 
 #define KEYWORD_VR_ISL69259 "isl69259"
 #define KEYWORD_VR_XDPE12284C "xdpe12284c"
+#define KEYWORD_VR_MP2856 "mp2856"
+#define KEYWORD_VR_MP2857 "mp2857"
 #define KEYWORD_VR_MP2971 "mp2971"
 
 #ifndef KEYWORD_CPLD_LATTICE

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
@@ -23,11 +23,22 @@
 #include "pldm_firmware_update.h"
 #include "plat_pldm_fw_update.h"
 #include "mctp_ctrl.h"
+#include "power_status.h"
+#include "plat_i2c.h"
+#include "mp2971.h"
+#include "util_spi.h"
 
 LOG_MODULE_REGISTER(plat_fwupdate);
 
+static uint8_t plat_pldm_pre_vr_update(void *fw_update_param);
+static uint8_t plat_pldm_post_vr_update(void *fw_update_param);
+static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len);
+
 enum FIRMWARE_COMPONENT {
 	SD_COMPNT_BIC,
+	SD_COMPNT_VR_PVDDCR_CPU1,
+	SD_COMPNT_VR_PVDD11_S3,
+	SD_COMPNT_VR_PVDDCR_CPU0,
 };
 
 uint8_t MCTP_SUPPORTED_MESSAGES_TYPES[] = {
@@ -49,6 +60,45 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = pldm_bic_activate,
 		.get_fw_version_fn = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = SD_COMPNT_VR_PVDDCR_CPU1,
+		.comp_classification_index = 0x00,
+		.pre_update_func = plat_pldm_pre_vr_update,
+		.update_func = pldm_vr_update,
+		.pos_update_func = plat_pldm_post_vr_update,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = plat_get_vr_fw_version,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = SD_COMPNT_VR_PVDD11_S3,
+		.comp_classification_index = 0x00,
+		.pre_update_func = plat_pldm_pre_vr_update,
+		.update_func = pldm_vr_update,
+		.pos_update_func = plat_pldm_post_vr_update,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = plat_get_vr_fw_version,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = SD_COMPNT_VR_PVDDCR_CPU0,
+		.comp_classification_index = 0x00,
+		.pre_update_func = plat_pldm_pre_vr_update,
+		.update_func = pldm_vr_update,
+		.pos_update_func = plat_pldm_post_vr_update,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = plat_get_vr_fw_version,
 	},
 };
 
@@ -114,4 +164,83 @@ int load_mctp_support_types(uint8_t *type_len, uint8_t *types)
 	*type_len = sizeof(MCTP_SUPPORTED_MESSAGES_TYPES);
 	memcpy(types, MCTP_SUPPORTED_MESSAGES_TYPES, sizeof(MCTP_SUPPORTED_MESSAGES_TYPES));
 	return MCTP_SUCCESS;
+}
+
+static uint8_t plat_pldm_pre_vr_update(void *fw_update_param) {
+	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, 1);
+
+	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
+
+	/* Stop sensor polling */
+	set_vr_monitor_status(false);
+	p->bus = I2C_BUS4;
+
+	if (p->comp_id == SD_COMPNT_VR_PVDDCR_CPU1) {
+		p->addr = 0x63;
+	} else if (p->comp_id == SD_COMPNT_VR_PVDD11_S3) {
+		p->addr = 0x72;
+	} else if (p->comp_id == SD_COMPNT_VR_PVDDCR_CPU0) {
+		p->addr = 0x76;
+	} else {
+		LOG_ERR("Unsupported VR image");
+	}
+
+	return 0;
+}
+
+static uint8_t plat_pldm_post_vr_update(void *fw_update_param) {
+	ARG_UNUSED(fw_update_param);
+
+	set_vr_monitor_status(true);
+
+	return 0;
+}
+
+static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(info_p, false);
+	CHECK_NULL_ARG_WITH_RETURN(buf, false);
+	CHECK_NULL_ARG_WITH_RETURN(len, false);
+
+	pldm_fw_update_info_t *p = (pldm_fw_update_info_t *)info_p;
+
+	bool ret = false;
+	uint32_t version;
+	uint8_t bus = I2C_BUS4;
+	uint8_t addr = 0;
+
+	if (p->comp_identifier == SD_COMPNT_VR_PVDDCR_CPU1) {
+		addr = 0x63;
+	} else if (p->comp_identifier == SD_COMPNT_VR_PVDD11_S3) {
+		addr = 0x72;
+	} else if (p->comp_identifier == SD_COMPNT_VR_PVDDCR_CPU0) {
+		addr = 0x76;
+	} else {
+		LOG_ERR("Unknown component identifier for VR");
+	}
+
+	set_vr_monitor_status(false);
+	if (!mp2971_get_checksum(bus, addr, &version)) {
+		LOG_ERR("The VR version reading failed");
+		return ret;
+	}
+	set_vr_monitor_status(true);
+
+	version = sys_cpu_to_be32(version);
+	uint8_t *buf_p = buf;
+	const uint8_t *vr_name_p = MPS_CRC_PREFIX;
+	if (!vr_name_p) {
+		LOG_ERR("The pointer of VR string name is NULL");
+		return ret;
+	}
+	*len = 0;
+
+	memcpy(buf_p, vr_name_p, strlen(vr_name_p));
+	buf_p += strlen(vr_name_p);
+	*len += bin2hex((uint8_t *)&version, 4, buf_p, 8) + strlen(vr_name_p);
+	buf_p += 8;
+
+	ret = true;
+
+	return ret;
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.h
@@ -21,6 +21,8 @@
 #include <stdint.h>
 #include "pldm_firmware_update.h"
 
+#define MPS_CRC_PREFIX "MPS "
+
 void load_pldmupdate_comp_config(void);
 int load_mctp_support_types(uint8_t *type_len, uint8_t *types);
 


### PR DESCRIPTION
# Description:
Add vr components for pldm fw update
support MP2856/MP2857 device

# Motivation:
Support PLDM vr update and get crc

# Test Plan:
- PLDM update vr fw: pass
- PLDM get vr crc: pass

# Test Log:
[get pld crc]
root@bmc:~# pldmtool fw_update GetFwParams -m 60
...
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 1,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "MPS 4049c9f9",
            "PendingComponentVersionString": ""
        },
...
[update vr]
root@bmc:~# busctl set-property xyz.openbmc_project.PLDM /xyz/openbmc_project/software/142344108 xyz.openbmc_project.Software.Activation RequestedActivation s "xyz.openbmc_project.Software.Activation.RequestedActivations.Active" uart:~$ [00:05:21.422,000] <inf> pldm: max transfer size(150), number of component(1), max_outstanding_transfer_req(1) [00:05:21.422,000] <inf> pldm: packet data length(0), component sting type(1) length(28) [00:05:21.422,000] <inf> pldm: Component image version:
                               50 4c 44 4d 5f 55 50 44  41 54 45 5f 53 55 50 50 |PLDM_UPD ATE_SUPP
                               4f 52 54 45 44 5f 44 45  56 49 43 45             |ORTED_DE VICE
[00:05:21.425,000] <inf> pldm: Received component class: ffffh id: 1 with version:
[00:05:21.425,000] <inf> pldm:
                               6d 70 32 38 35 36 5f 50  56 44 44 31 31 5f 53 33 |mp2856_P VDD11_S3
[00:05:21.429,000] <inf> pldm: Update component class 0xffff id: 1 image_size: 0x4359 version:
[00:05:21.429,000] <inf> pldm:
                               6d 70 32 38 35 36 5f 50  56 44 44 31 31 5f 53 33 |mp2856_P VDD11_S3
[00:05:22.429,000] <inf> pldm: Component 1 start update process...
[00:05:22.442,000] <inf> pldm: package loaded: 1%
[00:05:22.448,000] <inf> pldm: package loaded: 2%
[00:05:22.455,000] <inf> pldm: package loaded: 3%
[00:05:22.461,000] <inf> pldm: package loaded: 4%
[00:05:22.467,000] <inf> pldm: package loaded: 5%
[00:05:22.474,000] <inf> pldm: package loaded: 6%
[00:05:22.487,000] <inf> pldm: package loaded: 7%
[00:05:22.493,000] <inf> pldm: package loaded: 8%
[00:05:22.500,000] <inf> pldm: package loaded: 9%
[00:05:22.506,000] <inf> pldm: package loaded: 10%
[00:05:22.513,000] <inf> pldm: package loaded: 11%
[00:05:22.519,000] <inf> pldm: package loaded: 12%
[00:05:22.527,000] <inf> pldm: package loaded: 13%
[00:05:22.540,000] <inf> pldm: package loaded: 14%
[00:05:22.547,000] <inf> pldm: package loaded: 15%
[00:05:22.553,000] <inf> pldm: package loaded: 16%
[00:05:22.560,000] <inf> pldm: package loaded: 17%
[00:05:22.566,000] <inf> pldm: package loaded: 18%
[00:05:22.573,000] <inf> pldm: package loaded: 19%
[00:05:22.580,000] <inf> pldm: package loaded: 20%
[00:05:22.593,000] <inf> pldm: package loaded: 21%
[00:05:22.600,000] <inf> pldm: package loaded: 22%
[00:05:22.607,000] <inf> pldm: package loaded: 23%
[00:05:22.614,000] <inf> pldm: package loaded: 24%
[00:05:22.621,000] <inf> pldm: package loaded: 25%
[00:05:22.628,000] <inf> pldm: package loaded: 26%
[00:05:22.642,000] <inf> pldm: package loaded: 27%
[00:05:22.649,000] <inf> pldm: package loaded: 28%
[00:05:22.657,000] <inf> pldm: package loaded: 29%
[00:05:22.665,000] <inf> pldm: package loaded: 30%
[00:05:22.672,000] <inf> pldm: package loaded: 31%
[00:05:22.678,000] <inf> pldm: package loaded: 32%
[00:05:22.684,000] <inf> pldm: package loaded: 33%
[00:05:22.698,000] <inf> pldm: package loaded: 34%
[00:05:22.705,000] <inf> pldm: package loaded: 35%
[00:05:22.712,000] <inf> pldm: package loaded: 36%
[00:05:22.719,000] <inf> pldm: package loaded: 37%
[00:05:22.726,000] <inf> pldm: package loaded: 38%
[00:05:22.732,000] <inf> pldm: package loaded: 39%
[00:05:22.738,000] <inf> pldm: package loaded: 40%
[00:05:22.751,000] <inf> pldm: package loaded: 41%
[00:05:22.758,000] <inf> pldm: package loaded: 42%
[00:05:22.764,000] <inf> pldm: package loaded: 43%
[00:05:22.771,000] <inf> pldm: package loaded: 44%
[00:05:22.777,000] <inf> pldm: package loaded: 45%
[00:05:22.783,000] <inf> pldm: package loaded: 46%
[00:05:22.795,000] <inf> pldm: package loaded: 47%
[00:05:22.802,000] <inf> pldm: package loaded: 48%
[00:05:22.808,000] <inf> pldm: package loaded: 49%
[00:05:22.815,000] <inf> pldm: package loaded: 50%
[00:05:22.821,000] <inf> pldm: package loaded: 51%
[00:05:22.828,000] <inf> pldm: package loaded: 52%
[00:05:22.835,000] <inf> pldm: package loaded: 53%
[00:05:22.848,000] <inf> pldm: package loaded: 54%
[00:05:22.855,000] <inf> pldm: package loaded: 55%
[00:05:22.862,000] <inf> pldm: package loaded: 56%
[00:05:22.869,000] <inf> pldm: package loaded: 57%
[00:05:22.875,000] <inf> pldm: package loaded: 58%
[00:05:22.882,000] <inf> pldm: package loaded: 59%
[00:05:22.889,000] <inf> pldm: package loaded: 60%
[00:05:22.902,000] <inf> pldm: package loaded: 61%
[00:05:22.909,000] <inf> pldm: package loaded: 62%
[00:05:22.916,000] <inf> pldm: package loaded: 63%
[00:05:22.924,000] <inf> pldm: package loaded: 64%
[00:05:22.930,000] <inf> pldm: package loaded: 65%
[00:05:22.937,000] <inf> pldm: package loaded: 66%
[00:05:22.950,000] <inf> pldm: package loaded: 67%
[00:05:22.957,000] <inf> pldm: package loaded: 68%
[00:05:22.964,000] <inf> pldm: package loaded: 69%
[00:05:22.970,000] <inf> pldm: package loaded: 70%
[00:05:22.977,000] <inf> pldm: package loaded: 71%
[00:05:22.984,000] <inf> pldm: package loaded: 72%
[00:05:22.992,000] <inf> pldm: package loaded: 73%
[00:05:23.006,000] <inf> pldm: package loaded: 74%
[00:05:23.013,000] <inf> pldm: package loaded: 75%
[00:05:23.020,000] <inf> pldm: package loaded: 76%
[00:05:23.027,000] <inf> pldm: package loaded: 77%
[00:05:23.034,000] <inf> pldm: package loaded: 78%
[00:05:23.041,000] <inf> pldm: package loaded: 79%
[00:05:23.049,000] <inf> pldm: package loaded: 80%
[00:05:23.063,000] <inf> pldm: package loaded: 81%
[00:05:23.070,000] <inf> pldm: package loaded: 82%
[00:05:23.077,000] <inf> pldm: package loaded: 83%
[00:05:23.084,000] <inf> pldm: package loaded: 84%
[00:05:23.091,000] <inf> pldm: package loaded: 85%
[00:05:23.098,000] <inf> pldm: package loaded: 86%
[00:05:23.105,000] <inf> pldm: package loaded: 87%
[00:05:23.119,000] <inf> pldm: package loaded: 88%
[00:05:23.127,000] <inf> pldm: package loaded: 89%
[00:05:23.134,000] <inf> pldm: package loaded: 90%
[00:05:23.141,000] <inf> pldm: package loaded: 91%
[00:05:23.148,000] <inf> pldm: package loaded: 92%
[00:05:23.155,000] <inf> pldm: package loaded: 93%
[00:05:23.169,000] <inf> pldm: package loaded: 94%
[00:05:23.175,000] <inf> pldm: package loaded: 95%
[00:05:23.181,000] <inf> pldm: package loaded: 96%
[00:05:23.188,000] <inf> pldm: package loaded: 97%
[00:05:23.194,000] <inf> pldm: package loaded: 98%
[00:05:23.200,000] <inf> pldm: package loaded: 99%
[00:05:23.206,000] <inf> pldm: package loaded: 100%
[00:05:23.213,000] <inf> mp2971: updated: 0% (line: 1/380 page: 0)
[00:05:23.213,000] <inf> mp2971: updated: 0% (line: 2/380 page: 0)
[00:05:23.214,000] <inf> mp2971: updated: 0% (line: 3/380 page: 0)
[00:05:23.220,000] <inf> mp2971: updated: 10% (line: 38/380 page: 0)
[00:05:23.220,000] <inf> mp2971: updated: 10% (line: 39/380 page: 0)
[00:05:23.221,000] <inf> mp2971: updated: 10% (line: 40/380 page: 0)
[00:05:23.221,000] <inf> mp2971: updated: 10% (line: 41/380 page: 0)
[00:05:23.228,000] <inf> mp2971: updated: 20% (line: 76/380 page: 1)
[00:05:23.228,000] <inf> mp2971: updated: 20% (line: 77/380 page: 1)
[00:05:23.228,000] <inf> mp2971: updated: 20% (line: 78/380 page: 1)
[00:05:23.228,000] <inf> mp2971: updated: 20% (line: 79/380 page: 1)
[00:05:23.235,000] <inf> mp2971: updated: 30% (line: 114/380 page: 1)
[00:05:23.235,000] <inf> mp2971: updated: 30% (line: 115/380 page: 1)
[00:05:23.235,000] <inf> mp2971: updated: 30% (line: 116/380 page: 1)
[00:05:23.236,000] <inf> mp2971: updated: 30% (line: 117/380 page: 1)
[00:05:23.242,000] <inf> mp2971: updated: 40% (line: 152/380 page: 1)
[00:05:23.242,000] <inf> mp2971: updated: 40% (line: 153/380 page: 1)
[00:05:23.243,000] <inf> mp2971: updated: 40% (line: 154/380 page: 1)
[00:05:23.243,000] <inf> mp2971: updated: 40% (line: 155/380 page: 1)
[00:05:23.756,000] <inf> mp2971: updated: 50% (line: 190/380 page: 2)
[00:05:23.758,000] <inf> mp2971: updated: 50% (line: 191/380 page: 2)
[00:05:23.760,000] <inf> mp2971: updated: 50% (line: 192/380 page: 2)
[00:05:23.762,000] <inf> mp2971: updated: 50% (line: 193/380 page: 2)
[00:05:23.843,000] <inf> mp2971: updated: 60% (line: 228/380 page: 2)
[00:05:23.846,000] <inf> mp2971: updated: 60% (line: 229/380 page: 2)
[00:05:23.848,000] <inf> mp2971: updated: 60% (line: 230/380 page: 2)
[00:05:23.850,000] <inf> mp2971: updated: 60% (line: 231/380 page: 2)
[00:05:23.931,000] <inf> mp2971: updated: 70% (line: 266/380 page: 2)
[00:05:23.933,000] <inf> mp2971: updated: 70% (line: 267/380 page: 2)
[00:05:23.936,000] <inf> mp2971: updated: 70% (line: 268/380 page: 2)
[00:05:23.938,000] <inf> mp2971: updated: 70% (line: 269/380 page: 2)
[00:05:24.019,000] <inf> mp2971: updated: 80% (line: 304/380 page: 2)
[00:05:24.021,000] <inf> mp2971: updated: 80% (line: 305/380 page: 2)
[00:05:24.024,000] <inf> mp2971: updated: 80% (line: 306/380 page: 2)
[00:05:24.026,000] <inf> mp2971: updated: 80% (line: 307/380 page: 2)
[00:05:24.107,000] <inf> mp2971: updated: 90% (line: 342/380 page: 2)
[00:05:24.109,000] <inf> mp2971: updated: 90% (line: 343/380 page: 2)
[00:05:24.112,000] <inf> mp2971: updated: 90% (line: 344/380 page: 2)
[00:05:24.114,000] <inf> mp2971: updated: 90% (line: 345/380 page: 2)
[00:05:24.195,000] <inf> mp2971: updated: 100% (line: 380/380 page: 2)
[00:05:24.195,000] <inf> pldm: Component 1 update success!
[00:05:24.195,000] <inf> pldm: Transfer complete
[00:05:24.197,000] <inf> pldm: Verify complete
[00:05:24.199,000] <inf> pldm: Apply complete
[00:05:24.202,000] <inf> pldm: Activate firmware
[get new crc]
root@bmc:~# pldmtool fw_update GetFwParams -m 60
...
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 1,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "MPS 7a5d125c",
            "PendingComponentVersionString": ""
        },
...