### PR TITLE
Common: Fix cpuid and mca reading value exception

### DIFF
--- a/common/service/apml/apml.c
+++ b/common/service/apml/apml.c
@@ -168,7 +168,12 @@ static uint8_t read_MCA_response(apml_msg *msg)
 		return APML_ERROR;
 	}
 
-	memcpy(msg->RdData, &i2c_msg.data[2], sizeof(mca_RdData));
+	if ((command_code_len == SBRMI_CMD_CODE_LEN_TWO_BYTE) &&
+	    (msg->target_addr == SB_RMI_ADDR)) {
+		memcpy(msg->RdData, &i2c_msg.data[2], sizeof(mca_RdData));
+	} else {
+		memcpy(msg->RdData, &i2c_msg.data[1], sizeof(mca_RdData));
+	}
 	return APML_SUCCESS;
 }
 
@@ -255,7 +260,12 @@ static uint8_t read_CPUID_response(apml_msg *msg)
 		return APML_ERROR;
 	}
 
-	memcpy(msg->RdData, &i2c_msg.data[2], sizeof(cpuid_RdData));
+	if ((command_code_len == SBRMI_CMD_CODE_LEN_TWO_BYTE) &&
+	    (msg->target_addr == SB_RMI_ADDR)) {
+		memcpy(msg->RdData, &i2c_msg.data[2], sizeof(cpuid_RdData));
+	} else {
+		memcpy(msg->RdData, &i2c_msg.data[1], sizeof(cpuid_RdData));
+	}
 	return APML_SUCCESS;
 }
 

--- a/common/service/apml/apml.c
+++ b/common/service/apml/apml.c
@@ -211,7 +211,6 @@ static uint8_t write_CPUID_request(apml_msg *msg)
 	I2C_MSG i2c_msg;
 	i2c_msg.bus = msg->bus;
 	i2c_msg.target_addr = msg->target_addr;
-	i2c_msg.tx_len = 10;
 
 	if ((command_code_len == SBRMI_CMD_CODE_LEN_TWO_BYTE) &&
 	    (msg->target_addr == SB_RMI_ADDR)) {


### PR DESCRIPTION
Summary:
- Response offset of cpuid/mca depends on the SBRMI command code length.

Test Plan:
- Build code: PASS
- Get CPUID and MCA response on HalfDome: PASS