### PR TITLE
fby3.5: cl: Fix pldm over mctp fail

### DIFF
--- a/common/dev/snoop.c
+++ b/common/dev/snoop.c
@@ -217,6 +217,7 @@ void send_post_code_to_BMC()
 					continue;
 				}
 			} else {
+				send_postcode_msg->InF_target = PLDM;
 				status = pldm_send_ipmi_request(send_postcode_msg);
 				SAFE_FREE(send_postcode_msg);
 			}

--- a/common/service/host/kcs.c
+++ b/common/service/host/kcs.c
@@ -158,8 +158,8 @@ static void kcs_read_task(void *arvg0, void *arvg1, void *arvg2)
 			// Check BMC communication interface if use IPMB or not
 			if (!pal_is_interface_use_ipmb(IPMB_inf_index_map[BMC_IPMB])) {
 				int ret = 0;
-
 				// Send request to MCTP/PLDM thread to ask BMC
+				bridge_msg.InF_target = PLDM;
 				ret = pldm_send_ipmi_request(&bridge_msg);
 				if (ret < 0) {
 					LOG_ERR("kcs_read_task send to BMC fail");

--- a/common/service/ipmb/ipmb.c
+++ b/common/service/ipmb/ipmb.c
@@ -865,6 +865,7 @@ void IPMB_RXTask(void *pvParameters, void *arvg0, void *arvg1)
 						LOG_ERR("bridge_msg allocation failed");
 						goto cleanup;
 					}
+
 					memset(bridge_msg, 0, sizeof(ipmi_msg));
 
 					bridge_msg->data_len = current_msg_rx->buffer.data_len;
@@ -883,6 +884,7 @@ void IPMB_RXTask(void *pvParameters, void *arvg0, void *arvg1)
 					if (!pal_is_interface_use_ipmb(
 						    IPMB_inf_index_map[BMC_IPMB])) {
 						// Send ME request to MCTP/PLDM thread to BMC and get response
+						bridge_msg->InF_target = PLDM;
 						pldm_send_ipmi_request(bridge_msg);
 						bridge_msg->netfn = current_msg_rx->buffer.netfn;
 						bridge_msg->seq = current_msg_rx->buffer.seq;
@@ -1020,7 +1022,6 @@ ipmb_error ipmb_send_response(ipmi_msg *resp, uint8_t index)
 	resp_cfg.buffer.src_LUN = resp->dest_LUN;
 	resp_cfg.buffer.cmd = resp->cmd;
 	resp_cfg.retries = 0;
-
 	LOG_DBG("Send resp message, index(%d) cc(0x%x) data[%d]:", index,
 		resp_cfg.buffer.completion_code, resp_cfg.buffer.data_len);
 	LOG_HEXDUMP_DBG(resp_cfg.buffer.data, resp_cfg.buffer.data_len, "");

--- a/common/service/ipmi/ipmi.c
+++ b/common/service/ipmi/ipmi.c
@@ -165,7 +165,7 @@ static uint8_t send_msg_by_pldm(ipmi_msg_cfg *msg_cfg)
 
 __weak bool pal_set_dimm_presence_status(uint8_t *buf)
 {
-	return false;
+	return true;
 }
 
 __weak bool pal_request_msg_to_BIC_from_HOST(uint8_t netfn, uint8_t cmd)

--- a/common/service/ipmi/storage_handler.c
+++ b/common/service/ipmi/storage_handler.c
@@ -301,6 +301,7 @@ __weak void STORAGE_ADD_SEL(ipmi_msg *msg)
 			return;
 		}
 	} else {
+		add_sel_msg->InF_target = PLDM;
 		status = pldm_send_ipmi_request(add_sel_msg);
 		free(add_sel_msg);
 		msg->data_len = 0;

--- a/common/service/pldm/pldm.c
+++ b/common/service/pldm/pldm.c
@@ -559,7 +559,7 @@ int pldm_send_ipmi_response(uint8_t interface, ipmi_msg *msg)
 	memset(&pmsg, 0, sizeof(pmsg));
 	memset(&resp_buf, 0, sizeof(resp_buf));
 
-	mctp_port *p = pal_find_mctp_port_by_channel_target(msg->InF_target);
+	mctp_port *p = pal_find_mctp_port_by_channel_target(interface);
 	CHECK_NULL_ARG_WITH_RETURN(p, -1);
 
 	int medium_type = p->medium_type;
@@ -597,7 +597,6 @@ int pldm_send_ipmi_response(uint8_t interface, ipmi_msg *msg)
 	LOG_HEXDUMP_DBG(pmsg.buf, pmsg.len, "pmsg.buf");
 
 	CHECK_NULL_ARG_WITH_RETURN(p->mctp_inst, -1);
-
 	// Send response to PLDM/MCTP thread
 	mctp_pldm_send_msg(p->mctp_inst, &pmsg);
 	return 0;

--- a/meta-facebook/yv35-cl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.c
@@ -57,7 +57,7 @@ void send_gpio_interrupt(uint8_t gpio_num)
 
 	msg.data_len = 5;
 	msg.InF_source = SELF;
-	msg.InF_target = MCTP;
+	msg.InF_target = PLDM;
 	msg.netfn = NETFN_OEM_1S_REQ;
 	msg.cmd = CMD_OEM_1S_SEND_INTERRUPT_TO_BMC;
 
@@ -78,7 +78,7 @@ static void SLP3_handler()
 {
 	common_addsel_msg_t sel_msg;
 	if ((gpio_get(FM_SLPS3_PLD_N) == GPIO_HIGH) && (gpio_get(PWRGD_SYS_PWROK) == GPIO_LOW)) {
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
@@ -144,7 +144,7 @@ void ISR_DC_ON()
 		if ((gpio_get(FM_SLPS3_PLD_N) == GPIO_HIGH) &&
 		    (gpio_get(RST_RSMRST_BMC_N) == GPIO_HIGH)) {
 			common_addsel_msg_t sel_msg;
-			sel_msg.InF_target = MCTP;
+			sel_msg.InF_target = PLDM;
 			sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_OEM_C3;
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 			sel_msg.sensor_number = SENSOR_NUM_POWER_ERROR;
@@ -159,7 +159,7 @@ void ISR_DC_ON()
 
 	msg.data_len = 4;
 	msg.InF_source = SELF;
-	msg.InF_target = MCTP;
+	msg.InF_target = PLDM;
 	msg.netfn = NETFN_OEM_1S_REQ;
 	msg.cmd = CMD_OEM_1S_SEND_HOST_POWER_STATE_TO_BMC;
 
@@ -188,7 +188,7 @@ static void PROC_FAIL_handler(struct k_work *work)
 		bool ret = false;
 
 		memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_SENSOR_TYPE_PROCESSOR;
 		sel_msg.sensor_number = SENSOR_NUM_PROC_FAIL;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
@@ -232,7 +232,7 @@ static void CAT_ERR_handler(struct k_work *work)
 		bool ret = false;
 
 		memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_SENSOR_TYPE_PROCESSOR;
 		sel_msg.sensor_number = SENSOR_NUM_CATERR;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
@@ -285,7 +285,7 @@ void ISR_FM_THROTTLE()
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		}
 
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_FMTHROTTLE;
@@ -317,7 +317,7 @@ void ISR_HSC_THROTTLE()
 				return;
 			}
 
-			sel_msg.InF_target = MCTP;
+			sel_msg.InF_target = PLDM;
 			sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 			sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 			sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_PMBUSALERT;
@@ -346,7 +346,7 @@ static void mb_throttle_handler(struct k_work *work)
 			is_mb_throttle_assert = true;
 		}
 
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_FIRMWAREASSERT;
@@ -384,7 +384,7 @@ void ISR_SOC_THMALTRIP()
 			sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_MEMORY_THERMALTRIP;
 		}
 
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
@@ -410,7 +410,7 @@ void ISR_SYS_THROTTLE()
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		}
 
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_THROTTLE;
@@ -439,7 +439,7 @@ void ISR_PCH_THMALTRIP()
 		return;
 	}
 
