### PR TITLE
fby3.5: gl: op: support 2nd source I3C hub

### DIFF
--- a/common/dev/include/p3h284x.h
+++ b/common/dev/include/p3h284x.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef P3H284X_H
+#define P3H284X_H
+
+#include "hal_i2c.h"
+#include "hal_i3c.h"
+
+#define P3H284X_DEFAULT_STATIC_ADDRESS 0x70
+
+#define P3H284X_DEVICE_INFO0_REG 0x0
+#define P3H284X_DEVICE_INFO1_REG 0x1
+#define P3H284X_PROTECTION_REG 0x10
+#define P3H284X_CONTROLLER_PORT_CONFIG 0x11
+#define P3H284X_TARGET_PORT_ENABLE 0x12
+#define P3H284X_HUB_NETWORK_OPERATION_MODE 0x15
+#define P3H284X_VOLT_LDO_SETTING 0x16
+#define P3H284X_TARGET_PORTS_MODE_SETTING 0x17
+#define P3H284X_TARGET_PORTS_AGENT_ENABLE 0x18
+#define P3H284X_TARGET_PORTS_PULLUP_SETTING 0x19
+#define P3H284X_TARGET_PORTS_GPIO_ENABLE 0x1E
+#define P3H284X_TARGET_PORTSHUB_NETWORK_CONNECTION 0x51
+#define P3H284X_TARGET_PORTS_PULLUP_ENABLE 0x53
+
+/* 0x10 : Unlock Device Configuration Protection Code */
+#define P3H284X_PROTECTION_LOCK 0x00
+#define P3H284X_PROTECTION_UNLOCK 0x6A
+
+/* 0x15 : Master Side Port Configuration */
+#define P3H284X_HUB_NETWORK_ALWAYS_I3C 5
+
+/* 0x16 : Interface Voltage LDO Setting */
+#define TP_VCCIO1_OFFSET 6
+#define TP_VCCIO0_OFFSET 4
+#define CP1_OFFSET 2
+#define CP0_OFFSET 0
+
+/* 0x17 : Master Side Port Configuration */
+#define CP_OD_ONLY 4
+
+/* 0x19 : Pull-up Resistor Value */
+#define TARGET_PORTS_VCCIO0_PULLUP_OFFSET 6
+#define TARGET_PORTS_VCCIO1_PULLUP_OFFSET 4
+
+#define P3H284X_SSPORTS_ALL_DISCONNECT 0x00
+
+enum p3g284x_ldo_volt {
+	p3g284x_ldo_1_0_volt = 0,
+	p3g284x_ldo_1_1_volt,
+	p3g284x_ldo_1_2_volt,
+	p3g284x_ldo_1_8_volt,
+};
+
+enum p3g284x_pull_up_resistor {
+	p3g284x_pullup_250_ohm = 0,
+	p3g284x_pullup_500_ohm,
+	p3g284x_pullup_1k_ohm,
+	p3g284x_pullup_2k_ohm,
+};
+
+bool p3h284x_i2c_mode_only_init(uint8_t bus, uint8_t slave_port, uint8_t ldo_volt,
+				  uint8_t pullup_resistor);
+bool p3h284x_select_slave_port_connect(uint8_t bus, uint8_t slave_port);
+bool p3h284x_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt);
+bool p3h284x_set_slave_port(uint8_t bus, uint8_t addr, uint8_t setting);
+bool p3h284x_get_device_info(uint8_t bus, uint16_t *i3c_hub_type);
+
+#endif

--- a/common/dev/include/rg3mxxb12.h
+++ b/common/dev/include/rg3mxxb12.h
@@ -21,7 +21,13 @@
 #include "hal_i3c.h"
 
 #define RG3MXXB12_DEFAULT_STATIC_ADDRESS 0x70
+#define RG3M87B12_DEVICE_INFO 0x1287
+#define RG3M88B12_DEVICE_INFO 0x1288
+#define RG3M47B12_DEVICE_INFO 0x1247
+#define RG3M4812_DEVICE_INFO 0x1248
 
+#define RG3MXXB12_DEVICE_INFO0_REG 0x0
+#define RG3MXXB12_DEVICE_INFO1_REG 0x1
 #define RG3MXXB12_PROTECTION_REG 0x10
 #define RG3MXXB12_MASTER_PORT_CONFIG 0x11
 #define RG3MXXB12_SLAVE_PORT_ENABLE 0x12
