### PR TITLE
Common: Support PLDM Sensor Auxiliary Names PDR

### DIFF
--- a/common/service/sensor/pdr.c
+++ b/common/service/sensor/pdr.c
@@ -10,58 +10,142 @@
 
 LOG_MODULE_REGISTER(pdr);
 
-uint16_t pdr_count = 0;
+uint32_t total_record_count = 0;
+
 PDR_INFO *pdr_info = NULL;
 PDR_numeric_sensor *numeric_sensor_table = NULL;
+PDR_sensor_auxiliary_names *sensor_auxiliary_names_table = NULL;
 
-uint8_t pdr_init(void)
+int pdr_init(void)
 {
-	pdr_count = plat_get_pdr_size();
-	numeric_sensor_table =
-		(PDR_numeric_sensor *)malloc(pdr_count * sizeof(PDR_numeric_sensor));
-	plat_load_pdr_table(numeric_sensor_table);
-	if (numeric_sensor_table == NULL) {
-		LOG_ERR("Failed to load PDR table");
+	uint32_t pdr_count = 0, record_handle = 0x0, largest_record_size = 0;
+
+	pdr_count = plat_get_pdr_size(PLDM_NUMERIC_SENSOR_PDR);
+	if (pdr_count != 0) {
+		total_record_count += pdr_count;
+		numeric_sensor_table =
+			(PDR_numeric_sensor *)malloc(pdr_count * sizeof(PDR_numeric_sensor));
+		plat_load_numeric_sensor_pdr_table(numeric_sensor_table);
+		if (numeric_sensor_table == NULL) {
+			LOG_ERR("Failed to malloc numeric sensor PDR table");
+			return -1;
+		}
+		pdr_info->repository_size += pdr_count * sizeof(PDR_numeric_sensor);
+
+		for (uint32_t i = 0; i < pdr_count; i++) {
+			numeric_sensor_table[i].pdr_common_header.record_handle = record_handle;
+			numeric_sensor_table[i].pdr_common_header.data_length +=
+				(sizeof(PDR_numeric_sensor) - sizeof(PDR_common_header));
+			record_handle++;
+		}
+
+		if (largest_record_size < sizeof(PDR_numeric_sensor)) {
+			largest_record_size = sizeof(PDR_numeric_sensor);
+		}
+	}
+
+	pdr_count = plat_get_pdr_size(PLDM_SENSOR_AUXILIARY_NAMES_PDR);
+	if (pdr_count != 0) {
+		total_record_count += pdr_count;
+		sensor_auxiliary_names_table = (PDR_sensor_auxiliary_names *)malloc(
+			pdr_count * sizeof(PDR_sensor_auxiliary_names));
+		plat_load_aux_sensor_names_pdr_table(sensor_auxiliary_names_table);
+		if (sensor_auxiliary_names_table == NULL) {
+			LOG_ERR("Failed to malloc sensor auxiliary names PDR table");
+			return -1;
+		}
+		pdr_info->repository_size += pdr_count * sizeof(PDR_sensor_auxiliary_names);
+
+		for (uint32_t i = 0; i < pdr_count; i++) {
+			sensor_auxiliary_names_table[i].pdr_common_header.record_handle =
+				record_handle;
+			sensor_auxiliary_names_table[i].pdr_common_header.data_length +=
+				(sizeof(PDR_sensor_auxiliary_names) - sizeof(PDR_common_header));
+
+			// Convert sensor name to UTF16-BE
+			for (int j = 0; sensor_auxiliary_names_table[i].sensorName[j] != 0x0000;
+			     j++) {
+				sensor_auxiliary_names_table[i].sensorName[j] = sys_cpu_to_be16(
+					sensor_auxiliary_names_table[i].sensorName[j]);
+			}
+
+			record_handle++;
+		}
+
+		if (largest_record_size < sizeof(PDR_sensor_auxiliary_names)) {
+			largest_record_size = sizeof(PDR_sensor_auxiliary_names);
+		}
+	}
+
+	pdr_info = (PDR_INFO *)malloc(sizeof(PDR_INFO));
+	if (pdr_info == NULL) {
+		LOG_ERR("Failed to malloc PDR info");
 		return false;
 	}
-
-	for (uint32_t i = 0; i < pdr_count; i++) {
-		numeric_sensor_table[i].pdr_common_header.record_handle = i & 0xFFFFFFFF;
-		numeric_sensor_table[i].pdr_common_header.data_length +=
-			(sizeof(PDR_numeric_sensor) - sizeof(PDR_common_header));
-	}
-
 	pdr_info->repository_state = PDR_STATE_AVAILABLE;
-	pdr_info->record_count = pdr_count;
-	pdr_info->repository_size = pdr_count * sizeof(PDR_numeric_sensor);
-	pdr_info->largest_record_size = sizeof(PDR_numeric_sensor);
+	pdr_info->record_count = total_record_count;
+	pdr_info->largest_record_size = largest_record_size;
 
-	return true;
+	return 0;
 }
 
-PDR_INFO* get_pdr_info()
+PDR_INFO *get_pdr_info()
 {
 	return pdr_info;
 }
 
-PDR_numeric_sensor* get_pdr_table()
+int get_pdr_table_via_record_handle(uint8_t *record_data, uint32_t record_handle)
 {
-	return numeric_sensor_table;
+	uint32_t numeric_sensor_pdr_count = 0, aux_sensor_name_pdr_count = 0;
+
+	numeric_sensor_pdr_count = plat_get_pdr_size(PLDM_NUMERIC_SENSOR_PDR);
+	aux_sensor_name_pdr_count = plat_get_pdr_size(PLDM_SENSOR_AUXILIARY_NAMES_PDR);
+
+	if (record_handle < numeric_sensor_pdr_count) {
+		for (int i = 0; i < numeric_sensor_pdr_count; i++) {
+			if (numeric_sensor_table[i].pdr_common_header.record_handle ==
+			    record_handle) {
+				memcpy(record_data, &numeric_sensor_table[i],
+				       sizeof(PDR_numeric_sensor));
+				return sizeof(PDR_numeric_sensor);
+			}
+		}
+	} else if (record_handle < numeric_sensor_pdr_count + aux_sensor_name_pdr_count) {
+		for (int i = 0; i < aux_sensor_name_pdr_count; i++) {
+			if (sensor_auxiliary_names_table[i].pdr_common_header.record_handle ==
+			    record_handle) {
+				memcpy(record_data, &sensor_auxiliary_names_table[i],
+				       sizeof(PDR_sensor_auxiliary_names));
+				return sizeof(PDR_sensor_auxiliary_names);
+			}
+		}
+	} else {
+		LOG_ERR("Failed to get PDR via record handle: %x\n", record_handle);
+		return -1;
+	}
+
+	return -1;
 }
 
-uint16_t get_pdr_size()
+uint32_t get_record_count()
 {
-	return pdr_count;
+	return total_record_count;
 }
 
-__weak uint16_t plat_get_pdr_size()
+__weak uint32_t plat_get_pdr_size(uint8_t pdr_type)
 {
 	//implement in platform layer
 	return 0;
 }
 
-__weak void plat_load_pdr_table(PDR_numeric_sensor* numeric_sensor_table)
+__weak void plat_load_numeric_sensor_pdr_table(PDR_numeric_sensor *numeric_sensor_table)
 {
 	//implement in platform layer
 	numeric_sensor_table = NULL;
+}
+
+__weak void plat_load_aux_sensor_names_pdr_table(PDR_sensor_auxiliary_names *aux_sensor_name_table)
+{
+	//implement in platform layer
+	aux_sensor_name_table = NULL;
 }

--- a/common/service/sensor/pldm_sensor.c
+++ b/common/service/sensor/pldm_sensor.c
@@ -336,9 +336,12 @@ void pldm_sensor_poll_thread_init()
 void pldm_sensor_monitor_init()
 {
 	LOG_INF("Init PDR table");
-	uint16_t pdr_size = plat_get_pdr_size();
+	uint16_t pdr_size = plat_get_pdr_size(PLDM_NUMERIC_SENSOR_PDR);
 	if (pdr_size != 0) {
-		pdr_init();
+		if (pdr_init() != 0) {
+			LOG_ERR("Falied to initialize Platform PDR table");
+			return;
+		}
 	} else {
 		LOG_ERR("Platform PDR table not configured");
 	}

--- a/meta-facebook/yv4-sd/src/platform/plat_pdr_table.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pdr_table.c
@@ -37,7 +37,7 @@ PDR_numeric_sensor plat_pdr_table[] = {
 };
 
 const int PDR_TABLE_SIZE = ARRAY_SIZE(plat_pdr_table);
-uint16_t plat_get_pdr_size()
+uint32_t plat_get_pdr_size(uint8_t pdr_type)
 {
 	return PDR_TABLE_SIZE;
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_pdr_table.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pdr_table.h
@@ -22,7 +22,7 @@
 
 #define MAX_SENSOR_SIZE 60
 
-uint16_t plat_get_pdr_size();
+uint32_t plat_get_pdr_size(uint8_t pdr_type);
 void plat_load_pdr_table(PDR_numeric_sensor *numeric_sensor_table);
 
 #endif


### PR DESCRIPTION
# Description
- Support PLDM Sensor Auxiliary Names PDR.

# Motivation
- Support PLDM Sensor Auxiliary Names PDR so that the sensor at PLDM dbus interface in BMC could have name.

# Test plan
- Build code: Pass
- Check the PLDM sensors' name: Pass

# Test Log
1. Check the PLDM sensors' name are correct. root@bmc:~# busctl tree xyz.openbmc_project.PLDM `- /xyz `- /xyz/openbmc_project |- /xyz/openbmc_project/inventory | `- /xyz/openbmc_project/inventory/Item
        |   `- /xyz/openbmc_project/inventory/Item/Board
        |     `- /xyz/openbmc_project/inventory/Item/Board/PLDM_Device_1
        |- /xyz/openbmc_project/pldm
        `- /xyz/openbmc_project/sensors
          |- /xyz/openbmc_project/sensors/current
          | |- /xyz/openbmc_project/sensors/current/MB_VR_CPU0_CURR_A_36_1
          | |- /xyz/openbmc_project/sensors/current/MB_VR_CPU1_CURR_A_38_1
          | |- /xyz/openbmc_project/sensors/current/MB_VR_PVDD11_CURR_A_40_1
          | |- /xyz/openbmc_project/sensors/current/MB_VR_PVDDIO_CURR_A_39_1
          | `- /xyz/openbmc_project/sensors/current/MB_VR_SOC_CURR_A_37_1
          |- /xyz/openbmc_project/sensors/power
          | |- /xyz/openbmc_project/sensors/power/MB_VR_CPU0_PWR_W_41_1
          | |- /xyz/openbmc_project/sensors/power/MB_VR_CPU1_PWR_W_43_1
          | |- /xyz/openbmc_project/sensors/power/MB_VR_PVDD11_PWR_W_45_1
          | |- /xyz/openbmc_project/sensors/power/MB_VR_PVDDIO_PWR_W_44_1
          | `- /xyz/openbmc_project/sensors/power/MB_VR_SOC_PWR_W_42_1
          |- /xyz/openbmc_project/sensors/temperature
          | |- /xyz/openbmc_project/sensors/temperature/MB_FIO_TEMP_C_3_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_INLET_TEMP_C_1_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_OUTLET_TEMP_C_2_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_VR_CPU0_TEMP_C_19_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_VR_CPU1_TEMP_C_21_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_VR_PVDD11_TEMP_C_23_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_VR_PVDDIO_TEMP_C_22_1
          | `- /xyz/openbmc_project/sensors/temperature/MB_VR_SOC_TEMP_C_20_1
          `- /xyz/openbmc_project/sensors/voltage
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P12V_DIMM_0_VOLT_V_30_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P12V_DIMM_1_VOLT_V_31_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P12V_STBY_VOLT_V_24_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P1V2_STBY_VOLT_V_32_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P1V8_STBY_VOLT_V_33_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P3V3_STBY_VOLT_V_26_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P3V_BAT_VOLT_V_27_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P5V_STBY_VOLT_V_29_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_PVDD18_S5_VOLT_V_25_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_PVDD33_S5_VOLT_V_28_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_SIDECAR_DETECT_VOLT_V_35_1
            `- /xyz/openbmc_project/sensors/voltage/MB_ADC_SLOT_DETECT_VOLT_V_34_1