### PR TITLE
Artemis: cb: Fix wrong mutex unlocking issue

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_hook.c
+++ b/meta-facebook/at-cb/src/platform/plat_hook.c
@@ -872,11 +872,11 @@ bool pre_xdpe15284_read(sensor_cfg *cfg, void *args)
 	if (i2c_master_write(&msg, retry) != 0) {
 		LOG_ERR("Set xdpe15284 page fail");
 		ret = false;
+		k_mutex_unlock(&xdpe15284_mutex);
 	} else {
 		ret = true;
 	}
 
-	k_mutex_unlock(&xdpe15284_mutex);
 	return ret;
 }
 


### PR DESCRIPTION
# Description
- Fix wrong mutex unlocking issue.
  - When page setting fails, mutex should be unlocked when returning false.

# Motivation
- Fix wrong mutex unlocking issue.

# Test Plan
- Build code: Pass
- Get sensor reading: Pass

# Log
- Before fix ......
CB_P51V_STBY_L_VOLT_V        (0x53) :  50.787 Volts | (ok)
CB_P51V_STBY_R_VOLT_V        (0x54) :  50.738 Volts | (ok)
CB_P51V_STBY_L_PWR_W         (0x55) : 427.178 Watts | (ok)
CB_P51V_STBY_R_PWR_W         (0x56) : 417.051 Watts | (ok)
CB_P0V8_VDD_1_VOLT_V         (0x57) : NA | (na)
CB_P0V8_VDD_2_VOLT_V         (0x58) : NA | (na)
CB_P0V8_VDD_1_CURR_A         (0x59) : NA | (na)
CB_P0V8_VDD_2_CURR_A         (0x5A) : NA | (na)
CB_P0V8_VDD_1_PWR_W          (0x5B) : NA | (na)
CB_P0V8_VDD_2_PWR_W          (0x5C) : NA | (na)
CB_P51V_STBY_L_CURR_A        (0x5D) :   8.241 Amps  | (ok)
CB_P51V_STBY_R_CURR_A        (0x5E) :   8.066 Amps  | (ok)
CB_P0V8_1_VDD_TEMP_C         (0x5F) : NA | (na)
CB_P0V8_2_VDD_TEMP_C         (0x60) : NA | (na)
CB_P1V25_1_12VIN_VOLT_V      (0x61) :  12.102 Volts | (ok)
CB_P1V25_2_12VIN_VOLT_V      (0x62) :  12.106 Volts | (ok)
CB_P1V25_1_12VIN_CURR_A      (0x63) :   1.871 Amps  | (ok)
CB_P1V25_2_12VIN_CURR_A      (0x64) :   1.855 Amps  | (ok)
CB_P1V25_1_12VIN_PWR_W       (0x65) :  22.625 Watts | (ok)
CB_P1V25_2_12VIN_PWR_W       (0x66) :  22.450 Watts | (ok)
......

- After fix ......
CB_P51V_STBY_L_VOLT_V        (0x53) :  50.763 Volts | (ok)
CB_P51V_STBY_R_VOLT_V        (0x54) :  50.738 Volts | (ok)
CB_P51V_STBY_L_PWR_W         (0x55) : 425.545 Watts | (ok)
CB_P51V_STBY_R_PWR_W         (0x56) : 416.255 Watts | (ok)
CB_P0V8_VDD_1_VOLT_V         (0x57) :   0.802 Volts | (ok)
CB_P0V8_VDD_2_VOLT_V         (0x58) :   0.802 Volts | (ok)
CB_P0V8_VDD_1_CURR_A         (0x59) :  34.187 Amps  | (ok)
CB_P0V8_VDD_2_CURR_A         (0x5A) :  34.500 Amps  | (ok)
CB_P0V8_VDD_1_PWR_W          (0x5B) :  27.375 Watts | (ok)
CB_P0V8_VDD_2_PWR_W          (0x5C) :  27.625 Watts | (ok)
CB_P51V_STBY_L_CURR_A        (0x5D) :   8.233 Amps  | (ok)
CB_P51V_STBY_R_CURR_A        (0x5E) :   8.041 Amps  | (ok)
CB_P0V8_1_VDD_TEMP_C         (0x5F) :  45.000 C     | (ok)
CB_P0V8_2_VDD_TEMP_C         (0x60) :  45.000 C     | (ok)
CB_P1V25_1_12VIN_VOLT_V      (0x61) :  12.102 Volts | (ok)
CB_P1V25_2_12VIN_VOLT_V      (0x62) :  12.106 Volts | (ok)
CB_P1V25_1_12VIN_CURR_A      (0x63) :   1.872 Amps  | (ok)
CB_P1V25_2_12VIN_CURR_A      (0x64) :   1.856 Amps  | (ok)
CB_P1V25_1_12VIN_PWR_W       (0x65) :  22.649 Watts | (ok)
CB_P1V25_2_12VIN_PWR_W       (0x66) :  22.450 Watts | (ok)
......