### PR TITLE
fby4: ff: Support pldm QueryDeviceIdentifiers command

### DIFF
--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <logging/log.h>
+#include "libutil.h"
+#include "pldm.h"
+#include "pldm_firmware_update.h"
+#include "plat_pldm_fw_update.h"
+#include "mctp_ctrl.h"
+
+LOG_MODULE_REGISTER(plat_fwupdate);
+
+enum FIRMWARE_COMPONENT {
+	FF_COMPNT_BIC,
+};
+
+/* PLDM FW update table */
+pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = FF_COMPNT_BIC,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = pldm_bic_update,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_SPI,
+		.activate_method = COMP_ACT_SELF,
+		.self_act_func = pldm_bic_activate,
+		.get_fw_version_fn = NULL,
+	},
+};
+
+uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uint8_t *resp,
+					   uint16_t *resp_len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, false);
+	CHECK_NULL_ARG_WITH_RETURN(resp, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, PLDM_ERROR);
+
+	struct pldm_query_device_identifiers_resp *resp_p =
+		(struct pldm_query_device_identifiers_resp *)resp;
+
+	resp_p->completion_code = PLDM_SUCCESS;
+	resp_p->descriptor_count = 0x02;
+
+	uint8_t iana[PLDM_FWUP_IANA_ENTERPRISE_ID_LENGTH] = { 0x00, 0x00, 0xA0, 0x15 };
+
+	// Set the device id for ff bic
+	uint8_t deviceId[PLDM_FWUP_IANA_ENTERPRISE_ID_LENGTH] = { 0x00, 0x01 };
+
+	uint8_t total_size_of_iana_descriptor =
+		sizeof(struct pldm_descriptor_tlv) + sizeof(iana) - 1;
+
+	uint8_t total_size_of_device_id_descriptor =
+		sizeof(struct pldm_descriptor_tlv) + sizeof(deviceId) - 1;
+
+	if (sizeof(struct pldm_query_device_identifiers_resp) + total_size_of_iana_descriptor +
+		    total_size_of_device_id_descriptor >
+	    PLDM_MAX_DATA_SIZE) {
+		LOG_ERR("QueryDeviceIdentifiers data length is over PLDM_MAX_DATA_SIZE define size %d",
+			PLDM_MAX_DATA_SIZE);
+		resp_p->completion_code = PLDM_ERROR;
+		return PLDM_ERROR;
+	}
+
+	// Allocate data for tlv which including descriptors data
+	struct pldm_descriptor_tlv *tlv_ptr = malloc(total_size_of_iana_descriptor);
+	if (tlv_ptr == NULL) {
+		LOG_ERR("Memory allocation failed!");
+		return PLDM_ERROR;
+	}
+
+	tlv_ptr->descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID;
+	tlv_ptr->descriptor_length = PLDM_FWUP_IANA_ENTERPRISE_ID_LENGTH;
+	memcpy(tlv_ptr->descriptor_data, iana, sizeof(iana));
+
+	uint8_t *end_of_id_ptr =
+		(uint8_t *)resp + sizeof(struct pldm_query_device_identifiers_resp);
+
+	memcpy(end_of_id_ptr, tlv_ptr, total_size_of_iana_descriptor);
+	free(tlv_ptr);
+
+	tlv_ptr = malloc(total_size_of_device_id_descriptor);
+	if (tlv_ptr == NULL) {
+		LOG_ERR("Memory allocation failed!");
+		return PLDM_ERROR;
+	}
+
+	tlv_ptr->descriptor_type = PLDM_PCI_DEVICE_ID;
+	tlv_ptr->descriptor_length = PLDM_PCI_DEVICE_ID_LENGTH;
+	memcpy(tlv_ptr->descriptor_data, deviceId, sizeof(deviceId));
+
+	end_of_id_ptr += total_size_of_iana_descriptor;
+	memcpy(end_of_id_ptr, tlv_ptr, total_size_of_device_id_descriptor);
+	free(tlv_ptr);
+
+	resp_p->device_identifiers_len =
+		total_size_of_iana_descriptor + total_size_of_device_id_descriptor;
+
+	*resp_len = sizeof(struct pldm_query_device_identifiers_resp) +
+		    total_size_of_iana_descriptor + total_size_of_device_id_descriptor;
+
+	return PLDM_SUCCESS;
+}
+
+void load_pldmupdate_comp_config(void)
+{
+	if (comp_config) {
+		LOG_WRN("PLDM update component table has already been load");
+		return;
+	}
+
+	comp_config_count = ARRAY_SIZE(PLDMUPDATE_FW_CONFIG_TABLE);
+	comp_config = malloc(sizeof(pldm_fw_update_info_t) * comp_config_count);
+	if (!comp_config) {
+		LOG_ERR("comp_config malloc failed");
+		return;
+	}
+
+	memcpy(comp_config, PLDMUPDATE_FW_CONFIG_TABLE, sizeof(PLDMUPDATE_FW_CONFIG_TABLE));
+}

