### PR TITLE
ol2: op: Fix SSD won't be power off after power enable drop

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_isr.c
+++ b/meta-facebook/op2-op/src/platform/plat_isr.c
@@ -48,7 +48,7 @@ static bool is_e1s_P3V3_fault_assert[MAX_E1S_IDX] = { false, false, false, false
 	{                                                                                          \
 		uint8_t log = 0;                                                                   \
 		log = gpio_get(OPA_PWRGD_##power##_E1S_##device##_R);                              \
-		LOG_ERR("OPA GPIO = %d, OPA = %d", OPA_PWRGD_##power##_E1S_##device##_R, log);     \
+		LOG_DBG("OPA GPIO = %d, OPA = %d", OPA_PWRGD_##power##_E1S_##device##_R, log);     \
 		if ((gpio_get(OPA_PWRGD_##power##_E1S_##device##_R) == POWER_OFF) &&               \
 		    (gpio_get(OPA_E1S_##device##_##power##_POWER_EN) == POWER_ON)) {               \
 			send_system_status_event(IPMI_EVENT_TYPE_SENSOR_SPECIFIC,                  \
@@ -74,7 +74,7 @@ static bool is_e1s_P3V3_fault_assert[MAX_E1S_IDX] = { false, false, false, false
 	{                                                                                          \
 		uint8_t log = 0;                                                                   \
 		log = gpio_get(OPB_PWRGD_##power##_E1S_##device##_R);                              \
-		LOG_ERR("OPB GPIO = %d, OPB = %d", OPB_PWRGD_##power##_E1S_##device##_R, log);     \
+		LOG_DBG("OPB GPIO = %d, OPB = %d", OPB_PWRGD_##power##_E1S_##device##_R, log);     \
 		if ((gpio_get(OPB_PWRGD_##power##_E1S_##device##_R) == POWER_OFF) &&               \
 		    (gpio_get(OPB_##power##_E1S_##device##_EN_R) == POWER_ON)) {                   \
 			send_system_status_event(IPMI_EVENT_TYPE_SENSOR_SPECIFIC,                  \
@@ -124,10 +124,8 @@ void control_power_sequence()
 		}
 	} else { // op power off
 		if (board_revision != EVT_STAGE) {
-			if (!is_all_sequence_done(POWER_OFF)) {
-				abort_power_thread();
-				init_power_off_thread();
-			}
+			abort_power_thread();
+			init_power_off_thread();
 		}
 	}
 }
@@ -249,9 +247,10 @@ void ISR_E1S_0_PRSNT_N()
 	if (gpio_get(gpio_num) == GPIO_LOW) {
 		send_system_status_event(IPMI_EVENT_TYPE_SENSOR_SPECIFIC,
 					 IPMI_EVENT_OFFSET_STS_E1S_PRESENT, E1S_0);
-
-		abort_e1s_power_thread(E1S_0);
-		e1s_power_on_thread(E1S_0, E1S_POWER_ON_STAGE0);
+		if (gpio_get(FM_EXP_MAIN_PWR_EN) == GPIO_HIGH) {
+			abort_e1s_power_thread(E1S_0);
+			e1s_power_on_thread(E1S_0, E1S_POWER_ON_STAGE0);
+		}
 	} else {
 		send_system_status_event(IPMI_OEM_EVENT_TYPE_DEASSERT,
 					 IPMI_EVENT_OFFSET_STS_E1S_PRESENT, E1S_0);
@@ -281,9 +280,10 @@ void ISR_E1S_1_PRSNT_N()
 	if (gpio_get(gpio_num) == GPIO_LOW) {
 		send_system_status_event(IPMI_EVENT_TYPE_SENSOR_SPECIFIC,
 					 IPMI_EVENT_OFFSET_STS_E1S_PRESENT, E1S_1);
-
-		abort_e1s_power_thread(E1S_1);
-		e1s_power_on_thread(E1S_1, E1S_POWER_ON_STAGE0);
+		if (gpio_get(FM_EXP_MAIN_PWR_EN) == GPIO_HIGH) {
+			abort_e1s_power_thread(E1S_1);
+			e1s_power_on_thread(E1S_1, E1S_POWER_ON_STAGE0);
+		}
 	} else {
 		send_system_status_event(IPMI_OEM_EVENT_TYPE_DEASSERT,
 					 IPMI_EVENT_OFFSET_STS_E1S_PRESENT, E1S_1);
@@ -313,9 +313,10 @@ void ISR_E1S_2_PRSNT_N()
 	if (gpio_get(gpio_num) == GPIO_LOW) {
 		send_system_status_event(IPMI_EVENT_TYPE_SENSOR_SPECIFIC,
 					 IPMI_EVENT_OFFSET_STS_E1S_PRESENT, E1S_2);
-
-		abort_e1s_power_thread(E1S_2);
-		e1s_power_on_thread(E1S_2, E1S_POWER_ON_STAGE0);
+		if (gpio_get(FM_EXP_MAIN_PWR_EN) == GPIO_HIGH) {
+			abort_e1s_power_thread(E1S_2);
+			e1s_power_on_thread(E1S_2, E1S_POWER_ON_STAGE0);
+		}
 	} else {
 		send_system_status_event(IPMI_OEM_EVENT_TYPE_DEASSERT,
 					 IPMI_EVENT_OFFSET_STS_E1S_PRESENT, E1S_2);
@@ -331,9 +332,10 @@ void ISR_E1S_3_PRSNT_N()
 	if (gpio_get(OPB_E1S_3_PRSNT_N) == GPIO_LOW) {
 		send_system_status_event(IPMI_EVENT_TYPE_SENSOR_SPECIFIC,
 					 IPMI_EVENT_OFFSET_STS_E1S_PRESENT, E1S_3);
-
-		abort_e1s_power_thread(E1S_3);
-		e1s_power_on_thread(E1S_3, E1S_POWER_ON_STAGE0);
+		if (gpio_get(FM_EXP_MAIN_PWR_EN) == GPIO_HIGH) {
+			abort_e1s_power_thread(E1S_3);
+			e1s_power_on_thread(E1S_3, E1S_POWER_ON_STAGE0);
+		}
 	} else {
 		send_system_status_event(IPMI_OEM_EVENT_TYPE_DEASSERT,
 					 IPMI_EVENT_OFFSET_STS_E1S_PRESENT, E1S_3);
@@ -349,9 +351,10 @@ void ISR_E1S_4_PRSNT_N()
 	if (gpio_get(OPB_E1S_4_PRSNT_N) == GPIO_LOW) {
 		send_system_status_event(IPMI_EVENT_TYPE_SENSOR_SPECIFIC,
 					 IPMI_EVENT_OFFSET_STS_E1S_PRESENT, E1S_4);
-
-		abort_e1s_power_thread(E1S_4);
-		e1s_power_on_thread(E1S_4, E1S_POWER_ON_STAGE0);
+		if (gpio_get(FM_EXP_MAIN_PWR_EN) == GPIO_HIGH) {
+			abort_e1s_power_thread(E1S_4);
+			e1s_power_on_thread(E1S_4, E1S_POWER_ON_STAGE0);
+		}
 	} else {
 		send_system_status_event(IPMI_OEM_EVENT_TYPE_DEASSERT,
 					 IPMI_EVENT_OFFSET_STS_E1S_PRESENT, E1S_4);

--- a/meta-facebook/op2-op/src/platform/plat_power_seq.c
+++ b/meta-facebook/op2-op/src/platform/plat_power_seq.c
@@ -155,6 +155,7 @@ bool get_e1s_power_good(uint8_t index)
 		LOG_ERR("UNKNOWN CARD TYPE");
 		break;
 	}
+
 	return power_good;
 }
 
@@ -808,7 +809,7 @@ bool power_on_handler(uint8_t initial_stage)
 	while (enable_power_on_handler == true) {
 		switch (control_stage) { // Enable VR power machine
 		case BOARD_POWER_ON_STAGE0:
-			if (board_revision == DVT_STAGE && card_type == CARD_TYPE_OPB) {
+			if (board_revision != EVT_STAGE && card_type == CARD_TYPE_OPB) {
 				control_power_stage(ENABLE_POWER_MODE, OPB_BIC_MAIN_PWR_EN_R);
 			}
 			break;
@@ -860,7 +861,7 @@ bool power_on_handler(uint8_t initial_stage)
 				break;
 			}
 			if (check_power_stage(ENABLE_POWER_MODE, CHECK_POWER_SEQ_02) != 0) {
-				if (board_revision == DVT_STAGE && card_type == CARD_TYPE_OPB) {
+				if (board_revision != EVT_STAGE && card_type == CARD_TYPE_OPB) {
 					control_power_stage(DISABLE_POWER_MODE, OPB_BIC_MAIN_PWR_EN_R);
 				}
 				LOG_ERR("PWRGD_P12V_MAIN is not enabled!");
@@ -1005,7 +1006,7 @@ bool power_off_handler(uint8_t initial_stage)
 			control_power_stage(DISABLE_POWER_MODE, OPA_EN_P0V9_VR);
 			break;
 		case BOARD_POWER_OFF_STAGE2:
-			if (board_revision == DVT_STAGE && card_type == CARD_TYPE_OPB) {
+			if (board_revision != EVT_STAGE && card_type == CARD_TYPE_OPB) {
 				control_power_stage(DISABLE_POWER_MODE, OPB_BIC_MAIN_PWR_EN_R);
 			}
 			break;
@@ -1085,10 +1086,12 @@ bool power_off_handler(uint8_t initial_stage)
 			control_stage = BOARD_POWER_OFF_STAGE2;
 			break;
 		case BOARD_POWER_OFF_STAGE2:
-			if (check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_02) != 0) {
-				LOG_ERR("OPB_BIC_MAIN_PWR_EN_R is not disabled!");
-				check_power_ret = -1;
-				break;
+			if (board_revision != EVT_STAGE && card_type == CARD_TYPE_OPB) {
+				if (check_power_stage(DISABLE_POWER_MODE, CHECK_POWER_SEQ_02) != 0) {
+					LOG_ERR("OPB_BIC_MAIN_PWR_EN_R is not disabled!");
+					check_power_ret = -1;
+					break;
+				}
 			}
 			enable_power_off_handler = false;
 			break;


### PR DESCRIPTION
# Description:
Fix SSD won't be power off after power enable drop

# Motivation:
SSD won't be power off after power enable drop

# Test Plan:
1. Build and test pass on OLP2.0 system. pass

2. Check if BMC still receieve error SEL. root@bmc-oob:~# power-util slot1 graceful-shutdown Shutting down fru 1 gracefully...
root@bmc-oob:~# log-util all --print
2023 Dec 27 03:36:17 log-util: User cleared all logs
1    slot1    2023-12-27 03:36:30    power-util       SERVER_GRACEFUL_SHUTDOWN successful for FRU: 1
root@bmc-oob:~# power-util slot1 1U-dev0 status
Power status for fru 1 dev 1U-dev0 : OFF
root@bmc-oob:~# power-util slot1 2U-dev0 status
Power status for fru 1 dev 2U-dev0 : OFF