### PR TITLE
yv4-wf: add mctp routing table

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_i2c_target.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_i2c_target.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  NAME: I2C TARGET INIT
+  FILE: plat_i2c_target.c
+  DESCRIPTION: Provide i2c target EN/CFG table "I2C_TARGET_EN_TABLE[]/I2C_TARGET_CFG_TABLE[]" for init target config.
+  AUTHOR: MouchenHung
+  DATE/VERSION: 2021.11.26 - v1.1
+  Note: 
+    (1) "plat_i2c_target.h" is included by "hal_i2c_target.h"
+*/
+
+#include <zephyr.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "plat_i2c_target.h"
+
+/* I2C target init-enable table */
+const bool I2C_TARGET_ENABLE_TABLE[MAX_TARGET_NUM] = {
+	TARGET_DISABLE, TARGET_ENABLE,	TARGET_DISABLE, TARGET_ENABLE,
+	TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE,
+	TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE,
+	TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE,
+};
+
+/* I2C target init-config table */
+const struct _i2c_target_config I2C_TARGET_CONFIG_TABLE[MAX_TARGET_NUM] = {
+	{ 0xFF, 0xA }, { 0x40, 0xA }, { 0xFF, 0xA }, { 0x40, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA },
+	{ 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA },
+	{ 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA },
+};

--- a/meta-facebook/yv4-wf/src/platform/plat_i2c_target.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_i2c_target.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_I2C_SLAVE_H
+#define PLAT_I2C_SLAVE_H
+
+#include <drivers/i2c.h>
+#include "hal_i2c_target.h"
+
+#define TARGET_ENABLE 1
+#define TARGET_DISABLE 0
+
+#endif

--- a/meta-facebook/yv4-wf/src/platform/plat_init.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_init.c
@@ -22,8 +22,13 @@
 #include "plat_power_seq.h"
 #include "plat_pldm_monitor.h"
 #include "plat_isr.h"
+#include "plat_mctp.h"
+#include "plat_i2c_target.h"
 
 #define DEF_PROJ_GPIO_PRIORITY 78
+
+DEVICE_DEFINE(PRE_DEF_PROJ_GPIO, "PRE_DEF_PROJ_GPIO_NAME", &gpio_init, NULL, NULL, NULL,
+	      POST_KERNEL, DEF_PROJ_GPIO_PRIORITY, NULL);
 
 void pal_set_sys_status()
 {
@@ -33,12 +38,20 @@ void pal_set_sys_status()
 	set_ioe4_pin();
 }
 
+void pal_pre_init()
+{
+	/* init i2c target */
+	for (int index = 0; index < MAX_TARGET_NUM; index++) {
+		if (I2C_TARGET_ENABLE_TABLE[index])
+			i2c_target_control(
+				index, (struct _i2c_target_config *)&I2C_TARGET_CONFIG_TABLE[index],
+				1);
+	}
+}
+
 void pal_post_init()
 {
 	pldm_load_state_effecter_table(PLAT_PLDM_MAX_STATE_EFFECTER_IDX);
 	pldm_assign_gpio_effecter_id(PLAT_EFFECTER_ID_GPIO_HIGH_BYTE);
+	plat_mctp_init();
 }
-
-
-DEVICE_DEFINE(PRE_DEF_PROJ_GPIO, "PRE_DEF_PROJ_GPIO_NAME", &gpio_init, NULL, NULL, NULL,
-	      POST_KERNEL, DEF_PROJ_GPIO_PRIORITY, NULL);

--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.c
@@ -29,30 +29,125 @@ LOG_MODULE_REGISTER(plat_mctp);
 #define MCTP_IC_MASK 0x80
 
 /* i2c dev bus*/
-#define I2C_BUS_BMC 0x01
+#define I2C_BUS_CXL1 0x01
+#define I2C_BUS_CXL2 0x03
+
+// i2c dev address
+#define I2C_ADDR_BIC 0x40
+#define I2C_ADDR_CXL1 0x64
+#define I2C_ADDR_CXL2 0x64
+
+// i3c dev bus
+#define I3C_BUS_SD_BIC 0
+
+// i3c dev address
+#define I3C_ADDR_SD_BIC 0x8
+
+// mctp endpoint
+#define MCTP_EID_BMC 0x08
+
+// dynamic allocate eid
+#define MCTP_EID_SD_BIC 0
+#define MCTP_EID_CXL1 0
+#define MCTP_EID_CXL2 0
+
+K_TIMER_DEFINE(send_cmd_timer, send_cmd_to_dev, NULL);
+K_WORK_DEFINE(send_cmd_work, send_cmd_to_dev_handler);
 
 static mctp_port plat_mctp_port[] = {
-	/* TODO: Set smbus port table*/
-	{ 0 },
+	{ .conf.smbus_conf.addr = I3C_ADDR_SD_BIC,
+	  .conf.i3c_conf.bus = I3C_BUS_SD_BIC,
+	  .medium_type = MCTP_MEDIUM_TYPE_TARGET_I3C },
+	{ .conf.smbus_conf.addr = I2C_ADDR_BIC,
+	  .conf.smbus_conf.bus = I2C_BUS_CXL1,
+	  .medium_type = MCTP_MEDIUM_TYPE_SMBUS },
+	{ .conf.smbus_conf.addr = I2C_ADDR_BIC,
+	  .conf.smbus_conf.bus = I2C_BUS_CXL2,
+	  .medium_type = MCTP_MEDIUM_TYPE_SMBUS },
 };
 
