### PR TITLE
Artemis: mc: Support to monitor SSD presence status

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_class.h
+++ b/meta-facebook/at-mc/src/platform/plat_class.h
@@ -114,5 +114,6 @@ uint8_t get_board_revision();
 int get_pcie_card_power_status(uint8_t pcie_card_id);
 int init_platform_config();
 void set_reset_smb4_mux_pin();
+void init_accl_presence_check_work();
 
 #endif

--- a/meta-facebook/at-mc/src/platform/plat_init.c
+++ b/meta-facebook/at-mc/src/platform/plat_init.c
@@ -121,6 +121,7 @@ void pal_post_init()
 	if (is_ac_lost()) {
 		plat_ssd_present_check();
 	}
+	init_accl_presence_check_work();
 }
 
 void pal_device_init()

--- a/meta-facebook/at-mc/src/platform/plat_pldm_monitor.h
+++ b/meta-facebook/at-mc/src/platform/plat_pldm_monitor.h
@@ -30,6 +30,7 @@ enum plat_pldm_device_state_set_offset {
 	PLDM_STATE_SET_OFFSET_DEVICE_POWER_STATUS = 2,
 };
 
+void plat_send_ssd_present_event(uint8_t ssd_id);
 void plat_ssd_present_check();
 void plat_send_ssd_power_fault_event(uint8_t ssd_id, uint8_t status);
 


### PR DESCRIPTION
# Description
- Support to monitor SSD presence status.
  - Send event if the SSD presence status changes to not present.

# Motivation
- Support to monitor SSD presence status.

# Test Plan
- Build code: Pass
- Check SSD presence event if SSD presence status changes: Pass

# Log
0    all      2018-03-09 08:44:41    pldmd            State Sensor: MC_SENSOR_SSD_4, not present
0    all      2018-03-09 08:45:46    pldmd            State Sensor: MC_SENSOR_SSD_3, not present
0    all      2018-03-09 08:46:26    pldmd            State Sensor: MC_SENSOR_SSD_2, not present