### PR TITLE
ol2: op: Support to cache retimer version

### DIFF
--- a/common/dev/include/m88rt51632.h
+++ b/common/dev/include/m88rt51632.h
@@ -38,6 +38,8 @@
 
 #define M88RT51632_MUTEX_LOCK_MS 1000
 
+#define MAX_RETRY 3
+
 bool m88rt51632_get_vendor_id(I2C_MSG *msg);
 bool m88rt51632_get_fw_version(I2C_MSG *msg, uint32_t *version);
 uint8_t m88rt51632_fw_update(I2C_MSG *msg, uint32_t offset, uint16_t msg_len, uint8_t *msg_buf,

--- a/meta-facebook/op2-op/src/platform/plat_class.h
+++ b/meta-facebook/op2-op/src/platform/plat_class.h
@@ -20,6 +20,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#define RETIMER_UNKNOWN_VERSION -1
+#define RETIMER_VERSION_MAX_LENGTH 5
+
 enum CARD_POSITION {
 	CARD_POSITION_1OU,
 	CARD_POSITION_2OU,
@@ -71,5 +74,7 @@ uint8_t get_pcie_retimer_type(void);
 uint8_t get_board_revision();
 void init_board_revision();
 void init_i3c_hub_type();
+uint32_t get_pcie_retimer_version();
+void cache_pcie_retimer_version();
 
 #endif

--- a/meta-facebook/op2-op/src/platform/plat_hook.c
+++ b/meta-facebook/op2-op/src/platform/plat_hook.c
@@ -214,7 +214,7 @@ bool pre_i2c_bus_read(sensor_cfg *cfg, void *args)
 
 	i2c_proc_arg *pre_proc_args = (i2c_proc_arg *)args;
 
-	if (i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+	if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
 		if (!rg3mxxb12_select_slave_port_connect(pre_proc_args->bus, pre_proc_args->channel)) {
 			k_mutex_unlock(&i2c_hub_mutex);
 			return false;
@@ -242,7 +242,7 @@ bool post_i2c_bus_read(sensor_cfg *cfg, void *args, int *reading)
        * close all channels after the sensor read to avoid conflict with 
        * other devices reading.
        */
-	if (i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+	if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
 		if (!rg3mxxb12_select_slave_port_connect(post_proc_args->bus,
 						 RG3MXXB12_SSPORTS_ALL_DISCONNECT)) {
 			k_mutex_unlock(&i2c_hub_mutex);

--- a/meta-facebook/op2-op/src/platform/plat_init.c
+++ b/meta-facebook/op2-op/src/platform/plat_init.c
@@ -84,7 +84,7 @@ void pal_pre_init()
 		return;
 	}
 
-	if (i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+	if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
 		if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS2, slave_port, rg3mxxb12_ldo_1_2_volt, rg3mxxb12_pullup_1k_ohm)) {
 			printk("failed to initialize rg3mxxb12\n");
 		}

--- a/meta-facebook/op2-op/src/platform/plat_power_seq.c
+++ b/meta-facebook/op2-op/src/platform/plat_power_seq.c
@@ -186,6 +186,7 @@ void init_sequence_status()
 	case CARD_TYPE_OPA:
 		if (gpio_get(OPA_PERST_BIC_RTM_N) == GPIO_HIGH) {
 			is_retimer_sequence_done = true;
+			cache_pcie_retimer_version();
 		}
 
 		for (index = 0; index < OPA_MAX_E1S_IDX; ++index) {
@@ -928,6 +929,7 @@ bool power_on_handler(uint8_t initial_stage)
 					break;
 				}
 				is_retimer_sequence_done = true;
+				cache_pcie_retimer_version();
 			}
 			check_power_ret = 0;
 			control_stage = E1S_POWER_ON_STAGE0;

--- a/meta-facebook/yv35-gl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-gl/src/ipmi/plat_ipmi.c
@@ -162,7 +162,7 @@ void OEM_1S_WRITE_READ_DIMM(ipmi_msg *msg)
 	uint8_t slave_port_setting =
 		(dimm_id / (MAX_COUNT_DIMM / 2)) ? I3C_HUB_TO_DIMMEFGH : I3C_HUB_TO_DIMMABCD;
 
-	if (i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+	if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
 		if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
 				      slave_port_setting)) {
 			LOG_ERR("Failed to set slave port to slave port: 0x%x", slave_port_setting);

--- a/meta-facebook/yv35-gl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_class.c
@@ -329,7 +329,7 @@ void init_i3c_hub_type(void)
 		return;
 	}
 
-	if (rg3mxxb12_get_device_info(I3C_BUS4, &i3c_hub_type) && (i3c_hub_type == RG3M88B12_DEVICE_INFO)) {
+	if (rg3mxxb12_get_device_info(I3C_BUS4, &i3c_hub_type) && (i3c_hub_type == RG3M87B12_DEVICE_INFO)) {
 		LOG_INF("I3C hub type: rg3mxxb12");
 	} else if (p3h284x_get_device_info(I3C_BUS4, &i3c_hub_type)) {
 		LOG_INF("I3C hub type: p3h284x");

--- a/meta-facebook/yv35-gl/src/platform/plat_dimm.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_dimm.c
@@ -125,7 +125,7 @@ void get_dimm_info_handler()
 								   I3C_HUB_TO_DIMMEFGH :
 								   I3C_HUB_TO_DIMMABCD;
 
-			if (i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+			if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
 				if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
 						      slave_port_setting)) {
 					clear_unaccessible_dimm_data(dimm_id);

--- a/meta-facebook/yv35-gl/src/platform/plat_i3c.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_i3c.c
@@ -32,7 +32,7 @@ void init_i3c_hub()
 	i3c_msg.target_addr = RG3MXXB12_DEFAULT_STATIC_ADDRESS;
 	i3c_attach(&i3c_msg);
 
-	if (i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+	if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
 		if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
 			LOG_ERR("Failed to initialize i3c hub");
 		}

--- a/meta-facebook/yv35-gl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_init.c
@@ -66,7 +66,7 @@ void pal_pre_init()
 	CARD_STATUS _1ou_status = get_1ou_status();
 	CARD_STATUS _2ou_status = get_2ou_status();
 	if (_1ou_status.present && (_1ou_status.card_type == TYPE_1OU_OLMSTED_POINT)) {
-		if (exp_i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+		if (exp_i3c_hub_type == RG3M87B12_DEVICE_INFO) {
 			// Initialize I3C HUB (HD BIC connects to Olympic2 1ou expension-A and B)
 			if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS8, BIT(2), rg3mxxb12_ldo_1_8_volt, rg3mxxb12_pullup_1k_ohm)) {
 				printk("failed to initialize 1ou rg3mxxb12\n");
@@ -79,7 +79,7 @@ void pal_pre_init()
 	}
 	if (_2ou_status.present && (_1ou_status.card_type == TYPE_1OU_OLMSTED_POINT)) {
 		// Initialize I3C HUB (HD BIC connects to Olympic2 3ou expension-A and B)
-		if (exp_i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+		if (exp_i3c_hub_type == RG3M87B12_DEVICE_INFO) {
 			if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS9, BIT(2), rg3mxxb12_ldo_1_8_volt, rg3mxxb12_pullup_1k_ohm)) {
 				printk("failed to initialize 3ou rg3mxxb12\n");
 			}

--- a/meta-facebook/yv35-gl/src/platform/plat_pmic.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_pmic.c
@@ -355,7 +355,7 @@ void clear_pmic_error()
 							   I3C_HUB_TO_DIMMEFGH :
 							   I3C_HUB_TO_DIMMABCD;
 
-		if (i3c_hub_type == RG3M88B12_DEVICE_INFO) {
+		if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
 			if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
 					      slave_port_setting)) {
 				LOG_ERR("Failed to set slave port to slave port: 0x%x", slave_port_setting);


### PR DESCRIPTION
# Description:
Save retimer version in cache.

# Motivation:
To prevent getting abnormal version of retimer if BIC access retimer too often.

# Test Plan:
1. Test and build on OLP2.0 system. pass

2. Get retimer version: (1) Astera
root@bmc-oob:~# fw-util slot1 --version 1ou_retimer 1OU Retimer Version: Astera Labs v2_7_0

(2) Montage
root@bmc-oob:~# fw-util slot1 --version 1ou_retimer 1OU Retimer Version: Montage 08586300