### PR TITLE
fby4: ff: Support SPI reinit command

### DIFF
--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_monitor.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_monitor.h
@@ -17,7 +17,7 @@
 #ifndef PLAT_PLDM_MONITOR_H
 #define PLAT_PLDM_MONITOR_H
 
-#define PLAT_PLDM_MAX_STATE_EFFECTER_IDX 169
+#define PLAT_PLDM_MAX_STATE_EFFECTER_IDX 170
 
 #define LPC_BASE_ADDR 0x7E789000 // Refer to Chapter32: LPC Controller in AST1030 datasheet v1.0
 #define LPC_HICR9_REG (LPC_BASE_ADDR + 0x98)
@@ -29,6 +29,7 @@ enum pldm_plat_effecter_id_high_byte {
 
 enum plat_pldm_effecter_id {
 	PLAT_PLDM_EFFECTER_ID_UART_SWITCH = 0x0003,
+	PLAT_PLDM_EFFECTER_ID_SPI_REINIT = 0x0102,
 };
 
 enum plat_pldm_uart_number {


### PR DESCRIPTION
# Description:
- Support SPI reinit command in set state effecter state command as follow: Effecter id: 0x102 Effecter State: 1. Reinit (Enable)

# Motivation:
- Support SPI reinit command to debugging in BFT

# Test log:
- Check CXL data via SPI [BIC]
uart:~$ flash read spi1_cs0 fffe0 20
Read ERROR!

[BMC]
root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x27 0xff 0x02 0x00 0x00 0x00 0x2 -m 61 pldmtool: Tx: 80 02 39 27 ff 02 00 00 00 02
pldmtool: Rx: 00 02 39 00
root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x02 0x01 0x01 0x01 0x01 -m 61 pldmtool: Tx: 80 02 39 02 01 01 01 01
pldmtool: Rx: 00 02 39 00

[BIC]
flash read spi1_cs0 fffe0 20
000FFFE0: d6 97 80 e3 63 02 67 1b  81 49 93 0c 70 02 13 0d |....c.g. .I..p...| 000FFFF0: 00 03 93 0d 80 07 83 47  04 00 dd df 63 97 09 02 |.......G ....c...|