### PR TITLE
yv4-ff: Add pldm sensor table

### DIFF
--- a/meta-facebook/yv4-ff/src/platform/plat_def.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_def.h
@@ -22,5 +22,7 @@
 #define BMC_USB_PORT "CDC_ACM_0"
 
 #define ENABLE_PLDM
+#define ENABLE_PLDM_SENSOR
+#define ENABLE_CCI
 
 #endif

--- a/meta-facebook/yv4-ff/src/platform/plat_hook.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_hook.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <logging/log.h>
+#include <drivers/peci.h>
+
+#include "sensor.h"
+#include "intel_peci.h"
+#include "intel_dimm.h"
+#include "power_status.h"
+#include "i2c-mux-tca9548.h"
+#include "libutil.h"
+#include "hal_peci.h"
+
+#include "plat_hook.h"
+#include "plat_sensor_table.h"
+#include "plat_gpio.h"
+
+LOG_MODULE_REGISTER(plat_hook);
+
+vr_pre_read_arg vr_pre_read_args[] = {
+	[0] = { 0x0 },
+	[1] = { 0x1 },
+};
+
+adc_asd_init_arg ast_adc_init_args[] = {
+	[0] = { .is_init = false,
+		.deglitch[0] = { .deglitch_en = false,},
+		.deglitch[1] = { .deglitch_en = false,},
+		.deglitch[2] = { .deglitch_en = false,},
+		.deglitch[3] = { .deglitch_en = false,},
+		.deglitch[4] = { .deglitch_en = false,},
+		.deglitch[5] = { .deglitch_en = false,},
+	},
+	[1] = {
+		.is_init = false,
+		.deglitch[0] = { .deglitch_en = false,},
+		.deglitch[1] = { .deglitch_en = false,},
+		.deglitch[2] = { .deglitch_en = false,},
+		.deglitch[4] = { .deglitch_en = false,},
+		.deglitch[5] = { .deglitch_en = false,},
+		.deglitch[6] = { .deglitch_en = false,},
+	}
+};
+
+bool pre_vr_read(sensor_cfg *cfg, void *args)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(args, false);
+
+	vr_pre_read_arg *pre_read_args = (vr_pre_read_arg *)args;
+	uint8_t retry = 5;
+	I2C_MSG msg;
+
+	/* set page */
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = 0x00;
+	msg.data[1] = pre_read_args->vr_page;
+	if (i2c_master_write(&msg, retry)) {
+		LOG_ERR("Failed to set page");
+		return false;
+	}
+	return true;
+}

--- a/meta-facebook/yv4-ff/src/platform/plat_hook.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_hook.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_HOOK_H
+#define PLAT_HOOK_H
+
+typedef struct _vr_pre_read_arg {
+	/* vr page to set */
+	uint8_t vr_page;
+} vr_pre_read_arg;
+
+extern vr_pre_read_arg vr_pre_read_args[];
+extern adc_asd_init_arg ast_adc_init_args[];
+
+bool pre_vr_read(sensor_cfg *cfg, void *args);
+
+#endif

--- a/meta-facebook/yv4-ff/src/platform/plat_i2c.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_i2c.h
@@ -31,6 +31,7 @@ enum name {
 	I2C_BUS7,
 	I2C_BUS8,
 	I2C_BUS9,
+	I2C_BUS10,
 	I2C_BUS_MAX_NUM,
 };
 

--- a/meta-facebook/yv4-ff/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_mctp.c
@@ -66,6 +66,11 @@ mctp_route_entry plat_mctp_route_tbl[] = {
 	{ MCTP_EID_CXL, I2C_BUS_CXL, I2C_ADDR_CXL, .set_endpoint = true },
 };
 
+uint8_t MCTP_SUPPORTED_MESSAGES_TYPES[] = {
+	TYPE_MCTP_CONTROL,
+	TYPE_PLDM,
+};
+
 static mctp *find_mctp_by_bus(uint8_t bus)
 {
 	uint8_t i;
@@ -360,4 +365,11 @@ void plat_update_mctp_routing_table(uint8_t eid)
 	k_timer_start(&send_cmd_timer, K_MSEC(30000), K_NO_WAIT);
 
 	return;
+}
+
+int load_mctp_support_types(uint8_t *type_len, uint8_t *types)
+{
+	*type_len = sizeof(MCTP_SUPPORTED_MESSAGES_TYPES);
+	memcpy(types, MCTP_SUPPORTED_MESSAGES_TYPES, sizeof(MCTP_SUPPORTED_MESSAGES_TYPES));
+	return MCTP_SUCCESS;
 }

--- a/meta-facebook/yv4-ff/src/platform/plat_mctp.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_mctp.h
@@ -37,5 +37,6 @@ bool mctp_add_sel_to_ipmi(common_addsel_msg_t *sel_msg);
 uint8_t plat_get_mctp_port_count();
 mctp_port *plat_get_mctp_port(uint8_t index);
 void plat_update_mctp_routing_table(uint8_t eid);
+int load_mctp_support_types(uint8_t *type_len, uint8_t *types);
 
 #endif /* _PLAT_MCTP_h */

