### PR TITLE
fby35: gl: Initialize platform work queue

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_init.c
@@ -93,6 +93,8 @@ void pal_pre_init()
 	if (!pal_load_vw_gpio_config()) {
 		printk("failed to initialize vw gpio\n");
 	}
+
+	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
 }
 
 void pal_post_init()


### PR DESCRIPTION
# Description:
	Initialize platform work queue when initializing BIC.

# Motivation:
	BIC doesn't execute platform work queue.(e.g. : Reset BMC by IPMI command 0x38 0x16).

# Test plan:
	Send Reset BMC command to BIC and check if BMC do reset: Pass

# Test Log:
	before:
		root@bmc-oob:~# bic-util slot3 0xe0 0x16 0x15 0xA0 0x0
		root@bmc-oob:~#
		root@bmc-oob:~#
		/* BMC doesn't reset*/
		root@bmc-oob:~# log-util all --print | grep "BMC Reboot"
		/* blank */

	after:
		root@bmc-oob:~# bic-util slot3 0xe0 0x16 0x15 0xA0 0x0
		/* BMC reset*/
		root@bmc-oob:~# log-util all --print | grep "BMC Reboot"
		0    all      2023-11-09 16:40:42    healthd          BMC Reboot detected