### PR TITLE
Artemis: Remove the workaround of Artemis module firmware version

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_dev.c
+++ b/meta-facebook/at-cb/src/platform/plat_dev.c
@@ -81,20 +81,6 @@ void clear_freya_cache_flag(uint8_t card_id)
 	accl_freya_info[card_id].freya2_fw_info.is_freya_ready = FREYA_NOT_READY;
 }
 
-int check_fw_version_valid(uint8_t *check_fw_version, uint8_t check_len)
-{
-	CHECK_NULL_ARG_WITH_RETURN(check_fw_version, -1);
-
-	for (uint8_t index = 0; index < check_len; ++index) {
-		if (check_fw_version[index] == INVALID_FW_DATA ||
-		    check_fw_version[index] == UNEXPECTED_FW_DATA) {
-			return FREYA_NOT_READY_RET_CODE;
-		}
-	}
-
-	return 0;
-}
-
 int get_freya_fw_info(uint8_t bus, uint8_t addr, freya_fw_info *fw_info)
 {
 	CHECK_NULL_ARG_WITH_RETURN(fw_info, -1);
@@ -145,18 +131,6 @@ int get_freya_fw_info(uint8_t bus, uint8_t addr, freya_fw_info *fw_info)
 		fw_info->is_freya_ready = FREYA_NOT_READY;
 		LOG_ERR("Read freya firmware version fail, bus: 0x%x, addr: 0x%x", bus, addr);
 		return -1;
-	}
-
-	if ((addr == ACCL_ARTEMIS_MODULE_1_ADDR) || (addr == ACCL_ARTEMIS_MODULE_2_ADDR)) {
-		// Workaround: Check PSOC and QSPI firmware version, report freya not ready if reading value is invalid
-		ret = check_fw_version_valid(&read_buf[PSOC_QSPI_FW_INDEX], SOC_QSPI_FW_LENGTH);
-		if (ret != 0) {
-			if (ret == FREYA_NOT_READY_RET_CODE) {
-				memset(&fw_info, 0, FREYA_FW_VERSION_LENGTH);
-				fw_info->is_freya_ready = FREYA_NOT_READY;
-			}
-			return ret;
-		}
 	}
 
 	memcpy(&fw_info->major_version, &read_buf[FREYA_FIRMWARE_VERSION_OFFSET],

--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -1078,14 +1078,6 @@ bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 	switch (cfg->target_addr) {
 	case ACCL_FREYA_1_ADDR:
 	case ACCL_ARTEMIS_MODULE_1_ADDR:
-		if (accl_freya->freya1_fw_info.is_freya_ready != FREYA_READY) {
-			// Workaround: Record ready flag at the last sensor of ASIC, and get firmware version in the next sensor polling for confirming version ready
-			if (cfg->offset == NVME_VOLTAGE_RAIL_2_OFFSET) {
-				accl_freya->freya1_fw_info.is_freya_ready = FREYA_READY;
-			}
-			return true;
-		}
-
 		if (accl_freya->is_cache_freya1_info != true) {
 			ret = get_freya_fw_info(cfg->port, cfg->target_addr,
 						&accl_freya->freya1_fw_info);
@@ -1097,14 +1089,6 @@ bool pre_accl_nvme_read(sensor_cfg *cfg, void *args)
 		break;
 	case ACCL_FREYA_2_ADDR:
 	case ACCL_ARTEMIS_MODULE_2_ADDR:
-		if (accl_freya->freya2_fw_info.is_freya_ready != FREYA_READY) {
-			// Workaround: Record ready flag at the last sensor of ASIC, and get firmware version in the next sensor polling for confirming version ready
-			if (cfg->offset == NVME_VOLTAGE_RAIL_2_OFFSET) {
-				accl_freya->freya2_fw_info.is_freya_ready = FREYA_READY;
-			}
-			return true;
-		}
-
 		if (accl_freya->is_cache_freya2_info != true) {
 			ret = get_freya_fw_info(cfg->port, cfg->target_addr,
 						&accl_freya->freya2_fw_info);


### PR DESCRIPTION
# Description
- Remove the workaround after BRCM implements drive ready bit.

# Motivation
- Remove the workaround after BRCM implements drive ready bit.

# Test Plan
- Build code: Pass
- Get firmware version during DC cycle: 80 rounds Pass

# Log
root@bmc-oob:~# fw-util all --version
......
CB_ACCL1 DEV1 Version: v3.1.12.100.10
CB_ACCL1 DEV2 Version: v3.1.12.100.10
CB_ACCL2 DEV1 Version: v3.1.12.100.10
CB_ACCL2 DEV2 Version: v3.1.12.100.10
CB_ACCL3 DEV1 Version: v3.1.12.100.10
CB_ACCL3 DEV2 Version: v3.1.12.100.10
CB_ACCL4 DEV1 Version: v3.1.12.100.10
CB_ACCL4 DEV2 Version: v3.1.12.100.10
CB_ACCL5 DEV1 Version: v3.1.12.100.10
CB_ACCL5 DEV2 Version: v3.1.12.100.10
CB_ACCL6 DEV1 Version: v3.1.12.100.10
CB_ACCL6 DEV2 Version: v3.1.12.100.10
CB_ACCL7 DEV1 Version: v3.1.12.100.10
CB_ACCL7 DEV2 Version: v3.1.12.100.10
CB_ACCL8 DEV1 Version: v3.1.12.100.10
CB_ACCL8 DEV2 Version: v3.1.12.100.10
CB_ACCL9 DEV1 Version: v3.1.12.100.10
CB_ACCL9 DEV2 Version: v3.1.12.100.10
CB_ACCL10 DEV1 Version: v3.1.12.100.10
CB_ACCL10 DEV2 Version: v3.1.12.100.10
CB_ACCL11 DEV1 Version: v3.1.12.100.10
CB_ACCL11 DEV2 Version: v3.1.12.100.10
CB_ACCL12 DEV1 Version: v3.1.12.100.10
CB_ACCL12 DEV2 Version: v3.1.12.100.10
......