-	sel_msg.InF_target = MCTP;
+	sel_msg.InF_target = PLDM;
 	sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 	sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 	sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_PCHHOT;
@@ -460,7 +460,7 @@ void ISR_HSC_OC()
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		}
 
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_HSCTIMER;
@@ -482,7 +482,7 @@ void ISR_CPU_MEMHOT()
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		}
 
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_CPU_DIMM_HOT;
 		sel_msg.sensor_number = SENSOR_NUM_CPUDIMM_HOT;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_DIMM_HOT;
@@ -504,7 +504,7 @@ void ISR_CPUVR_HOT()
 			sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		}
 
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_CPU_DIMM_VR_HOT;
 		sel_msg.sensor_number = SENSOR_NUM_VR_HOT;
 		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_CPU_VR_HOT;
@@ -520,7 +520,7 @@ void ISR_PCH_PWRGD()
 {
 	common_addsel_msg_t sel_msg;
 	if (gpio_get(FM_SLPS3_PLD_N) == GPIO_HIGH) {
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_OEM_C3;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		sel_msg.sensor_number = SENSOR_NUM_POWER_ERROR;
@@ -537,7 +537,7 @@ void ISR_RMCA()
 {
 	if ((gpio_get(RST_PLTRST_BUF_N) == GPIO_HIGH) || (gpio_get(PWRGD_CPU_LVC3) == GPIO_HIGH)) {
 		common_addsel_msg_t sel_msg;
-		sel_msg.InF_target = MCTP;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_SENSOR_TYPE_PROCESSOR;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		sel_msg.sensor_number = SENSOR_NUM_CATERR;
@@ -617,7 +617,7 @@ void ISR_CPU_VPP_INT()
 			// Add SEL about VPP power event
 			if (gpio_get(FM_SLPS3_PLD_N) == LOW_INACTIVE) {
 				memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
-				sel_msg.InF_target = MCTP;
+				sel_msg.InF_target = PLDM;
 				sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 				sel_msg.event_type = IPMI_OEM_EVENT_TYPE_NOTIFY;
 				sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
@@ -637,7 +637,7 @@ void ISR_NMI()
 	if ((gpio_get(RST_PLTRST_PLD_N) == GPIO_HIGH) && (gpio_get(PWRGD_SYS_PWROK) == GPIO_HIGH)) {
 		common_addsel_msg_t sel_msg;
 		memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
-		sel_msg.InF_target = BMC_IPMB;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_SENSOR_TYPE_CRITICAL_INT;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
@@ -671,7 +671,7 @@ void smi_handler()
 		common_addsel_msg_t sel_msg;
 		memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
 
-		sel_msg.InF_target = BMC_IPMB;
+		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
 		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;

--- a/meta-facebook/yv35-cl/src/platform/plat_mctp.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_mctp.c
@@ -38,7 +38,7 @@ K_TIMER_DEFINE(send_cmd_timer, send_cmd_to_dev, NULL);
 K_WORK_DEFINE(send_cmd_work, send_cmd_to_dev_handler);
 
 mctp_port plat_mctp_port[] = {
-	{	.channel_target = BMC_IPMB,
+	{	.channel_target = PLDM,
 		.medium_type = MCTP_MEDIUM_TYPE_TARGET_I3C,
 		.conf.i3c_conf.bus = I3C_BUS_BMC,
 		.conf.i3c_conf.addr = I3C_STATIC_ADDR_BMC

--- a/meta-facebook/yv35-cl/src/platform/plat_pmic.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_pmic.c
@@ -365,7 +365,7 @@ void add_pmic_error_sel(uint8_t dimm_id, uint8_t error_type)
 	common_addsel_msg_t sel_msg;
 
 	memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
-	sel_msg.InF_target = MCTP;
+	sel_msg.InF_target = PLDM;
 	sel_msg.sensor_type = IPMI_SENSOR_TYPE_PROCESSOR;
 	sel_msg.sensor_number = SENSOR_NUM_PMIC_ERROR;
 	sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
@@ -385,7 +385,7 @@ int get_pmic_fault_status()
 
 	// Get slot ID
 	ipmi_msg.InF_source = SELF;
-	ipmi_msg.InF_target = MCTP;
+	ipmi_msg.InF_target = PLDM;
 	ipmi_msg.netfn = NETFN_OEM_REQ;
 	ipmi_msg.cmd = CMD_OEM_GET_BOARD_ID;
 	ipmi_msg.data_len = 0;
@@ -403,7 +403,7 @@ int get_pmic_fault_status()
 
 	// Read SB CPLD (BMC channel) to know which PMIC happen critical error
 	ipmi_msg.InF_source = SELF;
-	ipmi_msg.InF_target = MCTP;
+	ipmi_msg.InF_target = PLDM;
 	ipmi_msg.netfn = NETFN_APP_REQ;
 	ipmi_msg.cmd = CMD_APP_MASTER_WRITE_READ;
 	ipmi_msg.data_len = 4;


### PR DESCRIPTION
# Description:
Fix BIC fail to send pldm over mctp to BMC.

# Motivation:
Fix BIC fail to send pldm over mctp to BMC.

# Test Plan:
1. Build and test pass on YV35 system. pass

2. Get the sensor reading and firmware information. root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :  39.000 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :  51.000 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :  33.500 C     | (ok)
MB_PCH_TEMP_C                (0x4) :  57.000 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x5) :  55.000 C     | (ok)
MB_SOC_THERMAL_MARGIN_C      (0x14) : -22.000 C     | (ok)
MB_SOC_TJMAX_C               (0x15) :  77.000 C     | (ok)
MB_DIMMA0_TEMP_C             (0x6) : NA | (na)
MB_DIMMA2_TEMP_C             (0x7) :  50.000 C     | (ok)
MB_DIMMA3_TEMP_C             (0x9) :  48.000 C     | (ok)
MB_DIMMA4_TEMP_C             (0xA) : NA | (na)
MB_DIMMA6_TEMP_C             (0xB) :  48.000 C     | (ok)
MB_DIMMA7_TEMP_C             (0xC) :  45.000 C     | (ok)
MB_SSD0_M2A_TEMP_C           (0xD) :  40.000 C     | (ok)
MB_HSC_TEMP_C                (0xE) :  49.500 C     | (ok)
MB_VR_VCCIN_TEMP_C           (0xF) :  55.937 C     | (ok)
MB_VR_FIVRA_TEMP_C           (0x10) :  55.125 C     | (ok)
MB_VR_EHV_TEMP_C             (0x11) :  52.062 C     | (ok)
MB_VR_VCCD_TEMP_C            (0x12) :  52.875 C     | (ok)
MB_VR_FAON_TEMP_C            (0x13) :  54.750 C     | (ok)
MB_ADC_P12V_STBY_VOLT_V      (0x20) :  12.322 Volts | (ok)
MB_ADC_P3V_BAT_VOLT_V        (0x21) :   3.066 Volts | (ok)
MB_ADC_P3V3_STBY_VOLT_V      (0x22) :   3.314 Volts | (ok)
MB_ADC_P1V8_STBY_VOLT_V      (0x23) :   1.811 Volts | (ok)
MB_ADC_P1V05_PCH_VOLT_V      (0x24) :   1.044 Volts | (ok)
MB_ADC_P5V_STBY_VOLT_V       (0x25) :   5.005 Volts | (ok)
MB_ADC_P12V_DIMM_VOLT_V      (0x26) :  12.322 Volts | (ok)
MB_ADC_P1V2_STBY_VOLT_V      (0x27) :   1.203 Volts | (ok)
MB_ADC_P3V3_M2_VOLT_V        (0x28) :   3.320 Volts | (ok)
MB_HSC_INPUT_VOLT_V          (0x29) :  12.280 Volts | (ok)
MB_VR_VCCIN_VOLT_V           (0x2A) :   1.625 Volts | (ok)
MB_VR_FIVRA_VOLT_V           (0x2C) :   1.798 Volts | (ok)
MB_VR_EHV_VOLT_V             (0x2D) :   1.801 Volts | (ok)
MB_VR_VCCD_VOLT_V            (0x2E) :   1.143 Volts | (ok)
MB_VR_FAON_VOLT_V            (0x2F) :   1.058 Volts | (ok)
MB_HSC_OUTPUT_CURR_A         (0x30) :   4.526 Amps  | (ok)
MB_VR_VCCIN_CURR_A           (0x31) :   7.023 Amps  | (ok)
MB_VR_FIVRA_CURR_A           (0x32) :   3.078 Amps  | (ok)
MB_VR_EHV_CURR_A             (0x33) :   0.427 Amps  | (ok)
MB_VR_VCCD_CURR_A            (0x34) :   0.490 Amps  | (ok)
MB_VR_FAON_CURR_A            (0x35) :   7.750 Amps  | (ok)
MB_SOC_PACKAGE_PWR_W         (0x38) :  32.000 Watts | (ok)
MB_HSC_INPUT_PWR_W           (0x39) :  55.542 Watts | (ok)
MB_VR_VCCIN_PWR_W            (0x3A) :  11.531 Watts | (ok)
MB_VR_FIVRA_PWR_W            (0x3C) :   5.000 Watts | (ok)
MB_VR_EHV_PWR_W              (0x3D) :   0.951 Watts | (ok)
MB_VR_VCCD_PWR_W             (0x3E) :   0.505 Watts | (ok)
MB_VR_FAON_PWR_W             (0x3F) :   8.046 Watts | (ok)
MB_VR_DIMMA0_PMIC_PWR_W      (0x1E) : NA | (na)
MB_VR_DIMMA2_PMIC_PWR_W      (0x1F) :   0.625 Watts | (ok)
MB_VR_DIMMA3_PMIC_PWR_W      (0x36) :   0.500 Watts | (ok)
MB_VR_DIMMA4_PMIC_PWR_W      (0x37) : NA | (na)
MB_VR_DIMMA6_PMIC_PWR_W      (0x42) :   0.375 Watts | (ok)
MB_VR_DIMMA7_PMIC_PWR_W      (0x47) :   0.250 Watts | (ok)
VF_E1S_OUTLET_TEMP_C         (0x50) :  38.000 C     | (ok)
VF_E1S_P12V_AUX_VOLT_V       (0x51) :  12.390 Volts | (ok)
VF_E1S_P12V_EDGE_VOLT_V      (0x52) :  12.334 Volts | (ok)
VF_E1S_P3V3_AUX_VOLT_V       (0x53) :   3.321 Volts | (ok)
VF_E1S_P1V2_STBY_VOLT_V      (0x58) :   1.208 Volts | (ok)
VF_E1S_SSD0_PWR_WATT_W       (0x60) :   2.900 Watts | (ok)
VF_E1S_SSD0_VOLT_V           (0x61) :  12.280 Volts | (ok)
VF_E1S_SSD0_TEMP_C           (0x62) :  46.000 C     | (ok)
VF_E1S_SSD0_3V3_ADC_VOLT_V   (0x64) :   3.316 Volts | (ok)
VF_E1S_SSD0_12V_ADC_VOLT_V   (0x63) :  12.200 Volts | (ok)
VF_E1S_SSD1_PWR_WATT_W       (0x68) :   2.875 Watts | (ok)
VF_E1S_SSD1_VOLT_V           (0x69) :  12.281 Volts | (ok)
VF_E1S_SSD1_TEMP_C           (0x6A) :  45.000 C     | (ok)
VF_E1S_SSD1_3V3_ADC_VOLT_V   (0x6C) :   3.316 Volts | (ok)
VF_E1S_SSD1_12V_ADC_VOLT_V   (0x6B) :  12.165 Volts | (ok)
VF_E1S_SSD2_PWR_WATT_W       (0x70) : NA | (na)
VF_E1S_SSD2_VOLT_V           (0x71) : NA | (na)
VF_E1S_SSD2_TEMP_C           (0x72) : NA | (na)
VF_E1S_SSD2_3V3_ADC_VOLT_V   (0x74) : NA | (na)
VF_E1S_SSD2_12V_ADC_VOLT_V   (0x73) : NA | (na)
VF_E1S_SSD3_PWR_WATT_W       (0x78) :   2.925 Watts | (ok)
VF_E1S_SSD3_VOLT_V           (0x79) :  12.281 Volts | (ok)
VF_E1S_SSD3_TEMP_C           (0x7A) :  45.000 C     | (ok)
VF_E1S_SSD3_3V3_ADC_VOLT_V   (0x7C) :   3.309 Volts | (ok)
VF_E1S_SSD3_12V_ADC_VOLT_V   (0x7B) :  12.179 Volts | (ok)

root@bmc-oob:~# fw-util slot1 --version
1OU Bridge-IC Version: oby35-vf-v2023.40.01
SB Bridge-IC Version: oby35-cl-v2023.39.01
BIOS Version: Y35CLM04
BIOS Version after activation: Y35CLM04
SB CPLD Version: 00010A06
SB CPLD Version after activation: 00010A06
ME Version: 6.1.2.48
VCCIN/VCCFA_EHV_FIVRA Version: Texas Instruments E6BB, Remaining Writes: 1000 VCCIN/VCCFA_EHV_FIVRA Version after activation: Texas Instruments E6BB, Remaining Writes: 1000 VCCINFAON/VCCFA_EHV Version: Texas Instruments 7939, Remaining Writes: 1000 VCCINFAON/VCCFA_EHV Version after activation: Texas Instruments 7939, Remaining Writes: 1000 VCCD Version: Texas Instruments 812F, Remaining Writes: 1000 VCCD Version after activation: Texas Instruments 812F, Remaining Writes: 1000