### PR TITLE
fby4: sd: Setting the I3C bus frequency to 1 MHz to obtain DIMM infor…

### DIFF
--- a/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
@@ -92,10 +92,10 @@
 &i3c2 {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_i3c2_default>;
-	i3c-scl-hz = <12500000>;
+	i3c-scl-hz = <1000000>;
 	assigned-address = <0x11>;
-	i3c-pp-scl-hi-period-ns = <40>;
-	i3c-pp-scl-lo-period-ns = <40>;
+	i3c-pp-scl-hi-period-ns = <500>;
+	i3c-pp-scl-lo-period-ns = <500>;
 };
 
 &i2c13 {


### PR DESCRIPTION
…mation.

Description:
    1. Set the I3C scale to 1 MHz.
    2. Set the I3C high and low periods to 500 ns.
Motivation:
    DIMM information can only be read under I3C at 1 MHz.
Test plan:
    Get DIMM PMIC power by raw command: Pass
Test log:
    /* attach device address and broadcast CCC*/
    uart:~$ i3c xfer I3C_2 -a 0x48 -w 0x0c -r 1
    Private transfer to address 0x48

    00000000: 02