### PR TITLE
fby4: sd: Support switch bios spi mux

### DIFF
--- a/meta-facebook/yv4-sd/src/lib/plat_spi.h
+++ b/meta-facebook/yv4-sd/src/lib/plat_spi.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,34 +14,13 @@
  * limitations under the License.
  */
 
-#include "plat_spi.h"
-#include "hal_gpio.h"
-#include "plat_gpio.h"
-#include "util_spi.h"
-#include "plat_i2c.h"
+#ifndef PLAT_SPI_H
+#define PLAT_SPI_H
 
-int pal_get_bios_flash_position()
-{
-	return DEVSPI_SPI1_CS0;
-}
+#define I2C_BUS5 4
+#define CPLD_ADDR 0x21
+#define CPLD_SPI_OOB_CONTROL_REG 0x0B
+#define CPLD_SPI_OOB_FROM_BIC 0x0B
+#define CPLD_SPI_OOB_FROM_CPU 0x02
 
-bool pal_switch_bios_spi_mux(int gpio_status)
-{
-	uint8_t retry = 5;
-	I2C_MSG msg;
-
-	msg.bus = I2C_BUS5;
-	msg.target_addr = CPLD_ADDR;
-	msg.tx_len = 2;
-	msg.data[0] = CPLD_SPI_OOB_CONTROL_REG;
-	if (gpio_status == GPIO_HIGH) {
-		msg.data[1] = CPLD_SPI_OOB_FROM_BIC;
-	} else {
-		msg.data[1] = CPLD_SPI_OOB_FROM_CPU;
-	}
-
-	if (i2c_master_write(&msg, retry)) {
-		return false;
-	}
-	return true;
-}
+#endif


### PR DESCRIPTION
# Description:
- Support pal_switch_bios_spi_mux for switch spi mux.

# Motivation:
- Support pal_switch_bios_spi_mux for switch spi mux.

# Test Plan:
- Build code: pass
- Bios update: pass

# Log:
- Get current bios ver

Version 2.22.1285. Copyright (C) 2023 AMI
BIOS Date: 10/04/2023 09:01:12 Ver: Y4001
EVALUATION COPY.

- Do bios update

root@bmc:/tmp# ./bios-fw-update -f Y4001_Test.rom -s 1 256 blocks written...
BIOS update : blocks written done.
Elapsed time: 97sec.
BIOS update: success

- Host power on, check version is changed

Version 2.22.1285. Copyright (C) 2023 AMI
BIOS Date: 10/12/2023 13:22:16 Ver: Y4001_Test
EVALUATION COPY.
Press <DEL> or <ESC> to enter setup.[000000AD][000000AD][000000AD]