--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _PLAT_FWUPDATE_H_
+#define _PLAT_FWUPDATE_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "pldm_firmware_update.h"
+
+void load_pldmupdate_comp_config(void);
+
+#endif /* _PLAT_FWUPDATE_H_ */


### PR DESCRIPTION
# Description:
- Support QueryDeviceIdentifiers command
- Temporary use "PCI Device ID" as the identifier to distinguish bic type

# Motivation:
- Support QueryDeviceIdentifiers command so that pldmd can via this cmd to recognize ff bic.
- Device id list as below:
  - Device id 0x00 : sd
  - Device id 0x01 : ff
  - Device id 0x02 : wf

# Test Plan:
- Build code : pass
- Update ff bic success.

# Log:
1. Get fw image version before update root@bmc:~# pldmtool fw_update GetFwParams -m 41
{
    "CapabilitiesDuringUpdate": {
        "Component Update Failure Recovery Capability": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer.",
        "Component Update Failure Retry Capability": " Device can have component updated again without exiting update mode and restarting transfer via RequestUpdate command.",
        "Firmware Device Partial Updates": "Firmware Device cannot accept a partial update and all components present on the FD shall be updated.",
        "Firmware Device Host Functionality during Firmware Update": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer",
        "Firmware Device Update Mode Restrictions": "No host OS environment restriction for update mode"
    },
    "ComponentCount": 0,
    "ActiveComponentImageSetVersionString": "2023.49.02",
    "PendingComponentImageSetVersionString": "",
    "ComponentParameterEntries": null
}

2. Get ff QueryDeviceIdentifiers
root@bmc:~# pldmtool fw_update QueryDeviceIdentifiers -m 41 -v                                                               pldmtool: Tx: 80 05 01
pldmtool: Rx: 00 05 01 00 0e 00 00 00 02 01 00 04 00 00 00 a0 15 00 01 02 00 00 01
{
    "EID": 41,
    "Descriptors": [
        {
            "Type": "IANA Enterprise ID",
            "Value": [
                "0000a015"
            ]
        },
        {
            "Type": "PCI Device ID",
            "Value": [
                "0001"
            ]
        }
    ]
}

3. Updating Sep 27 03:21:27 bmc pldmd[2891]: Rx: 9f 05 16 00
Sep 27 03:21:27 bmc pldmd[2891]: Tx: 1f 05 16 00
Sep 27 03:21:27 bmc pldmd[2891]: Component Transfer complete, EID = 41, COMPONENT_VERSION = ast1030 v2023FF Sep 27 03:21:27 bmc pldmd[2891]: Rx: 80 05 17 00
Sep 27 03:21:27 bmc pldmd[2891]: Tx: 00 05 17 00
Sep 27 03:21:27 bmc pldmd[2891]: Component verification complete, EID=41, COMPONENT_VERSION=ast1030 v2023FF Sep 27 03:21:27 bmc pldmd[2891]: Rx: 81 05 18 00 00 00 Sep 27 03:21:27 bmc pldmd[2891]: Tx: 01 05 18 00
Sep 27 03:21:27 bmc pldmd[2891]: Component apply complete, EID = 41, COMPONENT_VERSION = ast1030 v2023FF Sep 27 03:21:27 bmc pldmd[2891]: Tx: 96 05 1a 00
Sep 27 03:21:27 bmc pldmd[2891]: Rx: 16 05 1a 00 00 00

4. Check version is changed root@bmc:~# pldmtool fw_update GetFwParams -m 41
{
    "CapabilitiesDuringUpdate": {
        "Component Update Failure Recovery Capability": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer.",
        "Component Update Failure Retry Capability": " Device can have component updated again without exiting update mode and restarting transfer via RequestUpdate command.",
        "Firmware Device Partial Updates": "Firmware Device cannot accept a partial update and all components present on the FD shall be updated.",
        "Firmware Device Host Functionality during Firmware Update": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer",
        "Firmware Device Update Mode Restrictions": "No host OS environment restriction for update mode"
    },
    "ComponentCount": 0,
    "ActiveComponentImageSetVersionString": "2023.44.01",
    "PendingComponentImageSetVersionString": "",
    "ComponentParameterEntries": null
}