### PR TITLE
fby4: wf: Support SPI reinit command

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_monitor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_monitor.c
@@ -32,12 +32,46 @@ struct pldm_state_effecter_info plat_state_effecter_table[] = {
 		.entity_type = PLDM_ENTITY_OTHER_BUS,
 		.effecter_id = PLAT_PLDM_EFFECTER_ID_UART_SWITCH,
 	},
+	[PLDM_PLATFORM_OEM_AST1030_GPIO_PIN_NUM_MAX + 2] = {
+		.entity_type = PLDM_ENTITY_DEVICE_DRIVER,
+		.effecter_id = PLAT_PLDM_EFFECTER_ID_SPI1_REINIT,
+	},
+	[PLDM_PLATFORM_OEM_AST1030_GPIO_PIN_NUM_MAX + 3] = {
+		.entity_type = PLDM_ENTITY_DEVICE_DRIVER,
+		.effecter_id = PLAT_PLDM_EFFECTER_ID_SPI2_REINIT,
+	},
 };
 
 void plat_pldm_load_state_effecter_table(void)
 {
 	memcpy(state_effecter_table, plat_state_effecter_table, sizeof(plat_state_effecter_table));
 	return;
+}
+
+void plat_pldm_dev_driver_hadnler(const uint8_t *buf, uint16_t len, uint8_t *resp,
+				     uint16_t *resp_len, uint16_t effecter_id)
+{
+	CHECK_NULL_ARG(buf);
+	CHECK_NULL_ARG(resp);
+	CHECK_NULL_ARG(resp_len);
+
+	uint8_t *completion_code_p = resp;
+
+	switch (effecter_id) {
+	case PLAT_PLDM_EFFECTER_ID_SPI1_REINIT:
+		pldm_spi_reinit("spi1_cs0", buf, len, resp, resp_len);
+		break;
+	case PLAT_PLDM_EFFECTER_ID_SPI2_REINIT:
+		pldm_spi_reinit("spi2_cs0", buf, len, resp, resp_len);
+		break;
+	default:
+		LOG_ERR("Unsupport effecter id, (0x%x)", effecter_id);
+		*completion_code_p = PLDM_ERROR_INVALID_DATA;
+		*resp_len = 1;
+		return;
+		break;
+	}
+
 }
 
 void plat_pldm_switch_uart(const uint8_t *buf, uint16_t len, uint8_t *resp, uint16_t *resp_len)
@@ -132,6 +166,9 @@ uint8_t plat_pldm_set_state_effecter_state_handler(const uint8_t *buf, uint16_t 
 		break;
 	case PLDM_ENTITY_OTHER_BUS:
 		plat_pldm_switch_uart(buf, len, resp, resp_len);
+		break;
+	case PLDM_ENTITY_DEVICE_DRIVER:
+		plat_pldm_dev_driver_hadnler(buf, len, resp, resp_len, info_p->effecter_id);
 		break;
 	default:
 		LOG_ERR("Unsupport entity type, (%d)", info_p->entity_type);

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_monitor.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_monitor.h
@@ -22,7 +22,7 @@
 #define LPC_HICR9_REG (LPC_BASE_ADDR + 0x98)
 #define LPC_HICRA_REG (LPC_BASE_ADDR + 0x9C)
 
-#define PLAT_PLDM_MAX_STATE_EFFECTER_IDX 169
+#define PLAT_PLDM_MAX_STATE_EFFECTER_IDX 171
 
 enum pldm_plat_effecter_id_high_byte {
 	PLAT_EFFECTER_ID_GPIO_HIGH_BYTE = (0xFF << 8),
@@ -30,6 +30,8 @@ enum pldm_plat_effecter_id_high_byte {
 
 enum plat_pldm_effecter_id {
 	PLAT_PLDM_EFFECTER_ID_UART_SWITCH = 0x0003,
+	PLAT_PLDM_EFFECTER_ID_SPI1_REINIT = 0x0102,
+	PLAT_PLDM_EFFECTER_ID_SPI2_REINIT = 0x0103
 };
 
 enum plat_pldm_uart_number {


### PR DESCRIPTION
# Description:
- Support SPI reinit command in set state effecter state command as follow: Effecter id: 0x102, 0x103 Effecter State: 1. Reinit (Enable)

# Motivation:
- Support SPI reinit command to debugging in BFT

# Test plan:
- Check CXL1 data and CXL2 data via SPI [BIC]
uart:~$ flash read spi1_cs0 fffe0 20
Read ERROR!
uart:~$ flash read spi2_cs0 fffe0 20
Read ERROR!

[BMC]

root@bmc:~# pldmtool raw -d 0x80 0x3f 0x1 0x15 0xa0 0x0 0x18 0x52 0xB 0x40 0x0 0x2 0x78 -m 62 pldmtool: Tx: 80 3f 01 15 a0 00 18 52 0b 40 00 02 78 pldmtool: Rx: 00 3f 01 00 15 a0 00 1c 52 00

root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x02 0x01 0x01 0x01 0x01 -m 62 pldmtool: Tx: 80 02 39 02 01 01 01 01
pldmtool: Rx: 00 02 39 00

[BIC]
uart:~$ flash read spi1_cs0 fffe0 20
000FFFE0: 23 aa 00 00 88 44 22 44  ee bb 00 cc 22 44 ee bb |#....D"D ...."D..| 000FFFF0: 88 cc aa 66 00 44 44 00  88 88 44 11 bf 00 22 5d |...f.DD. ..D..."]|

[BMC]
root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x03 0x01 0x01 0x01 0x01 -m 62 pldmtool: Tx: 80 02 39 03 01 01 01 01
pldmtool: Rx: 00 02 39 00

[BIC]
uart:~$ flash read spi2_cs0 fffe0 20
000FFFE0: 23 a0 07 00 81 45 2d 45  ef b0 0f c4 2d 45 ef b0 |#....E-E ....-E..| 000FFFF0: 8f c1 a2 60 01 45 41 01  82 80 41 11 b7 07 20 58 |...`.EA. ..A... X|