### PR TITLE
Artemis: cb: Accurate power monitor sensor reading for DVT

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -91,7 +91,7 @@ ltc4286_init_arg ltc4286_init_args[] = {
 };
 
 ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001151079, .mfr_config_init = true,
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -112,7 +112,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0011523, .mfr_config_init = true,
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -133,7 +133,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001149, .mfr_config_init = true,
+	[2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -154,7 +154,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001148, .mfr_config_init = true,
+	[3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -175,7 +175,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001147982, .mfr_config_init = true,
+	[4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -196,7 +196,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0009859, .mfr_config_init = true,
+	[5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -217,7 +217,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001147982, .mfr_config_init = true,
+	[6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -238,7 +238,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001152115, .mfr_config_init = true,
+	[7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -259,7 +259,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001114, .mfr_config_init = true,
+	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -280,7 +280,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0011547, .mfr_config_init = true,
+	[9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -301,7 +301,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001135758, .mfr_config_init = true,
+	[10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -322,7 +322,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0009848, .mfr_config_init = true,
+	[11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -534,7 +534,7 @@ pex89000_init_arg pex_sensor_init_args[] = {
 };
 
 sq52205_init_arg u178_179_sq52205_init_args[] = {
-	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0010002,
+	[0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
 	.config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
@@ -549,7 +549,7 @@ sq52205_init_arg u178_179_sq52205_init_args[] = {
 	.alert_threshold = 0x051D,
 	.alert_mask_config.value = SQ52205_ENABLE_OP,
 	},
-	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0010002,
+	[1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
 	.config = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,


### PR DESCRIPTION
# Description
- The layout have been changed for accuracy in DVT HW.
- Modify INA233/SQ52205 initial initial setting to accurate sensor reading.

# Motivation
- Modify the initial setting of INA233/SQ52205 according to EE suggestions. 
- Note:
  - JIRA link: https://metainfra.atlassian.net/browse/T17GTART-230

# Test plan
- Build code: Pass
- Get INA233/SQ52205 sensor reading: Pass

# Log
root@bmc-oob:~# sensor-util cb | grep P12V_ACCL
CB_P12V_ACCL1_VOLT_V         (0x23) :  12.085 Volts | (ok)
CB_P12V_ACCL2_VOLT_V         (0x24) :  12.081 Volts | (ok)
CB_P12V_ACCL3_VOLT_V         (0x25) :  12.081 Volts | (ok)
CB_P12V_ACCL4_VOLT_V         (0x26) :  12.079 Volts | (ok)
CB_P12V_ACCL5_VOLT_V         (0x27) :  12.081 Volts | (ok)
CB_P12V_ACCL6_VOLT_V         (0x28) :  12.077 Volts | (ok)
CB_P12V_ACCL7_VOLT_V         (0x29) :  12.102 Volts | (ok)
CB_P12V_ACCL8_VOLT_V         (0x2A) :  12.102 Volts | (ok)
CB_P12V_ACCL9_VOLT_V         (0x2C) :  12.106 Volts | (ok)
CB_P12V_ACCL10_VOLT_V        (0x2D) :  12.107 Volts | (ok)
CB_P12V_ACCL11_VOLT_V        (0x2E) :  12.107 Volts | (ok)
CB_P12V_ACCL12_VOLT_V        (0x2F) :  12.109 Volts | (ok)
CB_P12V_ACCL1_CURR_A         (0x34) :   5.581 Amps  | (ok)
CB_P12V_ACCL2_CURR_A         (0x35) :   5.519 Amps  | (ok)
CB_P12V_ACCL3_CURR_A         (0x36) :   5.549 Amps  | (ok)
CB_P12V_ACCL4_CURR_A         (0x37) :   5.636 Amps  | (ok)
CB_P12V_ACCL5_CURR_A         (0x38) :   5.479 Amps  | (ok)
CB_P12V_ACCL6_CURR_A         (0x39) :   4.829 Amps  | (ok)
CB_P12V_ACCL7_CURR_A         (0x3A) :   5.521 Amps  | (ok)
CB_P12V_ACCL8_CURR_A         (0x3C) :   5.564 Amps  | (ok)
CB_P12V_ACCL9_CURR_A         (0x3D) :   5.441 Amps  | (ok)
CB_P12V_ACCL10_CURR_A        (0x3E) :   5.604 Amps  | (ok)
CB_P12V_ACCL11_CURR_A        (0x3F) :   5.611 Amps  | (ok)
CB_P12V_ACCL12_CURR_A        (0x40) :   4.849 Amps  | (ok)
CB_P12V_ACCL1_PWR_W          (0x45) :  67.425 Watts | (ok)
CB_P12V_ACCL2_PWR_W          (0x46) :  66.675 Watts | (ok)
CB_P12V_ACCL3_PWR_W          (0x47) :  67.074 Watts | (ok)
CB_P12V_ACCL4_PWR_W          (0x48) :  68.074 Watts | (ok)
CB_P12V_ACCL5_PWR_W          (0x49) :  66.199 Watts | (ok)
CB_P12V_ACCL6_PWR_W          (0x4A) :  58.325 Watts | (ok)
CB_P12V_ACCL7_PWR_W          (0x4B) :  66.824 Watts | (ok)
CB_P12V_ACCL8_PWR_W          (0x4C) :  67.375 Watts | (ok)
CB_P12V_ACCL9_PWR_W          (0x4D) :  65.900 Watts | (ok)
CB_P12V_ACCL10_PWR_W         (0x50) :  67.849 Watts | (ok)
CB_P12V_ACCL11_PWR_W         (0x51) :  67.949 Watts | (ok)
CB_P12V_ACCL12_PWR_W         (0x52) :  58.700 Watts | (ok)

root@bmc-oob:~# sensor-util cb | grep VIN
CB_P1V25_1_12VIN_VOLT_V      (0x61) :  12.113 Volts | (ok)
CB_P1V25_2_12VIN_VOLT_V      (0x62) :  12.086 Volts | (ok)
CB_P1V25_1_12VIN_CURR_A      (0x63) :   1.857 Amps  | (ok)
CB_P1V25_2_12VIN_CURR_A      (0x64) :   2.133 Amps  | (ok)
CB_P1V25_1_12VIN_PWR_W       (0x65) :  22.475 Watts | (ok)
CB_P1V25_2_12VIN_PWR_W       (0x66) :  25.774 Watts | (ok)