-mctp_route_entry mctp_route_tbl[] = {
-	/* TODO: Set mtcp route table*/
-	{ 0 },
+mctp_route_entry plat_mctp_route_tbl[] = {
+	{ MCTP_EID_BMC, I3C_BUS_SD_BIC, I3C_ADDR_SD_BIC, .set_endpoint = false },
+	{ MCTP_EID_SD_BIC, I3C_BUS_SD_BIC, I3C_ADDR_SD_BIC, .set_endpoint = false },
+	{ MCTP_EID_CXL1, I2C_BUS_CXL1, I2C_ADDR_CXL1, .set_endpoint = true },
+	{ MCTP_EID_CXL2, I2C_BUS_CXL2, I2C_ADDR_CXL2, .set_endpoint = true },
 };
 
-static mctp *find_mctp_by_smbus(uint8_t bus)
+static mctp *find_mctp_by_bus(uint8_t bus)
 {
 	uint8_t i;
 	for (i = 0; i < ARRAY_SIZE(plat_mctp_port); i++) {
 		mctp_port *p = plat_mctp_port + i;
 
-		if (bus == p->conf.smbus_conf.bus) {
-			return p->mctp_inst;
+		if (p->medium_type == MCTP_MEDIUM_TYPE_SMBUS) {
+			if (bus == p->conf.smbus_conf.bus) {
+				return p->mctp_inst;
+			}
+		} else if (p->medium_type == MCTP_MEDIUM_TYPE_TARGET_I3C) {
+			if (bus == p->conf.i3c_conf.bus) {
+				return p->mctp_inst;
+			}
+		} else {
+			LOG_ERR("Unknown medium type");
+			return NULL;
 		}
 	}
 
 	return NULL;
+}
+
+static void set_endpoint_resp_handler(void *args, uint8_t *buf, uint16_t len)
+{
+	ARG_UNUSED(args);
+	CHECK_NULL_ARG(buf);
+
+	LOG_HEXDUMP_DBG(buf, len, __func__);
+}
+
+static void set_endpoint_resp_timeout(void *args)
+{
+	CHECK_NULL_ARG(args);
+
+	mctp_route_entry *p = (mctp_route_entry *)args;
+	LOG_DBG("Endpoint 0x%x set endpoint failed on bus %d", p->endpoint, p->bus);
+}
+
+static void set_dev_endpoint(void)
+{
+	// We only need to set CXL EID.
+	for (uint8_t i = 0; i < ARRAY_SIZE(plat_mctp_route_tbl); i++) {
+		mctp_route_entry *p = plat_mctp_route_tbl + i;
+		if (!p->set_endpoint)
+			continue;
+
+		for (uint8_t j = 0; j < ARRAY_SIZE(plat_mctp_port); j++) {
+			if (p->bus != plat_mctp_port[j].conf.smbus_conf.bus)
+				continue;
+
+			struct _set_eid_req req = { 0 };
+			req.op = SET_EID_REQ_OP_SET_EID;
+			req.eid = p->endpoint;
+
+			mctp_ctrl_msg msg;
+			memset(&msg, 0, sizeof(msg));
+			msg.ext_params.type = MCTP_MEDIUM_TYPE_SMBUS;
+			msg.ext_params.smbus_ext_params.addr = p->addr;
+
+			msg.hdr.cmd = MCTP_CTRL_CMD_SET_ENDPOINT_ID;
+			msg.hdr.rq = 1;
+
+			msg.cmd_data = (uint8_t *)&req;
+			msg.cmd_data_len = sizeof(req);
+
+			msg.recv_resp_cb_fn = set_endpoint_resp_handler;
+			msg.timeout_cb_fn = set_endpoint_resp_timeout;
+			msg.timeout_cb_fn_args = p;
+
+			uint8_t rc = mctp_ctrl_send_msg(find_mctp_by_bus(p->bus), &msg);
+			if (rc)
+				LOG_ERR("Fail to set endpoint %d", p->endpoint);
+		}
+	}
 }
 
 static uint8_t mctp_msg_recv(void *mctp_p, uint8_t *buf, uint32_t len, mctp_ext_params ext_params)
@@ -88,18 +183,34 @@ static uint8_t get_mctp_route_info(uint8_t dest_endpoint, void **mctp_inst,
 	uint8_t rc = MCTP_ERROR;
 	uint32_t i;
 
-	for (i = 0; i < ARRAY_SIZE(mctp_route_tbl); i++) {
-		mctp_route_entry *p = mctp_route_tbl + i;
+	for (i = 0; i < ARRAY_SIZE(plat_mctp_route_tbl); i++) {
+		mctp_route_entry *p = plat_mctp_route_tbl + i;
 		if (p->endpoint == dest_endpoint) {
-			*mctp_inst = find_mctp_by_smbus(p->bus);
-			ext_params->type = MCTP_MEDIUM_TYPE_SMBUS;
-			ext_params->smbus_ext_params.addr = p->addr;
+			*mctp_inst = find_mctp_by_bus(p->bus);
+			if (p->bus != I3C_BUS_SD_BIC) {
+				ext_params->type = MCTP_MEDIUM_TYPE_SMBUS;
+				ext_params->smbus_ext_params.addr = p->addr;
+			} else {
+				ext_params->type = MCTP_MEDIUM_TYPE_TARGET_I3C;
+				ext_params->i3c_ext_params.addr = p->addr;
+			}
 			rc = MCTP_SUCCESS;
 			break;
 		}
 	}
 
 	return rc;
+}
+
+void send_cmd_to_dev_handler(struct k_work *work)
+{
+	/* init the device endpoint */
+	set_dev_endpoint();
+}
+
+void send_cmd_to_dev(struct k_timer *timer)
+{
+	k_work_submit(&send_cmd_work);
 }
 
 int pal_get_medium_type(uint8_t interface)
@@ -119,28 +230,13 @@ int pal_get_medium_type(uint8_t interface)
 	return medium_type;
 }
 
-int pal_get_target(uint8_t interface)
-{
-	int target = -1;
-
-	switch (interface) {
-	case BMC_IPMB:
-	case MCTP:
-	case PLDM:
-		target = I2C_BUS_BMC;
-		break;
-	default:
-		break;
-	}
-
-	return target;
-}
-
 mctp *pal_get_mctp(uint8_t mctp_medium_type, uint8_t bus)
 {
 	switch (mctp_medium_type) {
 	case MCTP_MEDIUM_TYPE_SMBUS:
-		return find_mctp_by_smbus(bus);
+	case MCTP_MEDIUM_TYPE_TARGET_I3C:
+	case MCTP_MEDIUM_TYPE_CONTROLLER_I3C:
+		return find_mctp_by_bus(bus);
 	default:
 		return NULL;
 	}
@@ -160,8 +256,7 @@ void plat_mctp_init(void)
 			continue;
 		}
 
-		uint8_t rc =
-			mctp_set_medium_configure(p->mctp_inst, MCTP_MEDIUM_TYPE_SMBUS, p->conf);
+		uint8_t rc = mctp_set_medium_configure(p->mctp_inst, p->medium_type, p->conf);
 		if (rc != MCTP_SUCCESS) {
 			LOG_ERR("mctp set medium configure failed");
 		}
@@ -182,4 +277,24 @@ uint8_t plat_get_mctp_port_count()
 mctp_port *plat_get_mctp_port(uint8_t index)
 {
 	return plat_mctp_port + index;
+}
+
+void plat_update_mctp_routing_table(uint8_t eid)
+{
+	// update sd bic eid
+	mctp_route_entry *p = plat_mctp_route_tbl + 1;
+	p->endpoint = eid - 2;
+
+	// update cxl1 eid
+	p = plat_mctp_route_tbl + 2;
+	p->endpoint = eid + 2;
+
+	// update cxl2 eid
+	p = plat_mctp_route_tbl + 3;
+	p->endpoint = eid + 3;
+
+	// send set eid to cxl
+	k_timer_start(&send_cmd_timer, K_MSEC(30000), K_NO_WAIT);
+
+	return;
 }

--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.h
@@ -8,5 +8,7 @@
 void plat_mctp_init(void);
 uint8_t plat_get_mctp_port_count();
 mctp_port *plat_get_mctp_port(uint8_t index);
+void send_cmd_to_dev_handler(struct k_work *work);
+void send_cmd_to_dev(struct k_timer *timer);
 
 #endif /* _PLAT_MCTP_h */


### PR DESCRIPTION
# Description:
Add mctp routing table for yv4-wf.

# Motivation:
We need to support mctp over i2c/i3c for yv4.

# Test Plan:
- Build code: Pass
- Test on yv4 platform: Pass