### PR TITLE
fby4: ff: Support xdpe12284c vr firmware update

### DIFF
--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.c
@@ -19,15 +19,26 @@
 #include <string.h>
 #include <logging/log.h>
 #include "libutil.h"
+#include "plat_pldm_fw_update.h"
+#include "plat_i2c.h"
 #include "pldm.h"
 #include "pldm_firmware_update.h"
-#include "plat_pldm_fw_update.h"
+#include "plat_pldm_sensor.h"
+#include "power_status.h"
 #include "mctp_ctrl.h"
+#include "xdpe12284c.h"
 
 LOG_MODULE_REGISTER(plat_fwupdate);
 
+static bool plat_pldm_vr_i2c_info_get( int comp_identifier , uint8_t *bus, uint8_t *addr);
+static uint8_t plat_pldm_pre_vr_update(void *fw_update_param);
+static uint8_t plat_pldm_post_vr_update(void *fw_update_param);
+static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len);
+
 enum FIRMWARE_COMPONENT {
 	FF_COMPNT_BIC,
+	FF_COMPNT_VR_PVDDQ_AB_ASIC,
+	FF_COMPNT_VR_PVDDQ_CD_ASIC,
 };
 
 /* PLDM FW update table */
@@ -44,6 +55,32 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = pldm_bic_activate,
 		.get_fw_version_fn = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = FF_COMPNT_VR_PVDDQ_AB_ASIC,
+		.comp_classification_index = 0x00,
+		.pre_update_func = plat_pldm_pre_vr_update,
+		.update_func = pldm_vr_update,
+		.pos_update_func = plat_pldm_post_vr_update,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = plat_get_vr_fw_version,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = FF_COMPNT_VR_PVDDQ_CD_ASIC,
+		.comp_classification_index = 0x00,
+		.pre_update_func = plat_pldm_pre_vr_update,
+		.update_func = pldm_vr_update,
+		.pos_update_func = plat_pldm_post_vr_update,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = plat_get_vr_fw_version,
 	},
 };
 
@@ -135,4 +172,105 @@ void load_pldmupdate_comp_config(void)
 	}
 
 	memcpy(comp_config, PLDMUPDATE_FW_CONFIG_TABLE, sizeof(PLDMUPDATE_FW_CONFIG_TABLE));
+}
+
+static bool plat_pldm_vr_i2c_info_get( int comp_identifier , uint8_t *bus, uint8_t *addr)
+{
+	switch (comp_identifier) {
+	case FF_COMPNT_VR_PVDDQ_AB_ASIC:
+		*bus = (uint8_t)I2C_BUS9;
+		*addr = (uint8_t)ADDR_VR_PVDDQ_AB;
+		break;
+	case FF_COMPNT_VR_PVDDQ_CD_ASIC:
+		*bus = (uint8_t)I2C_BUS9;
+		*addr = (uint8_t)ADDR_VR_PVDDQ_CD;
+		break;
+	default:
+		LOG_ERR("Unknown component identifier for VR");
+		return false;
+	}
+	return true;
+}
+
+static uint8_t plat_pldm_pre_vr_update(void *fw_update_param) {
+	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, 1);
+
+	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
+
+	/* Stop sensor polling */
+	set_vr_monitor_status(false);
+
+	plat_pldm_vr_i2c_info_get(p->comp_id, &p->bus, &p->addr);
+
+	return 0;
+}
+
+static uint8_t plat_pldm_post_vr_update(void *fw_update_param) {
+	ARG_UNUSED(fw_update_param);
+
+	set_vr_monitor_status(true);
+
+	return 0;
+}
+
+static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(info_p, false);
+	CHECK_NULL_ARG_WITH_RETURN(buf, false);
+	CHECK_NULL_ARG_WITH_RETURN(len, false);
+
+	pldm_fw_update_info_t *p = (pldm_fw_update_info_t *)info_p;
+
+
+	bool ret = false;
+	uint8_t bus = 0;
+	uint8_t addr = 0;
+	uint32_t version;
+	uint16_t remain = 0xFFFF;
+
+	plat_pldm_vr_i2c_info_get(p->comp_identifier, &bus, &addr);
+
+	set_vr_monitor_status(false);
+	if (!xdpe12284c_get_checksum(bus, addr, (uint8_t *)&version)) {
+		LOG_ERR("The VR XDPE12284 version reading failed");
+		return ret;
+	}
+
+	if (!xdpe12284c_get_remaining_write(bus, addr, &remain)) {
+		LOG_ERR("The VR XDPE12284 remaining reading failed");
+		return ret;
+	}
+
+	set_vr_monitor_status(true);
+
+	const char *remain_str_p = ", Remaining Write: ";
+	uint8_t *buf_p = buf;
+	const uint8_t *vr_name_p = INF_CRC_PREFIX;
+	if (!vr_name_p) {
+		LOG_ERR("The pointer of VR string name is NULL");
+		return ret;
+	}
+	*len = 0;
+
+	if (PLDM_MAX_DATA_SIZE < (strlen(vr_name_p) + strlen(remain_str_p) + 10)) {
+		LOG_ERR("vr version string wiil be too long to operate, failed");
+		return ret;
+	}
+
+	memcpy(buf_p, vr_name_p, strlen(vr_name_p));
+	buf_p += strlen(vr_name_p);
+	*len += bin2hex((uint8_t *)&version, 4, buf_p, 8) + strlen(vr_name_p);
+	buf_p += 8;
+
+	if (remain != 0xFFFF) {
+		memcpy(buf_p, remain_str_p, strlen(remain_str_p));
+		buf_p += strlen(remain_str_p);
+		remain = (uint8_t)((remain % 10) | (remain / 10 << 4));
+		*len += bin2hex((uint8_t *)&remain, 1, buf_p, 2) + strlen(remain_str_p);
+		buf_p += 2;
+	}
+
+	ret = true;
+
+	return ret;
 }

