### PR TITLE
fby4: sd: support retimer temp sensors

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_hook.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_hook.h
@@ -27,11 +27,13 @@ extern adc_asd_init_arg ast_adc_init_args[];
 extern apml_mailbox_init_arg apml_mailbox_init_args[];
 extern vr_pre_proc_arg vr_pre_read_args[];
 extern ina233_init_arg ina233_init_args[];
+extern pt5161l_init_arg pt5161l_init_args[];
 
 bool pre_vr_read(sensor_cfg *cfg, void *args);
 bool post_amd_tsi_read(sensor_cfg *cfg, void *args, int *const reading);
 bool pre_p3v_bat_read(sensor_cfg *cfg, void *args);
 bool post_p3v_bat_read(sensor_cfg *cfg, void *args, int *const reading);
 bool pre_dimm_i3c_read(sensor_cfg *cfg, void *args);
+bool pre_retimer_read(sensor_cfg *cfg, void *args);
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -18,6 +18,7 @@
 #include "pmbus.h"
 #include "ast_adc.h"
 #include "pdr.h"
+#include "pt5161l.h"
 #include "sensor.h"
 #include "pldm_sensor.h"
 #include "pldm_monitor.h"
@@ -3067,6 +3068,144 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			.init_args = &ina233_init_args[1],
 		},
 	},
+	{
+		{
+			// x8 retimer Temperature
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			0x0018, //uint16_t sensor_id;
+			0x0089, //uint16_t entity_type;
+			0x0006, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x02, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x000000FF, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000064, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x0000007D, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_pt5161l,
+			.port = I2C_BUS6,
+			.target_addr = ADDR_X8_RETIMER,
+			.offset = PT5161L_TEMP_OFFSET,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_retimer_read,
+			.init_args = &pt5161l_init_args[0],
+		},
+	},
+	{
+		{
+			// x16 retimer Temperature
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			0x0019, //uint16_t sensor_id;
+			0x0089, //uint16_t entity_type;
+			0x0007, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x02, //uint8_t base_unit;
+			0, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x000000FF, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000000, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000064, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x0000007D, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.type = sensor_dev_pt5161l,
+			.port = I2C_BUS6,
+			.target_addr = ADDR_X16_RETIMER,
+			.offset = PT5161L_TEMP_OFFSET,
+			.access_checker = dc_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_retimer_read,
+			.init_args = &pt5161l_init_args[1],
+		},
+	},
 };
 
 pldm_sensor_info plat_pldm_sensor_dimm_table[] = {
@@ -4293,6 +4432,40 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
 		.sensorName = u"MB_VR_PVDD11_TEMP_C",
+	},
+	{
+		// MB_X8_RETIMER_TEMP_C
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0018,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"MB_X8_RETIMER_TEMP_C",
+	},
+	{
+		// MB_X16_RETIMER_TEMP_C
+		/*** PDR common header***/
+		{
+			.record_handle = 0x00000000,
+			.PDR_header_version = 0x01,
+			.PDR_type = PLDM_SENSOR_AUXILIARY_NAMES_PDR,
+			.record_change_number = 0x0000,
+			.data_length = 0x0000,
+		},
+		.terminus_handle = 0x0000,
+		.sensor_id = 0x0019,
+		.sensor_count = 0x1,
+		.nameStringCount = 0x1,
+		.nameLanguageTag = "en",
+		.sensorName = u"MB_X16_RETIMER_TEMP_C",
 	},
 	{
 		// MB_ADC_P12V_STBY_VOLT_V

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
@@ -27,8 +27,11 @@
 #define ADDR_VR_CPU1 (0XC6 >> 1)
 #define ADDR_VR_PVDDIO (0XC6 >> 1)
 #define ADDR_VR_PVDD11 (0XE4 >> 1)
+
 #define ADDR_X8_INA233 (0x8A >> 1)
 #define ADDR_X16_INA233 (0x82 >> 1)
+#define ADDR_X8_RETIMER (0x46 >> 1)
+#define ADDR_X16_RETIMER (0x40 >> 1)
 #define ADDR_NVME (0xD4 >> 1)
 
 #define OFFSET_TMP75_TEMP 0x00


### PR DESCRIPTION
# Description:
- Support retimer temp sensors

# Motivation:
- support retimer temp sensors

# Test Plan:
- Get corresponding sensor reading

# Test Log:
Processing sensor type: xyz.openbmc_project.PLDM|grep RETIMER_TEMP
sensor_name                        value    lnr      lcr      lnc      unc      ucr      unr
MB_X16_RETIMER_TEMP_C_25_134       40       nan      0        0        0        100      nan
MB_X8_RETIMER_TEMP_C_24_134        39       nan      0        0        0        100      nan