### PR TITLE
common: Support adc max11617

### DIFF
--- a/common/dev/max11617.c
+++ b/common/dev/max11617.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "pmbus.h"
+
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(max11617);
+
+#define MAX1363_CHANNEL_SEL_MASK 0x1E
+#define MAX1363_CHANNEL_SEL(a) ((a) << 1)
+#define MAX1363_CONFIG_SCAN_SINGLE_1 0x60
+#define MAX1363_CONFIG_SE 0x01
+#define MAX1363_SCAN_MASK 0x60
+#define MAX1363_SE_DE_MASK 0x01
+
+#define MAX11617_VREF 2.048 // unit: volt(V)
+
+static int max11617_set_scan_mode(sensor_cfg *cfg, uint8_t config_byte, uint8_t mode)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+
+	config_byte &= ~(MAX1363_CHANNEL_SEL_MASK | MAX1363_SCAN_MASK | MAX1363_SE_DE_MASK);
+	config_byte |= mode;
+	max11617_init_arg *init_arg = (max11617_init_arg *)cfg->init_args;
+
+	uint8_t retry = 5;
+	int ret = 0;
+	I2C_MSG msg;
+	memset(&msg, 0, sizeof(I2C_MSG));
+
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = init_arg->setup_byte;
+	msg.data[1] = config_byte;
+
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("i2c write fail, sensor number 0x%x  ret: %d", cfg->num, ret);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+	init_arg->config_byte = config_byte;
+	return ret;
+}
+
+uint8_t max11617_read(sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+
+	max11617_init_arg *init_arg = (max11617_init_arg *)cfg->init_args;
+	int ret = 0;
+	float val = 0;
+	sensor_val *sval = (sensor_val *)reading;
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("sensor num: 0x%x is invalid", cfg->num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	// set mode to single-ended to get channels'analog input
+	uint8_t mode = (cfg->offset << 1) | MAX1363_CONFIG_SCAN_SINGLE_1 | MAX1363_CONFIG_SE;
+	if (max11617_set_scan_mode(cfg, init_arg->config_byte, mode) != 0) {
+		LOG_ERR("max11617_init failed for sensor number 0x%x  ret: %d", cfg->num, ret);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	uint8_t retry = 5;
+	I2C_MSG msg;
+	memset(&msg, 0, sizeof(I2C_MSG));
+
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.rx_len = 2;
+
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("i2c read fail  sensor number 0x%x  ret: %d", cfg->num, ret);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	/* Get reading, 1 lsb = vref/4096 */
+	val = (msg.data[1] | msg.data[0] << 8) & ((1 << 12) - 1);
+	val *= (MAX11617_VREF / 4096);
+	val *= init_arg->scalefactor[cfg->offset];
+	sval->integer = val;
+	sval->fraction = (val - sval->integer) * 1000;
+
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t max11617_init(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(cfg->init_args, SENSOR_INIT_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	max11617_init_arg *init_arg = (max11617_init_arg *)cfg->init_args;
+	if (init_arg->is_init != true) {
+		uint8_t config_byte = init_arg->config_byte;
+		uint8_t mode = 0x16; // default mode: s0to11
+		if (max11617_set_scan_mode(cfg, config_byte, mode) != 0) {
+			LOG_ERR("max11617_init failed for sensor number 0x%x", cfg->num);
+			return SENSOR_INIT_UNSPECIFIED_ERROR;
+		}
+		init_arg->is_init = true;
+	}
+
+	cfg->read = max11617_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -155,6 +155,7 @@ enum SENSOR_DEV {
 	sensor_dev_bmr351 = 0x2D,
 	sensor_dev_cx7 = 0x2E,
 	sensor_dev_vistara = 0x2F,
+	sensor_dev_max11617 = 0x30,
 	sensor_dev_max
 };
 
@@ -691,6 +692,13 @@ typedef struct _cx7_init_arg {
 	uint8_t endpoint;
 	uint16_t sensor_id;
 } cx7_init_arg;
+
+typedef struct _max11617_init_arg {
+	bool is_init;
+	uint8_t setup_byte;
+	uint8_t config_byte;
+	float scalefactor[12];
+} max11617_init_arg;
 
 extern bool enable_sensor_poll_thread;
 extern sensor_cfg *sensor_config;


### PR DESCRIPTION
Summary:
Description:
- Support for max11617 for adc

Motivation:
- Support fby4-wf cxl2 adc sensor reading

Test Plan:
- Get corresponding sensor reading

Test Log:
root@bmc:/usr/libexec/phosphor-state-manager# busctl tree xyz.openbmc_project.PLDM|grep WF_ADC
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P0V75_ASIC1_VOLT_V_43_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P0V75_ASIC2_VOLT_V_54_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V2_ASIC1_VOLT_V_37_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V2_ASIC2_VOLT_V_48_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V2_STBY_VOLT_V_36_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V8_ASIC1_VOLT_V_38_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V8_ASIC2_VOLT_V_49_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P3V3_E1S_0_VOLT_V_35_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P3V3_STBY_VOLT_V_34_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_AB_ASIC1_VOLT_V_44_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_AB_ASIC2_VOLT_V__55_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_CD_ASIC1_VOLT_V_45_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_CD_ASIC2_VOLT_V__56_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_AB_ASIC1_VOLT_V_46_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_AB_ASIC2_VOLT_V__57_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_CD_ASIC1_VOLT_V_47_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_CD_ASIC2_VOLT_V__58_1
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_P0V75_ASIC2_VOLT_V_54_1 ...
.Value                                                property  d         0.754                                    emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V2_ASIC2_VOLT_V_48_1
...
.Value                                                property  d         1.2009                                   emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V8_ASIC2_VOLT_V_49_1
...
.Value                                                property  d         1.80299                                  emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_AB_ASIC2_VOLT_V__55_1
...
.Value                                                property  d         2.5                                      emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_CD_ASIC2_VOLT_V__56_1
...
.Value                                                property  d         2.51                                     emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_AB_ASIC2_VOLT_V__57_1
...
.Value                                                property  d         0.597                                    emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_CD_ASIC2_VOLT_V__58_1
...
.Value                                                property  d         0.597                                    emits-change writable
...