### PR TITLE
ol2: gl: Correct post-complete event

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_isr.c
@@ -462,13 +462,11 @@ struct vgpio_info post_complete;
 
 static void post_complete_handler(struct k_work *work)
 {
-	/* Add "END_OF_POST" event log to BMC */
-	struct vgpio_info *info = CONTAINER_OF(work, struct vgpio_info, work);
+	// Add "END_OF_POST" event log to BMC
 	common_addsel_msg_t sel_msg;
 	sel_msg.InF_target = BMC_IPMB;
 	sel_msg.sensor_type = IPMI_SENSOR_TYPE_SYS_EVENT;
-	sel_msg.event_type = (info->gpio_value == VW_GPIO_HIGH) ? IPMI_EVENT_TYPE_SENSOR_SPECIFIC :
-								  IPMI_OEM_EVENT_TYPE_DEASSERT;
+	sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
 	sel_msg.sensor_number = SENSOR_NUM_END_OF_POST;
 	sel_msg.event_data1 = IPMI_EVENT_OEM_SYSTEM_BOOT_EVENT;
 	sel_msg.event_data2 = 0xFF;
@@ -485,7 +483,11 @@ void ISR_POST_COMPLETE(uint8_t gpio_value)
 	set_post_complete(is_post_completed);
 
 	post_complete.gpio_value = gpio_value;
-	k_work_schedule(&post_completework, K_MSEC(10));
+
+	// Only send when post is complete
+	if (is_post_completed) {
+		k_work_schedule(&post_completework, K_MSEC(10));
+	}
 }
 
 static void adr_mode0_handler(struct k_work *work)


### PR DESCRIPTION
# Description:
- Fix the problem of post-complete event missing.
- Remove post not complete event.

# Motivation:
- Post-complete event is missing.

# Test plan:
- Build code: Pass
- Check post-complete event: Pass

Log:
- Before fix root@bmc-oob:~# log-util --print slot1
1    slot1    2023-12-11 03:08:35    power-util       SERVER_12V_CYCLE successful for FRU: 1
1    slot1    2023-12-11 03:08:36    gpiod            FRU: 1, System powered ON
1    slot1    2023-12-11 03:08:36    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-12-11 03:08:36, Sensor: END_OF_POST (0x11), Event Data: (01FFFF) OEM System boot event Deassertion
1    slot1    2023-12-11 03:08:58    gpiod            FRU: 1, System powered OFF
1    slot1    2023-12-11 03:09:01    gpiod            FRU: 1, System powered ON
1    slot1    2023-12-11 03:10:25    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-12-11 03:10:25, Sensor: END_OF_POST (0x11), Event Data: (01FFFF) OEM System boot event Deassertion
1    slot1    2023-12-11 03:10:30    ipmid            SEL Entry: FRU: 1, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15
1    slot1    2023-12-11 03:11:31    ipmid            SEL Entry: FRU: 1, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv4 fail, Error Code: 0x10

- After fix root@bmc-oob:~# log-util --print slot1
1    slot1    2023-12-11 03:48:28    power-util       SERVER_12V_CYCLE successful for FRU: 1
1    slot1    2023-12-11 03:48:29    gpiod            FRU: 1, System powered ON
1    slot1    2023-12-11 03:48:51    gpiod            FRU: 1, System powered OFF
1    slot1    2023-12-11 03:48:54    gpiod            FRU: 1, System powered ON
1    slot1    2023-12-11 03:50:18    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-12-11 03:50:18, Sensor: END_OF_POST (0x11), Event Data: (01FFFF) OEM System boot event Assertion
1    slot1    2023-12-11 03:50:23    ipmid            SEL Entry: FRU: 1, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv6 fail, Error Code: 0x15
1    slot1    2023-12-11 03:51:25    ipmid            SEL Entry: FRU: 1, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: System PXE boot fail, Fail Type: IPv4 fail, Error Code: 0x10