### PR TITLE
fby4: Fix i3c config setting

### DIFF
--- a/common/dev/rg3mxxb12.c
+++ b/common/dev/rg3mxxb12.c
@@ -183,6 +183,11 @@ out:
 bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt)
 {
 	bool ret = false;
+	uint8_t value;
+
+	// Set Low-Dropout Regulators(LDO) voltage to VIOM and VIOS
+	value = (ldo_volt << VIOM0_OFFSET) | (ldo_volt << VIOM1_OFFSET) |
+		(ldo_volt << VIOS0_OFFSET) | (ldo_volt << VIOS1_OFFSET);
 
 	uint8_t cmd_unprotect[2] = { RG3MXXB12_PROTECTION_REG, 0x69 };
 	uint8_t cmd_protect[2] = { RG3MXXB12_PROTECTION_REG, 0x00 };
@@ -191,7 +196,7 @@ bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt)
 		 * Refer to RG3MxxB12 datasheet page 13, LDO voltage depends
 		 * on each project's hard design
 		 */
-		{ RG3MXXB12_VOLT_LDO_SETTING, ldo_volt },
+		{ RG3MXXB12_VOLT_LDO_SETTING, value },
 		{ RG3MXXB12_SSPORTS_AGENT_ENABLE, 0x0 },
 		{ RG3MXXB12_SSPORTS_GPIO_ENABLE, 0x0 },
 		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0x0 },

--- a/meta-facebook/yv4-ff/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-ff/boards/ast1030_evb.overlay
@@ -77,7 +77,7 @@
 	status = "okay";
 	assigned-address = <0x9>;
 	pinctrl-0 = <&pinctrl_i3c0_default>;
-	i3c-scl-hz = <8000000>;
+	i3c-scl-hz = <12500000>;
 	ibi-append-pec;
 	secondary;
 	i3c0_smq: i3c-slave-mqueue@9 {

--- a/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
@@ -92,8 +92,8 @@
 	pinctrl-0 = <&pinctrl_i3c2_default>;
 	i3c-scl-hz = <12500000>;
 	assigned-address = <0x11>;
-	i3c-pp-scl-hi-period-ns = <100>;
-	i3c-pp-scl-lo-period-ns = <100>;
+	i3c-pp-scl-hi-period-ns = <40>;
+	i3c-pp-scl-lo-period-ns = <40>;
 };
 
 &i2c13 {


### PR DESCRIPTION
# Description
- Correct I3C HUB setting of voltage.
- Correct MB and 1OU BIC i3c frequence.

# Motivation
- Fix I3C config setting wrong.

# Test plan
- Build code: Pass
- I3C Hub init success: Pass
- I3C communication: Pass