### PR TITLE
fby4: sd: Disable GPIOC1/D2 internal PD

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -39,6 +39,7 @@
 
 SCU_CFG scu_cfg[] = {
 	//register    value
+	{ 0x7e6e2610, 0x04020000 },
 	{ 0x7e6e2618, 0x00c00000 },
 };
 


### PR DESCRIPTION
# Description
- Disable GPIOC1 and GPIOD2 internal PD to match voltage.
- GPIOC1: FM_HSC_TIMER_ALT_N
- GPIOD2: FAST_PROCHOT_N

# Motivation
- Voltage of GPIO is incompatible.

# Test Plan
- Build code: Pass
- Check register value: Pass

Log
1. Check register value.
- Before disable uart:~$ md 0x7e6e2610 1

[7e6e2610] 00000000

- After disable uart:~$ md 0x7e6e2610 1

[7e6e2610] 04020000