### PR TITLE
mctp: move mctp common code to common layer

### DIFF
--- a/common/hal/hal_i3c.c
+++ b/common/hal/hal_i3c.c
@@ -28,6 +28,7 @@ LOG_MODULE_REGISTER(hal_i3c);
 static const struct device *dev_i3c[I3C_MAX_NUM];
 static const struct device *dev_i3c_smq[I3C_MAX_NUM];
 static struct i3c_dev_desc i3c_desc_table[I3C_MAX_NUM];
+static i3c_ibi_dev i3c_ibi_dev_table[I3C_MAX_NUM];
 static int i3c_desc_count = 0;
 static struct k_mutex mutex_write[I3C_MAX_NUM];
 static struct k_mutex mutex_read[I3C_MAX_NUM];
@@ -374,4 +375,214 @@ void util_init_i3c(void)
 			LOG_ERR("Mutex %d init error.", i);
 		}
 	}
+}
+
+static int get_bus_id(struct i3c_dev_desc *desc)
+{
+	char i3c_dev_name[I3C_DEV_STR_LEN] = {0};
+	const char delim[2] = "_";
+	char *saveptr = NULL;
+	char *substr = NULL;
+	int bus_id;
+
+
+	strncpy(i3c_dev_name, desc->master_dev->name, I3C_DEV_STR_LEN);
+
+	substr = strtok_r(i3c_dev_name, delim, &saveptr);
+	substr = strtok_r(NULL, delim, &saveptr);
+
+	bus_id = atoi(substr);
+	if (bus_id > I3C_MAX_NUM) {
+		LOG_ERR("bus id out of range, bus = %d", bus_id);
+		return -1;
+	}
+
+	return bus_id;
+}
+
+static int find_dev_i3c_idx(struct i3c_dev_desc *desc)
+{
+	int bus_id = get_bus_id(desc);
+	if (bus_id < 0) {
+		return -1;
+	}
+
+	int i = 0;
+	struct i3c_dev_desc *desc_ptr = NULL;
+	for (i = 0; i < i3c_desc_count; i++) {
+		desc_ptr = &i3c_desc_table[i];
+
+		int table_bus_id = get_bus_id(desc_ptr);
+		if (table_bus_id < 0) {
+			return -1;
+		}
+
+		if ((table_bus_id == bus_id) && (desc->info.dynamic_addr == desc_ptr->info.dynamic_addr)) {
+			return i;
+		}
+	}
+
+	LOG_ERR("Not found id in i3c table");
+
+	return -1;
+}
+
+static struct i3c_ibi_payload *ibi_write_requested(struct i3c_dev_desc *desc)
+{
+	int idx = find_dev_i3c_idx(desc);
+	if (idx < 0) {
+		LOG_ERR("%s: find dev i3c idx failed. idx = %d", __func__, idx);
+	}
+	i3c_ibi_dev_table[idx].i3c_payload.size = 0;
+	i3c_ibi_dev_table[idx].i3c_payload.buf = i3c_ibi_dev_table[idx].data_rx;
+
+	return &i3c_ibi_dev_table[idx].i3c_payload;
+}
+
+static void ibi_write_done(struct i3c_dev_desc *desc)
+{
+	int idx = find_dev_i3c_idx(desc);
+	if (idx < 0) {
+		LOG_ERR("%s: find dev i3c idx failed. idx = %d", __func__, idx);
+	}
+	k_sem_give(&i3c_ibi_dev_table[idx].ibi_complete);
+}
+
+static struct i3c_ibi_callbacks i3c_ibi_def_callbacks = {
+	.write_requested = ibi_write_requested,
+	.write_done = ibi_write_done,
+};
+
+int
+i3c_controller_ibi_init(I3C_MSG *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+
+	if (!dev_i3c[msg->bus]) {
+		LOG_ERR("Failed to receive messages to address 0x%x due to undefined bus%u",
+			msg->target_addr, msg->bus);
+		return -ENODEV;
+	}
+
+	struct i3c_dev_desc *target;
+	target = find_matching_desc(dev_i3c[msg->bus], msg->target_addr, NULL);
+	if (target == NULL) {
+		LOG_ERR("Failed to reveive messages to address 0x%x due to unknown address",
+			msg->target_addr);
+		return -ENODEV;
+	}
+
+	int ret = 0;
+
+	int idx = find_dev_i3c_idx(target);
+	if (idx < 0) {
+		LOG_ERR("%s: find dev i3c idx failed. idx = %d", __func__, idx);
+	}
+
+	k_sem_init(&i3c_ibi_dev_table[idx].ibi_complete, 0, 1);
+
+	ret = i3c_master_send_rstdaa(dev_i3c[msg->bus]);
+	if (ret) {
+		LOG_ERR("Failed to send rstdaa");
+	}
+
+	ret = i3c_master_send_rstdaa(dev_i3c[msg->bus]);
+	if (ret) {
+		LOG_ERR("Failed to 2nd send rstdaa");
+	}
+
+	ret = i3c_master_send_aasa(dev_i3c[msg->bus]);
+	if (ret) {
+		LOG_ERR("Failed to send aasa");
+	}
+
+	ret = i3c_master_send_getpid(dev_i3c[msg->bus], target->info.dynamic_addr, &target->info.pid);
+	if (ret) {
+		LOG_ERR("Failed to get pid");
+	}
+
+	ret = i3c_master_send_getbcr(dev_i3c[msg->bus], target->info.dynamic_addr, &target->info.bcr);
+	if (ret) {
+		LOG_ERR("Failed to get bcr");
+	}
+
+	ret = i3c_master_request_ibi(target, &i3c_ibi_def_callbacks);
+	if (ret != 0) {
+		LOG_ERR("Failed to request SIR, bus = %x, addr = %u",msg->target_addr, msg->bus);
+	}
+
+	ret = i3c_master_enable_ibi(target);
+	if (ret != 0) {
+		LOG_ERR("Failed to enable SIR, bus = %x, addr = %u",msg->target_addr, msg->bus);
+	}
+
+	return -ret;
+}
+
+int i3c_controller_ibi_read(I3C_MSG *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+
+	if (!dev_i3c[msg->bus]) {
+		LOG_ERR("Failed to receive messages to address 0x%x due to undefined bus%u",
+			msg->target_addr, msg->bus);
+		return -ENODEV;
+	}
+
+	struct i3c_dev_desc *target;
+	target = find_matching_desc(dev_i3c[msg->bus], msg->target_addr, NULL);
+	if (target == NULL) {
+		LOG_ERR("Failed to reveive messages to address 0x%x due to unknown address",
+			msg->target_addr);
+		return -ENODEV;
+	}
+
+	int idx = find_dev_i3c_idx(target);
+	if (idx < 0) {
+		LOG_ERR("%s: find dev i3c idx failed. idx = %d", __func__, idx);
+	}
+
+	/* master device waits for the IBI from the target */
+	k_sem_take(&i3c_ibi_dev_table[idx].ibi_complete, K_FOREVER);
+
+	/* init the flag for the next loop */
+	k_sem_init(&i3c_ibi_dev_table[idx].ibi_complete, 0, 1);
+
+	int ret = 0;
+
+	/* check result: first byte (MDB) shall match the DT property mandatory-data-byte */
+	if (IS_MDB_PENDING_READ_NOTIFY(i3c_ibi_dev_table[idx].data_rx[0])) {
+		struct i3c_priv_xfer xfer;
+
+		/* initiate a private read transfer to read the pending data */
+		xfer.rnw = 1;
+		xfer.len = IBI_PAYLOAD_SIZE;
+		xfer.data.in = i3c_ibi_dev_table[idx].data_rx;
+		k_yield();
+		ret = i3c_master_priv_xfer(target, &xfer, 1);
+		if (ret) {
+ 			LOG_ERR("ibi read failed. ret = %d", ret);
+		}
+		msg->rx_len = xfer.len;
+		memcpy (msg->data, i3c_ibi_dev_table[idx].data_rx, IBI_PAYLOAD_SIZE);
+	}
+
+	return msg->rx_len;
+}
+
+int i3c_target_set_address(I3C_MSG *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+
+	if (!dev_i3c[msg->bus]) {
+		return -ENODEV;
+	}
+
+	int ret = i3c_slave_set_static_addr(dev_i3c[msg->bus], msg->target_addr);
+	if (ret != 0) {
+		LOG_ERR("Failed to set address 0x%x, ret: %d", msg->target_addr, ret);
+		return -1;
+	}
+
+	return 0;
 }

