### PR TITLE
common: pldm: support to get tid by platform

### DIFF
--- a/common/service/pldm/pldm_base.c
+++ b/common/service/pldm/pldm_base.c
@@ -25,6 +25,11 @@
 
 LOG_MODULE_DECLARE(pldm);
 
+__weak uint8_t plat_pldm_get_tid()
+{
+	return DEFAULT_TID;
+}
+
 uint8_t set_tid(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t instance_id, uint8_t *resp,
 		uint16_t *resp_len, void *ext_params)
 {
@@ -48,7 +53,7 @@ uint8_t get_tid(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t instance_id
 
 	struct _get_tid_resp *p = (struct _get_tid_resp *)resp;
 	p->completion_code = PLDM_SUCCESS;
-	p->tid = DEFAULT_TID;
+	p->tid = plat_pldm_get_tid();
 	*resp_len = sizeof(*p);
 	return PLDM_SUCCESS;
 }

--- a/common/service/pldm/pldm_base.h
+++ b/common/service/pldm/pldm_base.h
@@ -95,6 +95,8 @@ struct _get_pldm_commands_resp {
 
 uint8_t pldm_base_handler_query(uint8_t code, void **ret_fn);
 
+uint8_t plat_pldm_get_tid();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# Description:
Support to get tid by platform.

# Motivation:
PLDM sensors' name in OpenBMC would use TID as suffix. Therefore, BIC should respond the correct TID.

# Test Plan:
Check BMC could get the correct TID from BIC.

# Test log:
root@bmc:~# pldmtool base GetTID -m 40
{
    "Response": 40
}