### PR TITLE
fby4: wf: Support to read ADC sensor 

### DIFF
--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_sensor.c
@@ -3610,7 +3610,7 @@ int plat_pldm_sensor_get_sensor_count(int thread_id)
 	return count;
 }
 
-void plat_pldm_sensor_get_pdr_numeric_sesnor(int thread_id, int sensor_num,
+void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
 					     PDR_numeric_sensor *numeric_sensor_table)
 {
 	switch (thread_id) {
@@ -3653,8 +3653,8 @@ void plat_load_numeric_sensor_pdr_table(PDR_numeric_sensor *numeric_sensor_table
 	for (thread_id = 0; thread_id < MAX_SENSOR_THREAD_ID; thread_id++) {
 		max_sensor_num = plat_pldm_sensor_get_sensor_count(thread_id);
 		for (sensor_num = 0; sensor_num < max_sensor_num; sensor_num++) {
-			plat_pldm_sensor_get_pdr_numeric_sesnor(thread_id, sensor_num,
-					       &numeric_sensor_table[current_sensor_size]);
+			plat_pldm_sensor_get_pdr_numeric_sensor(
+				thread_id, sensor_num, &numeric_sensor_table[current_sensor_size]);
 			current_sensor_size++;
 		}
 	}

--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_sensor.h
@@ -49,7 +49,7 @@ enum SENSOR_THREAD_LIST {
 };
 
 int plat_pldm_sensor_get_sensor_count(int thread_id);
-void plat_pldm_sensor_get_pdr_numeric_sesnor(int thread_id, int sensor_num,
+void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
 					     PDR_numeric_sensor *numeric_sensor_table);
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -3294,7 +3294,7 @@ int plat_pldm_sensor_get_sensor_count(int thread_id)
 	return count;
 }
 
-void plat_pldm_sensor_get_pdr_numeric_sesnor(int thread_id, int sensor_num,
+void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
 					     PDR_numeric_sensor *numeric_sensor_table)
 {
 	switch (thread_id) {
@@ -3332,7 +3332,7 @@ void plat_load_numeric_sensor_pdr_table(PDR_numeric_sensor *numeric_sensor_table
 	for (thread_id = 0; thread_id < MAX_SENSOR_THREAD_ID; thread_id++) {
 		max_sensor_num = plat_pldm_sensor_get_sensor_count(thread_id);
 		for (sensor_num = 0; sensor_num < max_sensor_num; sensor_num++) {
-			plat_pldm_sensor_get_pdr_numeric_sesnor(
+			plat_pldm_sensor_get_pdr_numeric_sensor(
 				thread_id, sensor_num, &numeric_sensor_table[current_sensor_size]);
 			current_sensor_size++;
 		}

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
@@ -43,7 +43,7 @@ enum SENSOR_THREAD_LIST {
 };
 
 int plat_pldm_sensor_get_sensor_count(int thread_id);
-void plat_pldm_sensor_get_pdr_numeric_sesnor(int thread_id, int sensor_num,
-			    PDR_numeric_sensor *numeric_sensor_table);
+void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
+					     PDR_numeric_sensor *numeric_sensor_table);
 
 #endif

--- a/meta-facebook/yv4-wf/src/platform/plat_hook.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_hook.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <logging/log.h>
+#include <drivers/peci.h>
+
+#include "sensor.h"
+#include "intel_peci.h"
+#include "intel_dimm.h"
+#include "power_status.h"
+#include "i2c-mux-tca9548.h"
+#include "libutil.h"
+#include "hal_peci.h"
+
+#include "plat_hook.h"
+#include "plat_sensor_table.h"
+#include "plat_gpio.h"
+
+LOG_MODULE_REGISTER(plat_hook);
+
+adc_asd_init_arg ast_adc_init_args[] = {
+	[0] = { .is_init = false,
+		.deglitch[0] = { .deglitch_en = false,},
+		.deglitch[1] = { .deglitch_en = false,},
+		.deglitch[2] = { .deglitch_en = false,},
+		.deglitch[3] = { .deglitch_en = false,},
+		.deglitch[4] = { .deglitch_en = false,},
+		.deglitch[5] = { .deglitch_en = false,},
+		.deglitch[6] = { .deglitch_en = false,},
+		.deglitch[7] = { .deglitch_en = false,},
+	},
+	[1] = {
+		.is_init = false,
+		.deglitch[0] = { .deglitch_en = false,},
+		.deglitch[1] = { .deglitch_en = false,},
+		.deglitch[2] = { .deglitch_en = false,},
+		.deglitch[3] = { .deglitch_en = false,},
+	}
+};

--- a/meta-facebook/yv4-wf/src/platform/plat_hook.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_hook.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#ifndef PLAT_HOOK_H
+#define PLAT_HOOK_H
 
-#define BMC_USB_PORT "CDC_ACM_0"
+extern adc_asd_init_arg ast_adc_init_args[];
 
-#define ENABLE_MCTP_I3C
-
-#define ENABLE_PLDM
-#define ENABLE_PLDM_SENSOR
-#define ENABLE_CCI
 #endif

--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.c
@@ -73,6 +73,11 @@ mctp_route_entry plat_mctp_route_tbl[] = {
 	{ MCTP_EID_CXL2, I2C_BUS_CXL2, I2C_ADDR_CXL2, .set_endpoint = true },
 };
 
+uint8_t MCTP_SUPPORTED_MESSAGES_TYPES[] = {
+	TYPE_MCTP_CONTROL,
+	TYPE_PLDM,
+};
+
 static mctp *find_mctp_by_bus(uint8_t bus)
 {
 	uint8_t i;
@@ -297,4 +302,11 @@ void plat_update_mctp_routing_table(uint8_t eid)
 	k_timer_start(&send_cmd_timer, K_MSEC(30000), K_NO_WAIT);
 
 	return;
+}
+
+int load_mctp_support_types(uint8_t *type_len, uint8_t *types)
+{
+	*type_len = sizeof(MCTP_SUPPORTED_MESSAGES_TYPES);
+	memcpy(types, MCTP_SUPPORTED_MESSAGES_TYPES, sizeof(MCTP_SUPPORTED_MESSAGES_TYPES));
+	return MCTP_SUCCESS;
 }

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
@@ -1,0 +1,1068 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * youmay not use this file except in compliance with the License.
+ * Youmay obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <logging/log.h>
+#include "pmbus.h"
+#include "ast_adc.h"
+#include "pdr.h"
+#include "sensor.h"
+#include "pldm_sensor.h"
+#include "pldm_monitor.h"
+#include "plat_i2c.h"
+#include "plat_pldm_sensor.h"
+#include "plat_hook.h"
+
+LOG_MODULE_REGISTER(plat_pldm_sensor);
+
+static struct pldm_sensor_thread pal_pldm_sensor_thread[MAX_SENSOR_THREAD_ID] = {
+	// thread id, thread name
+	{ ADC_SENSOR_THREAD_ID, "ADC_PLDM_SENSOR_THREAD" },
+};
+
+pldm_sensor_info plat_pldm_sensor_adc_table[] = {
+	{
+		{
+			// WF_ADC_P3V3_STBY_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0015, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0001, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-5, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00057288, //uint32_t warning_high;
+			0x0004b320, //uint32_t warning_low;
+			0x000566d0, //uint32_t critical_high;
+			0x0004a3df, //uint32_t critical_low;
+			0x000617c4, //uint32_t fatal_high;
+			0x00038658, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT10,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 2,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[1],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// WF_ADC_P3V3_E1S_0_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0016, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0002, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-3, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000000, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT11,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 2,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[1],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// WF_ADC_P1V2_STBY_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0017, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0003, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-4, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x000032c8, //uint32_t warning_high;
+			0x00002ba4, //uint32_t warning_low;
+			0x00003200, //uint32_t critical_high;
+			0x00002af8, //uint32_t critical_low;
+			0x00003660, //uint32_t fatal_high;
+			0x00002580, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT2,
+			.access_checker = stby_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// WF_ADC_P1V2_ASIC1_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0018, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0004, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-4, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x000032c8, //uint32_t warning_high;
+			0x00002ba4, //uint32_t warning_low;
+			0x00003200, //uint32_t critical_high;
+			0x00002af8, //uint32_t critical_low;
+			0x00003660, //uint32_t fatal_high;
+			0x00002580, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT3,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// WF_ADC_P1V8_ASIC1_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x0019, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0005, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-5, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x0002e64a, //uint32_t warning_high;
+			0x00029580, //uint32_t warning_low;
+			0x0002ee00, //uint32_t critical_high;
+			0x00028c58, //uint32_t critical_low;
+			0x00032fa0, //uint32_t fatal_high;
+			0x00023280, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT4,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// WF_ADC_P0V75_ASIC1_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x001a, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0006, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-5, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00014438, //uint32_t warning_high;
+			0x000105b8, //uint32_t warning_low;
+			0x00014b96, //uint32_t critical_high;
+			0x0000ffe7, //uint32_t critical_low;
+			0x000161b6, //uint32_t fatal_high;
+			0x0000e8a8, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT9,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[1],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// WF_ADC_PVPP_AB_ASIC1_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x001b, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0007, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000112, //uint32_t warning_high;
+			0x000000e1, //uint32_t warning_low;
+			0x00000118, //uint32_t critical_high;
+			0x000000dc, //uint32_t critical_low;
+			0x0000012c, //uint32_t fatal_high;
+			0x000000c8, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT5,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 2,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// WF_ADC_PVPP_CD_ASIC1_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x001c, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0008, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000112, //uint32_t warning_high;
+			0x000000e1, //uint32_t warning_low;
+			0x00000118, //uint32_t critical_high;
+			0x000000dc, //uint32_t critical_low;
+			0x0000012c, //uint32_t fatal_high;
+			0x000000c8, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT6,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 2,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// WF_ADC_PVTT_AB_ASIC1_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x001d, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x0009, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-3, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000294, //uint32_t warning_high;
+			0x0000021c, //uint32_t warning_low;
+			0x0000029e, //uint32_t critical_high;
+			0x00000210, //uint32_t critical_low;
+			0x000002d0, //uint32_t fatal_high;
+			0x000001e0, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT7,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[0],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+	{
+		{
+			// WF_ADC_PVTT_CD_ASIC1_VOLT_V
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				0x02, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+
+			0x001e, //uint16_t sensor_id;
+			0x0087, //uint16_t entity_type;
+			0x000a, //uint16_t entity_instance_number;
+
+			0x0000, //uint16_t container_id;
+			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+
+			0x05, //uint8_t base_unit;
+			-3, //int8_t unit_modifier;
+
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x04, //uint8_t sensor_data_size;
+			1, //int32_t resolution;
+			0, //int32_t offset;
+
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+
+			UPDATE_INTERVAL_1S, //int32_t update_interval;
+			0x00000000, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+
+			0x00000294, //uint32_t warning_high;
+			0x0000021c, //uint32_t warning_low;
+			0x0000029e, //uint32_t critical_high;
+			0x00000210, //uint32_t critical_low;
+			0x000002d0, //uint32_t fatal_high;
+			0x000001e0, //uint32_t fatal_low;
+
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_ast_adc,
+			.port = ADC_PORT8,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.arg0 = 1,
+			.arg1 = 1,
+			.init_args = &ast_adc_init_args[1],
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+		},
+	},
+};
+// clang-format off
+PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
+	{
+		// WF_ADC_P3V3_STBY_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0015,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"WF_ADC_P3V3_STBY_VOLT_V",
+	},
+	{
+		// WF_ADC_P3V3_E1S_0_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0016,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"WF_ADC_P3V3_E1S_0_VOLT_V",
+	},
+	{
+		// WF_ADC_P1V2_STBY_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0017,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"WF_ADC_P1V2_STBY_VOLT_V",
+	},
+	{
+		// WF_ADC_P1V2_ASIC1_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0018,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"WF_ADC_P1V2_ASIC1_VOLT_V",
+	},
+	{
+		// WF_ADC_P1V8_ASIC1_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0019,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"WF_ADC_P1V8_ASIC1_VOLT_V",
+	},
+	{
+		// WF_ADC_P0V75_ASIC1_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x001a,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"WF_ADC_P0V75_ASIC1_VOLT_V",
+	},
+	{
+		// WF_ADC_PVPP_AB_ASIC1_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x001b,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"WF_ADC_PVPP_AB_ASIC1_VOLT_V",
+	},
+	{
+		// WF_ADC_PVPP_CD_ASIC1_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x001c,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"WF_ADC_PVPP_CD_ASIC1_VOLT_V",
+	},
+	{
+		// WF_ADC_PVTT_AB_ASIC1_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x001d,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"WF_ADC_PVTT_AB_ASIC1_VOLT_V",
+	},
+	{
+		// WF_ADC_PVTT_CD_ASIC1_VOLT_V
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x001e,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"WF_ADC_PVTT_CD_ASIC1_VOLT_V",
+	},
+};
+// clang-format on
+uint32_t plat_get_pdr_size(uint8_t pdr_type)
+{
+	int total_size = 0, i = 0;
+
+	switch (pdr_type) {
+	case PLDM_NUMERIC_SENSOR_PDR:
+		for (i = 0; i < MAX_SENSOR_THREAD_ID; i++) {
+			total_size += plat_pldm_sensor_get_sensor_count(i);
+		}
+		break;
+	case PLDM_SENSOR_AUXILIARY_NAMES_PDR:
+		total_size = ARRAY_SIZE(plat_pdr_sensor_aux_names_table);
+		break;
+	default:
+		break;
+	}
+
+	return total_size;
+}
+
+pldm_sensor_thread *plat_pldm_sensor_load_thread()
+{
+	return pal_pldm_sensor_thread;
+}
+
+pldm_sensor_info *plat_pldm_sensor_load(int thread_id)
+{
+	switch (thread_id) {
+	case ADC_SENSOR_THREAD_ID:
+		return plat_pldm_sensor_adc_table;
+	default:
+		LOG_ERR("Unknow pldm sensor thread id %d", thread_id);
+		return NULL;
+	}
+}
+
+int plat_pldm_sensor_get_sensor_count(int thread_id)
+{
+	int count = 0;
+
+	switch (thread_id) {
+	case ADC_SENSOR_THREAD_ID:
+		count = ARRAY_SIZE(plat_pldm_sensor_adc_table);
+		break;
+	default:
+		count = -1;
+		LOG_ERR("Unknow pldm sensor thread id %d", thread_id);
+		break;
+	}
+
+	return count;
+}
+
+void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
+					     PDR_numeric_sensor *numeric_sensor_table)
+{
+	switch (thread_id) {
+	case ADC_SENSOR_THREAD_ID:
+		memcpy(numeric_sensor_table,
+		       &plat_pldm_sensor_adc_table[sensor_num].pdr_numeric_sensor,
+		       sizeof(PDR_numeric_sensor));
+		break;
+	default:
+		LOG_ERR("Unknow pldm sensor thread id %d", thread_id);
+		break;
+	}
+}
+
+void plat_load_numeric_sensor_pdr_table(PDR_numeric_sensor *numeric_sensor_table)
+{
+	int thread_id = 0, sensor_num = 0;
+	int max_sensor_num = 0, current_sensor_size = 0;
+
+	for (thread_id = 0; thread_id < MAX_SENSOR_THREAD_ID; thread_id++) {
+		max_sensor_num = plat_pldm_sensor_get_sensor_count(thread_id);
+		for (sensor_num = 0; sensor_num < max_sensor_num; sensor_num++) {
+			plat_pldm_sensor_get_pdr_numeric_sensor(
+				thread_id, sensor_num, &numeric_sensor_table[current_sensor_size]);
+			current_sensor_size++;
+		}
+	}
+}
+
+void plat_load_aux_sensor_names_pdr_table(PDR_sensor_auxiliary_names *aux_sensor_name_table)
+{
+	memcpy(aux_sensor_name_table, &plat_pdr_sensor_aux_names_table,
+	       sizeof(plat_pdr_sensor_aux_names_table));
+}

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.h
@@ -14,14 +14,20 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#ifndef PLAT_PLDM_SENSOR_H
+#define PLAT_PLDM_SENSOR_H
 
-#define BMC_USB_PORT "CDC_ACM_0"
+#include "pdr.h"
 
-#define ENABLE_MCTP_I3C
+#define UPDATE_INTERVAL_1S 1
 
-#define ENABLE_PLDM
-#define ENABLE_PLDM_SENSOR
-#define ENABLE_CCI
+enum SENSOR_THREAD_LIST {
+	ADC_SENSOR_THREAD_ID = 0,
+	MAX_SENSOR_THREAD_ID,
+};
+
+int plat_pldm_sensor_get_sensor_count(int thread_id);
+void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
+					     PDR_numeric_sensor *numeric_sensor_table);
+
 #endif


### PR DESCRIPTION
# Description:
	- Add ADC PDR table (numeric sensor table and aux name table).
	- Set MCTP message type. BMC can read ADC sensors from BIC.

# Motivation:
	Support BIC monitors parts of ADC sensors.

# Test plan:
	1. Check sensors' cache which return to BMC are correct: Pass
	2. BMC read ADC sensor: Pass
# Test log:
	1. Check sensors' cache which return to BMC are correct:
		[00:00:27.054,000] <dbg> pldm_sensor.pldm_polling_sensor_reading: sensor0x15, value0x11e0003, status 0x0
		[00:00:27.054,000] <dbg> pldm_sensor.pldm_polling_sensor_reading: sensor0x16, value0x11e0003, status 0x0
		[00:00:27.054,000] <dbg> pldm_sensor.pldm_polling_sensor_reading: sensor0x17, value0xd20001, status 0x0
		[00:00:27.054,000] <dbg> pldm_sensor.pldm_polling_sensor_reading: sensor0x18, value0xd20001, status 0x0
		[00:00:27.054,000] <dbg> pldm_sensor.pldm_polling_sensor_reading: sensor0x19, value0x32d0001, status 0x0
		[00:00:27.054,000] <dbg> pldm_sensor.pldm_polling_sensor_reading: sensor0x1a, value0x2ef0000, status 0x0
		[00:00:27.054,000] <dbg> pldm_sensor.pldm_polling_sensor_reading: sensor0x1b, value0x2240002, status 0x0
		[00:00:27.054,000] <dbg> pldm_sensor.pldm_polling_sensor_reading: sensor0x1c, value0x2160002, status 0x0
		[00:00:27.054,000] <dbg> pldm_sensor.pldm_polling_sensor_reading: sensor0x1d, value0x25b0000, status 0x0
		[00:00:27.055,000] <dbg> pldm_sensor.pldm_polling_sensor_reading: sensor0x1e, value0x2560000, status 0x0
	2. BMC read ADC sensor
		2-1. ADC sensor name
			root@bmc:~# busctl tree xyz.openbmc_project.PLDM
			`- /xyz
			  `- /xyz/openbmc_project
				|- /xyz/openbmc_project/inventory
				| `- /xyz/openbmc_project/inventory/Item
				|   `- /xyz/openbmc_project/inventory/Item/Board
				|     |- /xyz/openbmc_project/inventory/Item/Board/PLDM_Device_1
				|     `- /xyz/openbmc_project/inventory/Item/Board/PLDM_Device_2
				|- /xyz/openbmc_project/pldm
				`- /xyz/openbmc_project/sensors
				  `- /xyz/openbmc_project/sensors/voltage
					|- /xyz/openbmc_project/sensors/voltage/WF_ADC_P0V75_ASIC1_VOLT_V_26_2
					|- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V2_ASIC1_VOLT_V_24_2
					|- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V2_STBY_VOLT_V_23_2
					|- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V8_ASIC1_VOLT_V_25_2
					|- /xyz/openbmc_project/sensors/voltage/WF_ADC_P3V3_E1S_0_VOLT_V_22_2
					|- /xyz/openbmc_project/sensors/voltage/WF_ADC_P3V3_STBY_VOLT_V_21_2
					|- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_AB_ASIC1_VOLT_V_27_2
					|- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_CD_ASIC1_VOLT_V_28_2
					|- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_AB_ASIC1_VOLT_V_29_2
					`- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_CD_ASIC1_VOLT_V_30_2
		2-2. ADC sensor info
			root@bmc:~# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_P0V75_ASIC1_VOLT_V_26_2
			NAME                                                  TYPE      SIGNATURE RESULT/VALUE                             FLAGS
			```
			.CriticalHighAlarmAsserted                            signa[ 1575.548233] i2c i2c-3: __i2c_transfer failed -5
			l    d         -                                        -
			.CriticalHighAlarmDeasserted                          signal    d         -                                        -
			.CriticalLowAlarmAsserted                             signal    d         -                                        -
			.CriticalLowAlarmDeasserted                           signal    d         -                                        -
			xyz.openbmc_project.Sensor.Threshold.Warning          interface -         -                                        -
			.WarningAlarmHigh                                     property  b         false                                    emits-change writable
			.WarningAlarmLow                                      property  b         false                                    emits-change writable
			.WarningHigh                                          property  d         0.83                                     emits-change writable
			.WarningLow                                           property  d         0.67                                     emits-change writable
			.WarningHighAlarmAsserted                             signal    d         -                                        -
			.WarningHighAlarmDeasserted                           signal    d         -                                        -
			.WarningLowAlarmAsserted                              signal    d         -                                        -
			.WarningLowAlarmDeasserted                            signal    d         -                                        -
			xyz.openbmc_project.Sensor.Value                      interface -         -                                        -
			.MaxValue                                             property  d         0                                        emits-change writable
			.MinValue                                             property  d         0                                        emits-change writable
			.Unit                                                 property  s         "xyz.openbmc_project.Sensor.Value.Uni... emits-change writable
			.Value                                                property  d         0.754                                    emits-change writable
			```