--- a/common/hal/hal_i3c.h
+++ b/common/hal/hal_i3c.h
@@ -92,6 +92,10 @@
 #define I3C_DEBUG 0
 #define I3C_SMQ_SUCCESS 0
 #define I3C_MAX_BUFFER_COUNT 2
+#define IBI_PAYLOAD_SIZE 128
+
+#define I3C_DEV_STR_LEN 8
+#define I3C_BUS_STR_LEN 4
 
 enum I3C_WRITE_READ_CMD {
 	I3C_WRITE_CMD = 0,
@@ -106,9 +110,18 @@ typedef struct _I3C_MSG_ {
 	uint8_t data[I3C_MAX_DATA_SIZE];
 } I3C_MSG;
 
+typedef struct _i3c_ibi_dev {
+	uint8_t data_rx[I3C_MAX_DATA_SIZE];
+	struct i3c_ibi_payload i3c_payload;
+	struct k_sem ibi_complete;
+} i3c_ibi_dev;
+
 void util_init_i3c(void);
 int i3c_smq_read(I3C_MSG *msg);
 int i3c_smq_write(I3C_MSG *msg);
+int i3c_slave_mqueue_read(const struct device *dev, uint8_t *dest, int budget);
+int i3c_slave_mqueue_write(const struct device *dev, uint8_t *src, int size);
+
 int i3c_attach(I3C_MSG *msg);
 int i3c_detach(I3C_MSG *msg);
 int i3c_transfer(I3C_MSG *msg);
@@ -116,5 +129,9 @@ int i3c_brocast_ccc(I3C_MSG *msg, uint8_t ccc_id, uint8_t ccc_addr);
 int i3c_spd_reg_read(I3C_MSG *msg, bool is_nvm);
 
 int i3c_controller_write(I3C_MSG *msg);
+int i3c_controller_ibi_init(I3C_MSG *msg);
+int i3c_controller_ibi_read(I3C_MSG *msg);
+int i3c_controller_write(I3C_MSG *msg);
+int i3c_target_set_address(I3C_MSG *msg);
 
 #endif

--- a/common/service/mctp/mctp_i3c.c
+++ b/common/service/mctp/mctp_i3c.c
@@ -30,6 +30,84 @@ LOG_MODULE_REGISTER(mctp_i3c);
 #define MCTP_I3C_PEC_ENABLE 0
 #endif
 
+static uint16_t mctp_i3c_read(void *mctp_p, uint8_t *buf, uint32_t len,
+				  mctp_ext_params *extra_data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_p, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(buf, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(extra_data, MCTP_ERROR);
+
+	mctp *mctp_inst = (mctp *)mctp_p;
+	I3C_MSG i3c_msg = {0};
+
+	i3c_msg.bus = mctp_inst->medium_conf.i3c_conf.bus;
+	i3c_msg.target_addr = mctp_inst->medium_conf.i3c_conf.addr;
+
+	int ret = i3c_controller_ibi_read(&i3c_msg);
+
+	/** mctp rx keep polling, return length 0 directly if no data or invalid data **/
+	if (ret <= 0) {
+		return 0;
+	}
+
+	i3c_msg.rx_len = ret;
+	LOG_HEXDUMP_DBG(&i3c_msg.data[0], i3c_msg.rx_len, "mctp_i3c_read_smq msg dump");
+
+	if (MCTP_I3C_PEC_ENABLE) {
+		/** pec byte use 7-degree polynomial with 0 init value and false reverse **/
+		uint8_t pec = crc8(&i3c_msg.data[0], i3c_msg.rx_len - 1, 0x07, 0x00, false);
+		if (pec != i3c_msg.data[i3c_msg.rx_len - 1]) {
+			LOG_ERR("mctp i3c pec error: crc8 should be 0x%02x, but got 0x%02x", pec,
+				i3c_msg.data[i3c_msg.rx_len - 1]);
+			return 0;
+		}
+	}
+
+	extra_data->type = MCTP_MEDIUM_TYPE_CONTROLLER_I3C;
+	memcpy(buf, &i3c_msg.data[0], i3c_msg.rx_len);
+	return i3c_msg.rx_len;
+}
+
+static uint16_t mctp_i3c_write(void *mctp_p, uint8_t *buf, uint32_t len,
+				   mctp_ext_params extra_data)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_p, MCTP_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(buf, MCTP_ERROR);
+
+	if (extra_data.type != MCTP_MEDIUM_TYPE_CONTROLLER_I3C) {
+		LOG_ERR("mctp medium type incorrect");
+		return MCTP_ERROR;
+	}
+
+	int ret;
+	I3C_MSG i3c_msg;
+	mctp *mctp_instance = (mctp *)mctp_p;
+
+	i3c_msg.bus = mctp_instance->medium_conf.i3c_conf.bus;
+	i3c_msg.target_addr = mctp_instance->medium_conf.i3c_conf.addr;
+
+	/** mctp package **/
+	memcpy(&i3c_msg.data[0], buf, len);
+
+	/** +1 pec; default no pec **/
+	if (MCTP_I3C_PEC_ENABLE) {
+		i3c_msg.tx_len = len + 1;
+		/** pec byte use 7-degree polynomial with 0 init value and false reverse **/
+		i3c_msg.data[len + 1] = crc8(&i3c_msg.data[0], len, 0x07, 0x00, false);
+	} else {
+		i3c_msg.tx_len = len;
+	}
+
+	LOG_HEXDUMP_DBG(&i3c_msg.data[0], i3c_msg.tx_len, "mctp_i3c_write msg dump");
+
+	ret = i3c_controller_write(&i3c_msg);
+	if (ret < 0) {
+		LOG_ERR("i3c controller write failed, %d", ret);
+		return MCTP_ERROR;
+	}
+	return MCTP_SUCCESS;
+}
+
 static uint16_t mctp_i3c_read_smq(void *mctp_p, uint8_t *buf, uint32_t len,
 				  mctp_ext_params *extra_data)
 {
@@ -61,7 +139,7 @@ static uint16_t mctp_i3c_read_smq(void *mctp_p, uint8_t *buf, uint32_t len,
 		}
 	}
 
-	extra_data->type = MCTP_MEDIUM_TYPE_I3C;
+	extra_data->type = MCTP_MEDIUM_TYPE_TARGET_I3C;
 	memcpy(buf, &i3c_msg.data[0], i3c_msg.rx_len);
 	return i3c_msg.rx_len;
 }
