### PR TITLE
fby3.5: gl: Fix memory thermal trip SEL won't be assert

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_isr.c
@@ -320,26 +320,24 @@ void ISR_MB_THROTTLE()
 void ISR_SOC_THMALTRIP()
 {
 	common_addsel_msg_t sel_msg;
-	if (gpio_get(RST_PLTRST_SYNC_LVC3_N) == GPIO_LOW) {
-		if (gpio_get(H_CPU_MEMTRIP_LVC3_N) ==
-		    GPIO_LOW) { // Reference pin for memory thermal trip event
-			sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_MEMORY_THERMALTRIP;
-		} else {
-			sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_THERMAL_TRIP;
-		}
+	if (gpio_get(H_CPU_MEMTRIP_LVC3_N) ==
+	    GPIO_LOW) { // Reference pin for memory thermal trip event
+		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_MEMORY_THERMALTRIP;
+	} else {
+		sel_msg.event_data1 = IPMI_OEM_EVENT_OFFSET_SYS_THERMAL_TRIP;
+	}
 
-		sel_msg.InF_target = BMC_IPMB;
-		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
-		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
-		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
-		sel_msg.event_data2 = 0xFF;
-		sel_msg.event_data3 = 0xFF;
-		if (!common_add_sel_evt_record(&sel_msg)) {
-			if (sel_msg.event_data1 == IPMI_OEM_EVENT_OFFSET_SYS_THERMAL_TRIP) {
-				LOG_ERR("Failed to add SOC Thermal trip SEL");
-			} else {
-				LOG_ERR("Failed to add Memory Thermal trip SEL");
-			}
+	sel_msg.InF_target = BMC_IPMB;
+	sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
+	sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
+	sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
+	sel_msg.event_data2 = 0xFF;
+	sel_msg.event_data3 = 0xFF;
+	if (!common_add_sel_evt_record(&sel_msg)) {
+		if (sel_msg.event_data1 == IPMI_OEM_EVENT_OFFSET_SYS_THERMAL_TRIP) {
+			LOG_ERR("Failed to add SOC Thermal trip SEL");
+		} else {
+			LOG_ERR("Failed to add Memory Thermal trip SEL");
 		}
 	}
 }


### PR DESCRIPTION
# Description:
Take off RST_PLTRST_SYNC_LVC3_N check in function of memory thermal trip SEL assertion.

# Motivation:
Fix memory thermal trip SEL won't be assert

# Test Plan:
1. Build and test pass on OLP2.0 system. pass

2. Test the SEL log. root@bmc-oob:~# log-util all --print
1    slot1    2023-12-19 21:21:31    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2018-03-09 08:10:22, Sensor: SYSTEM_STATUS (0x10), Event Data: (11FFFF) CPU/Hemory thermal trip Assertion
1    slot1    2023-12-19 21:21:31    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2018-03-09 08:10:22, Sensor: END OF POST (0x11), Event Data: (01FFFF) OEM Systen boot event Deassertion