--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_sensor.c
@@ -1,0 +1,3666 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <logging/log.h>
+#include "pmbus.h"
+#include "ast_adc.h"
+#include "pdr.h"
+#include "sensor.h"
+#include "pldm_sensor.h"
+#include "pldm_monitor.h"
+#include "plat_i2c.h"
+#include "plat_pldm_sensor.h"
+#include "plat_hook.h"
+
+LOG_MODULE_REGISTER(plat_pldm_sensor);
+
+static struct pldm_sensor_thread pal_pldm_sensor_thread[MAX_SENSOR_THREAD_ID] = {
+	// thread id, thread name
+	{ TMP_SENSOR_THREAD_ID, "TMP_PLDM_SENSOR_THREAD" },
+	{ ADC_SENSOR_THREAD_ID, "ADC_PLDM_SENSOR_THREAD" },
+	{ INA233_SENSOR_THREAD_ID, "INA233_PLDM_SENSOR_THREAD" },
+	{ VR_SENSOR_THREAD_ID, "VR_PLDM_SENSOR_THREAD" },
+	{ DIMM_SENSOR_THREAD_ID, "DIMM_PLDM_SENSOR_THREAD" },
+};
+
+pldm_sensor_info plat_pldm_sensor_tmp_table[] = {
+	{
+		{
+			// FF_1OU_BOARD_INLET_TEMP_C
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0050, //uint16_t sensor_id;
+			0x0089, //uint16_t entity_type;
+			0x0001, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x02, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x000000FF, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000032, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000096, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_tmp75,
+			.port = I2C_BUS2,
+			.target_addr = ADDR_TMP75_INLET,
+			.offset = OFFSET_TMP75_TEMP,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_CXL_CNTR_TEMP_C
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0051, //uint16_t sensor_id;
+			0x0089, //uint16_t entity_type;
+			0x0002, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x02, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x000000FF, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000000, //uint32_t critical_high;
+			0x00000054, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_tmp461,
+			.port = I2C_BUS8,
+			.target_addr = ADDR_TMP461AIRUNR,
+			.offset = OFFSET_TMP461_TEMP,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+};
+
+pldm_sensor_info plat_pldm_sensor_adc_table[] = {
+	{
+		{
+			// FF_ADC_P3V3_STBY_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0004, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0001, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-3, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000000, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT2,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 2,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_ADC_P1V2_STBY_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0057, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0002, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-4, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x000032C8, //uint32_t warning_high;
+			0x00002BA4, //uint32_t warning_low;
+			0x00003200, //uint32_t critical_high;
+			0x00002AF8, //uint32_t critical_low;
+			0x00003660, //uint32_t fatal_high;
+			0x00002580, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT3,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_ADC_P1V2_ASIC_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0058, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0003, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-4, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x000032C8, //uint32_t warning_high;
+			0x00002BA4, //uint32_t warning_low;
+			0x00003200, //uint32_t critical_high;
+			0x00002AF8, //uint32_t critical_low;
+			0x00003660, //uint32_t fatal_high;
+			0x00002580, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT4,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_ADC_P1V8_ASIC_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0059, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0004, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-5, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x0002E64A, //uint32_t warning_high;
+			0x00029580, //uint32_t warning_low;
+			0x0002EE00, //uint32_t critical_high;
+			0x00028C58, //uint32_t critical_low;
+			0x00032FA0, //uint32_t fatal_high;
+			0x00023280, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT5,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_ADC_P0V75_ASIC_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x005E, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0005, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-6, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x000CAA30, //uint32_t warning_high;
+			0x000A3930, //uint32_t warning_low;
+			0x000CF3E0, //uint32_t critical_high;
+			0x0009FF07, //uint32_t critical_low;
+			0x000DD0EA, //uint32_t fatal_high;
+			0x00091668, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT10,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[1],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_ADC_PVPP_AB_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x005A, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0006, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000112, //uint32_t warning_high;
+			0x000000E1, //uint32_t warning_low;
+			0x00000118, //uint32_t critical_high;
+			0x000000DC, //uint32_t critical_low;
+			0x0000012C, //uint32_t fatal_high;
+			0x000000C8, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT6,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 2,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_ADC_PVPP_CD_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x005B, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0007, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000112, //uint32_t warning_high;
+			0x000000E1, //uint32_t warning_low;
+			0x00000118, //uint32_t critical_high;
+			0x000000DC, //uint32_t critical_low;
+			0x0000012C, //uint32_t fatal_high;
+			0x000000C8, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT7,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 2,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_ADC_PVTT_AB_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x005C, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0008, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-3, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0X00000294, //uint32_t warning_high;
+			0X0000021C, //uint32_t warning_low;
+			0X0000029E, //uint32_t critical_high;
+			0X00000210, //uint32_t critical_low;
+			0X000002D0, //uint32_t fatal_high;
+			0x000001E0, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT8,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[1],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_ADC_PVTT_CD_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x005D, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0009, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-3, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0X00000294, //uint32_t warning_high;
+			0X0000021C, //uint32_t warning_low;
+			0X0000029E, //uint32_t critical_high;
+			0X00000210, //uint32_t critical_low;
+			0X000002D0, //uint32_t fatal_high;
+			0x000001E0, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT9,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[1],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+};
+
+pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
+	{
+		{
+			// FF_INA233_P12V_STBY_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x005F, //uint16_t sensor_id;
+			0x0000, //uint16_t entity_type; //Need to check
+			0x0001, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-3, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00003386, //uint32_t warning_high;
+			0x000029EA, //uint32_t warning_low;
+			0x00003340, //uint32_t critical_high;
+			0x00002A26, //uint32_t critical_low;
+			0x000037FD, //uint32_t fatal_high;
+			0x00002756, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ina233,
+			.port = I2C_BUS2,
+			.target_addr = ADDR_INA233,
+			.offset = OFFSET_INA233_VOL,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_INA233_P3V3_STBY_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0060, //uint16_t sensor_id;
+			0x0000, //uint16_t entity_type; //Need to check
+			0x0001, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-5, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00057288, //uint32_t warning_high;
+			0x0004B320, //uint32_t warning_low;
+			0x000566D0, //uint32_t critical_high;
+			0x0004A3DF, //uint32_t critical_low;
+			0x000617C4, //uint32_t fatal_high;
+			0x00038658, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ina233,
+			.port = I2C_BUS2,
+			.target_addr = ADDR_INA233,
+			.offset = OFFSET_INA233_VOL,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_INA233_P12V_STBY_CURR_A
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0065, //uint16_t sensor_id;
+			0x0000, //uint16_t entity_type; //Need to check
+			0x0003, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x06, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000000, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ina233,
+			.port = I2C_BUS2,
+			.target_addr = ADDR_INA233,
+			.offset = OFFSET_INA233_CURR,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_INA233_P3V3_STBY_CURR_A
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0066, //uint16_t sensor_id;
+			0x0000, //uint16_t entity_type; //Need to check
+			0x0004, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x06, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000000, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ina233,
+			.port = I2C_BUS2,
+			.target_addr = ADDR_INA233,
+			.offset = OFFSET_INA233_CURR,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_INA233_P12V_STBY_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x006B, //uint16_t sensor_id;
+			0x0000, //uint16_t entity_type; //Need to check
+			0x0005, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x07, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000000, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ina233,
+			.port = I2C_BUS2,
+			.target_addr = ADDR_INA233,
+			.offset = OFFSET_INA233_CURR,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_INA233_P3V3_STBY_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x006C, //uint16_t sensor_id;
+			0x0000, //uint16_t entity_type; //Need to check
+			0x0006, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x07, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000000, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ina233,
+			.port = I2C_BUS2,
+			.target_addr = ADDR_INA233,
+			.offset = OFFSET_INA233_CURR,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+};
+
+pldm_sensor_info plat_pldm_sensor_vr_table[] = {
+	{
+		{
+			// FF_VR_P0V8_ASIC_TEMP_C
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0054, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x0001, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x02, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000055, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000096, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_P0V8_ASIC,
+			.offset = PMBUS_READ_TEMPERATURE_1,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[1],
+		},
+	},
+	{
+		{
+			// FF_VR_PVDDQ_CD_TEMP_C
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0055, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x0002, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x02, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000055, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_PVDDQ_CD,
+			.offset = PMBUS_READ_TEMPERATURE_1,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[0],
+		},
+	},
+	{
+		{
+			// FF_VR_P0V85_ASIC_TEMP_C
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0052, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type; //Jeff_modify
+			0x0003, //uint16_t entity_instance_number; //Jeff_modify
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x02, //uint8_t base_unit;
+			1, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000055, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_P0V85_ASIC,
+			.offset = PMBUS_READ_TEMPERATURE_1,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[1],
+		},
+	},
+	{
+		{
+			// FF_VR_PVDDQ_AB_TEMP_C
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0053, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x0004, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x02, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000055, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_PVDDQ_AB,
+			.offset = PMBUS_READ_TEMPERATURE_1,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[0],
+		},
+	},
+	{
+		{
+			// FF_VR_P0V8_ASIC_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0063, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x0005, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-3, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000880, //uint32_t warning_high;
+			0x000002D0, //uint32_t warning_low;
+			0x00000384, //uint32_t critical_high;
+			0x000002C0, //uint32_t critical_low;
+			0x000003C0, //uint32_t fatal_high;
+			0x00000280, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_P0V8_ASIC,
+			.offset = PMBUS_READ_VOUT,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[1],
+		},
+	},
+	{
+		{
+			// FF_VR_PVDDQ_CD_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0064, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x0006, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-4, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000032, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000096, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_PVDDQ_CD,
+			.offset = PMBUS_READ_VOUT,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[0],
+		},
+	},
+	{
+		{
+			// FF_VR_P0V85_ASIC_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0061, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x0007, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-9, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x39387000, //uint32_t warning_high;
+			0x2AEA5400, //uint32_t warning_low;
+			0x3A855B46, //uint32_t critical_high;
+			0x29F63000, //uint32_t critical_low;
+			0x3E6C1D17, //uint32_t fatal_high;
+			0x2625A000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_P0V85_ASIC,
+			.offset = PMBUS_READ_VOUT,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[1],
+		},
+	},
+	{
+		{
+			// FF_VR_PVDDQ_AB_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0062, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type; //Jeff_modify
+			0x0008, //uint16_t entity_instance_number; //Jeff_modify
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-4, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x000000FF, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00003200, //uint32_t warning_high;
+			0x00002BA4, //uint32_t warning_low;
+			0x000032C8, //uint32_t critical_high;
+			0x00002AF8, //uint32_t critical_low;
+			0x00003660, //uint32_t fatal_high;
+			0x00002580, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_PVDDQ_AB,
+			.offset = PMBUS_READ_TEMPERATURE_1,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[0],
+		},
+	},
+	{
+		{
+			// FF_VR_P0V8_ASIC_CURR_A
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0069, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x0009, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x06, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000091, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000097, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x000000C8, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_P0V8_ASIC,
+			.offset = PMBUS_READ_IOUT,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[1],
+		},
+	},
+	{
+		{
+			// FF_VR_PVDDQ_CD_CURR_A
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x006A, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x000A, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x06, //uint8_t base_unit;
+			-1, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000078, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x0000007E, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x000000A0, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_PVDDQ_CD,
+			.offset = PMBUS_READ_IOUT,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[0],
+		},
+	},
+	{
+		{
+			// FF_VR_P0V85_ASIC_CURR_A
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0067, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x000B, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x06, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x000002EC, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000310, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x000004B0, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_P0V85_ASIC,
+			.offset = PMBUS_READ_IOUT,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[1],
+		},
+	},
+	{
+		{
+			// FF_VR_PVDDQ_AB_CURR_A
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0068, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x000C, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x06, //uint8_t base_unit;
+			-1, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000078, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x0000007E, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x000000A0, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_PVDDQ_AB,
+			.offset = PMBUS_READ_IOUT,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[0],
+		},
+	},
+	{
+		{
+			// FF_VR_P0V85_ASIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x006D, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x000D, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x07, //uint8_t base_unit;
+			-8, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x2ACD0800, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x2DE1622E, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x4AE82221, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_P0V85_ASIC,
+			.offset = PMBUS_READ_POUT,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[1],
+		},
+	},
+	{
+		{
+			// FF_VR_PVDDQ_AB_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x006E, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x000E, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x07, //uint8_t base_unit;
+			-3, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00003C00, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00003FFC, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00005700, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_PVDDQ_AB,
+			.offset = PMBUS_READ_POUT,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[0],
+		},
+	},
+	{
+		{
+			// FF_VR_P0V8_ASIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x006F, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x000F, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x07, //uint8_t base_unit;
+			-3, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x000004FC, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x0000054F, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000780, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_P0V8_ASIC,
+			.offset = PMBUS_READ_POUT,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[1],
+		},
+	},
+	{
+		{
+			// FF_VR_PVDDQ_CD_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0070, //uint16_t sensor_id;
+			0x007C, //uint16_t entity_type;
+			0x0010, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x07, //uint8_t base_unit;
+			-3, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00003C00, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00003FFC, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00005700, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_xdpe12284c,
+			.port = I2C_BUS9,
+			.target_addr = ADDR_VR_PVDDQ_CD,
+			.offset = PMBUS_READ_POUT,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_vr_read,
+			.pre_sensor_read_args = &vr_pre_read_args[0],
+		},
+	},
+};
+
+PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
+	{
+		// FF_1OU_BOARD_INLET_TEMP_C
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0050,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_1OU_BOARD_INLET_TEMP_C",
+	},
+	{
+		// FF_CXL_CNTR_TEMP_C
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0051,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_CXL_CNTR_TEMP_C",
+	},
+	{
+		// FF_VR_P0V85_ASIC_TEMP_C
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0052,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_P0V85_ASIC_TEMP_C",
+	},
+	{
+		// FF_VR_PVDDQ_AB_TEMP_C
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0053,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_PVDDQ_AB_TEMP_C",
+	},
+	{
+		// FF_VR_P0V8_ASIC_TEMP_C
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0054,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_P0V8_ASIC_TEMP_C",
+	},
+	{
+		// FF_VR_PVDDQ_CD_TEMP_C
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0055,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_PVDDQ_CD_TEMP_C",
+	},
+	{
+		// FF_INA233_P12V_STBY_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x005F,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_INA233_P12V_STBY_VOLT_V",
+	},
+	{
+		// FF_INA233_P3V3_STBY_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0060,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_INA233_P3V3_STBY_VOLT_V",
+	},
+	{
+		// FF_ADC_P1V2_STBY_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0057,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_ADC_P1V2_STBY_VOLT_V",
+	},
+	{
+		// FF_ADC_P1V2_ASIC_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0058,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_ADC_P1V2_ASIC_VOLT_V",
+	},
+	{
+		// FF_ADC_P1V8_ASIC_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0059,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_ADC_P1V8_ASIC_VOLT_V",
+	},
+	{
+		// FF_VR_P0V8_ASIC_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0063,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_P0V8_ASIC_VOLT_V",
+	},
+	{
+		// FF_VR_PVDDQ_CD_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0064,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_PVDDQ_CD_VOLT_V",
+	},
+	{
+		// FF_VR_P0V85_ASIC_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0061,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_P0V85_ASIC_VOLT_V",
+	},
+	{
+		// FF_VR_PVDDQ_AB_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0062,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_PVDDQ_AB_VOLT_V",
+	},
+	{
+		// FF_ADC_P0V75_ASIC_VOLT_V 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x005E,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_ADC_P0V75_ASIC_VOLT_V",
+	},
+	{
+		// FF_ADC_PVPP_AB_VOLT_V 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x005A,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_ADC_PVPP_AB_VOLT_V",
+	},
+	{
+		// FF_ADC_PVPP_CD_VOLT_V 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x005B,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_ADC_PVPP_CD_VOLT_V",
+	},
+	{
+		// FF_ADC_PVTT_AB_VOLT_V 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x005C,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_ADC_PVTT_AB_VOLT_V",
+	},
+	{
+		// FF_ADC_PVTT_CD_VOLT_V 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x005D,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_ADC_PVTT_CD_VOLT_V",
+	},
+	{
+		// FF_INA233_P12V_STBY_CURR_A 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0065,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_INA233_P12V_STBY_CURR_A",
+	},
+	{
+		// FF_INA233_P3V3_STBY_CURR_A 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0066,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_INA233_P3V3_STBY_CURR_A",
+	},
+	{
+		// FF_VR_P0V8_ASIC_CURR_A 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0069,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_P0V8_ASIC_CURR_A",
+	},
+	{
+		// FF_VR_PVDDQ_CD_CURR_A 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x006A,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_PVDDQ_CD_CURR_A",
+	},
+	{
+		// FF_VR_P0V85_ASIC_CURR_A 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0067,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_P0V85_ASIC_CURR_A",
+	},
+	{
+		// FF_VR_PVDDQ_AB_CURR_A 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0068,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_PVDDQ_AB_CURR_A",
+	},
+	{
+		// FF_INA233_P12V_STBY_PWR_W 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x006B,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_INA233_P12V_STBY_PWR_W",
+	},
+	{
+		// FF_INA233_P3V3_STBY_PWR_W 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x006C,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_INA233_P3V3_STBY_PWR_W",
+	},
+	{
+		// FF_VR_P0V85_ASIC_PWR_W 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x006D,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_P0V85_ASIC_PWR_W",
+	},
+	{
+		// FF_VR_PVDDQ_AB_PWR_W 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x006E,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_PVDDQ_AB_PWR_W",
+	},
+	{
+		// FF_VR_P0V8_ASIC_PWR_W 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x006F,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_P0V8_ASIC_PWR_W",
+	},
+	{
+		// FF_VR_PVDDQ_CD_PWR_W 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0070,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_VR_PVDDQ_CD_PWR_W",
+	},
+	{
+		// FF_ADC_P3V3_STBY_VOLT_V 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0004,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_ADC_P3V3_STBY_VOLT_V",
+	},
+	{
+		// FF_CH0_DIMM_A_TEMP_C 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0005,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_CH0_DIMM_A_TEMP_C",
+	},
+	{
+		// FF_CH0_DIMM_B_TEMP_C 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0006,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_CH0_DIMM_B_TEMP_C",
+	},
+	{
+		// FF_CH1_DIMM_C_TEMP_C 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0007,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_CH1_DIMM_C_TEMP_C",
+	},
+	{
+		// FF_CH1_DIMM_D_TEMP_C 
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0008,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"FF_CH1_DIMM_D_TEMP_C",
+	},
+};
+
+pldm_sensor_info plat_pldm_sensor_dimm_table[] = {
+	{
+		{
+			// FF_CH0_DIMM_A_TEMP_C
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0005, //uint16_t sensor_id;
+			0x0089, //uint16_t entity_type;
+			0x0001, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x02, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x000000FF, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x0000004B, //uint32_t warning_low;
+			0x0000005F, //uint32_t critical_high;
+			0x00000028, //uint32_t critical_low;
+			0x0000007D, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_i3c_dimm,
+			.port = I2C_BUS10,
+			.target_addr = ADDR_DIMM_A_CH0,
+			.offset = DIMM_SPD_TEMP,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_CH0_DIMM_B_TEMP_C
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0006, //uint16_t sensor_id;
+			0x0089, //uint16_t entity_type;
+			0x0002, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x02, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x000000FF, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x0000004B, //uint32_t warning_low;
+			0x0000005F, //uint32_t critical_high;
+			0x00000028, //uint32_t critical_low;
+			0x0000007D, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_i3c_dimm,
+			.port = I2C_BUS10,
+			.target_addr = ADDR_DIMM_B_CH0,
+			.offset = DIMM_SPD_TEMP,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_CH1_DIMM_C_TEMP_C
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0007, //uint16_t sensor_id;
+			0x0089, //uint16_t entity_type;
+			0x0001, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x02, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x000000FF, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x0000004B, //uint32_t warning_low;
+			0x0000005F, //uint32_t critical_high;
+			0x00000028, //uint32_t critical_low;
+			0x0000007D, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_i3c_dimm,
+			.port = I2C_BUS10,
+			.target_addr = ADDR_DIMM_A_CH1,
+			.offset = DIMM_SPD_TEMP,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// FF_CH1_DIMM_D_TEMP_C
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0008, //uint16_t sensor_id;
+			0x0089, //uint16_t entity_type;
+			0x0002, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x02, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x000000FF, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x0000004B, //uint32_t warning_low;
+			0x0000005F, //uint32_t critical_high;
+			0x00000028, //uint32_t critical_low;
+			0x0000007D, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_i3c_dimm,
+			.port = I2C_BUS10,
+			.target_addr = ADDR_DIMM_B_CH1,
+			.offset = DIMM_SPD_TEMP,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+};
+
+uint32_t plat_get_pdr_size(uint8_t pdr_type)
+{
+	int total_size = 0, i = 0;
+
+	switch (pdr_type)
+	{
+	case PLDM_NUMERIC_SENSOR_PDR:
+		for (i = 0; i < MAX_SENSOR_THREAD_ID; i++) {
+			total_size += plat_pldm_sensor_get_sensor_count(i);
+		}
+		break;
+	case PLDM_SENSOR_AUXILIARY_NAMES_PDR:
+		total_size = ARRAY_SIZE(plat_pdr_sensor_aux_names_table);
+		break;
+	default:
+		break;
+	}
+
+	return total_size;
+}
+
+pldm_sensor_thread *plat_pldm_sensor_load_thread()
+{
+	return pal_pldm_sensor_thread;
+}
+
+pldm_sensor_info *plat_pldm_sensor_load(int thread_id)
+{
+	switch (thread_id) {
+	case TMP_SENSOR_THREAD_ID:
+		return plat_pldm_sensor_tmp_table;
+	case ADC_SENSOR_THREAD_ID:
+		return plat_pldm_sensor_adc_table;
+	case INA233_SENSOR_THREAD_ID:
+		return plat_pldm_sensor_ina233_table;
+	case VR_SENSOR_THREAD_ID:
+		return plat_pldm_sensor_vr_table;
+	case DIMM_SENSOR_THREAD_ID:
+		return plat_pldm_sensor_dimm_table;
+	default:
+		LOG_ERR("Unknow pldm sensor thread id %d", thread_id);
+		return NULL;
+	}
+}
+
+int plat_pldm_sensor_get_sensor_count(int thread_id)
+{
+	int count = 0;
+
+	switch (thread_id) {
+	case TMP_SENSOR_THREAD_ID:
+		count = ARRAY_SIZE(plat_pldm_sensor_tmp_table);
+		break;
+	case ADC_SENSOR_THREAD_ID:
+		count = ARRAY_SIZE(plat_pldm_sensor_adc_table);
+		break;
+	case INA233_SENSOR_THREAD_ID:
+		count = ARRAY_SIZE(plat_pldm_sensor_ina233_table);
+		break;
+	case VR_SENSOR_THREAD_ID:
+		count = ARRAY_SIZE(plat_pldm_sensor_vr_table);
+		break;
+	case DIMM_SENSOR_THREAD_ID:
+		count = ARRAY_SIZE(plat_pldm_sensor_dimm_table);
+		break;
+	default:
+		count = -1;
+		LOG_ERR("Unknow pldm sensor thread id %d", thread_id);
+		break;
+	}
+
+	return count;
+}
+
+void plat_pldm_sensor_get_pdr_numeric_sesnor(int thread_id, int sensor_num,
+					     PDR_numeric_sensor *numeric_sensor_table)
+{
+	switch (thread_id) {
+	case TMP_SENSOR_THREAD_ID:
+		memcpy(numeric_sensor_table,
+		       &plat_pldm_sensor_tmp_table[sensor_num].pdr_numeric_sensor,
+		       sizeof(PDR_numeric_sensor));
+		break;
+	case ADC_SENSOR_THREAD_ID:
+		memcpy(numeric_sensor_table,
+		       &plat_pldm_sensor_adc_table[sensor_num].pdr_numeric_sensor,
+		       sizeof(PDR_numeric_sensor));
+		break;
+	case INA233_SENSOR_THREAD_ID:
+		memcpy(numeric_sensor_table,
+		       &plat_pldm_sensor_ina233_table[sensor_num].pdr_numeric_sensor,
+		       sizeof(PDR_numeric_sensor));
+		break;
+	case VR_SENSOR_THREAD_ID:
+		memcpy(numeric_sensor_table,
+		       &plat_pldm_sensor_vr_table[sensor_num].pdr_numeric_sensor,
+		       sizeof(PDR_numeric_sensor));
+		break;
+	case DIMM_SENSOR_THREAD_ID:
+		memcpy(numeric_sensor_table,
+		       &plat_pldm_sensor_dimm_table[sensor_num].pdr_numeric_sensor,
+		       sizeof(PDR_numeric_sensor));
+		break;
+	default:
+		LOG_ERR("Unknow pldm sensor thread id %d", thread_id);
+		break;
+	}
+}
+
+void plat_load_numeric_sensor_pdr_table(PDR_numeric_sensor *numeric_sensor_table)
+{
+	int thread_id = 0, sensor_num = 0;
+	int max_sensor_num = 0, current_sensor_size = 0;
+
+	for (thread_id = 0; thread_id < MAX_SENSOR_THREAD_ID; thread_id++) {
+		max_sensor_num = plat_pldm_sensor_get_sensor_count(thread_id);
+		for (sensor_num = 0; sensor_num < max_sensor_num; sensor_num++) {
+			plat_pldm_sensor_get_pdr_numeric_sesnor(thread_id, sensor_num,
+					       &numeric_sensor_table[current_sensor_size]);
+			current_sensor_size++;
+		}
+	}
+}
+
+void plat_load_aux_sensor_names_pdr_table(PDR_sensor_auxiliary_names *aux_sensor_name_table)
+{
+	memcpy(aux_sensor_name_table, &plat_pdr_sensor_aux_names_table, sizeof(plat_pdr_sensor_aux_names_table));
+}

--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_sensor.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_PLDM_SENSOR_H
+#define PLAT_PLDM_SENSOR_H
+
+#include "pdr.h"
+
+#define ADDR_TMP75_INLET (0x92 >> 1)
+#define ADDR_TMP461AIRUNR (0x98 >> 1)
+#define ADDR_INA233 (0x8A >> 1)
+#define ADDR_VR_PVDDQ_AB (0xEC >> 1)
+#define ADDR_VR_P0V85_ASIC (0xEC >> 1)
+#define ADDR_VR_P0V8_ASIC (0xE4 >> 1)
+#define ADDR_VR_PVDDQ_CD (0xE4 >> 1)
+#define ADDR_DIMM_A_CH0 0x50
+#define ADDR_DIMM_B_CH0 0x51
+#define ADDR_DIMM_A_CH1 0x52
+#define ADDR_DIMM_B_CH1 0x53
+
+#define OFFSET_TMP75_TEMP 0x00
+#define OFFSET_TMP461_TEMP 0x00
+#define OFFSET_INA233_VOL 0x8B
+#define OFFSET_INA233_CURR 0x8C
+#define OFFSET_INA233_PWR 0x96
+
+#define UPDATE_INTERVAL_1S 1
+
+enum SENSOR_THREAD_LIST {
+	TMP_SENSOR_THREAD_ID = 0,
+	ADC_SENSOR_THREAD_ID,
+	INA233_SENSOR_THREAD_ID,
+	VR_SENSOR_THREAD_ID,
+	DIMM_SENSOR_THREAD_ID,
+	MAX_SENSOR_THREAD_ID,
+};
+
+int plat_pldm_sensor_get_sensor_count(int thread_id);
+void plat_pldm_sensor_get_pdr_numeric_sesnor(int thread_id, int sensor_num,
+					     PDR_numeric_sensor *numeric_sensor_table);
+
+#endif


### PR DESCRIPTION
# Description
- Add numeric sensor PDR table and auxiliary sensor name PDR table for following sensors in Yv4 FF.
1. temperature sensor
2. VR sensors
3. ADC sensors
4. INA233 sensors
5. DIMM sensors

# Motivation
- Add numeric sensor PDR table and auxiliary sensor name PDR table for sensor monitor.

# Test Plan
- Build code: Pass
- Check PLDM sensor monitor thread: Pass
- Check the PLDM sensors' name: Pass

Log
1. Check PLDM sensor monitor thread.
    uart:~$ kernel stacks
    0x605f8 process_postcode_thread (real size 2048):       unused 1452     usage 596 / 2048 (29 %)
    0x4df28 mctptx_02_01_0a (real size 2048):       unused 1716     usage 332 / 2048 (16 %)
    0x4de60 mctprx_02_01_0a (real size 4096):       unused 3244     usage 852 / 4096 (20 %)
    0x4c1a0 mctptx_02_01_09 (real size 2048):       unused 1244     usage 804 / 2048 (39 %)
    0x4c0d8 mctprx_02_01_09 (real size 4096):       unused 3148     usage 948 / 4096 (23 %)
    0x4a520 mctptx_01_02_40 (real size 2048):       unused 1140     usage 908 / 2048 (44 %)
    0x4a458 mctprx_01_02_40 (real size 4096):       unused 2140     usage 1956 / 4096 (47 %)
    0x65380 USB_handler (real size 2048):   unused 1756     usage 292 / 2048 (14 %)
    0x61c78 IPMI_thread (real size 4096):   unused 3228     usage 868 / 4096 (21 %)
    0x641f0 CPU_TEMP_SENSOR_THREAD (real size 3056):        unused 2308     usage 748 / 3056 (24 %)
    0x64128 MB_TEMP_SENSOR_THREAD (real size 3056): unused 2316     usage 740 / 3056 (24 %)
    0x64060 VR_PLDM_SENSOR_THREAD (real size 3056): unused 2340     usage 716 / 3056 (23 %)
    0x63f98 ADC_PLDM_SENSOR_THREAD (real size 3056):        unused 2644     usage 412 / 3056 (13 %)
    0x60920 WDT_thread (real size 256):     unused 52       usage 204 / 256 (79 %)
    0x62e08 pldm_wait_resp_to (real size 1024):     unused 820      usage 204 / 1024 (19 %)
    0x62d40 monitor_tid (real size 1024):   unused 820      usage 204 / 1024 (19 %)
    0x60ae8 monitor_cci_msg (real size 1024):       unused 820      usage 204 / 1024 (19 %)
    0x65548 shell_uart (real size 2048):    unused 1044     usage 1004 / 2048 (49 %)
    0x606c0 gpio_workq (real size 3072):    unused 2788     usage 284 / 3072 (9 %)
    0x42798 ADC0       (real size 512):     unused 244      usage 268 / 512 (52 %)
    0x42b70 ADC1       (real size 512):     unused 244      usage 268 / 512 (52 %)
    0x6dad0 sysworkq   (real size 2048):    unused 1484     usage 564 / 2048 (27 %)
    0x656f8 usbdworkq  (real size 1024):    unused 556      usage 468 / 1024 (45 %)
    0x65610 usbworkq   (real size 1024):    unused 764      usage 260 / 1024 (25 %)
    0x65480 logging    (real size 768):     unused 244      usage 524 / 768 (68 %)
    0x65930 idle 00    (real size 512):     unused 460      usage 52 / 512 (10 %)
    0x7f4e0 IRQ 00     (real size 2048):    unused 1544     usage 504 / 2048 (24 %)

2. Check the PLDM sensors' name are correct.
    root@bmc:~# busctl tree xyz.openbmc_project.PLDM
    `- /xyz
      `- /xyz/openbmc_project
        |- /xyz/openbmc_project/inventory
        | `- /xyz/openbmc_project/inventory/Item
        |   `- /xyz/openbmc_project/inventory/Item/Board
        |     |- /xyz/openbmc_project/inventory/Item/Board/PLDM_Device_1
        |     `- /xyz/openbmc_project/inventory/Item/Board/PLDM_Device_2
        |- /xyz/openbmc_project/pldm
        `- /xyz/openbmc_project/sensors
          |- /xyz/openbmc_project/sensors/current
          | |- /xyz/openbmc_project/sensors/current/FF_INA233_P12V_STBY_CURR_A_101_2
          | |- /xyz/openbmc_project/sensors/current/FF_INA233_P3V3_STBY_CURR_A_102_2
          | |- /xyz/openbmc_project/sensors/current/FF_VR_P0V85_ASIC_CURR_A_103_2
          | |- /xyz/openbmc_project/sensors/current/FF_VR_P0V8_ASIC_CURR_A_105_2
          | |- /xyz/openbmc_project/sensors/current/FF_VR_PVDDQ_AB_CURR_A_104_2
          | |- /xyz/openbmc_project/sensors/current/FF_VR_PVDDQ_CD_CURR_A_106_2
          | |- /xyz/openbmc_project/sensors/current/MB_VR_CPU0_CURR_A_36_1
          | |- /xyz/openbmc_project/sensors/current/MB_VR_CPU1_CURR_A_38_1
          | |- /xyz/openbmc_project/sensors/current/MB_VR_PVDD11_CURR_A_40_1
          | |- /xyz/openbmc_project/sensors/current/MB_VR_PVDDIO_CURR_A_39_1
          | `- /xyz/openbmc_project/sensors/current/MB_VR_SOC_CURR_A_37_1
          |- /xyz/openbmc_project/sensors/power
          | |- /xyz/openbmc_project/sensors/power/FF_INA233_P12V_STBY_PWR_W_107_2
          | |- /xyz/openbmc_project/sensors/power/FF_INA233_P3V3_STBY_PWR_W_108_2
          | |- /xyz/openbmc_project/sensors/power/FF_VR_P0V85_ASIC_PWR_W_109_2
          | |- /xyz/openbmc_project/sensors/power/FF_VR_P0V8_ASIC_PWR_W_111_2
          | |- /xyz/openbmc_project/sensors/power/FF_VR_PVDDQ_AB_PWR_W_110_2
          | |- /xyz/openbmc_project/sensors/power/FF_VR_PVDDQ_CD_PWR_W_112_2
          | |- /xyz/openbmc_project/sensors/power/MB_VR_CPU0_PWR_W_41_1
          | |- /xyz/openbmc_project/sensors/power/MB_VR_CPU1_PWR_W_43_1
          | |- /xyz/openbmc_project/sensors/power/MB_VR_PVDD11_PWR_W_45_1
          | |- /xyz/openbmc_project/sensors/power/MB_VR_PVDDIO_PWR_W_44_1
          | `- /xyz/openbmc_project/sensors/power/MB_VR_SOC_PWR_W_42_1
          |- /xyz/openbmc_project/sensors/temperature
          | |- /xyz/openbmc_project/sensors/temperature/FF_1OU_BOARD_INLET_TEMP_C_80_2
          | |- /xyz/openbmc_project/sensors/temperature/FF_CH0_DIMM_A_TEMP_C_5_2
          | |- /xyz/openbmc_project/sensors/temperature/FF_CH0_DIMM_B_TEMP_C_6_2
          | |- /xyz/openbmc_project/sensors/temperature/FF_CH1_DIMM_C_TEMP_C_7_2
          | |- /xyz/openbmc_project/sensors/temperature/FF_CH1_DIMM_D_TEMP_C_8_2
          | |- /xyz/openbmc_project/sensors/temperature/FF_CXL_CNTR_TEMP_C_81_2
          | |- /xyz/openbmc_project/sensors/temperature/FF_VR_P0V85_ASIC_TEMP_C_82_2
          | |- /xyz/openbmc_project/sensors/temperature/FF_VR_P0V8_ASIC_TEMP_C_84_2
          | |- /xyz/openbmc_project/sensors/temperature/FF_VR_PVDDQ_AB_TEMP_C_83_2
          | |- /xyz/openbmc_project/sensors/temperature/FF_VR_PVDDQ_CD_TEMP_C_85_2
          | |- /xyz/openbmc_project/sensors/temperature/MB_FIO_TEMP_C_3_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_INLET_TEMP_C_1_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_OUTLET_TEMP_C_2_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_VR_CPU0_TEMP_C_19_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_VR_CPU1_TEMP_C_21_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_VR_PVDD11_TEMP_C_23_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_VR_PVDDIO_TEMP_C_22_1
          | |- /xyz/openbmc_project/sensors/temperature/MB_VR_SOC_TEMP_C_20_1
          | `- /xyz/openbmc_project/sensors/temperature/MB_CPU_TEMP_C_4_1
          `- /xyz/openbmc_project/sensors/voltage
            |- /xyz/openbmc_project/sensors/voltage/FF_ADC_P0V75_ASIC_VOLT_V_94_2
            |- /xyz/openbmc_project/sensors/voltage/FF_ADC_P1V2_ASIC_VOLT_V_88_2
            |- /xyz/openbmc_project/sensors/voltage/FF_ADC_P1V2_STBY_VOLT_V_87_2
            |- /xyz/openbmc_project/sensors/voltage/FF_ADC_P1V8_ASIC_VOLT_V_89_2
            |- /xyz/openbmc_project/sensors/voltage/FF_ADC_P3V3_STBY_VOLT_V_4_2
            |- /xyz/openbmc_project/sensors/voltage/FF_ADC_PVPP_AB_VOLT_V_90_2
            |- /xyz/openbmc_project/sensors/voltage/FF_ADC_PVPP_CD_VOLT_V_91_2
            |- /xyz/openbmc_project/sensors/voltage/FF_ADC_PVTT_AB_VOLT_V_92_2
            |- /xyz/openbmc_project/sensors/voltage/FF_ADC_PVTT_CD_VOLT_V_93_2
            |- /xyz/openbmc_project/sensors/voltage/FF_INA233_P12V_STBY_VOLT_V_95_2
            |- /xyz/openbmc_project/sensors/voltage/FF_INA233_P3V3_STBY_VOLT_V_96_2
            |- /xyz/openbmc_project/sensors/voltage/FF_VR_P0V85_ASIC_VOLT_V_97_2
            |- /xyz/openbmc_project/sensors/voltage/FF_VR_P0V8_ASIC_VOLT_V_99_2
            |- /xyz/openbmc_project/sensors/voltage/FF_VR_PVDDQ_AB_VOLT_V_98_2
            |- /xyz/openbmc_project/sensors/voltage/FF_VR_PVDDQ_CD_VOLT_V_100_2
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P12V_DIMM_0_VOLT_V_30_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P12V_DIMM_1_VOLT_V_31_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P12V_STBY_VOLT_V_24_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P1V2_STBY_VOLT_V_32_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P1V8_STBY_VOLT_V_33_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P3V3_STBY_VOLT_V_26_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P3V_BAT_VOLT_V_27_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_P5V_STBY_VOLT_V_29_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_PVDD18_S5_VOLT_V_25_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_PVDD33_S5_VOLT_V_28_1
            |- /xyz/openbmc_project/sensors/voltage/MB_ADC_SIDECAR_DETECT_VOLT_V_35_1
            `- /xyz/openbmc_project/sensors/voltage/MB_ADC_SLOT_DETECT_VOLT_V_34_1

3. Check sensor reading

    root@bmc:~# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/FF_ADC_P1V2_ASIC_VOLT_V_88_2
    NAME                                                  TYPE      SIGNATURE RESULT/VALUE                             FLAGS
    org.freedesktop.DBus.Introspectable                   interface -         -                                        -
    .Introspect                                           method    -         s                                        -
    org.freedesktop.DBus.Peer                             interface -         -                                        -
    .GetMachineId                                         method    -         s                                        -
    .Ping                                                 method    -         -                                        -
    org.freedesktop.DBus.Properties                       interface -         -                                        -
    .Get                                                  method    ss        v                                        -
    .GetAll                                               method    s         a{sv}                                    -
    .Set                                                  method    ssv       -                                        -
    .PropertiesChanged                                    signal    sa{sv}as  -                                        -
    xyz.openbmc_project.Association.Definitions           interface -         -                                        -
    .Associations                                         property  a(sss)    1 "chassis" "all_sensors" "/xyz/openb... emits-change writable
    xyz.openbmc_project.Sensor.Threshold.Critical         interface -         -                                        -
    .CriticalAlarmHigh                                    property  b         false                                    emits-change writable
    .CriticalAlarmLow                                     property  b         false                                    emits-change writable
    .CriticalHigh                                         property  d         1.28                                     emits-change writable
    .CriticalLow                                          property  d         1.1                                      emits-change writable
    .CriticalHighAlarmAsserted                            signal    d         -                                        -
    .CriticalHighAlarmDeasserted                          signal    d         -                                        -
    .CriticalLowAlarmAsserted                             signal    d         -                                        -
    .CriticalLowAlarmDeasserted                           signal    d         -                                        -
    xyz.openbmc_project.Sensor.Threshold.Warning          interface -         -                                        -
    .WarningAlarmHigh                                     property  b         false                                    emits-change writable
    .WarningAlarmLow                                      property  b         false                                    emits-change writable
    .WarningHigh                                          property  d         1.3                                      emits-change writable
    .WarningLow                                           property  d         1.1172                                   emits-change writable
    .WarningHighAlarmAsserted                             signal    d         -                                        -
    .WarningHighAlarmDeasserted                           signal    d         -                                        -
    .WarningLowAlarmAsserted                              signal    d         -                                        -
    .WarningLowAlarmDeasserted                            signal    d         -                                        -
    xyz.openbmc_project.Sensor.Value                      interface -         -                                        -
    .MaxValue                                             property  d         0                                        emits-change writable
    .MinValue                                             property  d         0                                        emits-change writable
    .Unit                                                 property  s         "xyz.openbmc_project.Sensor.Value.Uni... emits-change writable
    .Value                                                property  d         1.2009                                   emits-change writable
    xyz.openbmc_project.State.Decorator.Availability      interface -         -                                        -
    .Available                                            property  b         true                                     emits-change writable
    xyz.openbmc_project.State.Decorator.OperationalStatus interface -         -                                        -
    .Functional                                           property  b         true                                     emits-change writable