### PR TITLE
common: pldm: Support SPI reinit function

### DIFF
--- a/common/service/pldm/pldm_monitor.h
+++ b/common/service/pldm/pldm_monitor.h
@@ -60,6 +60,7 @@ typedef enum pldm_platform_monitor_commands {
 #define PLDM_PLATFORM_OEM_GPIO_EFFECTER_STATE_FIELD_COUNT 2
 #define PLDM_PLATFORM_OEM_HOST_POWER_CTRL_EFFECTER_STATE_FIELD_COUNT 1
 #define PLDM_PLATFORM_OEM_I3C_HUB_REINIT_EFFECTER_STATE_FIELD_COUNT 1
+#define PLDM_PLATFORM_OEM_SPI_REINIT_EFFECTER_STATE_FIELD_COUNT 1
 #define PLDM_PLATFORM_OEM_SWITCH_UART_EFFECTER_STATE_FIELD_COUNT 1
 #define PLDM_PLATFORM_OEM_AST1030_GPIO_PIN_NUM_MAX 167
 
@@ -134,6 +135,11 @@ enum oem_effecter_states_power_status {
 enum oem_effecter_states_reinit_i3c_hub {
 	EFFECTER_STATE_I3C_HUB_REINIT = 0x01,
 	EFFECTER_STATE_I3C_HUB_MAX,
+};
+
+enum oem_effecter_states_reinit_spi {
+	EFFECTER_STATE_SPI_REINIT = 0x01,
+	EFFECTER_STATE_SPI_REINIT_MAX,
 };
 
 enum pldm_sensor_present_state {
@@ -429,6 +435,9 @@ void set_effecter_state_gpio_handler(const uint8_t *buf, uint16_t len, uint8_t *
 
 void get_effecter_state_gpio_handler(const uint8_t *buf, uint16_t len, uint8_t *resp,
 				     uint16_t *resp_len, uint8_t gpio_pin);
+
+void pldm_spi_reinit(const char* spi_dev_str, const uint8_t *buf, uint16_t len, uint8_t *resp,
+				     uint16_t *resp_len);
 
 uint8_t plat_pldm_set_state_effecter_state_handler(const uint8_t *buf, uint16_t len, uint8_t *resp,
 						   uint16_t *resp_len,


### PR DESCRIPTION
# Description:
- Support SPI reinit function.

# Motivation:
- In order to debug the SPI function, add the function of manual reinit.

# Test plan:
- Test SPI reinit function in Floating falls [BIC]
uart:~$ flash read spi1_cs0 fffe0 20
Read ERROR!

[BMC]
root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x27 0xff 0x02 0x00 0x00 0x00 0x2 -m 61 pldmtool: Tx: 80 02 39 27 ff 02 00 00 00 02
pldmtool: Rx: 00 02 39 00
root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x02 0x01 0x01 0x01 0x01 -m 61 pldmtool: Tx: 80 02 39 02 01 01 01 01
pldmtool: Rx: 00 02 39 00

[BIC]
flash read spi1_cs0 fffe0 20
000FFFE0: d6 97 80 e3 63 02 67 1b  81 49 93 0c 70 02 13 0d |....c.g. .I..p...| 000FFFF0: 00 03 93 0d 80 07 83 47  04 00 dd df 63 97 09 02 |.......G ....c...|