### PR TITLE
mctp: add define for mctp over i3c communication

### DIFF
--- a/common/service/mctp/mctp.c
+++ b/common/service/mctp/mctp.c
@@ -23,6 +23,7 @@
 #include <sys/printk.h>
 #include <zephyr.h>
 #include "libutil.h"
+#include "plat_def.h"
 
 LOG_MODULE_REGISTER(mctp);
 
@@ -91,12 +92,14 @@ static uint8_t mctp_medium_init(mctp *mctp_inst, mctp_medium_conf medium_conf)
 	case MCTP_MEDIUM_TYPE_SMBUS:
 		ret = mctp_smbus_init(mctp_inst, medium_conf);
 		break;
+#ifdef ENABLE_MCTP_I3C
 	case MCTP_MEDIUM_TYPE_TARGET_I3C:
 		ret = mctp_i3c_target_init(mctp_inst, medium_conf);
 		break;
 	case MCTP_MEDIUM_TYPE_CONTROLLER_I3C:
 		ret = mctp_i3c_controller_init(mctp_inst, medium_conf);
 		break;
+#endif
 	default:
 		return MCTP_ERROR;
 	}
@@ -112,10 +115,12 @@ static uint8_t mctp_medium_deinit(mctp *mctp_inst)
 	case MCTP_MEDIUM_TYPE_SMBUS:
 		mctp_smbus_deinit(mctp_inst);
 		break;
+#ifdef ENABLE_MCTP_I3C
 	case MCTP_MEDIUM_TYPE_TARGET_I3C:
 	case MCTP_MEDIUM_TYPE_CONTROLLER_I3C:
 		mctp_i3c_deinit(mctp_inst);
 		break;
+#endif
 	default:
 		return MCTP_ERROR;
 	}

--- a/common/service/mctp/mctp_i3c.c
+++ b/common/service/mctp/mctp_i3c.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "plat_def.h"
+#ifdef ENABLE_MCTP_I3C
 #include "mctp.h"
 
 #include <stdlib.h>
@@ -222,3 +224,5 @@ uint8_t mctp_i3c_deinit(mctp *mctp_instance)
 	memset(&mctp_instance->medium_conf, 0, sizeof(mctp_instance->medium_conf));
 	return MCTP_SUCCESS;
 }
+
+#endif // ENABLE_MCTP_I3C

--- a/meta-facebook/yv35-cl/src/platform/plat_def.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_def.h
@@ -21,6 +21,7 @@
 #define ENABLE_ISL69260
 #define ENABLE_FIX_SENSOR
 #define ENABLE_PLDM
+#define ENABLE_MCTP_I3C
 
 #define BMC_USB_PORT "CDC_ACM_0"
 

--- a/meta-facebook/yv4-ff/src/platform/plat_def.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_def.h
@@ -17,6 +17,8 @@
 #ifndef PLAT_DEF_H
 #define PLAT_DEF_H
 
+#define ENABLE_MCTP_I3C
+
 #define BMC_USB_PORT "CDC_ACM_0"
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_def.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_def.h
@@ -18,6 +18,7 @@
 #define PLAT_DEF_H
 
 #define ENABLE_PLDM
+#define ENABLE_MCTP_I3C
 
 #define HOST_KCS_PORT kcs3
 #define BMC_USB_PORT "CDC_ACM_0"

--- a/meta-facebook/yv4-wf/src/platform/plat_def.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_def.h
@@ -17,6 +17,8 @@
 #ifndef PLAT_DEF_H
 #define PLAT_DEF_H
 
+#define ENABLE_MCTP_I3C
+
 #define BMC_USB_PORT "CDC_ACM_0"
 
 #endif


### PR DESCRIPTION
# Description:
Add define for mctp over i3c communication.

# Motivation:
It should fix build fail for the platform not utilizing mctp over i3c communication.

# Test Plan:
- Build code: Pass