### PR TITLE
yv4: sd: Revise formula for slot distinguish

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_class.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_class.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define CHANNEL_2 2
 #define CHANNEL_13 13
 #define NUMBER_OF_ADC_CHANNEL 16
 #define AST1030_ADC_BASE_ADDR 0x7e6e9000


### PR DESCRIPTION
# Description:
- Revise formula following hardware design

# Motivation:
- Revise the formula of the slot's judgment to make it more precisely.

# Test plan:
- Test on yosemite4 platform - Pass i2ctransfer -f -y 6 w2@0x22 0x08 0x04
obmc-console-client -i host2
[host1]
[00:00:00.038,000] <inf> plat_class: slot_id = 10
[host2]
[00:00:00.038,000] <inf> plat_class: slot_id = 20
[host3]
[00:00:00.038,000] <inf> plat_class: slot_id = 30
[host4]
[00:00:00.038,000] <inf> plat_class: slot_id = 40
[host5]
[00:00:00.038,000] <inf> plat_class: slot_id = 50
[host6]
[00:00:00.038,000] <inf> plat_class: slot_id = 60
[host7]
[00:00:00.038,000] <inf> plat_class: slot_id = 70
[host8]
[00:00:00.038,000] <inf> plat_class: slot_id = 80