### PR TITLE
fby4: sd/ff/wf: support to get correct TID

### DIFF
--- a/meta-facebook/yv4-ff/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_mctp.c
@@ -48,6 +48,8 @@ LOG_MODULE_REGISTER(plat_mctp);
 #define MCTP_EID_MB_BIC 0
 #define MCTP_EID_CXL 0
 
+uint8_t plat_eid = MCTP_DEFAULT_ENDPOINT;
+
 K_TIMER_DEFINE(send_cmd_timer, send_cmd_to_dev, NULL);
 K_WORK_DEFINE(send_cmd_work, send_cmd_to_dev_handler);
 
@@ -356,6 +358,9 @@ mctp_port *plat_get_mctp_port(uint8_t index)
 
 void plat_update_mctp_routing_table(uint8_t eid)
 {
+	// Set platform eid
+	plat_eid = eid;
+
 	// update sd bic eid
 	mctp_route_entry *p = plat_mctp_route_tbl + 1;
 	p->endpoint = eid - 1;
@@ -375,4 +380,9 @@ int load_mctp_support_types(uint8_t *type_len, uint8_t *types)
 	*type_len = sizeof(MCTP_SUPPORTED_MESSAGES_TYPES);
 	memcpy(types, MCTP_SUPPORTED_MESSAGES_TYPES, sizeof(MCTP_SUPPORTED_MESSAGES_TYPES));
 	return MCTP_SUCCESS;
+}
+
+uint8_t plat_get_eid()
+{
+	return plat_eid;
 }

--- a/meta-facebook/yv4-ff/src/platform/plat_pldm.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm.c
@@ -1,0 +1,15 @@
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <logging/log.h>
+#include <logging/log_ctrl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "plat_mctp.h"
+
+LOG_MODULE_REGISTER(plat_pldm);
+
+uint8_t plat_pldm_get_tid()
+{
+	// Set TID as EID
+	return plat_get_eid();
+}

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm.c
@@ -1,0 +1,15 @@
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <logging/log.h>
+#include <logging/log_ctrl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "plat_mctp.h"
+
+LOG_MODULE_REGISTER(plat_pldm);
+
+uint8_t plat_pldm_get_tid()
+{
+	// Set TID as EID
+	return plat_get_eid();
+}

--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.c
@@ -51,6 +51,8 @@ LOG_MODULE_REGISTER(plat_mctp);
 #define MCTP_EID_CXL1 0
 #define MCTP_EID_CXL2 0
 
+uint8_t plat_eid = MCTP_DEFAULT_ENDPOINT;
+
 K_TIMER_DEFINE(send_cmd_timer, send_cmd_to_dev, NULL);
 K_WORK_DEFINE(send_cmd_work, send_cmd_to_dev_handler);
 
@@ -286,6 +288,9 @@ mctp_port *plat_get_mctp_port(uint8_t index)
 
 void plat_update_mctp_routing_table(uint8_t eid)
 {
+	// Set platform eid
+	plat_eid = eid;
+
 	// update sd bic eid
 	mctp_route_entry *p = plat_mctp_route_tbl + 1;
 	p->endpoint = eid - 2;
@@ -309,4 +314,9 @@ int load_mctp_support_types(uint8_t *type_len, uint8_t *types)
 	*type_len = sizeof(MCTP_SUPPORTED_MESSAGES_TYPES);
 	memcpy(types, MCTP_SUPPORTED_MESSAGES_TYPES, sizeof(MCTP_SUPPORTED_MESSAGES_TYPES));
 	return MCTP_SUCCESS;
+}
+
+uint8_t plat_get_eid()
+{
+	return plat_eid;
 }

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm.c
@@ -1,0 +1,15 @@
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <logging/log.h>
+#include <logging/log_ctrl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "plat_mctp.h"
+
+LOG_MODULE_REGISTER(plat_pldm);
+
+uint8_t plat_pldm_get_tid()
+{
+	// Set TID as EID
+	return plat_get_eid();
+}


### PR DESCRIPTION
# Description:
Support to get TID by platform.
Set TID as EID.

# Motivation:
PLDM sensors' name in OpenBMC would use TID as suffix. Therefore, BIC should respond the correct TID.

# Test Plan:
Check BMC could get the correct TID from SD, FF, and WF BIC. Check PLDM sensors' suffix are correct.

# Test log:
1. Get SD TID root@bmc:~# pldmtool base GetTID -m 60
{
	"Response": 60
}

2. Get FF TID root@bmc:~# pldmtool base GetTID -m 61
{
	"Response": 61
}

3. Get WF TID root@bmc:~# pldmtool base GetTID -m 62
{
        "Response": 62
}

4. Check PLDM sensors' suffix are correct. root@bmc:~# busctl tree xyz.openbmc_project.PLDM
...
  |- /xyz/openbmc_project/sensors/current
  | |- /xyz/openbmc_project/sensors/current/FF_INA233_P12V_STBY_CURR_A_32_61
  | |- /xyz/openbmc_project/sensors/current/FF_VR_P0V85_ASIC_CURR_A_35_61
  | |- /xyz/openbmc_project/sensors/current/FF_VR_P0V8_ASIC_CURR_A_33_61
  | |- /xyz/openbmc_project/sensors/current/MB_ADC_P12V_DIMM_0_VOLT_V_38_60
  | |- /xyz/openbmc_project/sensors/current/MB_ADC_P12V_DIMM_1_VOLT_V_39_60
  | |- /xyz/openbmc_project/sensors/current/MB_ADC_P1V2_STBY_VOLT_V_40_60
  | |- /xyz/openbmc_project/sensors/current/WF_INA233_P12V_E1S_0_L_CURR_A_65_62
  | |- /xyz/openbmc_project/sensors/current/WF_INA233_P12V_STBY_CURR_A_64_62
  | |- /xyz/openbmc_project/sensors/current/WF_VR_P0V85_ASIC1_CURR_A_68_62
  | |- /xyz/openbmc_project/sensors/current/WF_VR_P0V85_ASIC2_CURR_A_72_62
...