### PR TITLE
fby3.5: gl: Fix BIC crash when dc off

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_isr.c
@@ -168,7 +168,6 @@ void Initialize_CPU()
 
 		k_work_submit(&clear_pmic_error_work);
 	} else {
-		ISR_POST_COMPLETE(VW_GPIO_LOW);
 		abort_snoop_thread();
 
 		// Read PMIC error when DC off
@@ -479,14 +478,14 @@ static void post_complete_handler(struct k_work *work)
 	}
 }
 
+K_WORK_DELAYABLE_DEFINE(post_completework, post_complete_handler);
 void ISR_POST_COMPLETE(uint8_t gpio_value)
 {
 	bool is_post_completed = (gpio_value == VW_GPIO_HIGH) ? true : false;
 	set_post_complete(is_post_completed);
 
 	post_complete.gpio_value = gpio_value;
-	k_work_init_delayable(&post_complete.work, post_complete_handler);
-	k_work_schedule(&post_complete.work, K_MSEC(10));
+	k_work_schedule(&post_completework, K_MSEC(10));
 }
 
 static void adr_mode0_handler(struct k_work *work)


### PR DESCRIPTION
# Description:
This issue was caused by the incorrect initialization of workqueue in interrupt function. The work function was initialized twice, if the interrupt received twice. And if the second function is initialed before the first function was done. the BIC will crash.

# Motivation:
To fix BIC crash when dc off.

# Test Plan:
1. Build and test pass on OLP2.0 system. pass

2. Check whether BIC will crash when DC off pass

3. Stress power cycle about 500 times. pass