### PR TITLE
fby4: ff: Fix DIMM temperature read failed

### DIFF
--- a/meta-facebook/yv4-ff/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_power_seq.c
@@ -392,7 +392,6 @@ void cxl_ready_handler()
 
 		/* Switch muxs to BIC*/
 		gpio_set(SEL_SMB_MUX_PMIC_R, GPIO_HIGH);
-		gpio_set(SEL_SMB_MUX_DIMM_R, GPIO_HIGH);
 		set_vr_monitor_status(true);
 		return;
 	}


### PR DESCRIPTION
Description
- Fixed the problem of DIMM MUX being switch incorrectly.

Motivation
- DIMM MUX accidentally switched to BIC causing DIMM temperature can't read successfully.

Test Plan
- Build code: Pass