@@ -72,7 +150,7 @@ static uint16_t mctp_i3c_write_smq(void *mctp_p, uint8_t *buf, uint32_t len,
 	CHECK_NULL_ARG_WITH_RETURN(mctp_p, MCTP_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(buf, MCTP_ERROR);
 
-	if (extra_data.type != MCTP_MEDIUM_TYPE_I3C) {
+	if (extra_data.type != MCTP_MEDIUM_TYPE_TARGET_I3C) {
 		LOG_ERR("mctp medium type incorrect");
 		return MCTP_ERROR;
 	}
@@ -102,7 +180,29 @@ static uint16_t mctp_i3c_write_smq(void *mctp_p, uint8_t *buf, uint32_t len,
 	return MCTP_SUCCESS;
 }
 
-uint8_t mctp_i3c_init(mctp *mctp_instance, mctp_medium_conf medium_conf)
+uint8_t mctp_i3c_controller_init(mctp *mctp_instance, mctp_medium_conf medium_conf)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_instance, MCTP_ERROR);
+
+	mctp_instance->medium_conf = medium_conf;
+	mctp_instance->read_data = mctp_i3c_read;
+	mctp_instance->write_data = mctp_i3c_write;
+
+	// i3c master initial
+	LOG_INF("Bus= 0x%x, Addr = 0x%x",medium_conf.i3c_conf.bus, medium_conf.i3c_conf.addr);
+	I3C_MSG i3c_msg = { 0 };
+	i3c_msg.bus = medium_conf.i3c_conf.bus;
+	i3c_msg.target_addr = medium_conf.i3c_conf.addr;
+
+	i3c_attach(&i3c_msg);
+
+	// i3c ibi mqueue initial
+	i3c_controller_ibi_init(&i3c_msg);
+
+	return MCTP_SUCCESS;
+}
+
+uint8_t mctp_i3c_target_init(mctp *mctp_instance, mctp_medium_conf medium_conf)
 {
 	CHECK_NULL_ARG_WITH_RETURN(mctp_instance, MCTP_ERROR);
 

--- a/common/service/pldm/pldm.c
+++ b/common/service/pldm/pldm.c
@@ -348,8 +348,9 @@ uint8_t mctp_pldm_cmd_handler(void *mctp_p, uint8_t *buf, uint32_t len, mctp_ext
 * invoked
 */
 
-	if (!hdr->rq)
+	if (!hdr->rq) {
 		return pldm_resp_msg_process(mctp_inst, buf, len, ext_params);
+	}
 
 	/* the message is a request, find the proper handler to handle it */
 
@@ -417,6 +418,7 @@ uint8_t mctp_pldm_send_msg(void *mctp_p, pldm_msg *msg)
 	* The request should be set inst_id/msg_type/mctp_tag_owner in the
 	* header
 	*/
+
 	if (msg->hdr.rq) {
 		if (register_instid(mctp_p, &get_inst_id) == false) {
 			LOG_ERR("Register failed!");
@@ -557,11 +559,14 @@ int pldm_send_ipmi_response(uint8_t interface, ipmi_msg *msg)
 	memset(&pmsg, 0, sizeof(pmsg));
 	memset(&resp_buf, 0, sizeof(resp_buf));
 
-	int medium_type = pal_get_medium_type(interface);
+	mctp_port *p = pal_find_mctp_port_by_channel_target(msg->InF_target);
+	CHECK_NULL_ARG_WITH_RETURN(p, -1);
+
+	int medium_type = p->medium_type;
 	if (medium_type < 0) {
 		return -1;
 	}
-	int target = pal_get_target(interface);
+	int target = pal_find_bus_in_mctp_port(p);
 	if (target < 0) {
 		return -1;
 	}
@@ -591,11 +596,10 @@ int pldm_send_ipmi_response(uint8_t interface, ipmi_msg *msg)
 
 	LOG_HEXDUMP_DBG(pmsg.buf, pmsg.len, "pmsg.buf");
 
-	mctp *mctp_inst = pal_get_mctp(medium_type, target);
-	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, -1);
+	CHECK_NULL_ARG_WITH_RETURN(p->mctp_inst, -1);
 
 	// Send response to PLDM/MCTP thread
-	mctp_pldm_send_msg(mctp_inst, &pmsg);
+	mctp_pldm_send_msg(p->mctp_inst, &pmsg);
 	return 0;
 }
 
@@ -609,18 +613,16 @@ int pldm_send_ipmi_request(ipmi_msg *msg)
 	memset(&pmsg, 0, sizeof(pmsg));
 	memset(req_buf, 0, sizeof(req_buf));
 
-	uint8_t target_interface = msg->InF_target;
-	int medium_type = pal_get_medium_type(target_interface);
-	if (medium_type < 0) {
-		return -1;
-	}
-	int target = pal_get_target(target_interface);
+	mctp_port *p = pal_find_mctp_port_by_channel_target(msg->InF_target);
+	CHECK_NULL_ARG_WITH_RETURN(p, -1);
+
+	int target = pal_find_bus_in_mctp_port(p);
 	if (target < 0) {
 		return -1;
 	}
 
 	// Set PLDM header
-	pmsg.ext_params.type = medium_type;
+	pmsg.ext_params.type = p->mctp_inst->medium_type;
 	pmsg.ext_params.i3c_ext_params.addr = target;
 
 	pmsg.hdr.msg_type = MCTP_MSG_TYPE_PLDM;
@@ -640,9 +642,11 @@ int pldm_send_ipmi_request(ipmi_msg *msg)
 	pmsg.len = sizeof(struct _ipmi_cmd_req) - 1 + msg->data_len;
 
 	uint8_t rbuf[PLDM_MAX_DATA_SIZE];
+
+	LOG_HEXDUMP_DBG(pmsg.buf, pmsg.len, "pmsg.buf");
 	// Send request to PLDM/MCTP thread and get response
 	uint8_t res_len =
-		mctp_pldm_read(pal_get_mctp(medium_type, target), &pmsg, rbuf, sizeof(rbuf));
+		mctp_pldm_read(p->mctp_inst, &pmsg, rbuf, sizeof(rbuf));
 
 	if (!res_len) {
 		LOG_ERR("mctp_pldm_read fail");


### PR DESCRIPTION
# Description:
Move mctp common code to common layer.

# Motivation:
We need to revise code for support both i2c and i3c mctp routing.

# Test Plan:
- Build Code: Pass