### PR TITLE
common: service: Support retimer update via pldm

### DIFF
--- a/common/service/pldm/pldm_firmware_update.h
+++ b/common/service/pldm/pldm_firmware_update.h
@@ -38,6 +38,9 @@ extern "C" {
 #define KEYWORD_CPLD_LATTICE "LCMXO3-9400C"
 #endif
 
+#define KEYWORD_RETIMER_PT5161L "pt5161l"
+#define RETIMER_PT5161L_FW_VER_LEN 4
+
 static const char hex_to_ascii[] = { '0', '1', '2', '3', '4', '5', '6', '7',
 				     '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 
@@ -55,7 +58,7 @@ static const char hex_to_ascii[] = { '0', '1', '2', '3', '4', '5', '6', '7',
 		return ret_val;                                                                            \
 	}
 
-/** 
+/**
  * PLDM Firmware update commands
  */
 enum pldm_firmware_update_commands {
@@ -104,7 +107,7 @@ enum pldm_firmware_update_completion_codes {
 };
 
 /**
- * PLDM Frimware update string type 
+ * PLDM Frimware update string type
  */
 enum pldm_firmware_update_string_type {
 	PLDM_COMP_VER_STR_TYPE_UNKNOWN = 0,
@@ -116,7 +119,7 @@ enum pldm_firmware_update_string_type {
 };
 
 /**
- * PLDM Frimware update state 
+ * PLDM Frimware update state
  */
 enum pldm_firmware_update_state {
 	STATE_IDLE,
@@ -129,7 +132,7 @@ enum pldm_firmware_update_state {
 };
 
 /**
- * PLDM Frimware update aux state 
+ * PLDM Frimware update aux state
  */
 enum pldm_firmware_update_aux_state {
 	STATE_AUX_INPROGRESS,
@@ -160,7 +163,7 @@ enum {
 	COMP_CLASS_TYPE_MAX = 0x10000,
 };
 
-/** 
+/**
  * Common error codes in TransferComplete, VerifyComplete and ApplyComplete request
  */
 enum pldm_firmware_update_common_error_codes {
@@ -169,12 +172,12 @@ enum pldm_firmware_update_common_error_codes {
 	PLDM_FW_UPDATE_GENERIC_ERROR = 0x0A
 };
 
-/** 
+/**
  * TransferResult values in the request of TransferComplete
  */
 enum pldm_firmware_update_transfer_result_values {
 	PLDM_FW_UPDATE_TRANSFER_SUCCESS = 0x00,
-	/* Other values that are not currently used, and will be defined if they are 
+	/* Other values that are not currently used, and will be defined if they are
   used in the future. */
 };
 
@@ -183,7 +186,7 @@ enum pldm_firmware_update_transfer_result_values {
  */
 enum pldm_firmware_update_verify_result_values {
 	PLDM_FW_UPDATE_VERIFY_SUCCESS = 0x00,
-	/* Other values that are not currently used, and will be defined if they are 
+	/* Other values that are not currently used, and will be defined if they are
   used in the future. */
 };
 
@@ -192,12 +195,12 @@ enum pldm_firmware_update_verify_result_values {
  */
 enum pldm_firmware_update_apply_result_values {
 	PLDM_FW_UPDATE_APPLY_SUCCESS = 0x00,
-	/* Other values that are not currently used, and will be defined if they are 
+	/* Other values that are not currently used, and will be defined if they are
   used in the future. */
 };
 
 /**
- * component classification values define in PLDM firmware update specification 
+ * component classification values define in PLDM firmware update specification
  * Table 27
  */
 enum pldm_component_classification_values {
@@ -304,7 +307,7 @@ struct pldm_fw_update_cfg {
 };
 extern struct pldm_fw_update_cfg fw_update_cfg;
 
-/** 
+/**
  * Structure representing fixed part of Request Update request
  */
 struct pldm_request_update_req {
@@ -347,7 +350,7 @@ struct pldm_pass_component_table_resp {
 	uint8_t comp_resp_code;
 } __attribute__((packed));
 
-/** 
+/**
  * Structure representing UpdateComponent request
  */
 struct pldm_update_component_req {
@@ -361,7 +364,7 @@ struct pldm_update_component_req {
 	uint8_t comp_ver_str_len;
 } __attribute__((packed));
 
-/** 
+/**
  * Structure representing UpdateComponent response
  */
 struct pldm_update_component_resp {
@@ -504,6 +507,7 @@ uint16_t pldm_fw_update_read(void *mctp_p, enum pldm_firmware_update_commands cm
 uint8_t pldm_bic_update(void *fw_update_param);
 uint8_t pldm_vr_update(void *fw_update_param);
 uint8_t pldm_cpld_update(void *fw_update_param);
+uint8_t pldm_retimer_update(void *fw_update_param);
 uint8_t pldm_bic_activate(void *arg);
 
 uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uint8_t *resp,


### PR DESCRIPTION
# Description:
Support retimer update via pldm

# Motivation:
Currently, BMC could not update retimer through pldm

# Test Plan:
Use pldm tool to update retimer - pass

# Test Log:
root@bmc:~# pldmtool fw_update GetFwParams -m 60
...
{
    "ComponentClassification": "Downstream Device",
    "ComponentIdentifier": 4,
    "ComponentClassificationIndex": 0,
    "ActiveComponentComparisonStamp": 0,
    "ActiveComponentReleaseDate": "",
    "PendingComponentComparisonStamp": 0,
    "PendingComponentReleaseDate": "",
    "ComponentActivationMethods": [
        "Self-Contained"
    ],
    "CapabilitiesDuringUpdate": {
         "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
    },
    "ActiveComponentVersionString": "02080000",
    "PendingComponentVersionString": ""
},
{
    "ComponentClassification": "Downstream Device",
    "ComponentIdentifier": 5,
    "ComponentClassificationIndex": 0,
    "ActiveComponentComparisonStamp": 0,
    "ActiveComponentReleaseDate": "",
    "PendingComponentComparisonStamp": 0,
    "PendingComponentReleaseDate": "",
    "ComponentActivationMethods": [
        "Self-Contained"
    ],
    "CapabilitiesDuringUpdate": {
        "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
    },
    "ActiveComponentVersionString": "02080000",
    "PendingComponentVersionString": ""
}
root@bmc:~# pldmtool fw_update GetStatus -m 60
{
    "CurrentState": "IDLE",
    "PreviousState": "IDLE",
    "AuxState": "Not applicable in current state",
    "AuxStateStatus": "AuxState is In Progress or Success",
    "ProgressPercent": 101,
    "ReasonCode": "Initialization of firmware device has occurred",
    "UpdateOptionFlagsEnabled": 0
}
root@bmc:~# busctl set-property xyz.openbmc_project.PLDM /xyz/openbmc_project/software/142344108 xyz.openbmc_project.Software.Activation RequestedActivation s "xyz.openbmc_project.Software.Activation.RequestedActivations.Active" root@bmc:~# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/software/142344108 |grep -i Progress
xyz.openbmc_project.Software.ActivationProgress interface -         -                                                                     -
.Progress                                       property  y         100                                                                   emits-change writable
uart:~$ [00:00:40.588,000] <inf> pldm: max transfer size(150), number of component(1), max_outstanding_transfer_req(1)
[00:00:40.588,000] <inf> pldm: packet data length(0), component sting type(1) length(28)
[00:00:40.588,000] <inf> pldm: Component image version:
                               50 4c 44 4d 5f 55 50 44  41 54 45 5f 53 55 50 50 |PLDM_UPD ATE_SUPP
                               4f 52 54 45 44 5f 44 45  56 49 43 45             |ORTED_DE VICE
[00:00:40.591,000] <inf> pldm: Received component class: ffffh id: 1 with version:
[00:00:40.591,000] <inf> pldm:
                               70 74 35 31 36 31 6c 20  76 32 30 32 33 2e 33 37 |pt5161l  v2023.37
                               2e 30 31                                         |.01
[00:00:40.594,000] <inf> pldm: Update component class 0xffff id: 1 image_size: 0x40000 version:
[00:00:40.594,000] <inf> pldm:
                               70 74 35 31 36 31 6c 20  76 32 30 32 33 2e 33 37 |pt5161l  v2023.37
                               2e 30 31                                         |.01
[00:00:41.594,000] <inf> pldm: Component 1 start update process...
[00:00:41.600,000] <inf> pldm: First block for retimer update
[00:00:41.729,000] <inf> dev_pt5161l: PCIE retimer 0 update success
[00:00:41.844,000] <inf> dev_pt5161l: PCIE retimer 100 update success
[00:00:41.960,000] <inf> dev_pt5161l: PCIE retimer 200 update success
[00:00:42.075,000] <inf> dev_pt5161l: PCIE retimer 300 update success
[00:00:42.190,000] <inf> dev_pt5161l: PCIE retimer 400 update success
[00:00:42.306,000] <inf> dev_pt5161l: PCIE retimer 500 update success
[00:00:42.392,000] <inf> dev_pt5161l: PCIE retimer 600 update success
[00:00:42.476,000] <inf> dev_pt5161l: PCIE retimer 700 update success
[00:00:42.591,000] <inf> dev_pt5161l: PCIE retimer 800 update success
[00:00:42.706,000] <inf> dev_pt5161l: PCIE retimer 900 update success
[00:00:42.712,000] <inf> pldm: package loaded: 1%
...
[00:02:34.055,000] <inf> pldm: package loaded: 100%
[00:02:34.155,000] <inf> dev_pt5161l: PCIE retimer 3ff00 update success
[00:02:34.155,000] <inf> pldm: Component 1 update success!
[00:02:34.155,000] <inf> pldm: Transfer complete
[00:02:34.157,000] <inf> pldm: Verify complete
[00:02:34.160,000] <inf> pldm: Apply complete
[00:02:34.165,000] <inf> pldm: Activate firmware
root@bmc:~# pldmtool fw_update GetFwParams -m 60
...
{
    "ComponentClassification": "Downstream Device",
    "ComponentIdentifier": 4,
    "ComponentClassificationIndex": 0,
    "ActiveComponentComparisonStamp": 0,
    "ActiveComponentReleaseDate": "",
    "PendingComponentComparisonStamp": 0,
    "PendingComponentReleaseDate": "",
    "ComponentActivationMethods": [
        "Self-Contained"
    ],
    "CapabilitiesDuringUpdate": {
         "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
    },
    "ActiveComponentVersionString": "02080100",
    "PendingComponentVersionString": ""
},
{
    "ComponentClassification": "Downstream Device",
    "ComponentIdentifier": 5,
    "ComponentClassificationIndex": 0,
    "ActiveComponentComparisonStamp": 0,
    "ActiveComponentReleaseDate": "",
    "PendingComponentComparisonStamp": 0,
    "PendingComponentReleaseDate": "",
    "ComponentActivationMethods": [
         "Self-Contained"
     ],
     "CapabilitiesDuringUpdate": {
         "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
     },
     "ActiveComponentVersionString": "02080100",
     "PendingComponentVersionString": ""
}