### PR TITLE
Artemis: cb: Add delay for power brick alert event

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_isr.c
+++ b/meta-facebook/at-cb/src/platform/plat_isr.c
@@ -34,6 +34,8 @@
 
 LOG_MODULE_REGISTER(plat_isr);
 
+#define ALERT_EVENT_DEFAULT_DELAY_MS 0
+#define POWER_BRICK_ALERT_DELAY_MS 400
 #define NORMAL_POWER_GOOD_CHECK_DELAY_MS 5000
 
 typedef struct _alert_sensor_info {
@@ -65,62 +67,77 @@ alert_sensor_info power_brick_info[] = {
 
 add_sel_info add_sel_work_item[] = {
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = SMB_P0V8_ALERT_N,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_DEFAULT,
 	  .event_type = PLDM_ADDSEL_EVENT_TYPE_DEFAULT },
 	{ .is_init = false,
+	  .delay_ms = POWER_BRICK_ALERT_DELAY_MS,
 	  .gpio_num = SMB_PMBUS_ALERT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_POWER_BRICK_0_ALERT,
 	  .event_type = PLDM_ADDSEL_EVENT_TYPE_DEFAULT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = SMB_P1V25_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P1V25_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_EVENT_TYPE_DEFAULT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL1_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL1_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL2_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL2_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL3_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL3_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL4_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL4_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL5_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL5_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL6_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL6_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL7_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL7_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL8_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL8_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL9_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL9_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL10_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL10_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL11_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL11_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
 	{ .is_init = false,
+	  .delay_ms = ALERT_EVENT_DEFAULT_DELAY_MS,
 	  .gpio_num = INA233_ACCL12_ALRT_N_R,
 	  .device_type = PLDM_ADDSEL_DEVICE_TYPE_P12V_ACCL12_MONITOR_ALERT,
 	  .event_type = PLDM_ADDSEL_OVER_POWER_EVENT },
@@ -157,7 +174,12 @@ add_sel_info *get_addsel_work(uint8_t gpio_num)
 		} else {                                                                           \
 			work->event_type = work->event_type & PLDM_ADDSEL_DEASSERT_MASK;           \
 		}                                                                                  \
-		k_work_schedule_for_queue(&plat_work_q, &work->add_sel_work, K_NO_WAIT);           \
+		if (work->delay_ms != ALERT_EVENT_DEFAULT_DELAY_MS) {                              \
+			k_work_schedule_for_queue(&plat_work_q, &work->add_sel_work,               \
+						  K_MSEC(work->delay_ms));                         \
+		} else {                                                                           \
+			k_work_schedule_for_queue(&plat_work_q, &work->add_sel_work, K_NO_WAIT);   \
+		}                                                                                  \
 	}
 
 K_WORK_DELAYABLE_DEFINE(fio_power_button_work, fio_power_button_work_handler);

--- a/meta-facebook/at-cb/src/platform/plat_isr.h
+++ b/meta-facebook/at-cb/src/platform/plat_isr.h
@@ -28,6 +28,7 @@ enum BUTTON_OPTIONAL {
 
 typedef struct _add_sel_info {
 	bool is_init;
+	int delay_ms;
 	uint8_t gpio_num;
 	uint8_t device_type;
 	uint8_t board_info;


### PR DESCRIPTION
# Description
- Add delay for power brick alert event.
  - EE had measure the power off timing between PG from 12V brick and P3V3_AUX on ACB during the AC off. (191 ms) Add delay for power brick alert event to avoid BMC record event that should not appear.

# Motivation
- Add delay for power brick alert event to avoid BMC record event that should not appear.

# Test Plan
- Build code: Pass
- Check power brick alert event after AC cycle: Pass

# Log
root@bmc-oob:~# log-util all --print
2018 Mar 09 19:58:17 log-util: User cleared all logs
0    all      2018-03-09 19:58:22    power-util       SLED_CYCLE starting...
1    mb       2018-03-09 04:35:18    power-util       SERVER_POWER_ON successful for FRU: 1
4    nic0     2018-03-09 04:35:59    ncsid            FRU: 4 NIC AEN Supported: 0x7, AEN Enable Mask=0x7
4    nic0     2018-03-09 04:35:59    ncsid            FRU: 4 PLDM type supported = 0x75
4    nic0     2018-03-09 04:35:59    ncsid            FRU: 4 PLDM type 0 version = 1.0.0.0
4    nic0     2018-03-09 04:35:59    ncsid            FRU: 4 PLDM type 2 version = 1.1.1.0
4    nic0     2018-03-09 04:35:59    ncsid            FRU: 4 PLDM type 4 version = 1.0.0.0
4    nic0     2018-03-09 04:35:59    ncsid            FRU: 4 PLDM type 5 version = 1.0.0.0
4    nic0     2018-03-09 04:35:59    ncsid            FRU: 4 PLDM type 6 version = 1.0.1.0
4    nic0     2018-03-09 04:35:59    ncsid            FRU: 4 PLDM sensor monitoring enabled
0    all      2018-03-09 04:35:59    healthd          ASSERT: Verified boot failure (3,35)
0    all      2018-03-09 04:35:59    healthd          Verified boot failure reason: U-Boot FIT did not contain the /keys node
0    all      2018-03-09 04:35:59    healthd          SLED Powered OFF at Fri Mar  9 19:58:22 2018
0    all      2018-03-09 04:36:00    gpiod            cb is Present
0    all      2018-03-09 04:36:00    gpiod            mc is Present
0    all      2018-03-09 04:36:00    gpiod            Cable A is Present
0    all      2018-03-09 04:36:00    gpiod            Cable B is Present
0    all      2018-03-09 04:36:00    gpiod            Cable C is Present
0    all      2018-03-09 04:36:00    gpiod            Cable D is Present
0    all      2018-03-09 04:36:00    gpiod            Cable E is Present
0    all      2018-03-09 04:36:00    gpiod            Cable F is Present
0    all      2018-03-09 04:36:01    pldmd            State Sensor: MC_SENSOR_SSD_1, present
0    all      2018-03-09 04:36:02    pldmd            State Sensor: MC_SENSOR_SSD_2, present
0    all      2018-03-09 04:36:03    pldmd            State Sensor: MC_SENSOR_SSD_3, present
0    all      2018-03-09 04:36:04    pldmd            State Sensor: MC_SENSOR_SSD_4, present
0    all      2018-03-09 04:36:11    pldmd            State Sensor: CB_SENSOR_FIO, present
0    all      2018-03-09 04:36:12    pldmd            State Sensor: CB_SENSOR_ACCL_1, present
0    all      2018-03-09 04:36:13    pldmd            State Sensor: CB_SENSOR_ACCL_2, present
0    all      2018-03-09 04:36:14    pldmd            State Sensor: CB_SENSOR_ACCL_3, present
0    all      2018-03-09 04:36:15    pldmd            State Sensor: CB_SENSOR_ACCL_4, present
0    all      2018-03-09 04:36:16    pldmd            State Sensor: CB_SENSOR_ACCL_5, present
0    all      2018-03-09 04:36:17    pldmd            State Sensor: CB_SENSOR_ACCL_6, present
0    all      2018-03-09 04:36:18    pldmd            State Sensor: CB_SENSOR_ACCL_7, present
0    all      2018-03-09 04:36:19    pldmd            State Sensor: CB_SENSOR_ACCL_8, present
0    all      2018-03-09 04:36:20    pldmd            State Sensor: CB_SENSOR_ACCL_9, present
0    all      2018-03-09 04:36:21    pldmd            State Sensor: CB_SENSOR_ACCL_10, present
0    all      2018-03-09 04:36:22    pldmd            State Sensor: CB_SENSOR_ACCL_11, present
0    all      2018-03-09 04:36:23    pldmd            State Sensor: CB_SENSOR_ACCL_12, present
0    all      2018-03-09 04:36:24    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_1, present
0    all      2018-03-09 04:36:25    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_2, present
0    all      2018-03-09 04:36:26    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_3, present
0    all      2018-03-09 04:36:27    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_4, present
0    all      2018-03-09 04:36:28    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_5, present
0    all      2018-03-09 04:36:29    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_6, present
0    all      2018-03-09 04:36:30    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_7, present
0    all      2018-03-09 04:36:31    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_8, present
0    all      2018-03-09 04:36:32    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_9, present
0    all      2018-03-09 04:36:33    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_10, present
0    all      2018-03-09 04:36:34    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_11, present
0    all      2018-03-09 04:36:35    pldmd            State Sensor: CB_SENSOR_ACCL_POWER_CABLE_12, present
1    mb       2018-03-09 04:37:34    gpiod            Record time delay 300ms, FRU: 1 ASSERT: SGPIO146 - FM_BIOS_POST_CMPLT_BUF_R_N
0    all      2018-03-09 04:37:38    healthd          SLED Powered ON at Fri Mar  9 04:34:44 2018