### PR TITLE
fby3.5: gl: fix i3c hub init fail

### DIFF
--- a/common/dev/include/p3h284x.h
+++ b/common/dev/include/p3h284x.h
@@ -78,5 +78,6 @@ bool p3h284x_select_slave_port_connect(uint8_t bus, uint8_t slave_port);
 bool p3h284x_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt);
 bool p3h284x_set_slave_port(uint8_t bus, uint8_t addr, uint8_t setting);
 bool p3h284x_get_device_info(uint8_t bus, uint16_t *i3c_hub_type);
+bool p3h284x_get_device_info_i3c(uint8_t bus, uint16_t *i3c_hub_type);
 
 #endif

--- a/common/dev/include/rg3mxxb12.h
+++ b/common/dev/include/rg3mxxb12.h
@@ -82,5 +82,6 @@ bool rg3mxxb12_select_slave_port_connect(uint8_t bus, uint8_t slave_port);
 bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt);
 bool rg3mxxb12_set_slave_port(uint8_t bus, uint8_t addr, uint8_t setting);
 bool rg3mxxb12_get_device_info(uint8_t bus, uint16_t *i3c_hub_type);
+bool rg3mxxb12_get_device_info_i3c(uint8_t bus, uint16_t *i3c_hub_type);
 
 #endif

--- a/common/dev/rg3mxxb12.c
+++ b/common/dev/rg3mxxb12.c
@@ -22,6 +22,27 @@ LOG_MODULE_REGISTER(dev_rg3mxxb12);
 
 #define RETRY 3
 
