### PR TITLE
fby4: sd: Support get retimer fw version

### DIFF
--- a/common/dev/mp2971.c
+++ b/common/dev/mp2971.c
@@ -47,6 +47,7 @@ LOG_MODULE_REGISTER(mp2971);
 #define VR_MPS_CMD_STORE_MULTI_CODE 0xF3
 
 #define MP2856_DISABLE_WRITE_PROTECT 0x63
+#define MP2856_DISABLE_MEM_PROTECT 0x00
 
 /*Page29 */
 #define VR_MPS_REG_CRC_USER 0xFF
@@ -79,7 +80,7 @@ struct mp2856_data {
 	uint16_t cfg_id;
 	uint8_t page;
 	uint8_t reg_addr;
-	uint32_t reg_data;
+	uint8_t reg_data[4];
 	uint8_t reg_len;
 };
 
@@ -124,7 +125,7 @@ static bool mp2856_write_data(uint8_t bus, uint8_t addr, struct mp2856_data *dat
 
 	i2c_msg.tx_len = data->reg_len + 1;
 	i2c_msg.data[0] = data->reg_addr;
-	memcpy(&i2c_msg.data[1], &data->reg_data, data->reg_len);
+	memcpy(&i2c_msg.data[1], &data->reg_data[0], data->reg_len);
 
 	if (i2c_master_write(&i2c_msg, retry)) {
 		LOG_ERR("Failed to write register 0x%02X", data->reg_addr);
@@ -250,6 +251,36 @@ static bool mp2856_unlock_write_protect_mode(uint8_t bus, uint8_t addr)
 				return false;
 			}
 		}
+	} else {
+		//Memory protection mode
+		//check write protect status
+		if (mp2856_set_page(bus, addr, VR_MPS_PAGE_0) == false) {
+			return false;
+		}
+
+		i2c_msg.tx_len = 1;
+		i2c_msg.rx_len = 1;
+		i2c_msg.data[0] = VR_MPS_REG_WRITE_PROTECT;
+
+		if (i2c_master_read(&i2c_msg, retry)) {
+			LOG_ERR("Failed to read register 0x%02X", VR_MPS_REG_WRITE_PROTECT);
+			return false;
+		}
+
+		if (i2c_msg.data[0] == MP2856_DISABLE_MEM_PROTECT) {
+			return true;
+		} else {
+			//Unlock Memory Write protection
+			i2c_msg.tx_len = 2;
+			i2c_msg.data[0] = VR_MPS_REG_WRITE_PROTECT;
+			i2c_msg.data[1] = MP2856_DISABLE_MEM_PROTECT;
+
+			if (i2c_master_write(&i2c_msg, retry)) {
+				LOG_ERR("Failed to write register 0x%02X",
+					VR_MPS_REG_WRITE_PROTECT);
+				return false;
+			}
+		}
 	}
 
 	return true;
@@ -287,17 +318,18 @@ static bool parsing_image(uint8_t *img_buff, uint32_t img_size, struct mp2856_co
 				break;
 			}
 		}
