### PR TITLE
Artemis: cb: Adjust power monitor calibration

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -259,7 +259,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 	.is_need_set_alert_threshold = true,
 	.pin_op_warn_limit = 0x2B01,
 	},
-	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001, .mfr_config_init = true,
+	[8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00101607, .mfr_config_init = true,
 	.mfr_config = {
 		.operating_mode = 0b111,
 		.shunt_volt_time = 0b100,
@@ -346,7 +346,7 @@ ina233_init_arg accl_pwr_monitor_ina233_init_args[] = {
 };
 
 sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
-        [0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [0] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00101688,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,
@@ -361,7 +361,7 @@ sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
         .alert_threshold = 0x2B01,
         .alert_mask_config.value = SQ52205_ENABLE_OP,
         },
-        [1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [1] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0010136,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,
@@ -376,7 +376,7 @@ sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
         .alert_threshold = 0x2B01,
         .alert_mask_config.value = SQ52205_ENABLE_OP,
         },
-        [2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [2] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0010242,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,
@@ -391,7 +391,7 @@ sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
         .alert_threshold = 0x2B01,
         .alert_mask_config.value = SQ52205_ENABLE_OP,
         },
-        [3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [3] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0010202,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,
@@ -406,7 +406,7 @@ sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
         .alert_threshold = 0x2B01,
         .alert_mask_config.value = SQ52205_ENABLE_OP,
         },
-        [4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [4] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00103205,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,
@@ -421,7 +421,7 @@ sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
         .alert_threshold = 0x2B01,
         .alert_mask_config.value = SQ52205_ENABLE_OP,
         },
-        [5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [5] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00103665,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,
@@ -436,7 +436,7 @@ sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
         .alert_threshold = 0x2B01,
         .alert_mask_config.value = SQ52205_ENABLE_OP,
         },
-        [6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [6] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00103143,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,
@@ -451,7 +451,7 @@ sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
         .alert_threshold = 0x2B01,
         .alert_mask_config.value = SQ52205_ENABLE_OP,
         },
-        [7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [7] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0010296,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,
@@ -466,7 +466,7 @@ sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
         .alert_threshold = 0x2B01,
         .alert_mask_config.value = SQ52205_ENABLE_OP,
         },
-        [8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [8] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.0010394,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,
@@ -481,7 +481,7 @@ sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
         .alert_threshold = 0x2B01,
         .alert_mask_config.value = SQ52205_ENABLE_OP,
         },
-        [9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [9] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.00102977,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,
@@ -496,7 +496,7 @@ sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
         .alert_threshold = 0x2B01,
         .alert_mask_config.value = SQ52205_ENABLE_OP,
         },
-        [10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [10] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001027288,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,
@@ -511,7 +511,7 @@ sq52205_init_arg accl_pwr_monitor_sq52205_init_args[] = {
         .alert_threshold = 0x2B01,
         .alert_mask_config.value = SQ52205_ENABLE_OP,
         },
-        [11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001,
+        [11] = { .is_init = false, .current_lsb = 0.001, .r_shunt = 0.001029353,
         .config = {
                 .operating_mode =0b111,
                 .shunt_volt_time = 0b100,


### PR DESCRIPTION
# Description
- Adjust ACB main/second source power monitor calibration for DVT.

# Motivation
- Accurate ACB main/second source power monitor reading for DVT.

# Test Plan
- Build code: Pass
- Get power monitor calibration: Pass

# Log
- ACB main source power monitor calibration
  - ACCL 9 uart:~$ i2c read I2C_3 0x43 0xD4 0x02
  00000000: af 13                                            |..               |

- ACB second source power monitor calibration
  - ACCL 1~12 uart:~$ i2c scan I2C_3 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
  00:             -- -- -- -- -- -- -- -- -- -- -- --
  10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  40: 40 41 42 43 44 45 -- -- -- -- -- -- -- -- -- --
  50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  70: -- -- -- -- -- -- -- --
  6 devices found on I2C_3
  uart:~$ i2c read I2C_3 0x40 0x05 0x02
  00000000: 13 6e                                            |.n               |
  uart:~$ i2c read I2C_3 0x41 0x05 0x02
  00000000: 13 78                                            |.x               |
  uart:~$ i2c read I2C_3 0x42 0x05 0x02
  00000000: 13 6c                                            |.l               |
  uart:~$ i2c read I2C_3 0x43 0x05 0x02
  00000000: 13 3e                                            |.>               |
  uart:~$ i2c read I2C_3 0x44 0x05 0x02
  00000000: 13 6d                                            |.m               |
  uart:~$ i2c read I2C_3 0x45 0x05 0x02
  00000000: 13 64                                            |.d               |
  uart:~$
  uart:~$ i2c scan I2C_8
       0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
  00:             -- -- -- -- -- -- -- -- -- -- -- --
  10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  40: 40 41 42 43 44 45 -- -- -- -- -- -- -- -- -- --
  50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
  70: -- -- -- -- -- -- -- --
  6 devices found on I2C_8
  uart:~$ i2c read I2C_8 0x40 0x05 0x02
  00000000: 13 4b                                            |.K               |
  uart:~$ i2c read I2C_8 0x41 0x05 0x02
  00000000: 13 61                                            |.a               |
  uart:~$ i2c read I2C_8 0x42 0x05 0x02
  00000000: 13 9b                                            |..               |
  uart:~$ i2c read I2C_8 0x43 0x05 0x02
  00000000: 13 87                                            |..               |
  uart:~$ i2c read I2C_8 0x44 0x05 0x02
  00000000: 13 bb                                            |..               |
  uart:~$ i2c read I2C_8 0x45 0x05 0x02
  00000000: 13 ab                                            |..               |