### PR TITLE
fby4: wf: Change CXL SPI frequency to 30M

### DIFF
--- a/meta-facebook/yv4-wf/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-wf/boards/ast1030_evb.overlay
@@ -163,7 +163,7 @@
 &spi1_cs0 {
 	status = "okay";
 	spi-max-buswidth = <4>;
-	spi-max-frequency = <50000000>;
+	spi-max-frequency = <30000000>;
 	re-init-support;
 };
 
@@ -174,14 +174,7 @@
 &spi2_cs0 {
 	status = "okay";
 	spi-max-buswidth = <4>;
-	spi-max-frequency = <50000000>;
-	re-init-support;
-};
-
-&spi2_cs1 {
-	status = "okay";
-	spi-max-buswidth = <4>;
-	spi-max-frequency = <50000000>;
+	spi-max-frequency = <30000000>;
 	re-init-support;
 };
 


### PR DESCRIPTION
Description
- Modify CXL SPI frequency from 50M to 30M Hz.
- Remove unused spi2_cs1.

Motivation
- Getting the ASIC FW version from flash, some bits will get wrong value. The result will become unstable, when using the 50M Hz. The reason is  distance from BIC to ASIC1 are greatly long. EE team suggest to unified the SPI CLK frequency to 30M.

Test plan
- Build code: Pass
- Check SPI normal: Pass

Log
1. Get CXL SPI flash data. root@bmc:~# pldmtool raw -d 0x80 0x3f 0x1 0x15 0xa0 0x0 0x18 0x52 0xB 0x40 0x0 0x2 0x78 -m 62 pldmtool: Tx: 80 3f 01 15 a0 00 18 52 0b 40 00 02 78 pldmtool: Rx: 00 3f 01 00 15 a0 00 1c 52 00

- CXL1 [BMC]
root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x02 0x01 0x01 0x01 0x01 -m 62 pldmtool: Tx: 80 02 39 02 01 01 01 01
pldmtool: Rx: 00 02 39 00

[BIC]
uart:~$ flash read spi1_cs0 00050360 20
00050360: 6f 6e 2d 32 2e 30 2e 36  2d 35 65 65 64 37 38 39 |on-2.0.6 -5eed789| 00050370: 62 35 36 37 38 22 00 00  71 2d 00 00 73 90 02 14 |b5678".. q-..s...|

- CXL2 [BMC]
root@bmc:~# pldmtool raw -d 0x80 0x02 0x39 0x03 0x01 0x01 0x01 0x01 -m 62 pldmtool: Tx: 80 02 39 03 01 01 01 01
pldmtool: Rx: 00 02 39 00

uart:~$ flash read spi2_cs0 00050360 20
00050360: 6f 6e 2d 32 2e 30 2e 35  2d 66 63 34 37 36 39 33 |on-2.0.5 -fc47693| 00050370: 64 35 30 38 33 22 00 00  71 2d 00 00 73 90 02 14 |d5083".. q-..s...|