### PR TITLE
fby3.5: gl: Version commit for oby35-gl-2023.46.01

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_version.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_version.h
@@ -21,7 +21,7 @@
 
 #define PLATFORM_NAME "Yosemite V3.5"
 #define PROJECT_NAME "Great Lakes"
-#define PROJECT_STAGE EVT
+#define PROJECT_STAGE DVT
 
 /*
  * 0x01 motherboard
@@ -32,7 +32,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0xb
+#define FIRMWARE_REVISION_2 0x01
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -41,7 +41,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x23
-#define BIC_FW_WEEK 0x40
+#define BIC_FW_WEEK 0x46
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x67 // char: g
 #define BIC_FW_platform_1 0x6c // char: l


### PR DESCRIPTION
# Description:
Version commit for Yv3.5 Greatlakes BIC oby35-gl-2023.46.01

# Motivation:
Version commit for Yv3.5 Greatlakes BIC oby35-gl-2023.46.01

# Test Plan:
1. Build and test pass on OLP2.0 system: pass

2. Get SB BIC version: root@bmc-oob:~# fw-util slot1 --version bic
SB Bridge-IC Version: oby35-gl-v2023.46.01