### PR TITLE
fby4: wf: Support xdpe12284c vr firmware update

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.h
@@ -21,6 +21,8 @@
 #include <stdint.h>
 #include "pldm_firmware_update.h"
 
+#define INF_CRC_PREFIX "Infineon "
+
 void load_pldmupdate_comp_config(void);
 
 #endif /* _PLAT_FWUPDATE_H_ */


### PR DESCRIPTION
# Description:
 - Add four pldm fwupdate components for inf vr update
 - Support get vr fw version

# Motivation:
 - Support xdpe12284c inf vr update

# Test Plan:
 - Get fw version after update all of vr devices

# Test Log:
root@bmc:/usr/libexec/phosphor-state-manager# pldmtool fw_update GetFwParams -m 32 {
    "CapabilitiesDuringUpdate": {
        "Component Update Failure Recovery Capability": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer.",
        "Component Update Failure Retry Capability": " Device can have component updated again without exiting update mode and restarting transfer via RequestUpdate command.",
        "Firmware Device Partial Updates": "Firmware Device cannot accept a partial update and all components present on the FD shall be updated.",
        "Firmware Device Host Functionality during Firmware Update": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer",
        "Firmware Device Update Mode Restrictions": "No host OS environment restriction for update mode"
    },
    "ComponentCount": 4,
    "ActiveComponentImageSetVersionString": "2023.49.01",
    "PendingComponentImageSetVersionString": "",
    "ComponentParameterEntries": [
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 1,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component ima                            ge to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 254551f9, Remaining Write: 26",
            "PendingComponentVersionString": ""
        },
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 2,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component ima                            ge to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 5f9e839d, Remaining Write: 26",
            "PendingComponentVersionString": ""
        },
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 3,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component ima                            ge to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 254551f9, Remaining Write: 26",
            "PendingComponentVersionString": ""
        },
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 4,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component ima                            ge to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 5f9e839d, Remaining Write: 26",
            "PendingComponentVersionString": ""
        }
    ]
}

eric@ber300-f5a-dhcp:~$ scp pldm_image_wf_vr_ab_cxl1 root@192.168.88.69:/tmp/images root@bmc:~# busctl set-property xyz.openbmc_project.PLDM /xyz/openbmc_project/software/3648103133 xyz.openbmc_project.Software.Activation RequestedActivation s "xyz.openbmc_project.Software.Activation.RequestedActivations.Active" root@bmc:~# systemctl restart pldmd
eric@ber300-f5a-dhcp:~$ scp pldm_image_wf_vr_cd_cxl1 root@192.168.88.69:/tmp/images root@bmc:~# busctl set-property xyz.openbmc_project.PLDM /xyz/openbmc_project/software/3648103133 xyz.openbmc_project.Software.Activation RequestedActivation s "xyz.openbmc_project.Software.Activation.RequestedActivations.Active" root@bmc:~# systemctl restart pldmd
eric@ber300-f5a-dhcp:~$ scp pldm_image_wf_vr_ab_cxl2 root@192.168.88.69:/tmp/images root@bmc:~# busctl set-property xyz.openbmc_project.PLDM /xyz/openbmc_project/software/3648103133 xyz.openbmc_project.Software.Activation RequestedActivation s "xyz.openbmc_project.Software.Activation.RequestedActivations.Active" root@bmc:~# systemctl restart pldmd
eric@ber300-f5a-dhcp:~$ scp pldm_image_wf_vr_cd_cxl2 root@192.168.88.69:/tmp/images root@bmc:~# busctl set-property xyz.openbmc_project.PLDM /xyz/openbmc_project/software/3648103133 xyz.openbmc_project.Software.Activation RequestedActivation s "xyz.openbmc_project.Software.Activation.RequestedActivations.Active" root@bmc:/usr/libexec/phosphor-state-manager# ./chassis-powercycle 3 Starting slot3 cycle
root@bmc:/usr/libexec/phosphor-state-manager# systemctl restart pldmd root@bmc:/usr/libexec/phosphor-state-manager# ./host-poweron 3 pldmtool: Tx: 80 02 39 00 00 01 00 01
pldmtool: Rx: 00 02 39 00
Host is power on
root@bmc:/usr/libexec/phosphor-state-manager# pldmtool fw_update GetFwParams -m 32 {
    "CapabilitiesDuringUpdate": {
        "Component Update Failure Recovery Capability": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer.",
        "Component Update Failure Retry Capability": " Device can have component updated again without exiting update mode and restarting transfer via RequestUpdate command.",
        "Firmware Device Partial Updates": "Firmware Device cannot accept a partial update and all components present on the FD shall be updated.",
        "Firmware Device Host Functionality during Firmware Update": "Device will revert to previous component image upon failure, timeout or cancellation of the transfer",
        "Firmware Device Update Mode Restrictions": "No host OS environment restriction for update mode"
    },
    "ComponentCount": 4,
    "ActiveComponentImageSetVersionString": "2023.49.01",
    "PendingComponentImageSetVersionString": "",
    "ComponentParameterEntries": [
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 1,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 64f8dcfc, Remaining Write: 25",
            "PendingComponentVersionString": ""
        },
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 2,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 6b619243, Remaining Write: 25",
            "PendingComponentVersionString": ""
        },
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 3,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 64f8dcfc, Remaining Write: 25",
            "PendingComponentVersionString": ""
        },
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 4,
            "ComponentClassificationIndex": 0,
            "ActiveComponentComparisonStamp": 0,
            "ActiveComponentReleaseDate": "",
            "PendingComponentComparisonStamp": 0,
            "PendingComponentReleaseDate": "",
            "ComponentActivationMethods": [
                "AC power cycle"
            ],
            "CapabilitiesDuringUpdate": {
                "Firmware Device apply state functionality": " Firmware Device will execute an operation during the APPLY state which will include migrating the new component image to its final non-volatile storage destination."
            },
            "ActiveComponentVersionString": "Infineon 44412cd2, Remaining Write: 25",
            "PendingComponentVersionString": ""
        }
    ]
}