### PR TITLE
Artemis: cb: Fix incorrect reading when INA230 reads negative current

### DIFF
--- a/common/dev/ina230.c
+++ b/common/dev/ina230.c
@@ -111,6 +111,10 @@ uint8_t ina230_read(sensor_cfg *cfg, int *reading)
 		val = (double)(reg_val)*init_args->pwr_lsb;
 		break;
 	case INA230_CUR_OFFSET:
+		if (GETBIT(msg.data[0], 7)) {
+			// If raw value is negative, set it zero.
+			reg_val = 0;
+		}
 		signed_reg_val = (int16_t)reg_val;
 		val = (double)(signed_reg_val)*init_args->cur_lsb;
 		break;


### PR DESCRIPTION
# Description
- Fix incorrect reading when INA230 reads negative current.

# Motivation
- Fix incorrect reading when INA230 reads negative current.

# Test Plan
- Build code: Pass
- Check sel during ACB power on/off: 30 rounds Pass

# Log
- Before fix
16   cb       2018-03-09 09:40:32    power-util       SERVER_POWER_ON successful for FRU: 16
16   cb       2018-03-09 09:40:33    sensord          DEASSERT: Upper Non Recoverable threshold - settled - FRU: 16, num: 0x63 curr_val: 1.77 Amps, thresh_val: 2.92 Amps, snr: CB_P1V25_1_12VIN_CURR_A
16   cb       2018-03-09 09:40:33    sensord          DEASSERT: Upper Critical threshold - settled - FRU: 16, num: 0x63 curr_val: 1.77 Amps, thresh_val: 2.48 Amps, snr: CB_P1V25_1_12VIN_CURR_A
16   cb       2018-03-09 09:40:33    sensord          DEASSERT: Upper Non Recoverable threshold - settled - FRU: 16, num: 0x64 curr_val: 1.82 Amps, thresh_val: 2.92 Amps, snr: CB_P1V25_2_12VIN_CURR_A
16   cb       2018-03-09 09:40:34    sensord          DEASSERT: Upper Critical threshold - settled - FRU: 16, num: 0x64 curr_val: 1.82 Amps, thresh_val: 2.48 Amps, snr: CB_P1V25_2_12VIN_CURR_A
16   cb       2018-03-09 09:40:41    power-util       SERVER_POWER_OFF successful for FRU: 16
16   cb       2018-03-09 09:40:52    sensord          ASSERT: Upper Critical threshold - raised - FRU: 16, num: 0x63 curr_val: 65.53 Amps, thresh_val: 2.48 Amps, snr: CB_P1V25_1_12VIN_CURR_A
16   cb       2018-03-09 09:40:52    sensord          ASSERT: Upper Non Recoverable threshold - raised - FRU: 16, num: 0x63 curr_val: 65.53 Amps, thresh_val: 2.92 Amps, snr: CB_P1V25_1_12VIN_CURR_A
16   cb       2018-03-09 09:40:52    sensord          ASSERT: Upper Critical threshold - raised - FRU: 16, num: 0x64 curr_val: 65.53 Amps, thresh_val: 2.48 Amps, snr: CB_P1V25_2_12VIN_CURR_A
16   cb       2018-03-09 09:40:52    sensord          ASSERT: Upper Non Recoverable threshold - raised - FRU: 16, num: 0x64 curr_val: 65.53 Amps, thresh_val: 2.92 Amps, snr: CB_P1V25_2_12VIN_CURR_A

- After fix
16   cb       2018-03-09 09:58:19    power-util       SERVER_POWER_ON successful for FRU: 16
16   cb       2018-03-09 09:58:21    power-util       SERVER_POWER_OFF successful for FRU: 16
16   cb       2018-03-09 09:58:30    power-util       SERVER_POWER_ON successful for FRU: 16
16   cb       2018-03-09 09:58:31    power-util       SERVER_POWER_OFF successful for FRU: 16
16   cb       2018-03-09 09:59:51    power-util       SERVER_POWER_ON successful for FRU: 16
16   cb       2018-03-09 09:59:53    power-util       SERVER_POWER_OFF successful for FRU: 16