### PR TITLE
fby4: wf: Fix missing include header

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
@@ -19,11 +19,13 @@
 #include "ast_adc.h"
 #include "pdr.h"
 #include "sensor.h"
+#include "vistara.h"
 #include "pldm_sensor.h"
 #include "pldm_monitor.h"
 #include "plat_i2c.h"
-#include "plat_pldm_sensor.h"
+#include "plat_power_seq.h"
 #include "plat_hook.h"
+#include "plat_pldm_sensor.h"
 
 LOG_MODULE_REGISTER(plat_pldm_sensor);
 


### PR DESCRIPTION
Description
- Include vistara.h and plat_power_seq.h to using defined variables.

Motivation
- Missing including header causes build WF BIC fail.

Test Plan
- Build code: Pass

Log
1. Build pass. [328/328] Linking C executable zephyr/Y4BWF.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:         12 KB        60 KB     20.00%
           FLASH:          0 GB         0 GB
            SRAM:      615648 B       708 KB     84.92%
        IDT_LIST:          0 GB         2 KB      0.00%