### PR TITLE
fby4: sd: Disable APML i2c bus internal PU

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -35,8 +35,14 @@
 #include "plat_i3c.h"
 #include "pcc.h"
 
+SCU_CFG scu_cfg[] = {
+	//register    value
+	{ 0x7e6e2618, 0x00c00000 },
+};
+
 void pal_pre_init()
 {
+	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
 	apml_init();
 
 	/* init i2c target */


### PR DESCRIPTION
# Description
- Disable APML of I2C bus (I2C_13) internal PU.

# Motivation
- Avoid leakage when DC is off.
- Avoid voltage levels not complying with the spec. when DC is on.

# Test plan
- Build code: Pass
- Check voltage of bus: Pass

# Log
1. Check SCU setting.
- Before uart:~$ md 0x7e6e2618 1

[7e6e2618] 00000000

- After uart:~$ md 0x7e6e2618 1

[7e6e2618] 00c00000