### PR TITLE
fby3.5: gl: support to monitor SMI out

### DIFF
--- a/common/hal/hal_vw_gpio.c
+++ b/common/hal/hal_vw_gpio.c
@@ -21,11 +21,6 @@
 
 LOG_MODULE_REGISTER(hal_vw_gpio);
 
-// Aspeed ESPI register definition
-#define AST_ESPI_BASE 0x7E6EE000
-#define AST_ESPI_GPIO_VAL 0x9C
-#define AST_ESPI_GPIO_DIR 0xC0
-
 static const struct device *espi_dev;
 static struct espi_callback vw_cb;
 static vw_gpio *vw_gpio_cfg;

--- a/common/hal/hal_vw_gpio.h
+++ b/common/hal/hal_vw_gpio.h
@@ -16,6 +16,12 @@
 
 #include <drivers/espi.h>
 
+// Aspeed ESPI register definition
+#define AST_ESPI_BASE 0x7E6EE000
+#define AST_ESPI_SYSEVT 0x98
+#define AST_ESPI_GPIO_VAL 0x9C
+#define AST_ESPI_GPIO_DIR 0xC0
+
 #define VW_GPIO_ENABLE true
 #define VW_GPIO_DISABLE false
 

--- a/meta-facebook/yv35-gl/src/platform/plat_cpu.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_cpu.h
@@ -21,6 +21,11 @@
 
 #define MONITOR_CPU_STACK_SIZE 600
 #define MONITOR_CPU_TIME_MS 1000
+#define MONITOR_SMIOUT_STACK_SIZE 400
+#define MONITOR_SMIOUT_TIME_MS 1000
+
+#define SMIOUT_INDEX 9
+#define SMIOUT_TIMEOUT 90
 
 #define RDPKG_IDX_PKG_THERMAL_STATUS 0x14
 #define THERMAL_STATUS_DEASSERT 0
@@ -28,5 +33,7 @@
 
 void monitor_cpu_handler();
 void start_monitor_cpu_thread();
+void monitor_smiout_handler();
+void start_monitor_smi_thread();
 
 #endif

--- a/meta-facebook/yv35-gl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_init.c
@@ -117,6 +117,7 @@ void pal_device_init()
 	start_get_dimm_info_thread();
 	start_monitor_pmic_error_thread();
 	start_monitor_cpu_thread();
+	start_monitor_smi_thread();
 }
 
 #define DEF_PROJ_GPIO_PRIORITY 78


### PR DESCRIPTION
# Description:
Support to monitor SMI out.

# Motivation:
Monitoring SMI out and will add a assertion SEL in BMC if SMI out stuck low for over 90 seconds.

# Test Plan:
1. Enter SMM mode using cscript.
2. Wait for 90 seconds.
3. Exit SMM mode using cscript.
4. Check SEL log in BMC.

# Test log:
1. Type "ei.utils.enter_smm(1)" in cscript to enter SMI mode.
2. Inject a CE memory error.
3. Type "go" to release CPU and count 90 seconds.
4. After 90 seconds Type "ei.utils.exit_smm(1)" and "go".
6. Check BMC SEL logs:
	1    slot1    2023-12-22 08:51:27    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-12-22 08:51:27, Sensor: SYSTEM_STATUS (0x10), Event Data: (0EFFFF) SMI stuck low over 90s Assertion
	1    slot1    2023-12-22 08:52:28    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2023-12-22 08:52:28, Sensor: SYSTEM_STATUS (0x10), Event Data: (0EFFFF) SMI stuck low over 90s Deassertion