### PR TITLE
Artemis: mc: Add 3V3 ADC sensor access_check function to avoid invali…

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_sensor_table.c
+++ b/meta-facebook/at-mc/src/platform/plat_sensor_table.c
@@ -91,7 +91,7 @@ sensor_cfg plat_sensor_config[] = {
 	{ SENSOR_NUM_VOL_P1V2_AUX, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE, stby_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
-	{ SENSOR_NUM_VOL_P3V3, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE, stby_access, 2, 1,
+	{ SENSOR_NUM_VOL_P3V3, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE, is_dc_access, 2, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_asd_init_args[0] },
 };


### PR DESCRIPTION
…d sensor reading

# Description
- Add 3V3 ADC sensor access_check function to avoid invalid sensor reading.

# Motivation
- Add 3V3 ADC sensor access_check function to avoid invalid sensor reading.

# Test Plan
- Build code: Pass
- Get 3V3 ADC sensor reading: Pass

# Log
- MEB on root@bmc-oob:~# sensor-util mc | grep MC_P3V3_VOLT_V
MC_P3V3_VOLT_V               (0x7) :   3.320 Volts | (ok)

- MEB off root@bmc-oob:~# sensor-util mc | grep MC_P3V3_VOLT_V
MC_P3V3_VOLT_V               (0x7) : NA | (na)