### PR TITLE
fby3: dl: initialize nvme device after it is accessible

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_hook.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_hook.c
@@ -101,6 +101,10 @@ bool pre_nvme_read(sensor_cfg *cfg, void *args)
 		uint8_t bus = cfg->port;
 		bool nvme_present_result = false;
 
+		if (!cfg->access_checker(cfg->num)) {
+			return false;
+		}
+
 		i2c_scan(bus, i2c_dev, &dev_count);
 
 		for (device_index = 0; device_index < dev_count; ++device_index) {
@@ -113,6 +117,11 @@ bool pre_nvme_read(sensor_cfg *cfg, void *args)
 		if (nvme_present_result == false) {
 			control_sensor_polling(cfg->num, DISABLE_SENSOR_POLLING,
 					       SENSOR_NOT_PRESENT);
+		} else {
+			if (!init_drive_type_delayed(cfg)) {
+				LOG_ERR("NVME initial fail");
+				return false;
+			}
 		}
 
 		pre_proc_args->is_present_checked = true;


### PR DESCRIPTION
# Description
As title.

# Motivation
There's a timing issue drive init before the device is accessible

# Test plan
Build and test pass on fby3.

1. Test SSD reading is expected after host 12V-cycle. root@bmc-oob:~# sensor-util slot1 --force 0xe
slot1:
SSD0 Temp                    (0xE) :  34.000 C     | (ok)

2. Test SSD(without temp sensor) reading is expected after host 12V-cycle.

root@bmc-oob:~# sensor-util slot2 --force 0xe
slot2:
SSD0 Temp                    (0xE) : 0/NA | (na)

uart:~$ platform sensor get_table_single_sensor 0 0xe --------------------------------------------------------------------------------- Table name: common sensor table | index: 0x0  | sensor count: 0x31 | access[O]

[0xe ] SSD0 Temp                : nvme       | access[O] | poll[X] 1    sec | sensor_not_present        | na