### PR TITLE
ol2: gl: Correct VR address after EVT stage

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
@@ -413,8 +413,8 @@ void pal_extend_sensor_config()
 	}
 
 	/* Following the hardware design,
-	 * MPS and Renesas VR chips are used in EVT stage.
-	 * And the slave address is changed in EVT stage.
+	 * MPS and Renesas VR chips are used after EVT stage.
+	 * And the slave address is changed after EVT stage.
 	 * So, BIC revises VR slave address according to server board revision.
 	 * Besides, BIC judges VR chip type by getting device id
 	 * and then replace sensor config table before loading.
@@ -423,7 +423,7 @@ void pal_extend_sensor_config()
 	sensor_count = ARRAY_SIZE(plat_sensor_config);
 	for (uint8_t index = 0; index < sensor_count; index++) {
 		if (sensor_config[index].type == sensor_dev_xdpe15284) {
-			if (board_revision == SYS_BOARD_EVT) {
+			if ((board_revision >= SYS_BOARD_EVT) && (board_revision <= SYS_BOARD_MP)) {
 				switch (sensor_config[index].target_addr) {
 				case FIVRA_ADDR:
 					sensor_config[index].target_addr = EVT_FIVRA_ADDR;


### PR DESCRIPTION
# Description
- Fix VR sensor reading NA problem.
- Change the VR address after the EVT stage.

# Motivation
- Currently, only change VR address on the EVT stage. This causes incorrect VR addresses and fails to get VR sensor readings after the EVT stage.

# Test plan
- Build code: Pass
- Get VR sensor reading: Pass

# Log
- Before fix root@bmc-oob:~# sensor-util slot1 | grep VR
slot1:
MB_VR_VCCIN_TEMP_C           (0xF) :  43.000 C     | (ok)
MB_VR_EHV_TEMP_C             (0x10) :  43.000 C     | (ok)
MB_VR_FIVRA_TEMP_C           (0x11) : NA | (na)
MB_VR_VCCINF_TEMP_C          (0x12) : NA | (na)
MB_VR_VCCD0_TEMP_C           (0x13) : NA | (na)
MB_VR_VCCD1_TEMP_C           (0x14) : NA | (na)
MB_VR_VCCIN_VOLT_V           (0x1D) :   1.825 Volts | (ok)
MB_VR_VCCINF_VOLT_V          (0x1E) : NA | (na)
MB_VR_FIVRA_VOLT_V           (0x1F) : NA | (na)
MB_VR_VCCD0_VOLT_V           (0x20) : NA | (na)
MB_VR_VCCD1_VOLT_V           (0x21) : NA | (na)
MB_VR_EHV_VOLT_V             (0x22) :   1.802 Volts | (ok)
MB_VR_VCCIN_CURR_A           (0x29) :   7.750 Amps  | (ok)
MB_VR_EHV_CURR_A             (0x2A) :   0.000 Amps  | (ok)
MB_VR_FIVRA_CURR_A           (0x2B) : NA | (na)
MB_VR_VCCINF_CURR_A          (0x2C) : NA | (na)
MB_VR_VCCD0_CURR_A           (0x2D) : NA | (na)
MB_VR_VCCD1_CURR_A           (0x2E) : NA | (na)
MB_VR_VCCIN_PWR_W            (0x30) :  15.000 Watts | (ok)
MB_VR_EHV_PWR_W              (0x31) :   0.000 Watts | (ok)
MB_VR_FIVRA_PWR_W            (0x32) : NA | (na)
MB_VR_VCCINF_PWR_W           (0x33) : NA | (na)
MB_VR_VCCD0_PWR_W            (0x34) : NA | (na)
MB_VR_VCCD1_PWR_W            (0x35) : NA | (na)

- After fix root@bmc-oob:~# sensor-util slot1 | grep VR
MB_VR_VCCIN_TEMP_C           (0xF) :  44.000 C     | (ok)
MB_VR_EHV_TEMP_C             (0x10) :  44.000 C     | (ok)
MB_VR_FIVRA_TEMP_C           (0x11) :  37.000 C     | (ok)
MB_VR_VCCINF_TEMP_C          (0x12) :  35.000 C     | (ok)
MB_VR_VCCD0_TEMP_C           (0x13) :  33.000 C     | (ok)
MB_VR_VCCD1_TEMP_C           (0x14) :  32.000 C     | (ok)
MB_VR_VCCIN_VOLT_V           (0x1D) :   1.787 Volts | (ok)
MB_VR_VCCINF_VOLT_V          (0x1E) :   0.750 Volts | (ok)
MB_VR_FIVRA_VOLT_V           (0x1F) :   1.800 Volts | (ok)
MB_VR_VCCD0_VOLT_V           (0x20) :   1.113 Volts | (ok)
MB_VR_VCCD1_VOLT_V           (0x21) :   1.118 Volts | (ok)
MB_VR_EHV_VOLT_V             (0x22) :   1.802 Volts | (ok)
MB_VR_VCCIN_CURR_A           (0x29) :  51.625 Amps  | (ok)
MB_VR_EHV_CURR_A             (0x2A) :   0.000 Amps  | (ok)
MB_VR_FIVRA_CURR_A           (0x2B) :   4.500 Amps  | (ok)
MB_VR_VCCINF_CURR_A          (0x2C) :   4.937 Amps  | (ok)
MB_VR_VCCD0_CURR_A           (0x2D) :   0.000 Amps  | (ok)
MB_VR_VCCD1_CURR_A           (0x2E) :   0.000 Amps  | (ok)
MB_VR_VCCIN_PWR_W            (0x30) :  93.000 Watts | (ok)
MB_VR_EHV_PWR_W              (0x31) :   0.000 Watts | (ok)
MB_VR_FIVRA_PWR_W            (0x32) :   8.000 Watts | (ok)
MB_VR_VCCINF_PWR_W           (0x33) :   3.500 Watts | (ok)
MB_VR_VCCD0_PWR_W            (0x34) :   0.000 Watts | (ok)
MB_VR_VCCD1_PWR_W            (0x35) :   0.000 Watts | (ok)