### PR TITLE
Common: Fix get post code command

### DIFF
--- a/common/dev/snoop.c
+++ b/common/dev/snoop.c
@@ -32,7 +32,7 @@
 LOG_MODULE_REGISTER(dev_snoop);
 
 const struct device *snoop_dev;
-uint8_t *snoop_data;
+uint8_t snoop_data;
 static uint8_t *snoop_read_buffer;
 int snoop_read_num = 0;
 int send_postcode_start_position = 0;
@@ -112,11 +112,11 @@ void snoop_read()
 	}
 
 	while (1) {
-		rc = snoop_aspeed_read(snoop_dev, 0, snoop_data, true);
+		rc = snoop_aspeed_read(snoop_dev, 0, &snoop_data, true);
 		if (rc == 0) {
 			proc_postcode_ok = true;
 			if (!k_mutex_lock(&snoop_mutex, K_MSEC(1000))) {
-				snoop_read_buffer[snoop_read_num % SNOOP_MAX_LEN] = *snoop_data;
+				snoop_read_buffer[snoop_read_num % SNOOP_MAX_LEN] = snoop_data;
 				snoop_read_num++;
 				if (k_mutex_unlock(&snoop_mutex)) {
 					LOG_ERR("snoop read unlock fail");

--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -707,9 +707,15 @@ __weak void OEM_1S_GET_POST_CODE(ipmi_msg *msg)
 		uint8_t offset = 0;
 		if (snoop_read_num > POST_CODE_BUF_SIZE) {
 			postcode_num = POST_CODE_BUF_SIZE;
-			offset = snoop_read_num % POST_CODE_BUF_SIZE;
+			if (snoop_read_num > SNOOP_MAX_LEN) {
+				offset = (snoop_read_num % SNOOP_MAX_LEN) + SNOOP_MAX_LEN -
+					 POST_CODE_BUF_SIZE;
+			} else {
+				offset = (snoop_read_num % SNOOP_MAX_LEN) + snoop_read_num -
+					 POST_CODE_BUF_SIZE;
+			}
 		}
-		copy_snoop_read_buffer(offset, postcode_num, msg->data, COPY_ALL_POSTCODE);
+		copy_snoop_read_buffer(offset, postcode_num, msg->data, COPY_SPECIFIC_POSTCODE);
 	}
 
 	for (int i = 0; i < (postcode_num / 2); ++i) {


### PR DESCRIPTION
Summary:
- The first 4 bytes post code are not the lastest(newest)

Test Plan:
- Build code: Pass

Old log:
root@bmc-oob:~# bic-util slot1 --get_post_code
util_get_postcode: returns 240 bytes
7E B5 BF B0 E3 E3 E3 AA 84 B1 B0 AF AD D9 AD D9
AD 92 A0 92 92 92 92 99 92 9C 9A 9D 98 97 92 92
92 92 92 92 91 99 92 92 92 92 92 EF 96 95 94 94
94 94 94 94 94 94 92 91 90 70 68 61 60 33 4F 47
42 41 40 7F 7F 15 0D 0C 0B 06 04 00 50 22 02 55
52 15 4D 4A 49 0E 48 7F 02 00 22 02 23 03 EE ED
EC EB E9 E7 E6 AF AF AF BF 7E C6 CE BC BC BC BC
BC CC 7E DC 70 7E D1 7E D1 7E D0 7E D0 7E D0 7E
7E BB BB BB BB BB BB BB BB BB BB CB 7E 7E 70 7E
70 70 7E 70 70 B9 BA DB D9 DA C9 D7 B8 B8 B8 B8
B8 B7 B7 B7 B7 B7 B7 7E B9 70 D6 D2 7E D2 7E 7E
BE BE B7 B7 7E B7 7E 70 70 7E 70 70 70 7E B7 B7
B6 B6 B7 B7 7E 7E 7E 7E B6 B6 B7 B0 B6 B6 B6 B3
B3 B3 B3 B3 C6 B2 C5 B8 7E B4 7E B6 B1 B1 B1 7E
7E 70 7E C2 7E 7E B1 B1 70 C1 7E B0 CD 73 7E CF

New log:
root@bmc-oob:~# bic-util slot1 --get_post_code
util_get_postcode: returns 240 bytes
E3 E3 E3 AA 84 B1 B0 AF AD D9 AD D9 AD 92 A0 92
92 92 92 99 92 9C 9A 9D 98 97 92 92 92 92 92 92
91 99 92 92 92 92 92 EF 96 95 94 94 94 94 94 94
94 94 92 91 90 70 68 61 60 33 4F 47 42 40 7F 7F
15 0D 0C 0B 06 04 00 50 22 02 55 52 15 4D 4A 49
0E 48 7F 02 00 22 02 23 03 EE ED EC EB E9 E7 E6
AF AF AF BF 7E C6 CE BC BC BC BC BC CC 7E DC CA
CA B7 7E 70 7E D1 7E D1 7E D0 7E D0 7E D0 7E 7E
BB BB BB BB BB BB BB BB BB BB CB 7E 7E 70 7E 70
70 7E 70 70 B9 BA DB D9 DA C9 D7 B8 B8 B8 B8 B8
B7 B7 B7 B7 B7 B7 7E B9 70 D6 D2 7E D2 7E 7E BE
BE B7 B7 7E B7 7E 70 70 7E 70 70 70 7E B7 B7 B6
B6 B7 B7 7E 7E 7E 7E B6 B6 B7 B0 B6 B6 B6 B3 B3
B3 B3 B3 C6 B2 C5 B8 7E B4 7E B6 B1 B1 B1 7E 7E
70 7E C2 7E 7E B1 B1 70 C1 7E B0 CD 73 7E CF 7E