### PR TITLE
Artemis: cb: Add retry to set VR page to avoid it busy to unable resp…

### DIFF
--- a/common/dev/include/xdpe15284.h
+++ b/common/dev/include/xdpe15284.h
@@ -52,5 +52,6 @@ bool xdpe15284_disable_write_protect(uint8_t bus, uint8_t addr);
 void xdpe15284_set_write_protect_default_val(uint8_t val);
 bool xdpe15284_fwupdate(uint8_t bus, uint8_t addr, uint8_t *img_buff, uint32_t img_size);
 bool xdpe15284_get_status_byte(uint8_t bus, uint8_t addr, uint8_t *data);
+bool xdpe15284_set_write_protect(uint8_t bus, uint8_t addr, uint8_t option);
 
 #endif

--- a/meta-facebook/at-cb/src/platform/plat_dev.h
+++ b/meta-facebook/at-cb/src/platform/plat_dev.h
@@ -88,5 +88,6 @@ bool is_sw_ready(uint8_t sensor_num);
 void init_sw_heartbeat_work();
 void clear_sw_error_check_flag();
 void get_switch_error_status(uint8_t sensor_num, uint8_t bus, uint8_t addr, uint8_t index);
+bool init_vr_write_protect(uint8_t bus, uint8_t addr, uint8_t default_val);
 
 #endif


### PR DESCRIPTION
…onse

# Description
- Add retry to set VR page to avoid it busy to unable response.
- Disable write protection on the two power rails of VR respectively.

# Motivation
- Add retry to set VR page to avoid it busy to unable response.
- Disable write protection on the two power rails of VR respectively.

# Test Plan
- Build code: Pass
- Triggering the OV manually will see the correct sel from the BMC: Pass
- Triggering the OT manually will see the correct sel from the BMC: Pass

# Log
- Triggering the OV manually will see the correct sel from the BMC uart:~$ i2c scan I2C_0
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: 10 -- -- 13 -- -- -- -- -- -- -- -- -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: 60 61 -- -- 64 -- -- -- -- -- -- -- -- -- -- --
70: -- -- -- -- -- -- -- --
5 devices found on I2C_0
uart:~$ i2c read I2C_0 0x64 0x00 0x01
00000000: 01                                               |.                |
uart:~$ i2c read I2C_0 0x64 0x10 0x01
00000000: 40                                               |@                |
uart:~$ i2c write I2C_0 0x64 0x02 0x00 0x00
uart:~$ i2c read I2C_0 0x64 0x00 0x01
00000000: 00                                               |.                |
uart:~$ i2c read I2C_0 0x64 0x10 0x01
00000000: 40                                               |@                |
uart:~$ i2c write I2C_0 0x64 0x02 0x10 0x00
uart:~$ i2c read I2C_0 0x64 0x10 0x01
00000000: 00                                               |.                |
uart:~$ i2c write I2C_0 0x64 0x03 0x40 0x01 0x00
uart:~$ i2c read I2C_0 0x64 0x00 0x01
00000000: 01                                               |.                |
uart:~$ i2c read I2C_0 0x64 0x10 0x01
00000000: 40                                               |@                |
uart:~$ i2c read I2C_0 0x64 0x78 0x01
00000000: c3                                               |.                |
uart:~$ i2c read I2C_0 0x64 0x00 0x01
00000000: 00                                               |.                |
uart:~$ i2c read I2C_0 0x64 0x78 0x01
00000000: e3                                               |.                |

root@bmc-oob:~# log-util all --print
2018 Mar 09 19:29:44 log-util: User cleared all logs
1    mb       2018-03-09 19:29:48    gpiod            FRU: 1 ASSERT: SGPIO240 - FM_PWRGD_CPU1_PWROK
0    all      2018-03-09 19:29:48    pldmd            Device type: CB_P0V8_VDD_1 (0x1), board info: MAIN_SOURCE (0x0), event type: OVER_VOLTAGE (0x2) Assert event
1    mb       2018-03-09 19:29:48    gpiod            FRU: 1 ASSERT: SGPIO200 - FM_RST_CPU1_RESETL_N
0    all      2018-03-09 19:29:48    pldmd            Device type: CB_P0V8_VDD_2 (0x2), board info: MAIN_SOURCE (0x0), event type: OVER_TEMPERATURE (0x5) Assert event
0    all      2018-03-09 19:29:48    pldmd            Device type: CB_P0V8_VDD_2 (0x2), board info: MAIN_SOURCE (0x0), event type: UNDER_VOLTAGE (0x4) Assert event
0    all      2018-03-09 19:29:48    pldmd            Device type: CB_P0V8_VDD_2 (0x2), board info: MAIN_SOURCE (0x0), event type: OVER_CURRENT (0x3) Assert event
0    all      2018-03-09 19:29:48    pldmd            Device type: CB_P0V8_VDD_2 (0x2), board info: MAIN_SOURCE (0x0), event type: OVER_VOLTAGE (0x2) Assert event

- Triggering the OT manually will see the correct sel from the BMC uart:~$ i2c scan I2C_0
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:             -- -- -- -- -- -- -- -- -- -- -- --
10: 10 -- -- 13 -- -- -- -- -- -- -- -- -- -- -- --
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
60: 60 61 -- -- 64 -- -- -- -- -- -- -- -- -- -- --
70: -- -- -- -- -- -- -- --
5 devices found on I2C_0
uart:~$ i2c read I2C_0 0x64 0x00 0x01
00000000: 01                                               |.                |
uart:~$ i2c read I2C_0 0x64 0x10 0x01
00000000: 40                                               |@                |
uart:~$ i2c write I2C_0 0x64 0x02 0x00 0x00
uart:~$ i2c read I2C_0 0x64 0x00 0x01
00000000: 00                                               |.                |
uart:~$ i2c read I2C_0 0x64 0x10 0x01
00000000: 40                                               |@                |
uart:~$ i2c read I2C_0 0x64 0x51 0x02
00000000: 64 00                                            |d.               |
uart:~$ i2c write I2C_0 0x64 0x02 0x10 0x00
uart:~$ i2c read I2C_0 0x64 0x10 0x01
00000000: 00                                               |.                |
uart:~$ i2c write I2C_0 0x64 0x03 0x51 0x01 0x00

root@bmc-oob:~# log-util all --print
2018 Mar 09 19:29:44 log-util: User cleared all logs
1    mb       2018-03-09 04:37:18    gpiod            Record time delay 300ms, FRU: 1 ASSERT: SGPIO146 - FM_BIOS_POST_CMPLT_BUF_R_N
0    all      2018-03-09 04:37:38    healthd          SLED Powered ON at Fri Mar  9 04:34:45 2018
0    all      2018-03-09 04:37:53    pldmd            Device type: CB_P0V8_VDD_1 (0x1), board info: MAIN_SOURCE (0x0), event type: OVER_TEMPERATURE (0x5) Assert event