### PR TITLE
fby4: sd: Support SD GPIO name

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_gpio.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_gpio.c
@@ -25,7 +25,9 @@
 
 #define gpio_name_to_num(x) #x,
 char *gpio_name[] = {
-        name_gpioA
+	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
+		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
+			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU
 };
 #undef gpio_name_to_num
 

--- a/meta-facebook/yv4-sd/src/platform/plat_gpio.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_gpio.h
@@ -26,20 +26,222 @@
 // clang-format off
 
 #define name_gpioA \
-	gpio_name_to_num(Reserve_GPIOA0) \
-	gpio_name_to_num(Reserve_GPIOA1) \
-	gpio_name_to_num(Reserve_GPIOA2) \
+	gpio_name_to_num(FM_CPU_BIC_SLP_S5_N) \
+	gpio_name_to_num(FM_CPU_BIC_SLP_S3_N) \
+	gpio_name_to_num(RST_RSMRST_BMC_N) \
 	gpio_name_to_num(PWRGD_CPU_LVC3) \
-	gpio_name_to_num(Reserve_GPIOA4) \
-	gpio_name_to_num(Reserve_GPIOA5) \
-	gpio_name_to_num(Reserve_GPIOA6) \
-	gpio_name_to_num(Reserve_GPIOA7)
+	gpio_name_to_num(CPU_SMERR_BIC_N) \
+	gpio_name_to_num(BMC_READY) \
+	gpio_name_to_num(RST_CPU_RESET_BIC_N) \
+	gpio_name_to_num(RST_USB_HUB_R_N)
+
+#define name_gpioB \
+	gpio_name_to_num(AUTH_PRSNT_BIC_N) \
+	gpio_name_to_num(BIC_CPU_NMI_N) \
+	gpio_name_to_num(FM_SMI_ACTIVE_N) \
+	gpio_name_to_num(IRQ_BIC_CPU_SMI_N) \
+	gpio_name_to_num(FM_CPU_BIC_THERMTRIP_N) \
+	gpio_name_to_num(APML_CPU_ALERT_BIC_N) \
+	gpio_name_to_num(PRSNT_CPU_R_N) \
+	gpio_name_to_num(SYS_PWRBTN_BIC_N)
+
+#define name_gpioC \
+	gpio_name_to_num(PVDDCR_CPU0_PMALERT_N) \
+	gpio_name_to_num(FM_HSC_TIMER_ALT_N) \
+	gpio_name_to_num(EXAMAX_RESERVED_1) \
+	gpio_name_to_num(PVDDCR_CPU1_PMALERT_N) \
+	gpio_name_to_num(PWRBTN_N) \
+	gpio_name_to_num(RST_BMC_R_N) \
+	gpio_name_to_num(HDT_BIC_DBREQ_R_N) \
+	gpio_name_to_num(BIC_READY_R)
+
+#define name_gpioD \
+	gpio_name_to_num(FM_SOL_UART_CH_SEL_R) \
+	gpio_name_to_num(EXAMAX_RESERVED_2) \
+	gpio_name_to_num(FAST_PROCHOT_N) \
+	gpio_name_to_num(BIC_JTAG_SEL_R) \
+	gpio_name_to_num(FM_CPU_BIC_PROCHOT_LVT3_N) \
+	gpio_name_to_num(SMB_E1S_0_RST_R_N) \
+	gpio_name_to_num(SMB_E1S_1_RST_R_N) \
+	gpio_name_to_num(SMB_E1S_0_INA233_ALRT_N)
+
+#define name_gpioE \
+	gpio_name_to_num(FM_BIOS_MRC_DEBUG_MSG_DIS) \
+	gpio_name_to_num(SMB_SENSOR_LVC3_ALERT_N) \
+	gpio_name_to_num(FM_BIOS_POST_CMPLT_BIC_N) \
+	gpio_name_to_num(IRQ_UV_DETECT_N) \
+	gpio_name_to_num(PVDDCR_CPU0_OCP_N) \
+	gpio_name_to_num(PVDDCR_CPU1_OCP_N) \
+	gpio_name_to_num(P3V_BAT_SCALED_R_EN) \
+	gpio_name_to_num(HDT_BIC_TRST_R_N)
+
+#define name_gpioF \
+	gpio_name_to_num(CARD_TYPE_EXP) \
+	gpio_name_to_num(CPU_ERROR_BIC_LVC3_R_N) \
+	gpio_name_to_num(PVDD11_S3_PMALERT_N) \
+	gpio_name_to_num(EXAMAX_RESERVED_4) \
+	gpio_name_to_num(CPU_TYPE0) \
+	gpio_name_to_num(FM_BMC_DEBUG_ENABLE_R_N) \
+	gpio_name_to_num(FM_DBP_PRESENT_N) \
+	gpio_name_to_num(FM_FAST_PROCHOT_R_EN_N)
+
+#define name_gpioG \
+	gpio_name_to_num(IO_EXP_ALERT) \
+	gpio_name_to_num(FM_CPLD_BMC_BIC_READY) \
+	gpio_name_to_num(BIC_JTAG_MUX_SEL) \
+	gpio_name_to_num(RST_PLTRST_BIC_N) \
+	gpio_name_to_num(CPU_TYPE1) \
+	gpio_name_to_num(RTM_IOEXP_INT_N) \
+	gpio_name_to_num(P3V3_STBY_SIDECAR_FAULT_N) \
+	gpio_name_to_num(EXAMAX_RESERVED_3)
+
+#define name_gpioH \
+	gpio_name_to_num(PRSNT_CEM_CONN) \
+	gpio_name_to_num(TOP_CXL_SMBUS_ALERT_N) \
+	gpio_name_to_num(FRONT_CXL_SMBUS_ALERT_N) \
+	gpio_name_to_num(P1V2_STBY_SIDECAR_FAULT_N) \
+	gpio_name_to_num(Reserve_GPIOH4) \
+	gpio_name_to_num(Reserve_GPIOH5) \
+	gpio_name_to_num(Reserve_GPIOH6) \
+	gpio_name_to_num(Reserve_GPIOH7)
+
+#define name_gpioI \
+	gpio_name_to_num(Reserve_GPIOI0) \
+	gpio_name_to_num(Reserve_GPIOI1) \
+	gpio_name_to_num(Reserve_GPIOI2) \
+	gpio_name_to_num(Reserve_GPIOI3) \
+	gpio_name_to_num(Reserve_GPIOI4) \
+	gpio_name_to_num(Reserve_GPIOI5) \
+	gpio_name_to_num(Reserve_GPIOI6) \
+	gpio_name_to_num(Reserve_GPIOI7)
+
+#define name_gpioJ \
+	gpio_name_to_num(AUTH_COMPLETE) \
+	gpio_name_to_num(BIC_READY_TOP_EXP) \
+	gpio_name_to_num(RTM2_IOEXP_INT_N) \
+	gpio_name_to_num(SIDECAR_CABLE_PRESENT) \
+	gpio_name_to_num(BIC_READY_FRONT_EXP) \
+	gpio_name_to_num(CPU_BIC_RTC_GET_N) \
+	gpio_name_to_num(SMB_RTM1_INA233_ALRT_N) \
+	gpio_name_to_num(SMB_RTM2_INA233_ALRT_N)
+
+#define name_gpioK \
+	gpio_name_to_num(Reserve_GPIOK0) \
+	gpio_name_to_num(Reserve_GPIOK1) \
+	gpio_name_to_num(Reserve_GPIOK2) \
+	gpio_name_to_num(Reserve_GPIOK3) \
+	gpio_name_to_num(Reserve_GPIOK4) \
+	gpio_name_to_num(Reserve_GPIOK5) \
+	gpio_name_to_num(Reserve_GPIOK6) \
+	gpio_name_to_num(Reserve_GPIOK7)
+
+#define name_gpioL \
+	gpio_name_to_num(Reserve_GPIOL0) \
+	gpio_name_to_num(Reserve_GPIOL1) \
+	gpio_name_to_num(PWRGD_HSC_SLOT_BIC) \
+	gpio_name_to_num(SIDECAR_PRESENT_BIC_N) \
+	gpio_name_to_num(SMB_E1S_1_INA233_ALRT_N) \
+	gpio_name_to_num(VR_TYPE_0) \
+	gpio_name_to_num(VR_TYPE_1) \
+	gpio_name_to_num(EXAMAX_TYPE)
+
+#define name_gpioM \
+	gpio_name_to_num(Reserve_GPIOM0) \
+	gpio_name_to_num(Reserve_GPIOM1) \
+	gpio_name_to_num(MEDUSA_HSC_R_PG) \
+	gpio_name_to_num(Reserve_GPIOM3) \
+	gpio_name_to_num(Reserve_GPIOM4) \
+	gpio_name_to_num(Reserve_GPIOM5) \
+	gpio_name_to_num(Reserve_GPIOM6) \
+	gpio_name_to_num(Reserve_GPIOM7)
+
+#define name_gpioN \
+	gpio_name_to_num(SGPIO_BMC_CLK_R) \
+	gpio_name_to_num(SGPIO_BMC_LD_R_N) \
+	gpio_name_to_num(SGPIO_BMC_DOUT_R) \
+	gpio_name_to_num(SGPIO_BMC_DIN) \
+	gpio_name_to_num(Reserve_GPION4) \
+	gpio_name_to_num(Reserve_GPION5) \
+	gpio_name_to_num(Reserve_GPION6) \
+	gpio_name_to_num(Reserve_GPION7)
+
+#define name_gpioO \
+	gpio_name_to_num(Reserve_GPIOO0) \
+	gpio_name_to_num(Reserve_GPIOO1) \
+	gpio_name_to_num(Reserve_GPIOO2) \
+	gpio_name_to_num(Reserve_GPIOO3) \
+	gpio_name_to_num(Reserve_GPIOO4) \
+	gpio_name_to_num(Reserve_GPIOO5) \
+	gpio_name_to_num(Reserve_GPIOO6) \
+	gpio_name_to_num(Reserve_GPIOO7)
+
+#define name_gpioP \
+	gpio_name_to_num(Reserve_GPIOP0) \
+	gpio_name_to_num(Reserve_GPIOP1) \
+	gpio_name_to_num(Reserve_GPIOP2) \
+	gpio_name_to_num(Reserve_GPIOP3) \
+	gpio_name_to_num(Reserve_GPIOP4) \
+	gpio_name_to_num(Reserve_GPIOP5) \
+	gpio_name_to_num(Reserve_GPIOP6) \
+	gpio_name_to_num(Reserve_GPIOP7)
+
+#define name_gpioQ \
+	gpio_name_to_num(Reserve_GPIOQ0) \
+	gpio_name_to_num(Reserve_GPIOQ1) \
+	gpio_name_to_num(Reserve_GPIOQ2) \
+	gpio_name_to_num(Reserve_GPIOQ3) \
+	gpio_name_to_num(Reserve_GPIOQ4) \
+	gpio_name_to_num(Reserve_GPIOQ5) \
+	gpio_name_to_num(Reserve_GPIOQ6) \
+	gpio_name_to_num(Reserve_GPIOQ7)
+
+#define name_gpioR \
+	gpio_name_to_num(Reserve_GPIOR0) \
+	gpio_name_to_num(Reserve_GPIOR1) \
+	gpio_name_to_num(Reserve_GPIOR2) \
+	gpio_name_to_num(Reserve_GPIOR3) \
+	gpio_name_to_num(Reserve_GPIOR4) \
+	gpio_name_to_num(Reserve_GPIOR5) \
+	gpio_name_to_num(Reserve_GPIOR6) \
+	gpio_name_to_num(Reserve_GPIOR7)
+
+#define name_gpioS \
+	gpio_name_to_num(Reserve_GPIOS0) \
+	gpio_name_to_num(Reserve_GPIOS1) \
+	gpio_name_to_num(Reserve_GPIOS2) \
+	gpio_name_to_num(Reserve_GPIOS3) \
+	gpio_name_to_num(Reserve_GPIOS4) \
+	gpio_name_to_num(Reserve_GPIOS5) \
+	gpio_name_to_num(Reserve_GPIOS6) \
+	gpio_name_to_num(Reserve_GPIOS7)
+
+#define name_gpioT \
+	gpio_name_to_num(Reserve_GPIOT0) \
+	gpio_name_to_num(Reserve_GPIOT1) \
+	gpio_name_to_num(Reserve_GPIOT2) \
+	gpio_name_to_num(Reserve_GPIOT3) \
+	gpio_name_to_num(Reserve_GPIOT4) \
+	gpio_name_to_num(Reserve_GPIOT5) \
+	gpio_name_to_num(Reserve_GPIOT6) \
+	gpio_name_to_num(Reserve_GPIOT7)
+
+#define name_gpioU \
+	gpio_name_to_num(Reserve_GPIOU0) \
+	gpio_name_to_num(Reserve_GPIOU1) \
+	gpio_name_to_num(Reserve_GPIOU2) \
+	gpio_name_to_num(Reserve_GPIOU3) \
+	gpio_name_to_num(Reserve_GPIOU4) \
+	gpio_name_to_num(Reserve_GPIOU5) \
+	gpio_name_to_num(Reserve_GPIOU6) \
+	gpio_name_to_num(Reserve_GPIOU7)
 
 // clang-format on
 
 #define gpio_name_to_num(x) x,
 enum _GPIO_NUMS_ {
-	name_gpioA
+	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
+		name_gpioI name_gpioJ name_gpioK name_gpioL name_gpioM name_gpioN name_gpioO
+			name_gpioP name_gpioQ name_gpioR name_gpioS name_gpioT name_gpioU
 };
 
 extern enum _GPIO_NUMS_ GPIO_NUMS;


### PR DESCRIPTION
# Description:
	Refer to "Sentinel Dome_Aspeed_AST1030_BIC_sensor_table_20230831" to define GPIO name

# Motivation:
	Define GPIO name in "plat_gpio.h"

# Test plan:
	Check GPIO list: Pass

# Test log:
	uart:~$ platform gpio list_all
	[0  ] FM_CPU_BIC_SLP_S5_N                : OD  | input (I) | 1(1)
	[1  ] FM_CPU_BIC_SLP_S3_N                : OD  | input (I) | 1(1)
	[2  ] RST_RSMRST_BMC_N                   : OD  | input (I) | 1(1)
	[3  ] PWRGD_CPU_LVC3                     : OD  | input (I) | 1(1)
```