### PR TITLE
common: Support access check for pldm sensors

### DIFF
--- a/common/service/sensor/pldm_sensor.h
+++ b/common/service/sensor/pldm_sensor.h
@@ -47,7 +47,7 @@ bool pldm_sensor_is_interval_ready(pldm_sensor_info *pldm_sensor_list);
 pldm_sensor_thread *plat_pldm_sensor_load_thread();
 pldm_sensor_info *plat_pldm_sensor_load(int thread_id);
 int plat_pldm_sensor_get_sensor_count(int thread_id);
-int pldm_sensor_polling_pre_check(pldm_sensor_info *pldm_snr_list);
+int pldm_sensor_polling_pre_check(pldm_sensor_info *pldm_snr_list, int sensor_num);
 int pldm_polling_sensor_reading(pldm_sensor_info *pldm_snr_list, int pldm_sensor_count,
 				int thread_id, int sensor_num);
 


### PR DESCRIPTION
Summary:
# Description:
- Add access_check condition for pldm sesnor reading

# Motivation:
- Support retimer temp sensors that be ready after cxl power on

# Test Plan:
- Get corresponding sensor reading

# Test Log:
Processing sensor type: xyz.openbmc_project.PLDM|grep RETIMER_TEMP
sensor_name                        value    lnr      lcr      lnc      unc      ucr      unr
MB_X16_RETIMER_TEMP_C_25_134       40       nan      0        0        0        100      nan
MB_X8_RETIMER_TEMP_C_24_134        39       nan      0        0        0        100      nan