### PR TITLE
fby4: wf: Add the SRAM size

### DIFF
--- a/meta-facebook/yv4-wf/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-wf/boards/ast1030_evb.overlay
@@ -206,7 +206,7 @@
 };
 
 &sram0 {
-	reg = <0 DT_SIZE_K(512)>, <0x80000 DT_SIZE_K(256)>;
+	reg = <0 DT_SIZE_K(642)>, <DT_SIZE_K(642) DT_SIZE_K(126)>;
 };
 
 &gpio0_a_d {


### PR DESCRIPTION
Description:
- Add the SRAM size

Motivation:
- SRAM is insufficient so we dynamically adjust the SRAM.

Test plan:
- Build pass - Pass
- SRAM check - Pass
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:         12 KB       126 KB      9.52%
           FLASH:          0 GB         0 GB
            SRAM:      525256 B       642 KB     79.90%
        IDT_LIST:          0 GB         2 KB      0.00%
- BIC boot up - Pass