### PR TITLE
common: mctp: revise extern parameter to fix build failure

### DIFF
--- a/common/service/mctp/mctp.c
+++ b/common/service/mctp/mctp.c
@@ -651,11 +651,21 @@ __weak int pal_find_bus_in_mctp_port(mctp_port *p)
 	return bus;
 }
 
+__weak uint8_t plat_get_mctp_port_count()
+{
+	return 0;
+}
+
+__weak mctp_port *plat_get_mctp_port(uint8_t index)
+{
+	return NULL;
+}
+
 __weak mctp *pal_find_mctp_by_bus(uint8_t bus)
 {
-	uint8_t i;
-	for (i = 0; i < mctp_config_table_size; i++) {
-		mctp_port *p = mctp_config_table + i;
+	uint8_t plat_mctp_port_count = plat_get_mctp_port_count();
+	for (uint8_t i = 0; i < plat_mctp_port_count; i++) {
+		mctp_port *p = plat_get_mctp_port(i);
 		int conf_bus = pal_find_bus_in_mctp_port(p);
 		if (bus == conf_bus) {
 			return p->mctp_inst;
@@ -667,9 +677,9 @@ __weak mctp *pal_find_mctp_by_bus(uint8_t bus)
 
 __weak mctp_port *pal_find_mctp_port_by_channel_target(uint8_t target)
 {
-	uint8_t i;
-	for (i = 0; i < mctp_config_table_size; i++) {
-		mctp_port *p = mctp_config_table + i;
+	uint8_t plat_mctp_port_count = plat_get_mctp_port_count();
+	for (uint8_t i = 0; i < plat_mctp_port_count; i++) {
+		mctp_port *p = plat_get_mctp_port(i);
 		if (target == p->channel_target) {
 			return p;
 		}

--- a/common/service/mctp/mctp.h
+++ b/common/service/mctp/mctp.h
@@ -214,8 +214,8 @@ typedef struct _mctp_msg_handler {
 	mctp_fn_cb msg_handler_cb;
 } mctp_msg_handler;
 
-extern mctp_port mctp_config_table[];
-extern int mctp_config_table_size;
+uint8_t plat_get_mctp_port_count();
+mctp_port *plat_get_mctp_port(uint8_t index);
 
 /* public function */
 mctp *mctp_init(void);

--- a/common/service/mctp/mctp_ctrl.c
+++ b/common/service/mctp/mctp_ctrl.c
@@ -49,16 +49,6 @@ __weak int load_mctp_support_types(uint8_t *type_len, uint8_t *types)
 	return -1;
 }
 
-__weak uint8_t plat_get_mctp_port_count()
-{
-	return 0;
-}
-
-__weak mctp_port *plat_get_mctp_port(uint8_t index)
-{
-	return NULL;
-}
-
 uint8_t mctp_ctrl_cmd_set_endpoint_id(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t *resp,
 				      uint16_t *resp_len, void *ext_params)
 {

--- a/common/service/mctp/mctp_ctrl.h
+++ b/common/service/mctp/mctp_ctrl.h
@@ -147,9 +147,6 @@ uint8_t mctp_ctrl_cmd_handler(void *mctp_p, uint8_t *buf, uint32_t len, mctp_ext
 uint8_t mctp_ctrl_send_msg(void *mctp_p, mctp_ctrl_msg *msg);
 uint8_t mctp_ctrl_read(void *mctp_p, mctp_ctrl_msg *msg, uint8_t *read_buf, uint16_t read_len);
 
-uint8_t plat_get_mctp_port_count();
-mctp_port *plat_get_mctp_port(uint8_t index);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# Description:
Revise the mctp code utilizing function api instead of extern.

# Motivation:
The extern parameter will cause build failure on platform that doesn't define it.

# Test Plan:
- Build code - Pass