### PR TITLE
Artemis: mc : adjust bus 4 sda hold time

### DIFF
--- a/meta-facebook/at-mc/boards/ast1030_evb.overlay
+++ b/meta-facebook/at-mc/boards/ast1030_evb.overlay
@@ -38,6 +38,7 @@
 &i2c4 {
 	pinctrl-0 = <&pinctrl_i2c4_default>;
 	clock-frequency = <I2C_BITRATE_FAST>;
+	manual-sda-delay = <1>;	
 	status = "okay";
 };
 


### PR DESCRIPTION
# Description
- SDA hold time is not enough with 2nd source MB. Adjust the timing register to meet i2c spec.

# Motivation:
- Compatible to 2nd source MB and meet i2c spec

# Test Plan
- Build code: Pass
- Test pass with EE measurement.