### PR TITLE
fby4: ff: Change CXL SPI frequency

### DIFF
--- a/meta-facebook/yv4-ff/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-ff/boards/ast1030_evb.overlay
@@ -154,7 +154,7 @@
 &spi1_cs0 {
 	status = "okay";
 	spi-max-buswidth = <4>;
-	spi-max-frequency = <50000000>;
+	spi-max-frequency = <3125000>;
 	re-init-support;
 };
 


### PR DESCRIPTION
Description
- Modify CXL SPI frequency from 50M to 3.125M Hz.

Motivation
- Getting the ASIC FW version from flash, some bits will get wrong value. The result will become unstable when using the 50M Hz.

Test plan
- Build code: Pass
- Check SPI normal: Pass