### PR TITLE
Artemis: cb: Remove FIO and FAC present SEL

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_pldm_monitor.c
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_monitor.c
@@ -102,13 +102,16 @@ void plat_accl_present_check()
 	for (uint8_t i = 0; i < ASIC_CARD_COUNT; i++) {
 		is_present = asic_card_info[i].card_status;
 		event.sensor_offset = PLDM_STATE_SET_OFFSET_DEVICE_PRESENCE;
-		event.event_state =
-			is_present ? PLDM_STATE_SET_PRESENT : PLDM_STATE_SET_NOT_PRESENT;
-		event.previous_event_state = PLDM_STATE_SET_NOT_PRESENT;
-		if (pldm_send_platform_event(PLDM_SENSOR_EVENT, PLDM_EVENT_ACCL_1 + i,
-					     PLDM_STATE_SENSOR_STATE, (uint8_t *)&event,
-					     sizeof(struct pldm_sensor_event_state_sensor_state))) {
-			LOG_ERR("Send ACCL%d presence event log failed", PLDM_EVENT_ACCL_1 + i);
+		if (is_present == ASIC_CARD_NOT_PRESENT) {
+			event.event_state = PLDM_STATE_SET_NOT_PRESENT;
+			event.previous_event_state = PLDM_STATE_SET_NOT_PRESENT;
+			if (pldm_send_platform_event(
+				    PLDM_SENSOR_EVENT, PLDM_EVENT_ACCL_1 + i,
+				    PLDM_STATE_SENSOR_STATE, (uint8_t *)&event,
+				    sizeof(struct pldm_sensor_event_state_sensor_state))) {
+				LOG_ERR("Send ACCL%d presence event log failed",
+					PLDM_EVENT_ACCL_1 + i);
+			}
 		}
 	}
 }
@@ -120,14 +123,16 @@ void plat_accl_power_cable_present_check()
 	for (uint8_t i = 0; i < ASIC_CARD_COUNT; i++) {
 		is_present = asic_card_info[i].pwr_cbl_status;
 		event.sensor_offset = PLDM_STATE_SET_OFFSET_DEVICE_PRESENCE;
-		event.event_state =
-			is_present ? PLDM_STATE_SET_PRESENT : PLDM_STATE_SET_NOT_PRESENT;
-		event.previous_event_state = PLDM_STATE_SET_NOT_PRESENT;
-		if (pldm_send_platform_event(PLDM_SENSOR_EVENT, PLDM_EVENT_ACCL_PWR_CBL_1 + i,
-					     PLDM_STATE_SENSOR_STATE, (uint8_t *)&event,
-					     sizeof(struct pldm_sensor_event_state_sensor_state))) {
-			LOG_ERR("Send ACCL%d power cable presence event log failed",
-				PLDM_EVENT_ACCL_PWR_CBL_1 + i);
+		if (is_present == ASIC_CARD_NOT_PRESENT) {
+			event.event_state = PLDM_STATE_SET_NOT_PRESENT;
+			event.previous_event_state = PLDM_STATE_SET_NOT_PRESENT;
+			if (pldm_send_platform_event(
+				    PLDM_SENSOR_EVENT, PLDM_EVENT_ACCL_PWR_CBL_1 + i,
+				    PLDM_STATE_SENSOR_STATE, (uint8_t *)&event,
+				    sizeof(struct pldm_sensor_event_state_sensor_state))) {
+				LOG_ERR("Send ACCL%d power cable presence event log failed",
+					PLDM_EVENT_ACCL_PWR_CBL_1 + i);
+			}
 		}
 	}
 }
@@ -136,13 +141,14 @@ void plat_fio_present_check()
 {
 	struct pldm_sensor_event_state_sensor_state event;
 	event.sensor_offset = PLDM_STATE_SET_OFFSET_DEVICE_PRESENCE;
-	event.event_state = gpio_get(PRSNT_FIO_N) == LOW_ACTIVE ? PLDM_STATE_SET_PRESENT :
-								  PLDM_STATE_SET_NOT_PRESENT;
-	event.previous_event_state = PLDM_STATE_SET_NOT_PRESENT;
-	if (pldm_send_platform_event(PLDM_SENSOR_EVENT, PLDM_EVENT_FIO, PLDM_STATE_SENSOR_STATE,
-				     (uint8_t *)&event,
-				     sizeof(struct pldm_sensor_event_state_sensor_state))) {
-		LOG_ERR("Send FIO cable presence event log failed");
+	if (gpio_get(PRSNT_FIO_N) == HIGH_ACTIVE) {
+		event.event_state = PLDM_STATE_SET_NOT_PRESENT;
+		event.previous_event_state = PLDM_STATE_SET_NOT_PRESENT;
+		if (pldm_send_platform_event(PLDM_SENSOR_EVENT, PLDM_EVENT_FIO,
+					     PLDM_STATE_SENSOR_STATE, (uint8_t *)&event,
+					     sizeof(struct pldm_sensor_event_state_sensor_state))) {
+			LOG_ERR("Send FIO cable presence event log failed");
+		}
 	}
 }
 


### PR DESCRIPTION
 # Description:
 - To remove FIO FAC not present SEL

 # Motivation:
 - To remove FIo FAC not present SEL

 # Test Plan:
 - Built passed and tested pass on GTA - pass

 # Log:
 ```
 root@bmc-oob:/var/log# cat /var/log/messages | grep pldmd
 2018 Mar  9 04:36:01 bmc-oob. user.crit gtartemis-3df49ff75e5: pldmd: State Sensor: MC_SENSOR_SSD_1, not present
 2018 Mar  9 04:36:02 bmc-oob. user.crit gtartemis-3df49ff75e5: pldmd: State Sensor: MC_SENSOR_SSD_3, not present
 2018 Mar  9 04:36:11 bmc-oob. user.crit gtartemis-3df49ff75e5: pldmd: State Sensor: CB_SENSOR_ACCL_3, not present
 2018 Mar  9 04:36:12 bmc-oob. user.crit gtartemis-3df49ff75e5: pldmd: State Sensor: CB_SENSOR_ACCL_11, not present
 2018 Mar  9 04:36:13 bmc-oob. user.crit gtartemis-3df49ff75e5: pldmd: State Sensor: CB_SENSOR_ACCL_POWER_CABLE_3, not present
 2018 Mar  9 04:36:14 bmc-oob. user.crit gtartemis-3df49ff75e5: pldmd: State Sensor: CB_SENSOR_ACCL_POWER_CABLE_11, not present
 ```