### PR TITLE
Artemis: cb: Unlock mutex when sensor reading fail

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -1135,23 +1135,22 @@ bool post_accl_nvme_read(sensor_cfg *cfg, void *args, int *reading)
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(args, false);
 
+	int unlock_status = 0;
+        uint8_t bus = cfg->port;
+        accl_card_info *card_info_args = (accl_card_info *)args;
+
+        struct k_mutex *mutex = get_i2c_mux_mutex(bus);
+        if (mutex->lock_count != 0) {
+                unlock_status = k_mutex_unlock(mutex);
+        }
+
+        if (unlock_status != 0) {
+                LOG_ERR("Mutex unlock fail, status: %d, card id: 0x%x, sensor num: 0x%x",
+                        unlock_status, card_info_args->card_id, cfg->num);
+        }
+
 	if (reading == NULL) {
 		return check_reading_pointer_null_is_allowed(cfg);
-	}
-
-	int unlock_status = 0;
-	uint8_t bus = cfg->port;
-	accl_card_info *card_info_args = (accl_card_info *)args;
-
-	struct k_mutex *mutex = get_i2c_mux_mutex(bus);
-	if (mutex->lock_count != 0) {
-		unlock_status = k_mutex_unlock(mutex);
-	}
-
-	if (unlock_status != 0) {
-		LOG_ERR("Mutex unlock fail, status: %d, card id: 0x%x, sensor num: 0x%x",
-			unlock_status, card_info_args->card_id, cfg->num);
-		return false;
 	}
 
 	if (cfg->offset == NVME_CORE_VOLTAGE_1_OFFSET ||


### PR DESCRIPTION
# Description
- Post-read function needs to unlock mutex first to avoid not unlocking the mutex when sensor reading fail.

# Motivation
- Post-read function needs to unlock mutex first to avoid not unlocking the mutex when sensor reading fail.

# Test Plan
- Build code: Pass
- Get ACCL related sensor reading: Pass

# Log
CB_ACCL1_ASIC_1_TEMP_C       (0x70) :  38.000 C     | (ok)
CB_ACCL1_ASIC_1_0V8_VOLT_V   (0x71) :   0.840 Volts | (ok)
CB_ACCL1_ASIC_1_1V05_VOLT_V  (0x72) :   1.049 Volts | (ok)
CB_ACCL1_ASIC_1_12V_AUX_VOLT_V (0xB8) :  12.084 Volts | (ok)
CB_ACCL1_ASIC_2_TEMP_C       (0x73) :  39.000 C     | (ok)
CB_ACCL1_ASIC_2_0V8_VOLT_V   (0x74) :   0.846 Volts | (ok)
CB_ACCL1_ASIC_2_1V05_VOLT_V  (0x75) :   1.049 Volts | (ok)
CB_ACCL1_ASIC_2_12V_AUX_VOLT_V (0xB9) :  12.080 Volts | (ok)
CB_ACCL2_ASIC_1_TEMP_C       (0x76) :  37.000 C     | (ok)
CB_ACCL2_ASIC_1_0V8_VOLT_V   (0x77) :   0.850 Volts | (ok)
CB_ACCL2_ASIC_1_1V05_VOLT_V  (0x78) :   1.049 Volts | (ok)
CB_ACCL2_ASIC_1_12V_AUX_VOLT_V (0xBA) :  12.107 Volts | (ok)
CB_ACCL2_ASIC_2_TEMP_C       (0x79) :  39.000 C     | (ok)
CB_ACCL2_ASIC_2_0V8_VOLT_V   (0x7A) :   0.850 Volts | (ok)
CB_ACCL2_ASIC_2_1V05_VOLT_V  (0x7B) :   1.049 Volts | (ok)
CB_ACCL2_ASIC_2_12V_AUX_VOLT_V (0xBB) :  12.059 Volts | (ok)
CB_ACCL3_ASIC_1_TEMP_C       (0x7C) :  37.000 C     | (ok)
CB_ACCL3_ASIC_1_0V8_VOLT_V   (0x7D) :   0.850 Volts | (ok)
CB_ACCL3_ASIC_1_1V05_VOLT_V  (0x7E) :   1.049 Volts | (ok)
CB_ACCL3_ASIC_1_12V_AUX_VOLT_V (0xBC) :  12.045 Volts | (ok)
CB_ACCL3_ASIC_2_TEMP_C       (0x7F) :  40.000 C     | (ok)
CB_ACCL3_ASIC_2_0V8_VOLT_V   (0x80) :   0.843 Volts | (ok)
CB_ACCL3_ASIC_2_1V05_VOLT_V  (0x81) :   1.052 Volts | (ok)
CB_ACCL3_ASIC_2_12V_AUX_VOLT_V (0xBD) :  12.046 Volts | (ok)
CB_ACCL4_ASIC_1_TEMP_C       (0x82) :  37.000 C     | (ok)
CB_ACCL4_ASIC_1_0V8_VOLT_V   (0x83) :   0.833 Volts | (ok)
CB_ACCL4_ASIC_1_1V05_VOLT_V  (0x84) :   0.056 Volts | (ok)
CB_ACCL4_ASIC_1_12V_AUX_VOLT_V (0xBE) :  12.108 Volts | (ok)
CB_ACCL4_ASIC_2_TEMP_C       (0x85) :  37.000 C     | (ok)
CB_ACCL4_ASIC_2_0V8_VOLT_V   (0x86) :   0.831 Volts | (ok)
CB_ACCL4_ASIC_2_1V05_VOLT_V  (0x87) :   1.049 Volts | (ok)
CB_ACCL4_ASIC_2_12V_AUX_VOLT_V (0xBF) :  12.091 Volts | (ok)
CB_ACCL5_ASIC_1_TEMP_C       (0x88) :  38.000 C     | (ok)
CB_ACCL5_ASIC_1_0V8_VOLT_V   (0x89) :   0.846 Volts | (ok)
CB_ACCL5_ASIC_1_1V05_VOLT_V  (0x8A) :   1.049 Volts | (ok)
CB_ACCL5_ASIC_1_12V_AUX_VOLT_V (0xC0) :  12.145 Volts | (ok)
CB_ACCL5_ASIC_2_TEMP_C       (0x8B) :  36.000 C     | (ok)
CB_ACCL5_ASIC_2_0V8_VOLT_V   (0x8C) :   0.850 Volts | (ok)
CB_ACCL5_ASIC_2_1V05_VOLT_V  (0x8D) :   1.052 Volts | (ok)
CB_ACCL5_ASIC_2_12V_AUX_VOLT_V (0xC1) :  12.130 Volts | (ok)
CB_ACCL6_ASIC_1_TEMP_C       (0x8E) :  37.000 C     | (ok)
CB_ACCL6_ASIC_1_0V8_VOLT_V   (0x8F) :   0.852 Volts | (ok)
CB_ACCL6_ASIC_1_1V05_VOLT_V  (0x90) :   1.052 Volts | (ok)
CB_ACCL6_ASIC_1_12V_AUX_VOLT_V (0xC2) :  12.063 Volts | (ok)
CB_ACCL6_ASIC_2_TEMP_C       (0x91) :  40.000 C     | (ok)
CB_ACCL6_ASIC_2_0V8_VOLT_V   (0x92) :   0.852 Volts | (ok)
CB_ACCL6_ASIC_2_1V05_VOLT_V  (0x93) :   1.052 Volts | (ok)
CB_ACCL6_ASIC_2_12V_AUX_VOLT_V (0xC3) :  12.087 Volts | (ok)
CB_ACCL7_ASIC_1_TEMP_C       (0x94) :  39.000 C     | (ok)
CB_ACCL7_ASIC_1_0V8_VOLT_V   (0x95) :   0.850 Volts | (ok)
CB_ACCL7_ASIC_1_1V05_VOLT_V  (0x96) :   1.049 Volts | (ok)
CB_ACCL7_ASIC_1_12V_AUX_VOLT_V (0xC4) :  12.032 Volts | (ok)
CB_ACCL7_ASIC_2_TEMP_C       (0x97) :  40.000 C     | (ok)
CB_ACCL7_ASIC_2_0V8_VOLT_V   (0x98) :   0.850 Volts | (ok)
CB_ACCL7_ASIC_2_1V05_VOLT_V  (0x99) :   1.052 Volts | (ok)
CB_ACCL7_ASIC_2_12V_AUX_VOLT_V (0xC5) :  12.056 Volts | (ok)
CB_ACCL8_ASIC_1_TEMP_C       (0x9A) :  36.000 C     | (ok)
CB_ACCL8_ASIC_1_0V8_VOLT_V   (0x9B) :   0.852 Volts | (ok)
CB_ACCL8_ASIC_1_1V05_VOLT_V  (0x9C) :   1.052 Volts | (ok)
CB_ACCL8_ASIC_1_12V_AUX_VOLT_V (0xC6) :  12.040 Volts | (ok)
CB_ACCL8_ASIC_2_TEMP_C       (0x9D) :  36.000 C     | (ok)
CB_ACCL8_ASIC_2_0V8_VOLT_V   (0x9E) :   0.846 Volts | (ok)
CB_ACCL8_ASIC_2_1V05_VOLT_V  (0x9F) :   1.052 Volts | (ok)
CB_ACCL8_ASIC_2_12V_AUX_VOLT_V (0xC7) :  12.088 Volts | (ok)
CB_ACCL9_ASIC_1_TEMP_C       (0xA0) :  41.000 C     | (ok)
CB_ACCL9_ASIC_1_0V8_VOLT_V   (0xA1) :   0.850 Volts | (ok)
CB_ACCL9_ASIC_1_1V05_VOLT_V  (0xA2) :   1.052 Volts | (ok)
CB_ACCL9_ASIC_1_12V_AUX_VOLT_V (0xC8) :  12.071 Volts | (ok)
CB_ACCL9_ASIC_2_TEMP_C       (0xA3) :  43.000 C     | (ok)
CB_ACCL9_ASIC_2_0V8_VOLT_V   (0xA4) :   0.846 Volts | (ok)
CB_ACCL9_ASIC_2_1V05_VOLT_V  (0xA5) :   1.049 Volts | (ok)
CB_ACCL9_ASIC_2_12V_AUX_VOLT_V (0xC9) :  12.103 Volts | (ok)
CB_ACCL10_ASIC_1_TEMP_C      (0xA6) :  34.000 C     | (ok)
CB_ACCL10_ASIC_1_0V8_VOLT_V  (0xA7) :   0.846 Volts | (ok)
CB_ACCL10_ASIC_1_1V05_VOLT_V (0xA8) :   1.052 Volts | (ok)
CB_ACCL10_ASIC_1_12V_AUX_VOLT_V (0xCA) :  12.045 Volts | (ok)
CB_ACCL10_ASIC_2_TEMP_C      (0xA9) :  39.000 C     | (ok)
CB_ACCL10_ASIC_2_0V8_VOLT_V  (0xAA) :   0.850 Volts | (ok)
CB_ACCL10_ASIC_2_1V05_VOLT_V (0xAB) :   1.049 Volts | (ok)
CB_ACCL10_ASIC_2_12V_AUX_VOLT_V (0xCB) :  12.122 Volts | (ok)
CB_ACCL11_ASIC_1_TEMP_C      (0xAC) :  39.000 C     | (ok)
CB_ACCL11_ASIC_1_0V8_VOLT_V  (0xAD) :   0.850 Volts | (ok)
CB_ACCL11_ASIC_1_1V05_VOLT_V (0xAE) :   1.052 Volts | (ok)
CB_ACCL11_ASIC_1_12V_AUX_VOLT_V (0xCC) :  12.040 Volts | (ok)
CB_ACCL11_ASIC_2_TEMP_C      (0xAF) :  41.000 C     | (ok)
CB_ACCL11_ASIC_2_0V8_VOLT_V  (0xB0) :   0.846 Volts | (ok)
CB_ACCL11_ASIC_2_1V05_VOLT_V (0xB1) :   1.049 Volts | (ok)
CB_ACCL11_ASIC_2_12V_AUX_VOLT_V (0xCD) :  12.122 Volts | (ok)
CB_ACCL12_ASIC_1_TEMP_C      (0xB2) :  41.000 C     | (ok)
CB_ACCL12_ASIC_1_0V8_VOLT_V  (0xB3) :   0.846 Volts | (ok)
CB_ACCL12_ASIC_1_1V05_VOLT_V (0xB4) :   1.052 Volts | (ok)
CB_ACCL12_ASIC_1_12V_AUX_VOLT_V (0xCE) :  12.083 Volts | (ok)
CB_ACCL12_ASIC_2_TEMP_C      (0xB5) :  37.000 C     | (ok)
CB_ACCL12_ASIC_2_0V8_VOLT_V  (0xB6) :   0.843 Volts | (ok)
CB_ACCL12_ASIC_2_1V05_VOLT_V (0xB7) :   1.049 Volts | (ok)
CB_ACCL12_ASIC_2_12V_AUX_VOLT_V (0xCF) :  12.061 Volts | (ok)