### PR TITLE
common: Setup EID before sending pldm postcode message to bmc

### DIFF
--- a/common/dev/pcc.c
+++ b/common/dev/pcc.c
@@ -213,6 +213,7 @@ bool pldm_send_post_code_to_bmc(uint16_t send_index)
 	pldm_msg msg = { 0 };
 	msg.ext_params.type = MCTP_MEDIUM_TYPE_SMBUS;
 	msg.ext_params.smbus_ext_params.addr = I2C_ADDR_BMC;
+	msg.ext_params.ep = MCTP_EID_BMC;
 
 	msg.hdr.pldm_type = PLDM_TYPE_OEM;
 	msg.hdr.cmd = PLDM_OEM_WRITE_FILE_IO;


### PR DESCRIPTION
Description:
Don't set the eid may cause the destination eid to be incorrect and the message cannot be sent.

Motivation:
Set up bmc eid before sending message.

Test Plan:
- build pass
- Get post code from bic successfully

Jul 28 03:52:08 bmc pldmd[1387]: Rx: 88 3f 02 00 04 00 00 00 0c e6 00 ea
Jul 28 03:52:08 bmc pldmd[1387]: Tx: 08 3f 02 05
Jul 28 03:52:08 bmc pldmd[1387]: Rx: 89 3f 02 00 04 00 00 00 00 ea 00 ea
Jul 28 03:52:08 bmc pldmd[1387]: Tx: 09 3f 02 05
Jul 28 03:52:08 bmc pldmd[1387]: Rx: 8a 3f 02 00 04 00 00 00 00 55 00 ea
Jul 28 03:52:08 bmc pldmd[1387]: Tx: 0a 3f 02 05
Jul 28 03:52:08 bmc pldmd[1387]: Rx: 8b 3f 02 00 04 00 00 00 14 e0 00 ea
Jul 28 03:52:08 bmc pldmd[1387]: Tx: 0b 3f 02 05
Jul 28 03:52:08 bmc pldmd[1387]: Rx: 8c 3f 02 00 04 00 00 00 15 e0 00 ea
Jul 28 03:52:08 bmc pldmd[1387]: Tx: 0c 3f 02 05