### PR TITLE
fby4: sd: Modified host power control behavior

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_i2c.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_i2c.h
@@ -29,6 +29,9 @@
 #define I2C_BUS6 5
 #define I2C_BUS14 13
 
+#define CPLD_IO_I2C_BUS I2C_BUS5
+#define CPLD_IO_I2C_ADDR 0x21
+
 #define I2C_BUS_MAX_NUM 14
 
 #endif


### PR DESCRIPTION
# Description:
- Check the power status before doing the operation.
- Use thread to execute power off and cycle command
- Modified behavior for power cycle

# Motivation:
- Check power status at first to avoid wasting resources to do the same thing.
- Power cycle and off using thread to avoid BMC pldmd causing i2c bus stuck when bic sleeps a long time.

# Test Plan:
1. Power off success.
2. Power cycle success.
3. Power on success.

# Log:
1. Power off

- Do power off root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x0 0x0 0x1 0x0 0x02 -m 40 pldmtool: Tx: 80 02 39 00 00 01 00 02
pldmtool: Rx: 00 02 39 00

- Check power status is off root@bmc:~# gpioget $(basename ""/sys/bus/i2c/devices/${slot_bus}-0023/""*gpiochip*) 16 0

2.Power cycle

- Do power cycle root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x0 0x0 0x1 0x0 0x03 -m 40 pldmtool: Tx: 80 02 39 00 00 01 00 03
pldmtool: Rx: 00 02 39 00

- Check power status is ON->OFF->ON root@bmc:~# gpioget $(basename ""/sys/bus/i2c/devices/${slot_bus}-0023/""*gpiochip*) 16 1
root@bmc:~# gpioget $(basename ""/sys/bus/i2c/devices/${slot_bus}-0023/""*gpiochip*) 16 0
root@bmc:~# gpioget $(basename ""/sys/bus/i2c/devices/${slot_bus}-0023/""*gpiochip*) 16 1

3. Power on

- Do power on root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x0 0x0 0x1 0x0 0x01 -m 60 pldmtool: Tx: 80 02 39 00 00 01 00 01
pldmtool: Rx: 00 02 39 00

- Check power status is ON root@bmc:~# gpioget $(basename ""/sys/bus/i2c/devices/${slot_bus}-0023/""*gpiochip*) 16 1