### PR TITLE
fby4: sd: Reinitialize I3C hub after DC on

### DIFF
--- a/common/service/pldm/pldm_monitor.h
+++ b/common/service/pldm/pldm_monitor.h
@@ -59,6 +59,7 @@ typedef enum pldm_platform_monitor_commands {
 
 #define PLDM_PLATFORM_OEM_GPIO_EFFECTER_STATE_FIELD_COUNT 2
 #define PLDM_PLATFORM_OEM_HOST_POWER_CTRL_EFFECTER_STATE_FIELD_COUNT 1
+#define PLDM_PLATFORM_OEM_I3C_HUB_REINIT_EFFECTER_STATE_FIELD_COUNT 1
 #define PLDM_PLATFORM_OEM_SWITCH_UART_EFFECTER_STATE_FIELD_COUNT 1
 #define PLDM_PLATFORM_OEM_AST1030_GPIO_PIN_NUM_MAX 167
 
@@ -130,6 +131,11 @@ enum oem_effecter_states_power_status {
 	EFFECTER_STATE_POWER_STATUS_MAX
 };
 
+enum oem_effecter_states_reinit_i3c_hub {
+	EFFECTER_STATE_I3C_HUB_REINIT = 0x01,
+	EFFECTER_STATE_I3C_HUB_MAX,
+};
+
 enum pldm_sensor_present_state {
 	PLDM_SENSOR_UNKNOWN = 0x0,
 	PLDM_SENSOR_NORMAL = 0x01,
@@ -179,6 +185,7 @@ enum pldm_oem_platform_completion_codes {
 /* Define from Platform Level Data Model (PLDM) State
 Set Specification (DSP0249) Table 15 – Entity ID codes*/
 enum pldm_entity_types {
+	PLDM_ENTITY_DEVICE_DRIVER = 35,
 	PLDM_ENTITY_SUB_CHASSIS = 46,
 	PLDM_ENTITY_IO_CONTROLLER = 145,
 	PLDM_ENTITY_OTHER_BUS = 160,
@@ -433,6 +440,9 @@ uint8_t plat_pldm_get_state_effecter_state_handler(const uint8_t *buf, uint16_t 
 
 void plat_pldm_set_effecter_state_host_power_control(const uint8_t *buf, uint16_t len,
 						     uint8_t *resp, uint16_t *resp_len);
+
+void plat_pldm_set_effecter_state_reinit_i3c_hub(const uint8_t *buf, uint16_t len, uint8_t *resp,
+						 uint16_t *resp_len);
 
 void pldm_assign_gpio_effecter_id();
 

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -69,7 +69,7 @@ void pal_pre_init()
 	i3c_attach(&i3c_msg);
 
 	// Initialize I3C HUB
-	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, ldo_1_2_volt)) {
+	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, rg3mxxb12_ldo_1_2_volt)) {
 		printk("failed to initialize 1ou rg3mxxb12\n");
 	}
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -21,19 +21,60 @@
 #include "power_status.h"
 #include "sensor.h"
 #include "snoop.h"
+#include "rg3mxxb12.h"
 #include "plat_gpio.h"
 #include "plat_class.h"
 #include "plat_sensor_table.h"
 #include "plat_i2c.h"
 #include "hal_gpio.h"
 #include "hal_i2c.h"
+#include "hal_i3c.h"
 #include "util_sys.h"
 #include "util_worker.h"
 #include "plat_mctp.h"
 
 LOG_MODULE_REGISTER(plat_isr, LOG_LEVEL_DBG);
 
+/*
+ *	TODO: I3C hub is supplied by DC power currently. When DC off, it can't be initialized.
+ *  	  Therefore, BIC needs to implement a workaround to reinitialize the I3C hub during DC on.
+ *        This part will be removed after the hardware design be modified.
+ */
+void reinit_i3c_hub()
+{
+	// i3c master initial
+	I3C_MSG i3c_msg = { 0 };
+	i3c_msg.bus = I3C_BUS_HUB;
+	i3c_msg.target_addr = I3C_ADDR_HUB;
+
+	const int rstdaa_count = 2;
+	int ret = 0;
+
+	for (int i = 0; i < rstdaa_count; i++) {
+		ret = i3c_brocast_ccc(&i3c_msg, I3C_CCC_RSTDAA, I3C_BROADCAST_ADDR);
+		if (ret != 0) {
+			printf("Error to reset daa. count = %d\n", i);
+		}
+	}
+
+	ret = i3c_brocast_ccc(&i3c_msg, I3C_CCC_SETAASA, I3C_BROADCAST_ADDR);
+	if (ret != 0) {
+		printf("Error to set daa\n");
+	}
+
+	i3c_attach(&i3c_msg);
+
+	// Initialize I3C HUB
+	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, rg3mxxb12_ldo_1_2_volt)) {
+		printk("failed to initialize 1ou rg3mxxb12\n");
+	}
+
+	// Set FF/WF's EID
+	send_cmd_to_dev_handler(NULL);
+}
+
 K_WORK_DELAYABLE_DEFINE(set_DC_on_5s_work, set_DC_on_delayed_status);
