### PR TITLE
common: Obtain BIOS information via PLDM SMBIOS

### DIFF
--- a/common/service/main.c
+++ b/common/service/main.c
@@ -29,6 +29,9 @@
 #ifdef ENABLE_PLDM_SENSOR
 #include "pldm_sensor.h"
 #endif
+#ifdef ENABLE_PLDM
+#include "pldm_smbios.h"
+#endif
 #include "timer.h"
 #include "usb.h"
 #include <logging/log.h>
@@ -67,6 +70,9 @@ void main(void)
 	sensor_init();
 #ifdef ENABLE_PLDM_SENSOR
 	pldm_sensor_monitor_init();
+#endif
+#ifdef ENABLE_PLDM
+	pldm_smbios_init_structures();
 #endif
 	FRU_init();
 	ipmi_init();

--- a/common/service/pldm/pldm.c
+++ b/common/service/pldm/pldm.c
@@ -61,6 +61,7 @@ typedef struct _pldm_recv_resp_arg {
 
 static struct _pldm_handler_query_entry query_tbl[] = {
 	{ PLDM_TYPE_BASE, pldm_base_handler_query },
+	{ PLDM_TYPE_SMBIOS, pldm_smbios_handler_query },
 	{ PLDM_TYPE_PLAT_MON_CTRL, pldm_monitor_handler_query },
 	{ PLDM_TYPE_FW_UPDATE, pldm_fw_update_handler_query },
 	{ PLDM_TYPE_OEM, pldm_oem_handler_query },

--- a/common/service/pldm/pldm.h
+++ b/common/service/pldm/pldm.h
@@ -27,6 +27,7 @@ extern "C" {
 #include "pldm_monitor.h"
 #include "pldm_firmware_update.h"
 #include "pldm_state_set.h"
+#include "pldm_smbios.h"
 #include "ipmb.h"
 
 #define MONITOR_THREAD_STACK_SIZE 1024
@@ -41,7 +42,7 @@ typedef uint8_t (*pldm_cmd_proc_fn)(void *, uint8_t *, uint16_t, uint8_t, uint8_
 
 typedef enum {
 	PLDM_TYPE_BASE = 0x00,
-	PLDM_TYPE_SMBIOS,
+	PLDM_TYPE_SMBIOS = 0x01,
 	PLDM_TYPE_PLAT_MON_CTRL,
 	PLDM_TYPE_BIOS_CTRL_CONF,
 	PLDM_TYPE_FW_UPDATE = 0x05,

--- a/common/service/pldm/pldm_smbios.c
+++ b/common/service/pldm/pldm_smbios.c
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <logging/log.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "plat_def.h"
+#include "libutil.h"
+#include "pldm.h"
+#include "pldm_smbios.h"
+
+LOG_MODULE_DECLARE(pldm);
+
+static smbios_bios_information bios_information = {
+    .header = {
+        .type = 0x0,           // type BIOS Information (Type 0) structure
+        .handle = 0x0000,      // Handle values are in the range 0 to 0xFEFFh.
+    },
+    .vendor = 0x0,             // Type STRING default value.
+    .bios_version = 0x0,       // Type STRING default value.
+    .bios_release_date = 0x0,  // Type STRING default value.
+};
+
+static smbios_structure_header **structures;
+static uint8_t structures_count;
+
+static void init_bios_information()
+{
+	bios_information.text_strings = malloc(sizeof(char) * 2);
+	if (!bios_information.text_strings) {
+		LOG_ERR("%s:%s:%d: Failed to allocate memory.", __FILE__, __func__, __LINE__);
+		return;
+	}
+	bios_information.text_strings[0] = '\0';
+	bios_information.text_strings[1] = '\0';
+
+	structures_count = 1;
+	structures = malloc(sizeof(smbios_structure_header *) * structures_count);
+	if (!structures) {
+		LOG_ERR("%s:%s:%d: Failed to allocate memory.", __FILE__, __func__, __LINE__);
+		return;
+	}
+	(*structures) = (smbios_structure_header *)&bios_information;
+}
+
+__weak void pldm_smbios_init_structures()
+{
+	init_bios_information();
+
+	return;
+}
+
+uint8_t pldm_smbios_get_text_strings_count(char *text_strings)
+{
+	char *iter = text_strings;
+	const uint16_t MAXIMUM_COUNT = MAXIMUM_STRUCTURE_SIZE; /*Prevent infinite loop*/
+	uint8_t count = 0, i = 0;
+
+	if (!text_strings)
+		return 0;
+
+	while (*iter != '\0') {
+		uint8_t len = strlen(iter);
+		count++;
+		if (*(iter + len) == '\0' && *(iter + len + 1) == '\0') {
+			break;
+		}
+
+		iter = iter + len + 1;
+		if (++i > MAXIMUM_COUNT) {
+			return 0;
+		}
+	}
+	return count;
+}
+
+uint8_t pldm_smbios_get_text_strings_size(char *text_strings)
+{
+	const uint8_t NULL_BYTE = 1;
+	const uint16_t MAXIMUM_COUNT = MAXIMUM_STRUCTURE_SIZE; /*Prevent infinite loop*/
+	char *iter = text_strings;
+	uint8_t size = 0, i = 0;
+
+	if (!text_strings)
+		return 0;
+
+	while (true) {
+		uint8_t len = strlen(iter);
+		size += len + NULL_BYTE;
+		if (*(iter + len) == '\0' && *(iter + len + 1) == '\0') {
+			size += NULL_BYTE;
+			break;
+		}
+
+		iter = iter + len + NULL_BYTE;
+		if (++i > MAXIMUM_COUNT) {
+			return 0;
+		}
+	}
+	return size;
+}
+
+int pldm_smbios_set_bios_information(smbios_bios_information *new_bios_information)
+{
+	CHECK_NULL_ARG_WITH_RETURN(new_bios_information, -1);
+
+	uint8_t new_text_strings_length =
+		pldm_smbios_get_text_strings_size(new_bios_information->text_strings);
+	SAFE_FREE(bios_information.text_strings);
+	bios_information.text_strings = (char *)malloc(sizeof(char) * new_text_strings_length);
+	if (!bios_information.text_strings) {
+		LOG_ERR("%s:%s:%d: Failed to allocate memory.", __FILE__, __func__, __LINE__);
+		return -1;
+	}
+
+	memcpy(&bios_information, new_bios_information,
+	       sizeof(bios_information) - sizeof(bios_information.text_strings));
+	memcpy(bios_information.text_strings, new_bios_information->text_strings,
+	       new_text_strings_length);
+
+	return 0;
+}
+
+static uint8_t filterStructureDataByType(uint8_t type, smbios_structure_header **result)
+{
+	uint8_t filtered_structure_data_count = 0;
+	for (uint8_t i = 0; i < structures_count; i++) {
+		if ((*(structures + i))->type == type) {
+			filtered_structure_data_count++;
+			result = realloc(result, sizeof(smbios_structure_header *) *
+							 filtered_structure_data_count);
+			if (!result) {
+				LOG_ERR("%s:%s:%d: Failed to allocate memory.", __FILE__, __func__,
+					__LINE__);
+				return 0;
+			}
+			*(result + filtered_structure_data_count - 1) = *(structures + i);
+		}
+	}
+
+	return filtered_structure_data_count;
+}
+
+static int get_structure_data_index_by_handle(uint16_t target_handle,
+					      smbios_structure_header **data, uint8_t count)
+{
+	for (uint8_t i = 0; i < count; i++) {
+		if ((*(data + i))->handle == target_handle) {
+			return i;
+		}
+	}
+	LOG_ERR("%s:%s:%d: Corresponding structure data is not found.", __FILE__, __func__,
+		__LINE__);
+	return -1;
+}
+
+static uint8_t get_formatted_area_size(uint8_t structure_type)
+{
+	uint8_t formatted_area_size = 0;
+
+	switch (structure_type) {
+	case (SMBIOS_BIOS_INFORMATION):
+		formatted_area_size = sizeof(smbios_bios_information) - sizeof(char *);
+		break;
+	default:
+		LOG_ERR("%s:%s:%d: Unsupported structure type.", __FILE__, __func__, __LINE__);
+		return 0;
+	}
+
+	return formatted_area_size;
+}
+
+static char *get_structure_text_string(smbios_structure_header *structure)
+{
+	switch (structure->type) {
+	case (SMBIOS_BIOS_INFORMATION):
+		return ((smbios_bios_information *)structure)->text_strings;
+	default:
+		LOG_ERR("%s:%s:%d: Unsupported structure type.", __FILE__, __func__, __LINE__);
+		break;
+	}
+
+	return NULL;
+}
+
+static int get_maximum_data_count_under_size(const uint16_t maximum_size,
+					     smbios_structure_header **filtered_structure_data,
+					     const uint8_t filtered_structure_data_count,
+					     const uint8_t start_index)
+{
+	const uint8_t type = (*filtered_structure_data)->type;
+	const uint8_t formatted_area_size = get_formatted_area_size(type);
+	uint8_t total_data_size = 0, current_data_size = 0, result = 0;
+
+	if (!formatted_area_size) {
+		return -1;
+	}
+
+	for (uint8_t i = start_index; i < filtered_structure_data_count; i++) {
+		current_data_size = formatted_area_size +
+				    pldm_smbios_get_text_strings_size(get_structure_text_string(
+					    *(filtered_structure_data + i)));
+
+		if (total_data_size + current_data_size > maximum_size)
+			break;
+
+		total_data_size += current_data_size;
+		result += 1;
+	}
+
+	return result;
+}
+
+static int copy_structure_data(uint8_t *dest, smbios_structure_header **data, uint8_t start_index,
+			       uint8_t count)
+{
+	uint8_t *iter = dest;
+	uint8_t i = 0, structure_type = 0, formatted_area_size = 0, unformatted_area_size = 0;
+
+	for (i = start_index; i < start_index + count; i++) {
+		structure_type = (*(data + i))->type;
+
+		switch (structure_type) {
+		case (SMBIOS_BIOS_INFORMATION): {
+			smbios_bios_information *current = (smbios_bios_information *)(*(data + i));
+			formatted_area_size = sizeof(smbios_bios_information) - sizeof(char *);
+			unformatted_area_size =
+				pldm_smbios_get_text_strings_size(current->text_strings);
+			memcpy(iter, current, formatted_area_size);
+			memcpy(iter + formatted_area_size, current->text_strings,
+			       unformatted_area_size);
+		} break;
+		default:
+			return -1;
+			break;
+		}
+
+		iter += formatted_area_size + unformatted_area_size;
+	}
+
+	return iter - dest;
+}
+
+uint8_t get_smbios_structure_data_by_type(void *mctp_inst, uint8_t *req, uint16_t req_len,
+					  uint8_t instance_id, uint8_t *resp, uint16_t *resp_len,
+					  void *ext_params)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(req, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, PLDM_ERROR);
+	const uint16_t GET_ALL_INSTANCES_OF_SPECIFIC_TYPE = 0xFFFF;
+	uint8_t ret = PLDM_SUCCESS;
+
+	pldm_get_smbios_structure_by_type_req *req_p = (pldm_get_smbios_structure_by_type_req *)req;
+	pldm_get_smbios_structure_by_type_resp *resp_p =
+		(pldm_get_smbios_structure_by_type_resp *)resp;
+	uint8_t *completion_code_p = resp;
+	*resp_len = sizeof(*completion_code_p);
+
+	// Initial malloc to avoid -Wmaybe-uninitialized.
+	smbios_structure_header **filtered_structure_data =
+		malloc(sizeof(smbios_structure_header *));
+	if (!filtered_structure_data) {
+		LOG_ERR("%s:%s:%d: Failed to allocate memory.", __FILE__, __func__, __LINE__);
+		return -1;
+	}
+
+	if (req_p->data_transfer_handle > MAXIMUM_HANDLE_NUM) {
+		*completion_code_p = ret = PLDM_SMBIOS_INVALID_DATA_TRANSFER_HANDLE;
+		goto exit;
+	} else if (req_p->structure_instance_id > MAXIMUM_HANDLE_NUM &&
+		   req_p->structure_instance_id != GET_ALL_INSTANCES_OF_SPECIFIC_TYPE) {
+		*completion_code_p = ret = PLDM_SMBIOS_INVALID_SMBIOS_STRUCTURE_INSTANCE_ID;
+		goto exit;
+	}
+
+	uint8_t result_count = 0;
+	int result_start_idx = 0;
+	const uint8_t filtered_structure_data_count =
+		filterStructureDataByType(req_p->type, filtered_structure_data);
+
+	if (req_p->structure_instance_id != GET_ALL_INSTANCES_OF_SPECIFIC_TYPE) {
+		result_start_idx =
+			get_structure_data_index_by_handle(req_p->structure_instance_id,
+							   filtered_structure_data,
+							   filtered_structure_data_count);
+		result_count = 1;
+	} else {
+		if (req_p->transfer_operation_flag ==
+		    PLDM_SMBIOS_TRANSFER_OPERATION_FLAG_GET_FIRST_PART) {
+			result_start_idx = 0;
+
+		} else if (req_p->transfer_operation_flag ==
+			   PLDM_SMBIOS_TRANSFER_OPERATION_FLAG_GET_NEXT_PART) {
+			result_start_idx =
+				get_structure_data_index_by_handle(req_p->data_transfer_handle,
+								   filtered_structure_data,
+								   filtered_structure_data_count);
+		} else {
+			*completion_code_p = PLDM_SMBIOS_INVALID_TRANSFER_OPERATION_FLAG;
+			return PLDM_SMBIOS_INVALID_TRANSFER_OPERATION_FLAG;
+		}
+
+		result_count = get_maximum_data_count_under_size(
+			PLDM_MAX_DATA_SIZE - sizeof(pldm_hdr), filtered_structure_data,
+			filtered_structure_data_count, result_start_idx);
+	}
+
+	if (!filtered_structure_data_count || result_start_idx < 0) {
+		*completion_code_p = ret = PLDM_SMBIOS_NO_SMBIOS_STRUCTURES;
+		goto exit;
+	} else if (result_count == 0) {
+		LOG_ERR("%s:%s:%d: A single structure data is over maximum transfer size.",
+			__FILE__, __func__, __LINE__);
+		*completion_code_p = ret = PLDM_ERROR_INVALID_LENGTH;
+		goto exit;
+	} else if (result_count == -1) {
+		*completion_code_p = ret = PLDM_SMBIOS_INVALID_SMBIOS_STRUCTURE_TYPE;
+		goto exit;
+	}
+
+	*completion_code_p = PLDM_SUCCESS;
+	if (result_start_idx == 0) {
+		if (result_count == filtered_structure_data_count) {
+			resp_p->transfer_flag = PLDM_SMBIOS_TRANSFER_FLAG_START_AND_END;
+		} else {
+			resp_p->transfer_flag = PLDM_SMBIOS_TRANSFER_FLAG_START;
+			resp_p->next_data_transfer_handle =
+				(*(filtered_structure_data + result_count))->handle;
+		}
+	} else {
+		if (result_start_idx + result_count == filtered_structure_data_count) {
+			resp_p->transfer_flag = PLDM_SMBIOS_TRANSFER_FLAG_END;
+		} else if (result_start_idx + result_count < filtered_structure_data_count) {
+			resp_p->transfer_flag = PLDM_SMBIOS_TRANSFER_FLAG_MIDDLE;
+			resp_p->next_data_transfer_handle =
+				(*(filtered_structure_data + result_start_idx + result_count))
+					->handle;
+		}
+	}
+
+	uint8_t *smbios_structure_data_p =
+		(uint8_t *)resp_p + sizeof(pldm_get_smbios_structure_by_type_resp);
+	const int structure_data_len = copy_structure_data(
+		smbios_structure_data_p, filtered_structure_data, result_start_idx, result_count);
+
+	if (!structure_data_len) {
+		*completion_code_p = ret = PLDM_SMBIOS_INVALID_SMBIOS_STRUCTURE_TYPE;
+		goto exit;
+	}
+
+	*resp_len = sizeof(pldm_get_smbios_structure_by_type_resp) + structure_data_len;
+
+exit:
+	SAFE_FREE(filtered_structure_data);
+	return ret;
+}
+
+static pldm_cmd_handler pldm_smbios_cmd_tbl[] = {
+	{ PLDM_SMBIOS_CMD_CODE_GET_SMBIOS_STRUCTURE_BY_TYPE, get_smbios_structure_data_by_type },
+};
+
+uint8_t pldm_smbios_handler_query(uint8_t code, void **ret_fn)
+{
+	if (!ret_fn)
+		return PLDM_ERROR;
+
+	pldm_cmd_proc_fn fn = NULL;
+
+	for (uint8_t i = 0; i < ARRAY_SIZE(pldm_smbios_cmd_tbl); i++) {
+		if (pldm_smbios_cmd_tbl[i].cmd_code == code) {
+			fn = pldm_smbios_cmd_tbl[i].fn;
+			break;
+		}
+	}
+
+	*ret_fn = (void *)fn;
+	return fn ? PLDM_SUCCESS : PLDM_ERROR;
+}

--- a/common/service/pldm/pldm_smbios.h
+++ b/common/service/pldm/pldm_smbios.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _PLDM_SMBIOS_H
+#define _PLDM_SMBIOS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "pldm.h"
+
+// Size of the largest SMBIOS structure, DSP0134_3.6.0
+#define MAXIMUM_STRUCTURE_SIZE 65535
+// For version 2.1 and later, handle values are in the range 0 to 0xFEFFh.
+#define MAXIMUM_HANDLE_NUM 0xFEFF
+
+typedef enum {
+	PLDM_SMBIOS_CMD_CODE_GET_SMBIOS_STRUCTURE_BY_TYPE = 0x05,
+} pldm_smbios_commands;
+
+typedef enum {
+	/* GetSMBIOSStructureByType */
+	PLDM_SMBIOS_INVALID_DATA_TRANSFER_HANDLE = 0x80,
+	PLDM_SMBIOS_INVALID_TRANSFER_OPERATION_FLAG = 0x81,
+	PLDM_SMBIOS_NO_SMBIOS_STRUCTURES = 0x86,
+	PLDM_SMBIOS_INVALID_SMBIOS_STRUCTURE_TYPE = 0x87,
+	PLDM_SMBIOS_INVALID_SMBIOS_STRUCTURE_INSTANCE_ID = 0x89,
+} pldm_smbios_completion_codes;
+
+typedef enum {
+	PLDM_SMBIOS_TRANSFER_FLAG_START = 0x01,
+	PLDM_SMBIOS_TRANSFER_FLAG_MIDDLE = 0x02,
+	PLDM_SMBIOS_TRANSFER_FLAG_END = 0x04,
+	PLDM_SMBIOS_TRANSFER_FLAG_START_AND_END = 0x05
+} pldm_smbios_transfer_flag;
+
+typedef enum {
+	PLDM_SMBIOS_TRANSFER_OPERATION_FLAG_GET_NEXT_PART = 0x00,
+	PLDM_SMBIOS_TRANSFER_OPERATION_FLAG_GET_FIRST_PART = 0x01
+} pldm_smbios_transfer_operation_flag;
+
+// Based on DSP0134 v3.6.0
+typedef enum {
+	SMBIOS_BIOS_INFORMATION = 0,
+} smbios_structure_types;
+
+typedef struct {
+	uint8_t type;
+	uint8_t length;
+	uint16_t handle;
+} __attribute__((packed)) smbios_structure_header;
+
+typedef struct {
+	smbios_structure_header header;
+	uint8_t vendor;
+	uint8_t bios_version;
+	uint16_t bios_starting_address_segment;
+	uint8_t bios_release_date;
+	uint8_t bios_rom_size;
+	uint64_t bios_characteristics;
+	uint16_t bios_characteristics_extension_bytes;
+	uint8_t system_bios_major_release;
+	uint8_t system_bios_minor_release;
+	uint8_t embedded_controller_firmware_major_release;
+	uint8_t embedded_controller_firmware_minor_release;
+	uint16_t extended_bios_rom_size;
+	char *text_strings;
+} __attribute__((packed)) smbios_bios_information;
+
+typedef struct {
+	uint32_t data_transfer_handle;
+	uint8_t transfer_operation_flag;
+	uint8_t type;
+	uint16_t structure_instance_id;
+} __attribute__((packed)) pldm_get_smbios_structure_by_type_req;
+
+typedef struct {
+	uint8_t completion_code;
+	uint32_t next_data_transfer_handle;
+	uint8_t transfer_flag;
+} __attribute__((packed)) pldm_get_smbios_structure_by_type_resp;
+
+void pldm_smbios_init_structures();
+
+uint8_t pldm_smbios_handler_query(uint8_t code, void **ret_fn);
+
+uint8_t pldm_smbios_get_text_strings_count(char *text_strings);
+
+uint8_t pldm_smbios_get_text_strings_size(char *text_strings);
+
+int pldm_smbios_set_bios_information(smbios_bios_information *new_bios_information);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*_PLDM_SMBIOS_H*/


### PR DESCRIPTION
Summary:
# Description
- Add PLDM SMBIOS command handler, when BIOS is powered on (post code complete), notify BIC, let BIC can store BIOS information.
- Add PLDM SMBIOS command handler and GetSMBIOSStructureByType command, let BMC can obtain the bios information, bios version is included.
- Set BIOS information when kcs receive CMD_APP_SET_SYS_INFO_PARAMS.

# Motivation
- Support BMC can obtain BIOS version by standard PLDM command.

# Test Plan
- BMC can obtain BIOS version by sending GetSMBIOSStructureByType command.

# Log:

[First query]
root@bmc:~# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x00 0x00 0x00 0x00 0x01 0x00 0xff 0xff pldmtool: Tx: 80 01 05 00 00 00 00 01 00 ff ff
pldmtool: Rx: 00 01 05 00 00 00 00 00 05 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\
                                       |
                                       (Transfer Flag Start and End)
              00 00 00 00 00 00 00 00 00

[Power on the host]
root@bmc:/tmp# busctl set-property xyz.openbmc_project.State.Host4 /xyz/openbmc_project/state/host4
  xyz.openbmc_project.State.Host RequestedHostTransition s "xyz.openbmc_project.State.Host.Transition.On"

[Wait for post code complete and query again]
root@bmc:~# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x00 0x00 0x00 0x00 0x01 0x00 0xff 0xff pldmtool: Tx: 80 01 05 00 00 00 00 01 00 ff ff
pldmtool: Rx: 00 01 05 00 00 00 00 00 05 00 12 00 00 01 02 00 00 03 00 00 00 00 00 00 00 00 00 00\
                                                         |
                                                        (bios version: 2nd text string)

              00 00 00 00 00 00 00 4e 2f 41 00 59 34 54 52 5f 31 31 30 38 00 4e 2f 41 00 00
                                    |  |  |     |  |  |  |  |  |  |  |  |     |  |  |
                                   (N  /  A)   (Y  4  T  R  _  1  1  0  8)   (N  /  A)

# Extra Tests:

Test Case 1: Get Type 0, all instances
Expect: Return the one bios information with bios version. Log:

root@bmc:~# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x00 0x00 0x00 0x00 0x01               0x00 0xff 0xff
                                                                           |                  |         |
                                                                           (get first part)   (type 0)  (get all instances)
pldmtool: Tx: 80 01 05 00 00 00 00 01 00 ff ff
pldmtool: Rx: 00 01 05 00 00 00 00 00 05 00 12 00 00 01 02 00 00 03 00 00 00 00 00 00 00 00 00 00\
              00 00 00 00 00 00 00 4e 2f 41 00 59 34 54 52 5f 31 31 30 38 00 4e 2f 41 00 00
-------------------------------------------------------------------------------------------------------------
Test Case 2: Get Type 0, handle 0x0000
Expect: Return the bios information with handle 0x0000.
Log:

root@bmc:~# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x00 0x00 0x00 0x00 0x01 0x00 0x00 0x00
                                                                                          |
                                                                                          (get handle 0x0000)
pldmtool: Tx: 80 01 05 00 00 00 00 01 00 00 00
pldmtool: Rx: 00 01 05 00 00 00 00 00 05 00 12 00 00 01 02 00 00 03 00 00 00 00 00 00 00 00 00 00\
              00 00 00 00 00 00 00 4e 2f 41 00 59 34 54 52 5f 31 31 30 38 00 4e 2f 41 00 00
------------------------------------------------------------------------------------------------------------- Test Case 3: Get Type 0, handle 0x0001
Expect: The structure is not found.
Log:

root@bmc:~# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x00 0x00 0x00 0x00 0x01 0x00 0x01 0x00
                                                                                          |
                                                                                          (get handle 0x0001)
pldmtool: Tx: 80 01 05 00 00 00 00 01 00 01 00
pldmtool: Rx: 00 01 05 86 (NO_SMBIOS_STRUCTURES)
------------------------------------------------------------------------------------------------------------- Test Case 4: Get Type 1(don't exit)
Expect: The type of structure is not found.
Log:

root@bmc:~# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x00 0x00 0x00 0x00 0x01 0x01 0xff 0xff
                                                                                |
                                                                                (type 1)
pldmtool: Tx: 80 01 05 00 00 00 00 01 01 ff ff
pldmtool: Rx: 00 01 05 86 (NO_SMBIOS_STRUCTURES)
------------------------------------------------------------------------------------------------------------- Test Case 5: Test multiple structures in one transaction Setup:
  1. Mock a new empty bios information. Expect: Return two structure data in one transaction.

root@bmc:~# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x00 0x00 0x00 0x00 0x01 0x00 0xff 0xff pldmtool: Tx: 80 01 05 00 00 00 00 01 00 ff ff
pldmtool: Rx: 00 01 05 00 00 00 00 00 05 00 12 00 00 01 02 00 00 03 00 00 00 00 00 00 00 00 00 00\
              00 00 00 00 00 00 00 4e 2f 41 00 59 34 54 52 5f 31 31 30 38 00 4e 2f 41 00 00 00 00\
                                                                                          |
                                                                                          (The end of first structure data)
              01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
                                                                                          |
                                                                                          (The end of second structure data)
------------------------------------------------------------------------------------------------------------- Test Case 6: Return structure data in multiple transactions Setup:
  1. Mock a new empty bios information.
  2. Set the maximum bytes of one message from 512 down to 50. Expect: Return the first structure data (length 45), and return the
  second structure data at the second request.

root@bmc:~# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0xff 0xff (Get Type 0, all instance) pldmtool: Tx: 80 01 05 00 00 00 00 00 00 ff ff
pldmtool: Rx: 00 01 05 00 01 00 00 00 01 00 12 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\
                                       |
                                       (transfer flag start)
              00 00 00 00 00 4e 2f 41 00 59 34 54 52 5f 31 31 30 38 00 4e 2f 41 00 00
              (first data's length is 45, return 1 structure data)

root@bmc:~# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x01 0x00 0x00 0x00 0x00 0x00 0xff 0xff
                                                       |
                                                       (Get next part)
pldmtool: Tx: 80 01 05 01 00 00 00 00 00 ff ff
pldmtool: Rx: 00 01 05 00 00 00 00 00 04 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\
                                       |
                                       (transfer flag end)
              00 00 00 00 00 00 00
              (the second empty structure)