### PR TITLE
Artemis: mc : adjust bmc to meb bic i2c frequency

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_init.c
+++ b/meta-facebook/at-mc/src/platform/plat_init.c
@@ -89,11 +89,6 @@ void check_cxl_ioexp_is_initialized()
 
 void pal_pre_init()
 {
-	uint8_t board_rev = get_board_revision();
-	if (board_rev == REV_EVT2) {
-		i2c_freq_set(I2C_BUS_BMC, I2C_SPEED_STANDARD, 0);
-	}
-
 	check_pcie_card_type();
 	check_cxl_ioexp_is_initialized();
 


### PR DESCRIPTION
# Description:
- Adjust bmc to meb bic i2c frequency to 400k 
# Motivation:
- Avoid encountering i2c glitch issue on evt2 system

# Test Plan:
- Build code: Pass