@@ -35,11 +41,11 @@
 #define RG3MXXB12_SSPORTS_PULLUP_ENABLE 0x53
 
 /* 0x10 : Unlock Device Configuration Protection Code */
-#define PROTECTION_LOCK 0x00
-#define PROTECTION_UNLOCK 0x69
+#define RG3MXXB12_PROTECTION_LOCK 0x00
+#define RG3MXXB12_PROTECTION_UNLOCK 0x69
 
 /* 0x15 : Master Side Port Configuration */
-#define HUB_NETWORK_ALWAYS_I3C 5
+#define RG3MXXB12_HUB_NETWORK_ALWAYS_I3C 5
 
 /* 0x16 : Interface Voltage LDO Setting */
 #define VIOS1_OFFSET 6
@@ -47,7 +53,7 @@
 #define VIOM1_OFFSET 2
 #define VIOM0_OFFSET 0
 
-/* 0x17 : Master Side Port Configuration */
+/* 0x11 : Master Side Port Configuration */
 #define MPORT_OD_ONLY 4
 
 /* 0x19 : Pull-up Resistor Value */
@@ -56,18 +62,18 @@
 
 #define RG3MXXB12_SSPORTS_ALL_DISCONNECT 0x00
 
-enum ldo_volt {
-	ldo_1_0_volt = 0,
-	ldo_1_1_volt,
-	ldo_1_2_volt,
-	ldo_1_8_volt,
+enum rg3mxxb12_ldo_volt {
+	rg3mxxb12_ldo_1_0_volt = 0,
+	rg3mxxb12_ldo_1_1_volt,
+	rg3mxxb12_ldo_1_2_volt,
+	rg3mxxb12_ldo_1_8_volt,
 };
 
-enum pull_up_resistor {
-	pullup_250_ohm = 0,
-	pullup_500_ohm,
-	pullup_1k_ohm,
-	pullup_2k_ohm,
+enum rg3mxxb12_pull_up_resistor {
+	rg3mxxb12_pullup_250_ohm = 0,
+	rg3mxxb12_pullup_500_ohm,
+	rg3mxxb12_pullup_1k_ohm,
+	rg3mxxb12_pullup_2k_ohm,
 };
 
 bool rg3mxxb12_i2c_mode_only_init(uint8_t bus, uint8_t slave_port, uint8_t ldo_volt,
@@ -75,5 +81,6 @@ bool rg3mxxb12_i2c_mode_only_init(uint8_t bus, uint8_t slave_port, uint8_t ldo_v
 bool rg3mxxb12_select_slave_port_connect(uint8_t bus, uint8_t slave_port);
 bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt);
 bool rg3mxxb12_set_slave_port(uint8_t bus, uint8_t addr, uint8_t setting);
+bool rg3mxxb12_get_device_info(uint8_t bus, uint16_t *i3c_hub_type);
 
 #endif

--- a/common/dev/p3h284x.c
+++ b/common/dev/p3h284x.c
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <logging/log.h>
+
+#include "p3h284x.h"
+#include "libutil.h"
+
+LOG_MODULE_REGISTER(dev_p3h284x);
+
+#define RETRY 3
+
+static bool p3h284x_register_read(uint8_t bus, uint8_t offset, uint8_t *value)
+{
+	CHECK_NULL_ARG_WITH_RETURN(value, false);
+	int ret = -1;
+	I2C_MSG msg = { 0 };
+
+	msg.bus = bus;
+	msg.target_addr = P3H284X_DEFAULT_STATIC_ADDRESS;
+	msg.tx_len = 1;
+	msg.data[0] = offset;
+	msg.rx_len = 1;
+	ret = i2c_master_read(&msg, RETRY);
+	if (ret != 0) {
+		LOG_ERR("Failed to read p3h284x register 0x%x, bus-%d", offset, bus);
+		return false;
+	}
+	*value = msg.data[0];
+
+	return true;
+}
+
+static bool p3h284x_register_write(uint8_t bus, uint8_t offset, uint8_t value)
+{
+	int ret = -1;
+	I2C_MSG msg = { 0 };
+
+	msg.bus = bus;
+	msg.target_addr = P3H284X_DEFAULT_STATIC_ADDRESS;
+	msg.tx_len = 2;
+	msg.data[0] = offset;
+	msg.data[1] = value;
+	ret = i2c_master_write(&msg, RETRY);
+	if (ret != 0) {
+		LOG_ERR("Failed to write p3h284x register 0x%x, bus-%d", offset, bus);
+		return false;
+	}
+
+	msg.tx_len = 1;
+	msg.data[0] = offset;
+	msg.rx_len = 1;
+	ret = i2c_master_read(&msg, RETRY);
+	if ((ret != 0) || (msg.data[0] != value)) {
+		LOG_ERR("Failed to read p3h284x register 0x%x after setting,"
+			"bus-%d",
+			offset, bus);
+		return false;
+	}
+	return true;
+}
+
+static bool p3h284x_protected_register(uint8_t bus, bool lock)
+{
+	uint8_t val = lock ? P3H284X_PROTECTION_LOCK : P3H284X_PROTECTION_UNLOCK;
+	if (!p3h284x_register_write(bus, P3H284X_PROTECTION_REG, val)) {
+		return false;
+	}
+	return true;
+}
+
+bool p3h284x_select_slave_port_connect(uint8_t bus, uint8_t slave_port)
+{
+	// Connect selected slave port to HUB network
+	if (!p3h284x_register_write(bus, P3H284X_TARGET_PORTSHUB_NETWORK_CONNECTION, slave_port)) {
+		return false;
+	}
+	return true;
+}
+
+bool p3h284x_get_device_info(uint8_t bus, uint16_t *i3c_hub_type)
+{
+	uint8_t device_info0, device_info1 = 0;
+
+	if (p3h284x_register_read(bus, P3H284X_DEVICE_INFO0_REG, &device_info0)) {
+		p3h284x_register_read(bus, P3H284X_DEVICE_INFO1_REG, &device_info1);
+	} else {
+		return false;
+	}
+
+	*i3c_hub_type = (device_info1 << 8) | device_info0;
+	return true;
+}
+
+bool p3h284x_i2c_mode_only_init(uint8_t bus, uint8_t slave_port, uint8_t ldo_volt,
+				  uint8_t pullup_resistor)
+{
+	bool ret = false;
+	uint8_t value;
+	// Unlock protected regsiter
+	if (!p3h284x_protected_register(bus, false)) {
+		return false;
+	}
+
+	// Target Port VCCIO operating voltage shall be set
+	value = (ldo_volt << CP0_OFFSET) | (ldo_volt << CP1_OFFSET) |
+		(ldo_volt << TP_VCCIO0_OFFSET) | (ldo_volt << TP_VCCIO1_OFFSET);
+	if (!p3h284x_register_write(bus, P3H284X_VOLT_LDO_SETTING, value)) {
+		goto out;
+	}
+
+	// Disable all slave ports
+	if (!p3h284x_register_write(bus, P3H284X_TARGET_PORT_ENABLE, 0x00)) {
+		goto out;
+	}
+
+	// Target Ports pull up termination and LDO enable (if required) shall be configured
+	if (!p3h284x_register_read(bus, P3H284X_TARGET_PORTS_PULLUP_SETTING, &value)) {
+		goto out;
+	}
+	value = SETBITS(value, pullup_resistor, TARGET_PORTS_VCCIO0_PULLUP_OFFSET);
+	value = SETBITS(value, pullup_resistor, TARGET_PORTS_VCCIO1_PULLUP_OFFSET);
+	if (!p3h284x_register_write(bus, P3H284X_TARGET_PORTS_PULLUP_SETTING, value)) {
+		goto out;
+	}
+	if (!p3h284x_register_write(bus, P3H284X_TARGET_PORTS_PULLUP_ENABLE, 0xFF)) {
+		goto out;
+	}
+
+	// Target Port GPIO and SMbus Agent modes are disabled
+	if (!p3h284x_register_write(bus, P3H284X_TARGET_PORTS_AGENT_ENABLE, 0x00)) {
+		goto out;
+	}
+	if (!p3h284x_register_write(bus, P3H284X_TARGET_PORTS_GPIO_ENABLE, 0x00)) {
+		goto out;
+	}
+
+	// Target Port signaling mode is set (I2C only)
+	if (!p3h284x_register_write(bus, P3H284X_TARGET_PORTS_MODE_SETTING, slave_port)) {
+		goto out;
+	}
+
+	// Enable master port OD only mode
+	if (!p3h284x_register_read(bus, P3H284X_CONTROLLER_PORT_CONFIG, &value)) {
+		goto out;
+	}
+	value = SETBIT(value, CP_OD_ONLY);
+	if (!p3h284x_register_write(bus, P3H284X_CONTROLLER_PORT_CONFIG, value)) {
+		goto out;
+	}
+
+	// Clear I3C HUB network traffic protocol setting
+	if (!p3h284x_register_read(bus, P3H284X_HUB_NETWORK_OPERATION_MODE, &value)) {
+		goto out;
+	}
+	value = CLEARBIT(value, P3H284X_HUB_NETWORK_ALWAYS_I3C);
+	if (!p3h284x_register_write(bus, P3H284X_HUB_NETWORK_OPERATION_MODE, value)) {
+		goto out;
+	}
+
+	// Enable selected slave port
+	if (!p3h284x_register_write(bus, P3H284X_TARGET_PORT_ENABLE, slave_port)) {
+		goto out;
+	}
+
+	// Connect selected slave port to HUB network
+	if (!p3h284x_register_write(bus, P3H284X_TARGET_PORTSHUB_NETWORK_CONNECTION, slave_port)) {
+		goto out;
+	}
+
+	ret = true;
+out:
+	// Lock protected register
+	if (!p3h284x_protected_register(bus, true)) {
+		return false;
+	}
+
+	return ret;
+}
+
+bool p3h284x_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt)
+{
+	bool ret = false;
+
+	uint8_t cmd_unprotect[2] = { P3H284X_PROTECTION_REG, 0x6A };
+	uint8_t cmd_protect[2] = { P3H284X_PROTECTION_REG, 0x00 };
+	uint8_t cmd_initial[][2] = {
+		/*
+		 * Refer to p3h284x datasheet page 8 and 9, LDO voltage depends
+		 * on each project's hard design
+		 */
+		{ P3H284X_VOLT_LDO_SETTING, ldo_volt },
+		{ P3H284X_TARGET_PORTS_AGENT_ENABLE, 0x0 },
+		{ P3H284X_TARGET_PORTS_GPIO_ENABLE, 0x0 },
+		{ P3H284X_TARGET_PORT_ENABLE, 0x0 },
+		{ P3H284X_TARGET_PORTS_PULLUP_ENABLE, 0xFF },
+		{ P3H284X_TARGET_PORTS_MODE_SETTING, 0x0 },
+		{ P3H284X_TARGET_PORT_ENABLE, 0xFF },
+		{ P3H284X_TARGET_PORTSHUB_NETWORK_CONNECTION, 0xFF },
+	};
+
+	i3c_msg->tx_len = 2;
+	memcpy(i3c_msg->data, cmd_unprotect, 2);
+	int initial_cmd_size = sizeof(cmd_initial) / sizeof(cmd_initial[0]);
+
+	// Unlock protected regsiter
+	if (!i3c_controller_write(i3c_msg)) {
+		goto out;
+	}
+
+	for (int cmd = 0; cmd < initial_cmd_size; cmd++) {
+		i3c_msg->tx_len = 2;
+		memcpy(i3c_msg->data, cmd_initial[cmd], 2);
+		if (!i3c_controller_write(i3c_msg)) {
+			LOG_ERR("Failed to initial i3c mode. offset = 0x%02x, value = 0x%02x",
+				cmd_initial[cmd][0], cmd_initial[cmd][1]);
+			goto out;
+		}
+		k_msleep(10);
+	}
+
+	ret = true;
+out:
+	memcpy(i3c_msg->data, cmd_protect, 2);
+	if (!i3c_controller_write(i3c_msg)) {
+		goto out;
+	}
+
+	return ret;
+}
+
+bool p3h284x_set_slave_port(uint8_t bus, uint8_t addr, uint8_t setting)
+{
+	I3C_MSG i3c_msg = { 0 };
+	int ret = 0;
+	uint8_t cmd_unprotect[2] = { P3H284X_PROTECTION_REG, 0x6A };
+	uint8_t cmd_protect[2] = { P3H284X_PROTECTION_REG, 0x00 };
+
+	i3c_msg.bus = bus;
+	i3c_msg.target_addr = addr;
+	i3c_msg.tx_len = 2;
+	memcpy(&i3c_msg.data, cmd_unprotect, 2);
+	if (!i3c_controller_write(&i3c_msg)) {
+		LOG_ERR("Failed to unprotect slave port register");
+		ret = false;
+		goto out;
+	}
+
+	memset(&i3c_msg.data, 0, 2);
+	i3c_msg.tx_len = 2;
+	i3c_msg.data[0] = P3H284X_TARGET_PORT_ENABLE;
+	i3c_msg.data[1] = setting;
+	if (!i3c_controller_write(&i3c_msg)) {
+		LOG_ERR("Failed to set slave port settings");
+		ret = false;
+		goto out;
+	}
+
+	ret = true;
+out:
+	memset(&i3c_msg.data, 0, 2);
+	i3c_msg.tx_len = 2;
+	memcpy(&i3c_msg.data, cmd_protect, 2);
+	if (!i3c_controller_write(&i3c_msg)) {
+		goto out;
+	}
+
+	return ret;
+}

--- a/common/dev/rg3mxxb12.c
+++ b/common/dev/rg3mxxb12.c
@@ -74,7 +74,7 @@ static bool rg3mxxb12_register_write(uint8_t bus, uint8_t offset, uint8_t value)
 
 static bool rg3mxxb12_protected_register(uint8_t bus, bool lock)
 {
-	uint8_t val = lock ? PROTECTION_LOCK : PROTECTION_UNLOCK;
+	uint8_t val = lock ? RG3MXXB12_PROTECTION_LOCK : RG3MXXB12_PROTECTION_UNLOCK;
 	if (!rg3mxxb12_register_write(bus, RG3MXXB12_PROTECTION_REG, val)) {
 		return false;
 	}
@@ -87,6 +87,20 @@ bool rg3mxxb12_select_slave_port_connect(uint8_t bus, uint8_t slave_port)
 	if (!rg3mxxb12_register_write(bus, RG3MXXB12_SSPORTS_HUB_NETWORK_CONNECTION, slave_port)) {
 		return false;
 	}
+	return true;
+}
+
+bool rg3mxxb12_get_device_info(uint8_t bus, uint16_t *i3c_hub_type)
+{
+	uint8_t device_info0, device_info1 = 0;
+
+	if (rg3mxxb12_register_read(bus, RG3MXXB12_DEVICE_INFO0_REG, &device_info0)) {
+		rg3mxxb12_register_read(bus, RG3MXXB12_DEVICE_INFO1_REG, &device_info1);
+	} else {
+		return false;
+	}
+
+	*i3c_hub_type = (device_info1 << 8) | device_info0;
 	return true;
 }
 
@@ -135,7 +149,7 @@ bool rg3mxxb12_i2c_mode_only_init(uint8_t bus, uint8_t slave_port, uint8_t ldo_v
 	if (!rg3mxxb12_register_read(bus, RG3MXXB12_HUB_NETWORK_OPERATION_MODE, &value)) {
 		goto out;
 	}
-	value = CLEARBIT(value, HUB_NETWORK_ALWAYS_I3C);
+	value = CLEARBIT(value, RG3MXXB12_HUB_NETWORK_ALWAYS_I3C);
 	if (!rg3mxxb12_register_write(bus, RG3MXXB12_HUB_NETWORK_OPERATION_MODE, value)) {
 		goto out;
 	}

--- a/meta-facebook/op2-op/src/platform/plat_class.c
+++ b/meta-facebook/op2-op/src/platform/plat_class.c
@@ -22,6 +22,8 @@
 #include "plat_sensor_table.h"
 #include "plat_i2c.h"
 #include "pt5161l.h"
+#include "rg3mxxb12.h"
+#include "p3h284x.h"
 
 LOG_MODULE_REGISTER(plat_class);
 
@@ -29,6 +31,7 @@ static uint8_t card_position = CARD_POSITION_UNKNOWN;
 static uint8_t card_type = CARD_TYPE_UNKNOWN;
 static uint8_t pcie_retimer_type = RETIMER_TYPE_UNKNOWN;
 static uint8_t board_revision = UNKNOWN_STAGE;
+static uint16_t i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
 
 uint8_t get_card_position()
 {
@@ -38,6 +41,11 @@ uint8_t get_card_position()
 uint8_t get_card_type()
 {
 	return card_type;
+}
+
+uint16_t get_i3c_hub_type()
+{
+	return i3c_hub_type;
 }
 
 uint8_t get_pcie_retimer_type(void)
@@ -125,5 +133,17 @@ void init_board_revision(void)
 		board_revision = gpio_get(OPB_BOARD_REV_0);
 		board_revision |= gpio_get(OPB_BOARD_REV_1) << 1;
 		board_revision |= gpio_get(OPB_BOARD_REV_2) << 2;
+	}
+}
+
+void init_i3c_hub_type(void)
+{
+	if (rg3mxxb12_get_device_info(I2C_BUS2, &i3c_hub_type) && (i3c_hub_type == RG3M88B12_DEVICE_INFO)) {
+		LOG_INF("I3C hub type: rg3mxxb12");
+	} else if (p3h284x_get_device_info(I2C_BUS2, &i3c_hub_type)) {
+		LOG_INF("I3C hub type: p3h284x");
+	} else {
+		LOG_ERR("I3C hub get device type fail");
+		return;
 	}
 }

--- a/meta-facebook/op2-op/src/platform/plat_class.h
+++ b/meta-facebook/op2-op/src/platform/plat_class.h
@@ -40,6 +40,12 @@ enum RETIMER_TYPE {
 	RETIMER_TYPE_UNKNOWN,
 };
 
+enum I3C_HUB_TYPE {
+	I3C_HUB_TYPE_RNS,
+	I3C_HUB_TYPE_NXP,
+	I3C_HUB_TYPE_UNKNOWN,
+};
+
 enum E1S_NUMBER {
 	E1S_0,
 	E1S_1,
@@ -59,9 +65,11 @@ enum BOARD_REVISION_ID {
 int init_platform_config();
 uint8_t get_card_type();
 uint8_t get_card_position();
+uint16_t get_i3c_hub_type();
 int check_pcie_retimer_type(void);
 uint8_t get_pcie_retimer_type(void);
 uint8_t get_board_revision();
 void init_board_revision();
+void init_i3c_hub_type();
 
 #endif

--- a/meta-facebook/op2-op/src/platform/plat_init.c
+++ b/meta-facebook/op2-op/src/platform/plat_init.c
@@ -17,6 +17,7 @@
 #include "hal_gpio.h"
 #include "power_status.h"
 #include "rg3mxxb12.h"
+#include "p3h284x.h"
 #include "plat_gpio.h"
 #include "plat_class.h"
 #include "plat_i2c.h"
@@ -52,8 +53,11 @@ void pal_pre_init()
 {
 	uint8_t type = get_card_type();
 	uint8_t slave_port = 0x0;
+	uint16_t i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
 
 	init_board_revision();
+	init_i3c_hub_type();
+	i3c_hub_type = get_i3c_hub_type();
 
 	/* Initialize I3C HUB (connects to E1.s)
 	 * For OPA expansion,
@@ -80,9 +84,16 @@ void pal_pre_init()
 		return;
 	}
 
-	if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS2, slave_port, ldo_1_2_volt, pullup_1k_ohm)) {
-		printk("failed to initialize rg3mxxb12\n");
+	if (i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+		if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS2, slave_port, rg3mxxb12_ldo_1_2_volt, rg3mxxb12_pullup_1k_ohm)) {
+			printk("failed to initialize rg3mxxb12\n");
+		}
+	} else {
+		if (!p3h284x_i2c_mode_only_init(I2C_BUS2, slave_port, p3g284x_ldo_1_2_volt, p3g284x_pullup_1k_ohm)) {
+			printk("failed to initialize p3h284x\n");
+		}
 	}
+
 }
 
 DEVICE_DEFINE(PRE_DEF_PLAT_CONFIG, "PRE_DEF_PLATFOMR", &init_platform_config, NULL, NULL, NULL,

--- a/meta-facebook/yv35-gl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_class.c
@@ -26,6 +26,8 @@
 #include "libutil.h"
 #include "plat_gpio.h"
 #include "plat_i2c.h"
+#include "rg3mxxb12.h"
+#include "p3h284x.h"
 LOG_MODULE_REGISTER(plat_class);
 
 #define NUMBER_OF_ADC_CHANNEL 16
@@ -35,6 +37,8 @@ static uint8_t board_revision = 0x0F;
 static uint8_t hsc_module = HSC_MODULE_UNKNOWN;
 static CARD_STATUS _1ou_status = { false, TYPE_1OU_UNKNOWN };
 static CARD_STATUS _2ou_status = { false, TYPE_2OU_UNKNOWN };
+static uint16_t i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
+static uint16_t exp_i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
 
 uint8_t get_system_class()
 {
@@ -59,6 +63,16 @@ uint8_t get_board_revision()
 uint8_t get_hsc_module()
 {
 	return hsc_module;
+}
+
+uint16_t get_i3c_hub_type()
+{
+	return i3c_hub_type;
+}
+
+uint16_t get_exp_i3c_hub_type()
+{
+	return exp_i3c_hub_type;
 }
 
 /* ADC information for each channel
@@ -302,4 +316,25 @@ void init_platform_config()
 
 	LOG_INF("BIC class type(class-%d), 1ou present status(%d), 2ou present status(%d), board revision(0x%x)\n",
 		system_class, (int)_1ou_status.present, (int)_2ou_status.present, board_revision);
+}
+
+void init_i3c_hub_type(void)
+{
+	if (rg3mxxb12_get_device_info(I2C_BUS8, &exp_i3c_hub_type)) {
+		LOG_INF("I3C hub type: rg3mxxb12");
+	} else if (p3h284x_get_device_info(I2C_BUS8, &exp_i3c_hub_type)) {
+		LOG_INF("I3C hub type: p3h284x");
+	} else {
+		LOG_ERR("I3C hub get device type fail");
+		return;
+	}
+
+	if (rg3mxxb12_get_device_info(I3C_BUS4, &i3c_hub_type) && (i3c_hub_type == RG3M88B12_DEVICE_INFO)) {
+		LOG_INF("I3C hub type: rg3mxxb12");
+	} else if (p3h284x_get_device_info(I3C_BUS4, &i3c_hub_type)) {
+		LOG_INF("I3C hub type: p3h284x");
+	} else {
+		LOG_ERR("I3C hub get device type fail");
+		return;
+	}
 }

--- a/meta-facebook/yv35-gl/src/platform/plat_class.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_class.h
@@ -25,6 +25,8 @@
 #define NUMBER_OF_ADC_CHANNEL 16
 #define AST1030_ADC_BASE_ADDR 0x7e6e9000
 
+#define I3C_BUS4 3
+
 enum BIC_BOARD_REVISION {
 	SYS_BOARD_POC = 0x0,
 	SYS_BOARD_EVT,
@@ -69,6 +71,12 @@ enum HSC_MODULE {
 	HSC_MODULE_UNKNOWN,
 };
 
+enum I3C_HUB_TYPE {
+	I3C_HUB_TYPE_RNS,
+	I3C_HUB_TYPE_NXP,
+	I3C_HUB_TYPE_UNKNOWN,
+};
+
 /* ADC channel number */
 enum ADC_CHANNEL {
 	CHANNEL_6 = 6,
@@ -82,5 +90,8 @@ uint8_t get_hsc_module();
 bool get_adc_voltage(int channel, float *voltage);
 uint8_t get_board_revision();
 void init_platform_config();
+uint16_t get_i3c_hub_type();
+uint16_t get_exp_i3c_hub_type();
+void init_i3c_hub_type();
 
 #endif

--- a/meta-facebook/yv35-gl/src/platform/plat_i3c.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_i3c.c
@@ -1,7 +1,9 @@
 #include <stdio.h>
 #include <logging/log.h>
 #include "plat_i3c.h"
+#include "plat_class.h"
 #include "rg3mxxb12.h"
+#include "p3h284x.h"
 #include <errno.h>
 
 LOG_MODULE_REGISTER(plat_i3c);
@@ -10,6 +12,8 @@ void init_i3c_hub()
 {
 	I3C_MSG i3c_msg = { 0 };
 	i3c_msg.bus = I3C_BUS4;
+	uint16_t i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
+	i3c_hub_type = get_i3c_hub_type();
 
 	int ret = 0;
 	int i;
@@ -28,12 +32,23 @@ void init_i3c_hub()
 	i3c_msg.target_addr = RG3MXXB12_DEFAULT_STATIC_ADDRESS;
 	i3c_attach(&i3c_msg);
 
-	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
-		LOG_ERR("Failed to initialize i3c hub");
-	}
+	if (i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+		if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
+			LOG_ERR("Failed to initialize i3c hub");
+		}
 
-	if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
-				      DEFAULT_SLAVE_PORT_SETTING)) {
-		LOG_ERR("Error to set slave port");
+		if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
+					      DEFAULT_SLAVE_PORT_SETTING)) {
+			LOG_ERR("Error to set slave port");
+		}
+	} else {
+		if (!p3h284x_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
+			LOG_ERR("Failed to initialize i3c hub");
+		}
+
+		if (!p3h284x_set_slave_port(I3C_BUS4, P3H284X_DEFAULT_STATIC_ADDRESS,
+					      DEFAULT_SLAVE_PORT_SETTING)) {
+			LOG_ERR("Error to set slave port");
+		}
 	}
 }

--- a/meta-facebook/yv35-gl/src/platform/plat_i3c.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_i3c.h
@@ -23,8 +23,6 @@
 #define LDO_VOLT 0x3A
 #define DEFAULT_SLAVE_PORT_SETTING 0x3F
 
-#define I3C_BUS4 3
-
 void init_i3c_hub();
 
 #endif

--- a/meta-facebook/yv35-gl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_init.c
@@ -29,6 +29,7 @@
 #include "plat_cpu.h"
 #include "plat_kcs.h"
 #include "rg3mxxb12.h"
+#include "p3h284x.h"
 #include "util_worker.h"
 
 /*
@@ -57,20 +58,35 @@ SCU_CFG scu_cfg[] = {
 
 void pal_pre_init()
 {
-	init_i3c_hub();
+	uint16_t exp_i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
 	init_platform_config();
+	init_i3c_hub_type();
+	init_i3c_hub();
+	exp_i3c_hub_type = get_exp_i3c_hub_type();
 	CARD_STATUS _1ou_status = get_1ou_status();
 	CARD_STATUS _2ou_status = get_2ou_status();
 	if (_1ou_status.present && (_1ou_status.card_type == TYPE_1OU_OLMSTED_POINT)) {
-		// Initialize I3C HUB (HD BIC connects to Olympic2 1ou expension-A and B)
-		if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS8, BIT(2), ldo_1_8_volt, pullup_1k_ohm)) {
-			printk("failed to initialize 1ou rg3mxxb12\n");
+		if (exp_i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+			// Initialize I3C HUB (HD BIC connects to Olympic2 1ou expension-A and B)
+			if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS8, BIT(2), rg3mxxb12_ldo_1_8_volt, rg3mxxb12_pullup_1k_ohm)) {
+				printk("failed to initialize 1ou rg3mxxb12\n");
+			}
+		} else {
+			if (!p3h284x_i2c_mode_only_init(I2C_BUS8, BIT(2), p3g284x_ldo_1_8_volt, p3g284x_pullup_1k_ohm)) {
+				printk("failed to initialize 1ou p3h284x\n");
+			}
 		}
 	}
 	if (_2ou_status.present && (_1ou_status.card_type == TYPE_1OU_OLMSTED_POINT)) {
 		// Initialize I3C HUB (HD BIC connects to Olympic2 3ou expension-A and B)
-		if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS9, BIT(2), ldo_1_8_volt, pullup_1k_ohm)) {
-			printk("failed to initialize 3ou rg3mxxb12\n");
+		if (exp_i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+			if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS9, BIT(2), rg3mxxb12_ldo_1_8_volt, rg3mxxb12_pullup_1k_ohm)) {
+				printk("failed to initialize 3ou rg3mxxb12\n");
+			}
+		} else {
+			if (!p3h284x_i2c_mode_only_init(I2C_BUS9, BIT(2), p3g284x_ldo_1_8_volt, p3g284x_pullup_1k_ohm)) {
+				printk("failed to initialize 1ou p3h284x\n");
+			}
 		}
 	}
 	scu_init(scu_cfg, ARRAY_SIZE(scu_cfg));


### PR DESCRIPTION
# Description:
To support 2nd source I3c hub P3H284X.

# Motivation:
To support 2nd source I3c hub P3H284X.

# Test Plan:
1. Build and test pass on OLP2.0 system. pass
2. Test the functionality after we get the real board. Pending