--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.h
@@ -21,6 +21,8 @@
 #include <stdint.h>
 #include "pldm_firmware_update.h"
 
+#define INF_CRC_PREFIX "Infineon "
+
 void load_pldmupdate_comp_config(void);
 
 #endif /* _PLAT_FWUPDATE_H_ */


### PR DESCRIPTION
# Description:
 - Add two pldm fwupdate components for inf vr update
 - Support get vr fw version

# Motivation:
 - Support xdpe12284c inf vr update

# Test Plan:
 - Get fw version after update both of vr devices

# Test log:
root@bmc:~# pldmtool fw_update GetFwParams -m 31
{
    "CapabilitiesDuringUpdate": {
        "Component Update Failure Recovery Capability": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer.",
        "Component Update Failure Retry Capability": " Device can have component updated again without exiting update mode and restarting transfer via RequestUpdate command.",
        "Firmware Device Partial Updates": "Firmware Device cannot accept a partial update and all components present on the FD shall be updated.",
        "Firmware Device Host Functionality during Firmware Update": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer",
        "Firmware Device Update Mode Restrictions": "No host OS environment restriction for update mode"
    },
    "ComponentCount": 2,
    "ActiveComponentImageSetVersionString": "2023.49.01",
    "PendingComponentImageSetVersionString": "",
    "ComponentParameterEntries": [
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 1,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 254551f9, Remaining Write: 26",
            "PendingComponentVersionString": ""
        },
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 2,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 5f9e839d, Remaining Write: 26",
            "PendingComponentVersionString": ""
        }
    ]
}

eric@ber300-f5a-dhcp:~$ scp pldm_image_ff_vr_ab root@192.168.88.69:/tmp/images root@bmc:~# busctl set-property xyz.openbmc_project.PLDM /xyz/openbmc_project/software/3463480235 xyz.openbmc_project.Software.Activation RequestedActivation s "xyz.openbmc_project.Software.Activation.RequestedActivations.Active" root@bmc:/usr/libexec/phosphor-state-manager# systemctl restart pldmd eric@ber300-f5a-dhcp:~$ scp pldm_image_ff_vr_cd root@192.168.88.69:/tmp/images root@bmc:~# busctl set-property xyz.openbmc_project.PLDM /xyz/openbmc_project/software/3463480235 xyz.openbmc_project.Software.Activation RequestedActivation s "xyz.openbmc_project.Software.Activation.RequestedActivations.Active"

root@bmc:/usr/libexec/phosphor-state-manager# ./chassis-powercycle 3 Starting slot3 cycle
root@bmc:/usr/libexec/phosphor-state-manager# systemctl restart mctpd root@bmc:/usr/libexec/phosphor-state-manager# systemctl restart pldmd root@bmc:/usr/libexec/phosphor-state-manager# ./host-poweron 3 pldmtool: Tx: 80 02 39 00 00 01 00 01
pldmtool: Rx: 00 02 39 00
Host is power on
root@bmc:~# pldmtool fw_update GetFwParams -m 31
{
    "CapabilitiesDuringUpdate": {
        "Component Update Failure Recovery Capability": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer.",
        "Component Update Failure Retry Capability": " Device can have component updated again without exiting update mode and restarting transfer via RequestUpdate command.",
        "Firmware Device Partial Updates": "Firmware Device cannot accept a partial update and all components present on the FD shall be updated.",
        "Firmware Device Host Functionality during Firmware Update": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer",
        "Firmware Device Update Mode Restrictions": "No host OS environment restriction for update mode"
    },
    "ComponentCount": 2,
    "ActiveComponentImageSetVersionString": "2023.49.01",
    "PendingComponentImageSetVersionString": "",
    "ComponentParameterEntries": [
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 1,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 1e230e98, Remaining Write: 25",
            "PendingComponentVersionString": ""
        },
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 2,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 8aaff349, Remaining Write: 25",
            "PendingComponentVersionString": ""
        }
    ]
}