### PR TITLE
yv4-ff: fix set_dev_endpiont

### DIFF
--- a/meta-facebook/yv4-ff/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_mctp.c
@@ -114,6 +114,9 @@ static void set_dev_endpoint(void)
 			continue;
 
 		for (uint8_t j = 0; j < ARRAY_SIZE(plat_mctp_port); j++) {
+			if (p->bus != plat_mctp_port[j].conf.smbus_conf.bus)
+				continue;
+
 			struct _set_eid_req req = { 0 };
 			req.op = SET_EID_REQ_OP_SET_EID;
 			req.eid = p->endpoint;


### PR DESCRIPTION
# Description:
Add condition check when paring the plat_mctp_port.

# Motivation:
The check was missing so it will send the same command twice.

# Test Plan:
- Build code: Pass
- Test on yv4 platform: Pass