### PR TITLE
common: Add function for setting i3c pid

### DIFF
--- a/common/hal/hal_i3c.c
+++ b/common/hal/hal_i3c.c
@@ -316,6 +316,19 @@ int i3c_controller_write(I3C_MSG *msg)
 	return true;
 }
 
+int i3c_set_pid(I3C_MSG *msg, uint16_t slot_pid)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+
+	int ret = i3c_set_pid_extra_info(dev_i3c[msg->bus], slot_pid);
+	if (ret != 0) {
+		LOG_ERR("Failed to set pid to bus 0x%d, ret: %d", msg->bus, ret);
+		return false;
+	}
+
+	return true;
+}
+
 void util_init_i3c(void)
 {
 #ifdef DEV_I3C_0

--- a/common/hal/hal_i3c.h
+++ b/common/hal/hal_i3c.h
@@ -127,6 +127,7 @@ int i3c_detach(I3C_MSG *msg);
 int i3c_transfer(I3C_MSG *msg);
 int i3c_brocast_ccc(I3C_MSG *msg, uint8_t ccc_id, uint8_t ccc_addr);
 int i3c_spd_reg_read(I3C_MSG *msg, bool is_nvm);
+int i3c_set_pid(I3C_MSG *msg, uint16_t slot_pid);
 
 int i3c_controller_write(I3C_MSG *msg);
 int i3c_controller_ibi_init(I3C_MSG *msg);


### PR DESCRIPTION
Description:
- Add function to setting i3c pid

Motivation:
- To support multi-host configurations, we have added a "i3c_set_pid" feature that allows for the setting of different PIDs.

Test plan:
- Check PID in different slot
  - Slot5 root@bmc:~# ls /sys/bus/i3c/devices/
  0-4cd5e469914  1-4cd44469918  1-7ec80010014  i3c-0          i3c-1

  - Slot6 root@bmc:~# ls /sys/bus/i3c/devices/
  0-4cd5e469914  1-4cd44469918  1-7ec80010019  i3c-0          i3c-1