+static bool rg3mxxb12_register_read_i3c(uint8_t bus, uint8_t offset, uint8_t *value)
+{
+	CHECK_NULL_ARG_WITH_RETURN(value, false);
+	int ret = -1;
+	I3C_MSG i3c_msg = { 0 };
+
+	i3c_msg.bus = bus;
+	i3c_msg.target_addr = RG3MXXB12_DEFAULT_STATIC_ADDRESS;
+	i3c_msg.tx_len = 1;
+	i3c_msg.data[0] = offset;
+	i3c_msg.rx_len = 1;
+	ret = i3c_transfer(&i3c_msg);
+	if (ret != 0) {
+		LOG_ERR("Failed to read rg3mxxb12 register via I3C 0x%x, bus-%d ret = %d", offset, bus, ret);
+		return false;
+	}
+	*value = i3c_msg.data[0];
+
+	return true;
+}
+
 static bool rg3mxxb12_register_read(uint8_t bus, uint8_t offset, uint8_t *value)
 {
 	CHECK_NULL_ARG_WITH_RETURN(value, false);
@@ -96,6 +117,20 @@ bool rg3mxxb12_get_device_info(uint8_t bus, uint16_t *i3c_hub_type)
 
 	if (rg3mxxb12_register_read(bus, RG3MXXB12_DEVICE_INFO0_REG, &device_info0)) {
 		rg3mxxb12_register_read(bus, RG3MXXB12_DEVICE_INFO1_REG, &device_info1);
+	} else {
+		return false;
+	}
+
+	*i3c_hub_type = (device_info1 << 8) | device_info0;
+	return true;
+}
+
+bool rg3mxxb12_get_device_info_i3c(uint8_t bus, uint16_t *i3c_hub_type)
+{
+	uint8_t device_info0, device_info1 = 0;
+
+	if (rg3mxxb12_register_read_i3c(bus, RG3MXXB12_DEVICE_INFO0_REG, &device_info0)) {
+		rg3mxxb12_register_read_i3c(bus, RG3MXXB12_DEVICE_INFO1_REG, &device_info1);
 	} else {
 		return false;
 	}

--- a/meta-facebook/yv35-gl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_class.c
@@ -321,20 +321,18 @@ void init_platform_config()
 void init_i3c_hub_type(void)
 {
 	if (rg3mxxb12_get_device_info(I2C_BUS8, &exp_i3c_hub_type)) {
-		LOG_INF("I3C hub type: rg3mxxb12");
+		LOG_INF("Expansion I3C hub type: rg3mxxb12");
 	} else if (p3h284x_get_device_info(I2C_BUS8, &exp_i3c_hub_type)) {
-		LOG_INF("I3C hub type: p3h284x");
+		LOG_INF("Expansion I3C hub type: p3h284x");
 	} else {
-		LOG_ERR("I3C hub get device type fail");
-		return;
+		LOG_ERR("Expansion I3C hub get device type fail");
 	}
 
-	if (rg3mxxb12_get_device_info(I3C_BUS4, &i3c_hub_type) && (i3c_hub_type == RG3M87B12_DEVICE_INFO)) {
+	if (rg3mxxb12_get_device_info_i3c(I3C_BUS4, &i3c_hub_type) && (i3c_hub_type == RG3M87B12_DEVICE_INFO)) {
 		LOG_INF("I3C hub type: rg3mxxb12");
-	} else if (p3h284x_get_device_info(I3C_BUS4, &i3c_hub_type)) {
+	} else if (p3h284x_get_device_info_i3c(I3C_BUS4, &i3c_hub_type)) {
 		LOG_INF("I3C hub type: p3h284x");
 	} else {
 		LOG_ERR("I3C hub get device type fail");
-		return;
 	}
 }

--- a/meta-facebook/yv35-gl/src/platform/plat_i3c.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_i3c.c
@@ -13,7 +13,6 @@ void init_i3c_hub()
 	I3C_MSG i3c_msg = { 0 };
 	i3c_msg.bus = I3C_BUS4;
 	uint16_t i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
-	i3c_hub_type = get_i3c_hub_type();
 
 	int ret = 0;
 	int i;
@@ -31,6 +30,8 @@ void init_i3c_hub()
 
 	i3c_msg.target_addr = RG3MXXB12_DEFAULT_STATIC_ADDRESS;
 	i3c_attach(&i3c_msg);
+	init_i3c_hub_type();
+	i3c_hub_type = get_i3c_hub_type();
 
 	if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
 		if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {


### PR DESCRIPTION
# Description:
Fix BIC cannot acess DIMM sensor.

# Motivation:
Fix BIC cannot acess DIMM sensor.

# Test Plan:
1. Build and test pass on OLP 2.0 system. pass

2. Get DIMM temp and PMIC power root@bmc-oob:~# sensor-util slot1 | grep DIMM
MB_DIMMA0_TEMP_C             (0x5) :  23.500 C     | (ok)
MB_DIMMA1_TEMP_C             (0x6) :  23.750 C     | (ok)
MB_DIMMA2_TEMP_C             (0x7) :  23.750 C     | (ok)
MB_DIMMA3_TEMP_C             (0x8) :  23.500 C     | (ok)
MB_DIMMA4_TEMP_C             (0x9) :  24.000 C     | (ok)
MB_DIMMA5_TEMP_C             (0xA) :  23.750 C     | (ok)
MB_DIMMA6_TEMP_C             (0xB) :  23.500 C     | (ok)
MB_DIMMA7_TEMP_C             (0xC) :  23.250 C     | (ok)
MB_ADC_P12V_DIMM_VOLT_V      (0x25) :  12.439 Volts | (ok)
MB_VR_DIMMA0_PMIC_PWR_W      (0x36) :   0.250 Watts | (ok)
MB_VR_DIMMA1_PMIC_PWR_W      (0x37) :   0.125 Watts | (ok)
MB_VR_DIMMA2_PMIC_PWR_W      (0x38) :   0.000 Watts | (ok)
MB_VR_DIMMA3_PMIC_PWR_W      (0x39) :   0.000 Watts | (ok)
MB_VR_DIMMA4_PMIC_PWR_W      (0x3A) :   0.000 Watts | (ok)
MB_VR_DIMMA5_PMIC_PWR_W      (0x3B) :   0.000 Watts | (ok)
MB_VR_DIMMA6_PMIC_PWR_W      (0x3C) :   0.125 Watts | (ok)
MB_VR_DIMMA7_PMIC_PWR_W      (0x3D) :   0.000 Watts | (ok)