### PR TITLE
yv35-rf: revise mctp code

### DIFF
--- a/meta-facebook/yv35-rf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv35-rf/src/platform/plat_mctp.c
@@ -41,7 +41,8 @@ LOG_MODULE_REGISTER(plat_mctp);
 K_TIMER_DEFINE(send_cmd_timer, send_cmd_to_dev, NULL);
 K_WORK_DEFINE(send_cmd_work, send_cmd_to_dev_handler);
 
-static mctp_smbus_port smbus_port[] = {
+int mctp_config_table_size = 1;
+mctp_port mctp_config_table[] = {
 	{ .conf.smbus_conf.addr = I2C_ADDR_BIC, .conf.smbus_conf.bus = I2C_BUS_CXL },
 };
 
@@ -52,8 +53,8 @@ static mctp_route_entry mctp_route_tbl[] = {
 mctp *find_mctp_by_smbus(uint8_t bus)
 {
 	uint8_t i;
-	for (i = 0; i < ARRAY_SIZE(smbus_port); i++) {
-		mctp_smbus_port *p = smbus_port + i;
+	for (i = 0; i < mctp_config_table_size; i++) {
+		mctp_port *p = mctp_config_table + i;
 		if (!p) {
 			return NULL;
 		}
@@ -83,11 +84,11 @@ static void set_dev_endpoint(void)
 {
 	for (uint8_t i = 0; i < ARRAY_SIZE(mctp_route_tbl); i++) {
 		mctp_route_entry *p = mctp_route_tbl + i;
-		for (uint8_t j = 0; j < ARRAY_SIZE(smbus_port); j++) {
+		for (uint8_t j = 0; j < mctp_config_table_size; j++) {
 			if (!p) {
 				return;
 			}
-			if (p->bus != smbus_port[j].conf.smbus_conf.bus) {
+			if (p->bus != mctp_config_table[j].conf.smbus_conf.bus) {
 				continue;
 			}
 			printk("Prepare send endpoint bus 0x%x, addr 0x%x\n", p->bus, p->addr);
@@ -201,8 +202,8 @@ void send_cmd_to_dev(struct k_timer *timer)
 void plat_mctp_init()
 {
 	LOG_INF("plat_mctp_init");
-	for (uint8_t i = 0; i < ARRAY_SIZE(smbus_port); i++) {
-		mctp_smbus_port *p = smbus_port + i;
+	for (uint8_t i = 0; i < mctp_config_table_size; i++) {
+		mctp_port *p = mctp_config_table + i;
 		if (!p) {
 			return;
 		}

--- a/meta-facebook/yv35-rf/src/platform/plat_mctp.h
+++ b/meta-facebook/yv35-rf/src/platform/plat_mctp.h
@@ -32,25 +32,6 @@
 /* mctp endpoint */
 #define CXL_EID 0x2E
 
-typedef struct _mctp_smbus_port {
-	mctp *mctp_inst;
-	mctp_medium_conf conf;
-	uint8_t user_idx;
-} mctp_smbus_port;
-
-/* mctp route entry struct */
-typedef struct _mctp_route_entry {
-	uint8_t endpoint;
-	uint8_t bus; /* TODO: only consider smbus/i3c */
-	uint8_t addr; /* TODO: only consider smbus/i3c */
-	uint8_t dev_present_pin;
-} mctp_route_entry;
-
-typedef struct _mctp_msg_handler {
-	MCTP_MSG_TYPE type;
-	mctp_fn_cb msg_handler_cb;
-} mctp_msg_handler;
-
 /* init the mctp moduel for platform */
 void send_cmd_to_dev(struct k_timer *timer);
 void send_cmd_to_dev_handler(struct k_work *work);


### PR DESCRIPTION
# Description:
- Move mctp common code to common layer.
- Revise mctp struct to support i3c controller device.

# Motivation:
We need to revise code for support both i2c and i3c mctp routing.

# Test Plan:
- Build Code: Pass