### PR TITLE
Artemis: mc: Support MC SSD Present Log

### DIFF
--- a/meta-facebook/at-mc/CMakeLists.txt
+++ b/meta-facebook/at-mc/CMakeLists.txt
@@ -48,3 +48,6 @@ target_include_directories(app PRIVATE src/platform)
 
 # Fail build if there are any warnings 
 target_compile_options(app PRIVATE -Werror)
+
+add_compile_definitions(PLDM_MONITOR_EVENT_QUEUE_MSG_NUM_MAX=30)
+add_compile_definitions(PLDM_MAX_DATA_SIZE=1024)

--- a/meta-facebook/at-mc/src/platform/plat_class.c
+++ b/meta-facebook/at-mc/src/platform/plat_class.c
@@ -29,14 +29,6 @@
 
 LOG_MODULE_REGISTER(plat_class);
 
-struct PCIE_CARD_INFO {
-	uint8_t cpld_offset;
-	uint8_t power_status_offset;
-	uint8_t value_bit;
-	uint8_t value_shift_bit;
-	uint8_t card_device_type;
-};
-
 uint8_t board_revision = REV_UNKNOWN;
 
 struct PCIE_CARD_INFO pcie_card_info[] = {

--- a/meta-facebook/at-mc/src/platform/plat_class.h
+++ b/meta-facebook/at-mc/src/platform/plat_class.h
@@ -90,6 +90,16 @@ enum PCIE_CARD_TYPE {
 	UNKNOWN_CARD = 0xFF,
 };
 
+struct PCIE_CARD_INFO {
+	uint8_t cpld_offset;
+	uint8_t power_status_offset;
+	uint8_t value_bit;
+	uint8_t value_shift_bit;
+	uint8_t card_device_type;
+};
+
+extern struct PCIE_CARD_INFO pcie_card_info[CARD_INDEX_MAX];
+
 void check_pcie_card_type();
 uint8_t prsnt_status_to_card_type(uint8_t presence_status);
 int get_pcie_card_type(uint8_t card_id, uint8_t *card_type);

--- a/meta-facebook/at-mc/src/platform/plat_init.c
+++ b/meta-facebook/at-mc/src/platform/plat_init.c
@@ -28,6 +28,7 @@
 #include "util_worker.h"
 #include "plat_isr.h"
 #include "plat_sys.h"
+#include "plat_pldm_monitor.h"
 
 LOG_MODULE_REGISTER(plat_init);
 
@@ -117,6 +118,9 @@ void pal_post_init()
 	plat_mctp_init();
 	check_mb_reset_status();
 	check_debug_sel_mode_status();
+	if (is_ac_lost()) {
+		plat_ssd_present_check();
+	}
 }
 
 void pal_device_init()

--- a/meta-facebook/at-mc/src/platform/plat_pldm_monitor.c
+++ b/meta-facebook/at-mc/src/platform/plat_pldm_monitor.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <logging/log.h>
+
+#include "sensor.h"
+#include "hal_gpio.h"
+#include "pldm.h"
+#include "pmbus.h"
+#include "plat_fru.h"
+#include "plat_gpio.h"
+#include "plat_sensor_table.h"
+#include "plat_pldm_monitor.h"
+#include "plat_class.h"
+
+LOG_MODULE_REGISTER(plat_pldm_monitor);
+
+void plat_ssd_present_check()
+{
+	bool is_present = CARD_NOT_PRESENT;
+	struct pldm_sensor_event_state_sensor_state event;
+	for (uint8_t i = CARD_8_INDEX; i >= CARD_5_INDEX; i--) {
+		is_present = pcie_card_info[i].card_device_type;
+		event.sensor_offset = PLDM_STATE_SET_OFFSET_DEVICE_PRESENCE;
+		event.event_state = is_present == E1S_PRESENT ? PLDM_STATE_SET_PRESENT :
+								PLDM_STATE_SET_NOT_PRESENT;
+		event.previous_event_state = PLDM_STATE_SET_NOT_PRESENT;
+		if (pldm_send_platform_event(PLDM_SENSOR_EVENT, PLDM_EVENT_SSD_1 + CARD_8_INDEX - i,
+					     PLDM_STATE_SENSOR_STATE, (uint8_t *)&event,
+					     sizeof(struct pldm_sensor_event_state_sensor_state))) {
+			LOG_ERR("Send SSD%d presence event log failed", CARD_8_INDEX - i + 1);
+		}
+	}
+}

--- a/meta-facebook/at-mc/src/platform/plat_pldm_monitor.h
+++ b/meta-facebook/at-mc/src/platform/plat_pldm_monitor.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_PLDM_MONITOR_H
+#define PLAT_PLDM_MONITOR_H
+
+enum plat_pldm_event_sensor_num {
+	PLDM_EVENT_SSD_1 = 0x80,
+	PLDM_EVENT_SSD_2,
+	PLDM_EVENT_SSD_3,
+	PLDM_EVENT_SSD_4,
+};
+
+enum plat_pldm_device_state_set_offset {
+	PLDM_STATE_SET_OFFSET_DEVICE_PRESENCE = 0,
+	PLDM_STATE_SET_OFFSET_DEVICE_STATUS = 1,
+};
+
+void plat_ssd_present_check();
+
+#endif


### PR DESCRIPTION
 # Description
 - As title.

 # Motivation
 - As title.

 # Test Plan
 - Check BMC logs and can see present/not present of SSD - pass

 # Log
 ```
0    all      2018-03-09 04:36:00    pldmd            State Sensor: MC_SENSOR_SSD_1, not present
0    all      2018-03-09 04:36:01    pldmd            State Sensor: MC_SENSOR_SSD_2, present
0    all      2018-03-09 04:36:02    pldmd            State Sensor: MC_SENSOR_SSD_3, not present
0    all      2018-03-09 04:36:03    pldmd            State Sensor: MC_SENSOR_SSD_4, present
0    all      2018-03-09 04:36:10    pldmd            State Sensor: CB_SENSOR_FIO, present
0    all      2018-03-09 04:36:11    pldmd            State Sensor: CB_SENSOR_ACCL_1, present
0    all      2018-03-09 04:36:12    pldmd            State Sensor: CB_SENSOR_ACCL_2, present
0    all      2018-03-09 04:36:13    pldmd            State Sensor: CB_SENSOR_ACCL_3, present
0    all      2018-03-09 04:36:14    pldmd            State Sensor: CB_SENSOR_ACCL_4, present
0    all      2018-03-09 04:36:15    pldmd            State Sensor: CB_SENSOR_ACCL_5, present
0    all      2018-03-09 04:36:16    pldmd            State Sensor: CB_SENSOR_ACCL_6, present
0    all      2018-03-09 04:36:17    pldmd            State Sensor: CB_SENSOR_ACCL_7, present
0    all      2018-03-09 04:36:18    pldmd            State Sensor: CB_SENSOR_ACCL_8, present
 ```