### PR TITLE
fby4: ff: Add the SRAM size

### DIFF
--- a/meta-facebook/yv4-ff/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-ff/boards/ast1030_evb.overlay
@@ -175,7 +175,7 @@
 };
 
 &sram0 {
-	reg = <0 DT_SIZE_K(512)>, <0x80000 DT_SIZE_K(256)>;
+	reg = <0 DT_SIZE_K(642)>, <DT_SIZE_K(642) DT_SIZE_K(126)>;
 };
 
 &gpio0_a_d {


### PR DESCRIPTION
Description:
- Add the SRAM size

Motivation:
- SRAM is insufficient so we dynamically adjust the SRAM.

Test plan:
- Build pass