-		if (img_buff[i] != 0x09 && img_buff[i] != 0x0d) {
+		if (((img_buff[i] != 0x09) && img_buff[i] != 0x0d) &&
+			(cur_ele_idx != ATE_WRITE_TYPE)) {
 			// pass non hex charactor
 			int val = ascii_to_val(img_buff[i]);
 			if (val == -1)
 				continue;
+
 			data_store = (data_store << 4) | val;
 			data_idx++;
 			continue;
 		}
 
-		uint8_t byte_cnt = data_idx % 2 == 0 ? data_idx / 2 : (data_idx / 2 + 1);
 		switch (cur_ele_idx) {
 		case ATE_CONF_ID:
 			cur_line->cfg_id = data_store & 0xffff;
@@ -318,14 +350,19 @@ static bool parsing_image(uint8_t *img_buff, uint32_t img_size, struct mp2856_co
 			break;
 
 		case ATE_REG_DATA_HEX:
-			cur_line->reg_data = data_store;
-			cur_line->reg_len = byte_cnt;
+			*((uint32_t*)cur_line->reg_data) = data_store;
+			cur_line->reg_len = data_idx % 2 == 0 ? data_idx / 2 : (data_idx / 2 + 1);
 			break;
 
 		case ATE_REG_DATA_DEC:
 			break;
 
 		case ATE_WRITE_TYPE:
+			if (!strncmp(&img_buff[i], "B", 1)) {
+				memmove(&cur_line->reg_data[1], &cur_line->reg_data[0], cur_line->reg_len);
+				cur_line->reg_data[0] = cur_line->reg_len;
+				cur_line->reg_len += 1;
+			}
 			break;
 
 		default:
@@ -335,11 +372,15 @@ static bool parsing_image(uint8_t *img_buff, uint32_t img_size, struct mp2856_co
 
 		data_idx = 0;
 		data_store = 0;
+
 		if (img_buff[i] == 0x09) {
 			cur_ele_idx++;
 		} else if (img_buff[i] == 0x0d) {
-			LOG_DBG("vr[%d] page: %d addr:%x data:%x", dev_cfg->wr_cnt, cur_line->page,
-				cur_line->reg_addr, cur_line->reg_data);
+			LOG_DBG("vr[%d] page: %d addr:%x", dev_cfg->wr_cnt, cur_line->page,
+				cur_line->reg_addr);
+			for(int i=0; i< cur_line->reg_len; i++) {
+				LOG_DBG("data:%x", cur_line->reg_data[i]);
+			}
 			cur_ele_idx = 0;
 			dev_cfg->wr_cnt++;
 			if (dev_cfg->wr_cnt > max_line) {

--- a/common/service/pldm/pldm_firmware_update.c
+++ b/common/service/pldm/pldm_firmware_update.c
@@ -153,8 +153,12 @@ uint8_t pldm_vr_update(void *fw_update_param)
 		if (xdpe12284c_fwupdate(p->bus, p->addr, hex_buff, fw_update_cfg.image_size) ==
 		    false)
 			goto exit;
-	} else if (!strncmp(p->comp_version_str, KEYWORD_VR_MP2971,
-			    ARRAY_SIZE(KEYWORD_VR_MP2971) - 1)) {
+	} else if ((!strncmp(p->comp_version_str, KEYWORD_VR_MP2971,
+				ARRAY_SIZE(KEYWORD_VR_MP2971) - 1)) ||
+				(!strncmp(p->comp_version_str, KEYWORD_VR_MP2856,
+			    ARRAY_SIZE(KEYWORD_VR_MP2856) - 1)) ||
+				(!strncmp(p->comp_version_str, KEYWORD_VR_MP2857,
+			    ARRAY_SIZE(KEYWORD_VR_MP2857) - 1))) {
 		if (mp2971_fwupdate(p->bus, p->addr, hex_buff, fw_update_cfg.image_size) == false)
 			goto exit;
 	} else {

--- a/common/service/pldm/pldm_firmware_update.h
+++ b/common/service/pldm/pldm_firmware_update.h
@@ -29,6 +29,8 @@ extern "C" {
 
 #define KEYWORD_VR_ISL69259 "isl69259"
 #define KEYWORD_VR_XDPE12284C "xdpe12284c"
+#define KEYWORD_VR_MP2856 "mp2856"
+#define KEYWORD_VR_MP2857 "mp2857"
 #define KEYWORD_VR_MP2971 "mp2971"
 
 #ifndef KEYWORD_CPLD_LATTICE

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
@@ -23,11 +23,22 @@
 #include "pldm_firmware_update.h"
 #include "plat_pldm_fw_update.h"
 #include "mctp_ctrl.h"
+#include "power_status.h"
+#include "plat_i2c.h"
+#include "mp2971.h"
+#include "util_spi.h"
 
 LOG_MODULE_REGISTER(plat_fwupdate);
 
+static uint8_t plat_pldm_pre_vr_update(void *fw_update_param);
+static uint8_t plat_pldm_post_vr_update(void *fw_update_param);
+static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len);
+
 enum FIRMWARE_COMPONENT {
 	SD_COMPNT_BIC,
+	SD_COMPNT_VR_PVDDCR_CPU1,
+	SD_COMPNT_VR_PVDD11_S3,
+	SD_COMPNT_VR_PVDDCR_CPU0,
 };
 
 uint8_t MCTP_SUPPORTED_MESSAGES_TYPES[] = {
@@ -49,6 +60,45 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = pldm_bic_activate,
 		.get_fw_version_fn = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = SD_COMPNT_VR_PVDDCR_CPU1,
+		.comp_classification_index = 0x00,
+		.pre_update_func = plat_pldm_pre_vr_update,
+		.update_func = pldm_vr_update,
+		.pos_update_func = plat_pldm_post_vr_update,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = plat_get_vr_fw_version,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = SD_COMPNT_VR_PVDD11_S3,
+		.comp_classification_index = 0x00,
+		.pre_update_func = plat_pldm_pre_vr_update,
+		.update_func = pldm_vr_update,
+		.pos_update_func = plat_pldm_post_vr_update,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = plat_get_vr_fw_version,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = SD_COMPNT_VR_PVDDCR_CPU0,
+		.comp_classification_index = 0x00,
+		.pre_update_func = plat_pldm_pre_vr_update,
+		.update_func = pldm_vr_update,
+		.pos_update_func = plat_pldm_post_vr_update,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = plat_get_vr_fw_version,
 	},
 };
 
@@ -114,4 +164,83 @@ int load_mctp_support_types(uint8_t *type_len, uint8_t *types)
 	*type_len = sizeof(MCTP_SUPPORTED_MESSAGES_TYPES);
 	memcpy(types, MCTP_SUPPORTED_MESSAGES_TYPES, sizeof(MCTP_SUPPORTED_MESSAGES_TYPES));
 	return MCTP_SUCCESS;
+}
+
+static uint8_t plat_pldm_pre_vr_update(void *fw_update_param) {
+	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, 1);
+
+	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
+
+	/* Stop sensor polling */
+	set_vr_monitor_status(false);
+	p->bus = I2C_BUS4;
+
+	if (p->comp_id == SD_COMPNT_VR_PVDDCR_CPU1) {
+		p->addr = 0x63;
+	} else if (p->comp_id == SD_COMPNT_VR_PVDD11_S3) {
+		p->addr = 0x72;
+	} else if (p->comp_id == SD_COMPNT_VR_PVDDCR_CPU0) {
+		p->addr = 0x76;
+	} else {
+		LOG_ERR("Unsupported VR image");
+	}
+
+	return 0;
+}
+
+static uint8_t plat_pldm_post_vr_update(void *fw_update_param) {
+	ARG_UNUSED(fw_update_param);
+
+	set_vr_monitor_status(true);
+
+	return 0;
+}
+
+static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(info_p, false);
+	CHECK_NULL_ARG_WITH_RETURN(buf, false);
+	CHECK_NULL_ARG_WITH_RETURN(len, false);
+
+	pldm_fw_update_info_t *p = (pldm_fw_update_info_t *)info_p;
+
+	bool ret = false;
+	uint32_t version;
+	uint8_t bus = I2C_BUS4;
+	uint8_t addr = 0;
+
+	if (p->comp_identifier == SD_COMPNT_VR_PVDDCR_CPU1) {
+		addr = 0x63;
+	} else if (p->comp_identifier == SD_COMPNT_VR_PVDD11_S3) {
+		addr = 0x72;
+	} else if (p->comp_identifier == SD_COMPNT_VR_PVDDCR_CPU0) {
+		addr = 0x76;
+	} else {
+		LOG_ERR("Unknown component identifier for VR");
+	}
+
+	set_vr_monitor_status(false);
+	if (!mp2971_get_checksum(bus, addr, &version)) {
+		LOG_ERR("The VR version reading failed");
+		return ret;
+	}
+	set_vr_monitor_status(true);
+
+	version = sys_cpu_to_be32(version);
+	uint8_t *buf_p = buf;
+	const uint8_t *vr_name_p = MPS_CRC_PREFIX;
+	if (!vr_name_p) {
+		LOG_ERR("The pointer of VR string name is NULL");
+		return ret;
+	}
+	*len = 0;
+
+	memcpy(buf_p, vr_name_p, strlen(vr_name_p));
+	buf_p += strlen(vr_name_p);
+	*len += bin2hex((uint8_t *)&version, 4, buf_p, 8) + strlen(vr_name_p);
+	buf_p += 8;
+
+	ret = true;
+
+	return ret;
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.h
@@ -21,6 +21,8 @@
 #include <stdint.h>
 #include "pldm_firmware_update.h"
 
+#define MPS_CRC_PREFIX "MPS "
+
 void load_pldmupdate_comp_config(void);
 int load_mctp_support_types(uint8_t *type_len, uint8_t *types);
 


### PR DESCRIPTION
# Description:
Support get retimer fw version

# Motivation:
Currently, BMC could not get retimer fw version through pldm

# Test Plan:
Check retimer fw version - pass

# Test Log:
root@bmc:~# pldmtool fw_update GetFwParams -m 60
...
{
    "ComponentClassification": "Downstream Device",
    "ComponentIdentifier": 4,
    "ComponentClassificationIndex": 0,
    "ActiveComponentComparisonStamp": 0,
    "ActiveComponentReleaseDate": "",
    "PendingComponentComparisonStamp": 0,
    "PendingComponentReleaseDate": "",
    "ComponentActivationMethods": [
        "Self-Contained"
    ],
    "CapabilitiesDuringUpdate": {
         "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
    },
    "ActiveComponentVersionString": "02080000",
    "PendingComponentVersionString": ""
}
