### PR TITLE
fby4: ff: Support switch UART2

### DIFF
--- a/meta-facebook/yv4-ff/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-ff/boards/ast1030_evb.overlay
@@ -105,6 +105,10 @@
   status = "okay";
 };
 
+&uart2 {
+  status = "okay";
+};
+
 &uart5 {
 	current-speed = <57600>;
 };

--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_monitor.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_monitor.c
@@ -112,13 +112,22 @@ void plat_pldm_switch_uart(const uint8_t *buf, uint16_t len, uint8_t *resp, uint
 	clear_bits(&hicra_val, 0, 2);
 
 	switch (uart_number) {
-	case UART_VISTARA:
+	case UART1:
 		// IO1 to IO5: Ｗrite 0101b to bit[11:8]
 		hicr9_val = SETBITS(hicr9_val, 0b0101, 8);
 		sys_write32(hicr9_val, LPC_HICR9_REG);
 
 		// IO5 to IO1: Write 111b to bit[2:0]
 		hicra_val = SETBITS(hicra_val, 0b111, 0);
+		sys_write32(hicra_val, LPC_HICRA_REG);
+		break;
+	case UART2:
+		// IO5 to IO2: Write 0110b to bit[11:8]
+		hicr9_val = SETBITS(hicr9_val, 0b0110, 8);
+		sys_write32(hicr9_val, LPC_HICR9_REG);
+
+		// IO2 to IO5: Write 111b to bit[5:3]
+		hicra_val = SETBITS(hicra_val, 0b111, 3);
 		sys_write32(hicra_val, LPC_HICRA_REG);
 		break;
 	case UART_BIC:

--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_monitor.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_monitor.h
@@ -33,8 +33,9 @@ enum plat_pldm_effecter_id {
 };
 
 enum plat_pldm_uart_number {
-	UART_BIC = 0,
-	UART_VISTARA,
+	UART_BIC = 0, // Uart5
+	UART1,
+	UART2,
 	UART_MAX,
 };
 


### PR DESCRIPTION
Description
- Support switch UART2.

Motivation
- Support switch UART2.

Test plan
- Build code: Pass
- Switch UART: Pass

Log:
1. Switch to UART2 to login Vistara console on EVT board. root@bmc:~# i2ctransfer -f -y "$slot_bus"  w2@0x22 0x08 0x5 root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x3 0x0 0x1 0x01 0x02 -m 31 pldmtool: Tx: 80 02 39 03 00 01 01 02
pldmtool: Rx: 00 02 39 00
root@bmc:~# obmc-console-client -i host"$slot_bus" bld_ver get_bld_ver
CRM ver: v1.0.12:d89e8d29fc91 Feb  6 202

CMRT sboot ver: 2.0.3-13728358d9e2

CMRT mw ver: 2.0.3-13728358d9e2

CMRT uc ver:

CTRL fw ver: 2.0.3-13728358d9e2