+K_WORK_DEFINE(reinit_i3c_work, reinit_i3c_hub);
 #define DC_ON_5_SECOND 5
 void ISR_DC_ON()
 {
@@ -43,6 +84,7 @@ void ISR_DC_ON()
 
 	if (dc_status) {
 		k_work_schedule(&set_DC_on_5s_work, K_SECONDS(DC_ON_5_SECOND));
+		k_work_submit(&reinit_i3c_work);
 	} else {
 		set_DC_on_delayed_status();
 	}

--- a/meta-facebook/yv4-sd/src/platform/plat_isr.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.h
@@ -20,5 +20,8 @@
 #include <stdint.h>
 
 void ISR_DC_ON();
+void ISR_POST_COMPLETE();
+
+void reinit_i3c_hub();
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_monitor.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_monitor.h
@@ -17,7 +17,7 @@
 #ifndef PLAT_PLDM_MONITOR_H
 #define PLAT_PLDM_MONITOR_H
 
-#define PLAT_PLDM_MAX_STATE_EFFECTER_IDX 169
+#define PLAT_PLDM_MAX_STATE_EFFECTER_IDX 170
 
 #define PLAT_PLDM_HOST_PWR_CTRL_DEFAULT 0xFF
 #define PLAT_PLDM_HOST_PWR_BTN_LOW 0xFE
@@ -25,6 +25,10 @@
 
 enum pldm_plat_effecter_id_high_byte {
 	PLAT_EFFECTER_ID_GPIO_HIGH_BYTE = (0xFF << 8),
+};
+
+enum plat_pldm_effecter_id {
+	PLAT_PLDM_EFFECTER_ID_REINIT_I3C_HUB = 0x0101,
 };
 
 extern struct pldm_state_effecter_info plat_state_effecter_table[];


### PR DESCRIPTION
# Description:
       - BIC reinitializes I3C hub and set 1OU board EID when DC on.
       - Support PLDM command to reinitializes I3C hub

# Motivation:
	I3C hub is supplied by DC power, but serverboard won't DC on automatically after AC on. It is result in failing to initialize I3C hub.

# Test plan:
	- BMC can get FF EID when DC on: Pass - BMC send PLDM command and get WF EID: Pass

# Test log:
        - BMC can get FF EID when DC on:
	/* after DC on */
	root@bmc:/usr/libexec/phosphor-state-manager# systemctl restart mctpd
	```
	root@bmc:/usr/libexec/phosphor-state-manager# busctl tree xyz.openbmc_project.MCTP
	`- /xyz
	  `- /xyz/openbmc_project `- /xyz/openbmc_project/mctp `- /xyz/openbmc_project/mctp/1 |- /xyz/openbmc_project/mctp/1/40 |- /xyz/openbmc_project/mctp/1/41 /* FF EID */ `- /xyz/openbmc_project/mctp/1/8 - BMC send PLDM command and get WF EID: root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x1 0x1 0x1 0x1 0x1 -m 60 pldmtool: Tx: 80 02 39 01 01 01 01 01 pldmtool: Rx: 00 02 39 00 root@bmc:~# systemctl restart mctpd ``` root@bmc:~# busctl tree xyz.openbmc_project.MCTP `- /xyz `- /xyz/openbmc_project `- /xyz/openbmc_project/mctp `- /xyz/openbmc_project/mctp/1 |- /xyz/openbmc_project/mctp/1/60 |- /xyz/openbmc_project/mctp/1/62 /* WF EID */ `- /xyz/openbmc_project/mctp/1/8