### PR TITLE
fby35: gl: Add Renesas ISL69259 VR type checking

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
@@ -371,6 +371,9 @@ static void check_vr_type(uint8_t index)
 		sensor_config[index].init_args = &mp2985_init_args[0];
 	} else if ((msg.data[0] == 0x02) && (msg.data[2] == 0x8A)) {
 		sensor_config[index].type = sensor_dev_xdpe15284;
+	} else if ((msg.data[0] == 0x04) && (msg.data[1] == 0x00) && (msg.data[2] == 0x81) &&
+		   (msg.data[3] == 0xD2) && (msg.data[4] == 0x49)) {
+		sensor_config[index].type = sensor_dev_isl69259;
 	} else {
 		LOG_ERR("Unknown VR type");
 	}


### PR DESCRIPTION
# Description:
Add Renesas ISL69259 VR type checking

# Motivation:
Currently, VR sensor values are over upper non recoverable since using the wrong formula.

# Test Plan:
Check VR sensor values - pass

# Test Log:
Before fix -
root@bmc-oob:~# sensor-util slot3 --thres|grep -i ehv
MB_VR_EHV_VOLT_V             (0x22) : 1800.000 Volts | (unr) | UCR: 1.901 | UNC: 1.882 | UNR: 2.293 | LCR: 1.695 | LNC: 1.715 | LNR: 1.392
MB_VR_EHV_CURR_A             (0x2A) :   9.000 Amps  | (unr) | UCR: 5.187 | UNC: 4.914 | UNR: 6.981 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_PWR_W              (0x31) :   2.000 Watts | (ok) | UCR: 9.310 | UNC: 8.820 | UNR: 12.250 | LCR: NA | LNC: NA | LNR: NA
After fix -
root@bmc-oob:~# sensor-util slot3 --thres|grep -i ehv
MB_VR_EHV_VOLT_V             (0x22) :   1.800 Volts | (ok) | UCR: 1.901 | UNC: 1.882 | UNR: 2.293 | LCR: 1.695 | LNC: 1.715 | LNR: 1.392
MB_VR_EHV_CURR_A             (0x2A) :   1.000 Amps  | (ok) | UCR: 5.187 | UNC: 4.914 | UNR: 6.981 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_PWR_W              (0x31) :   2.000 Watts | (ok) | UCR: 9.310 | UNC: 8.820 | UNR: 12.250 | LCR: NA | LNC: NA | LNR: NA