### PR TITLE
common: Adjust rg3mxxb12 I3C HUB init function

### DIFF
--- a/common/dev/include/rg3mxxb12.h
+++ b/common/dev/include/rg3mxxb12.h
@@ -20,6 +20,10 @@
 #include "hal_i2c.h"
 #include "hal_i3c.h"
 
+#define V_LDO_SETTING(vios1, vios0, viom1, viom0)                                                  \
+	((vios1 << VIOS1_OFFSET) | (vios0 << VIOS0_OFFSET) | (viom1 << VIOM1_OFFSET) |             \
+	 (viom0 << VIOM0_OFFSET))
+
 #define RG3MXXB12_DEFAULT_STATIC_ADDRESS 0x70
 #define RG3M87B12_DEVICE_INFO 0x1287
 #define RG3M88B12_DEVICE_INFO 0x1288

--- a/common/dev/rg3mxxb12.c
+++ b/common/dev/rg3mxxb12.c
@@ -197,11 +197,6 @@ out:
 bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt)
 {
 	bool ret = false;
-	uint8_t value;
-
-	// Set Low-Dropout Regulators(LDO) voltage to VIOM and VIOS
-	value = (ldo_volt << VIOM0_OFFSET) | (ldo_volt << VIOM1_OFFSET) |
-		(ldo_volt << VIOS0_OFFSET) | (ldo_volt << VIOS1_OFFSET);
 
 	uint8_t cmd_unprotect[2] = { RG3MXXB12_PROTECTION_REG, 0x69 };
 	uint8_t cmd_protect[2] = { RG3MXXB12_PROTECTION_REG, 0x00 };
@@ -210,7 +205,7 @@ bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt)
 		 * Refer to RG3MxxB12 datasheet page 13, LDO voltage depends
 		 * on each project's hard design
 		 */
-		{ RG3MXXB12_VOLT_LDO_SETTING, value },
+		{ RG3MXXB12_VOLT_LDO_SETTING, ldo_volt },
 		{ RG3MXXB12_SSPORTS_AGENT_ENABLE, 0x0 },
 		{ RG3MXXB12_SSPORTS_GPIO_ENABLE, 0x0 },
 		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0x0 },

--- a/meta-facebook/yv4-sd/src/platform/plat_i3c.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_i3c.h
@@ -17,14 +17,10 @@
 #ifndef PLAT_I3C_H
 #define PLAT_I3C_H
 
-#include "hal_i3c.h"
+#include "rg3mxxb12.h"
 
-#define RSTDAA_COUNT 2
 #define LDO_VOLT                                                                                   \
-	V_LDO_SETTING(rg3mxxb12_ldo_1_0_volt, rg3mxxb12_ldo_1_8_volt, rg3mxxb12_ldo_1_2_volt,      \
+	V_LDO_SETTING(rg3mxxb12_ldo_1_2_volt, rg3mxxb12_ldo_1_2_volt, rg3mxxb12_ldo_1_2_volt,      \
 		      rg3mxxb12_ldo_1_2_volt)
-#define DEFAULT_SLAVE_PORT_SETTING 0x3F
-
-void init_i3c_hub();
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -32,6 +32,7 @@
 #include "plat_i2c_target.h"
 #include "plat_pldm_monitor.h"
 #include "plat_class.h"
+#include "plat_i3c.h"
 #include "pcc.h"
 
 void pal_pre_init()
@@ -72,7 +73,7 @@ void pal_pre_init()
 	i3c_attach(&i3c_msg);
 
 	// Initialize I3C HUB
-	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, rg3mxxb12_ldo_1_2_volt)) {
+	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
 		printk("failed to initialize 1ou rg3mxxb12\n");
 	}
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -33,6 +33,7 @@
 #include "plat_i2c.h"
 #include "plat_mctp.h"
 #include "plat_apml.h"
+#include "plat_i3c.h"
 #include "plat_isr.h"
 
 LOG_MODULE_REGISTER(plat_isr, LOG_LEVEL_DBG);
@@ -67,7 +68,7 @@ void reinit_i3c_hub()
 	i3c_attach(&i3c_msg);
 
 	// Initialize I3C HUB
-	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, rg3mxxb12_ldo_1_2_volt)) {
+	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
 		printk("failed to initialize 1ou rg3mxxb12\n");
 	}
 


### PR DESCRIPTION
# Description
- Let Rg3mxxb12 I3C HUB initial function using the same way to set LOD_VOLT.

# Motivation
- The two projects use the function in different way, adjust it in the same to avoid confused.

# Test plan:
- Build code: Pass
- Check I3C Hub init in GL: Pass
- Check I3C HUB init in Yv4: Pass

# Log:
1. Check I3C Hub config setting is correct on Yv4. [BIC console]
uart:~$ i3c ccc I3C_1 -a 0x7E -i 0x06
Send CCC ID 0x06 (w) to address 0x7e

uart:~$ i3c ccc I3C_1 -a 0x7E -i 0x06
Send CCC ID 0x06 (w) to address 0x7e

uart:~$ i3c ccc I3C_1 -a 0x7E -i 0x29
Send CCC ID 0x29 (w) to address 0x7e

uart:~$
uart:~$ i3c ccc I3C_1 -a 0x70 -i 0x8D -r 6
Send CCC ID 0x8d (r) to address 0x70

00000000: 04 cd 0c 46 99 04                                |...F..           |
uart:~$ i3c xfer I3C_1 -a 0x70 -w 0x16 -r 1
Private transfer to address 0x70

00000000: aa                                               |.                |

2. Get DIMM information through I3C on GL. root@bmc-oob:~# dimm-util slot1 --serial
FRU: slot1
DIMM A Serial Number: 76833FCE
DIMM B Serial Number: 76833F04
DIMM C Serial Number: 76833F1E
DIMM D Serial Number: 76833F3E
DIMM E Serial Number: 76833EFE
DIMM F Serial Number: 76833FCB
DIMM G Serial Number: 76833ED2
DIMM H Serial Number: 76833F28