### PR TITLE
fby3: dl: Update UCR of SOC Therm Margin

### DIFF
--- a/meta-facebook/yv3-dl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv3-dl/src/platform/plat_sdr_table.c
@@ -359,7 +359,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x00, // sensor unit
+		0x80, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization


### PR DESCRIPTION
# Description
1. Older BMC will not overwrite this sensor unit.
2. Make this sensor be two's complement to prevent incorrect UCR.

# Motivation
Backward compatible to older BMC FW.

# Test plan
Build and test pass on fyb3.

1. Check sensor threshold is expected with older BMC FW

root@bmc-oob:~# fw-util bmc --version
BMC Version: fby3-v2023.38.2

root@bmc-oob:~# sensor-util slot1 0xd --th
slot1:
SOC Therm Margin             (0xD) : -45.000 C     | (ok) | UCR: -3.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA