### PR TITLE
fby35: cl: Fix NMI event sensor number

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_isr.c
@@ -640,7 +640,7 @@ void ISR_NMI()
 		sel_msg.InF_target = PLDM;
 		sel_msg.sensor_type = IPMI_SENSOR_TYPE_CRITICAL_INT;
 		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
-		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
+		sel_msg.sensor_number = SENSOR_NUM_NMI;
 		sel_msg.event_data1 = IPMI_EVENT_CRITICAL_INT_FP_NMI;
 		sel_msg.event_data2 = 0xFF;
 		sel_msg.event_data3 = 0xFF;


### PR DESCRIPTION
Description:
NMI event sensor number incorrect

Motivation:
NMI event sensor number incorrect

Test Log:
Before change:
1    slot1    2106-02-06 22:44:47    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 1969-12-31 16:16:31, Sensor: SYSTEM_STATUS (0x10), Event Data: (00FFFF) SOC thermal trip Assertion
After change:
1    slot1    2106-02-06 22:49:19    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 1969-12-31 16:21:03, Sensor: CRITICAL_IRQ (0xEA), Event Data: (00FFFF) NMI / Diagnostic Interrupt Assertion