### PR TITLE
fby4: sd: correct DCR and MDB of the I3C bus to BMC

### DIFF
--- a/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
@@ -70,12 +70,13 @@
 	i3c-scl-hz = <12500000>;
 	secondary;
 	ibi-append-pec;
+	dcr = <0xCC>;
 	i3c0_smq: i3c-slave-mqueue@9 {
 		compatible = "aspeed,i3c-slave-mqueue";
 		reg = <0x9>;
 		msg-size = <256>;
 		num-of-msgs = <8>;
-		mandatory-data-byte = <0xbf>;
+		mandatory-data-byte = <0xAE>;
 		label = "I3C_SMQ_0";
 		status = "okay";
 	};


### PR DESCRIPTION
# Description:
1. The Mandatory Data Byte in an IBI for MCTP I3C should be 0xAE which defined in DSP0233.
2. The Device Characteristics Register should be set to 0xCC according to the "MIPI I3C v1.1 DCR Table" to use MCTP function.

# Motivation:
Correct the DCR and MDB so that we could communicate with mctp-i3c driver in BMC.

# Test Plan:
Build pass.