### PR TITLE
yv4: wf: Switch DIMM and PMIC's muxes when DC off

### DIFF
--- a/common/lib/libutil.h
+++ b/common/lib/libutil.h
@@ -31,6 +31,10 @@
 #define SETBITS(x, y, z) (x | (y << z))
 #define GETBIT(x, y) ((x & (1ULL << y)) > y)
 #define CLEARBIT(x, y) (x & (~(1ULL << y)))
+#define CLEARBITS(x, y, z)                                                                         \
+	for (int i = y; i <= z; ++i) {                                                             \
+		x = CLEARBIT(x, i);                                                                \
+	}
 
 #define SHELL_CHECK_NULL_ARG(arg_ptr)                                                              \
 	if (arg_ptr == NULL) {                                                                     \

--- a/meta-facebook/yv4-wf/src/platform/plat_gpio.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_gpio.h
@@ -244,4 +244,25 @@ extern enum _GPIO_NUMS_ GPIO_NUMS;
 
 extern char *gpio_name[];
 
+/*IO expander cofiguration*/
+
+enum IOE_PIN_NUM {
+	IOE_P00 = 0,
+	IOE_P01 = 1,
+	IOE_P02 = 2,
+	IOE_P03 = 3,
+	IOE_P04 = 4,
+	IOE_P05 = 5,
+	IOE_P06 = 6,
+	IOE_P07 = 7,
+	IOE_P10 = 0,
+	IOE_P11 = 1,
+	IOE_P12 = 2,
+	IOE_P13 = 3,
+	IOE_P14 = 4,
+	IOE_P15 = 5,
+	IOE_P16 = 6,
+	IOE_P17 = 7,
+};
+
 #endif

--- a/meta-facebook/yv4-wf/src/platform/plat_isr.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_isr.h
@@ -53,5 +53,7 @@ void ISR_E1S_PWR_ON();
 void ISR_CXL_PG_ON();
 
 void set_ioe_init();
+int get_ioe_value(uint8_t ioe_addr, uint8_t ioe_reg, uint8_t *value);
+int set_ioe_value(uint8_t ioe_addr, uint8_t ioe_reg, uint8_t value);
 
 #endif

--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
@@ -22,6 +22,7 @@
 //#include "plat_class.h"
 #include "plat_gpio.h"
 #include "plat_power_seq.h"
+#include "plat_isr.h"
 
 LOG_MODULE_REGISTER(plat_power_seq);
 
@@ -345,6 +346,14 @@ void execute_power_off_sequence()
 	} else {
 		is_cxl_power_on[CXL_ID_1] = true;
 		LOG_ERR("CXL 2 power off fail");
+	}
+
+	uint8_t ioe2_output_value = 0;
+
+	if (get_ioe_value(ADDR_IOE2, TCA9555_OUTPUT_PORT_REG_0, &ioe2_output_value) == 0) {
+		CLEARBITS(ioe2_output_value, IOE_P00,
+			  IOE_P03) // Disable P0~P3 to switch mux to CXL.
+		set_ioe_value(ADDR_IOE2, TCA9555_OUTPUT_PORT_REG_0, ioe2_output_value);
 	}
 }
 


### PR DESCRIPTION
# Description:
	Control IOExpander to switch DIMM and PMIC's muxes connected to CXL when DC off.

# Motivation:
	When booting CXL, it is necessary to verify the information of DIMM and PMIC before the system can boot successfully.
	Therefore, when DC off, the muxes for DIMM and PMIC should be switched back to CXL.

# Test plan:
	- PMIC and DIMM can't be scanned after DC off: Pass

# Test log:
	- DC on: uart:~$ i2c scan I2C_2 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
		00:             -- -- -- -- -- -- -- -- -- -- -- --
		10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		70: -- -- 72 -- -- -- 76 --
		2 devices found on I2C_2
		uart:~$ i2c scan I2C_4
			 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
		00:             -- -- -- -- -- -- -- -- -- -- -- --
		10: -- -- -- -- -- -- -- -- 18 19 1a 1b -- -- -- --
		20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		30: -- -- -- -- -- -- 36 37 -- -- -- -- -- -- -- --
		40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		50: 50 51 52 53 -- -- -- -- -- -- -- -- -- -- -- --
		60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		70: -- -- -- -- -- -- -- --
		10 devices found on I2C_4
		uart:~$ i2c scan I2C_7
			 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
		00:             -- -- -- -- -- -- -- -- -- -- -- --
		10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		50: -- -- -- -- -- -- -- -- -- -- 5a -- -- -- -- --
		60: -- -- 62 -- -- -- -- -- -- -- -- -- -- -- -- --
		70: -- -- -- -- -- -- -- --
		2 devices found on I2C_7
		uart:~$ i2c scan I2C_8
			 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
		00:             -- -- -- -- -- -- -- -- -- -- -- --
		10: -- -- -- -- -- -- -- -- 18 19 1a 1b -- -- -- --
		20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		30: -- -- -- -- -- -- 36 37 -- -- -- -- -- -- -- --
		40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		50: 50 51 52 53 -- -- -- -- -- -- -- -- -- -- -- --
		60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		70: -- -- -- -- -- -- -- --
		10 devices found on I2C_8

	- DC off: [00:04:52.691,000] <wrn> power_status: DC_STATUS: off [00:04:52.691,000] <wrn> power_status: DC_STATUS: off [00:04:56.892,000] <inf> plat_power_seq: CXL 1 power off success [00:05:01.092,000] <inf> plat_power_seq: CXL 2 power off success uart:~$ i2c scan I2C_2 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
		00:             -- -- -- -- -- -- -- -- -- -- -- --
		10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		70: -- -- -- -- -- -- -- --
		0 devices found on I2C_2
		uart:~$ i2c scan I2C_4
			 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
		00:             -- -- -- -- -- -- -- -- -- -- -- --
		10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		70: -- -- -- -- -- -- -- --
		0 devices found on I2C_4
		uart:~$ i2c scan I2C_7
			 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
		00:             -- -- -- -- -- -- -- -- -- -- -- --
		10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		70: -- -- -- -- -- -- -- --
		0 devices found on I2C_7
		uart:~$
		uart:~$ i2c scan I2C_8
			 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
		00:             -- -- -- -- -- -- -- -- -- -- -- --
		10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
		70: -- -- -- -- -- -- -- --
		0 devices found on I2C_8