### PR TITLE
op2: op: Recode retimer type avoid read conflict

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_class.c
+++ b/meta-facebook/op2-op/src/platform/plat_class.c
@@ -133,7 +133,7 @@ int check_pcie_retimer_type(void)
 
 void cache_pcie_retimer_version(void)
 {
-	check_pcie_retimer_type();
+	uint8_t retimer_type = get_pcie_retimer_type();
 	I2C_MSG *i2c_msg = NULL;
 	i2c_msg = malloc(sizeof(I2C_MSG));
 	i2c_msg->bus = I2C_BUS4;
@@ -141,7 +141,7 @@ void cache_pcie_retimer_version(void)
 	uint8_t data[RETIMER_VERSION_MAX_LENGTH];
 	memset(data, 0, RETIMER_VERSION_MAX_LENGTH);
 
-	switch (pcie_retimer_type) {
+	switch (retimer_type) {
 	case RETIMER_TYPE_PT5161L:
 		if (get_retimer_fw_version(i2c_msg, data)) {
 			convert_uint8_t_pointer_to_uint32_t(&pcie_retimer_version, data, 4,

--- a/meta-facebook/op2-op/src/platform/plat_hook.c
+++ b/meta-facebook/op2-op/src/platform/plat_hook.c
@@ -285,7 +285,7 @@ bool pre_retimer_read(sensor_cfg *cfg, void *args)
 			return false;
 		}
 
-		retimer_type = check_pcie_retimer_type();
+		retimer_type = get_pcie_retimer_type();
 		switch (retimer_type) {
 		case RETIMER_TYPE_PT5161L:
 			check_init_count += 1;

--- a/meta-facebook/op2-op/src/platform/plat_power_seq.c
+++ b/meta-facebook/op2-op/src/platform/plat_power_seq.c
@@ -187,6 +187,7 @@ void init_sequence_status()
 	case CARD_TYPE_OPA:
 		if (gpio_get(OPA_PERST_BIC_RTM_N) == GPIO_HIGH) {
 			is_retimer_sequence_done = true;
+			check_pcie_retimer_type();
 			cache_pcie_retimer_version();
 		}
 
@@ -931,6 +932,7 @@ bool power_on_handler(uint8_t initial_stage)
 					break;
 				}
 				is_retimer_sequence_done = true;
+				check_pcie_retimer_type();
 				cache_pcie_retimer_version();
 			}
 			check_power_ret = 0;


### PR DESCRIPTION
# Description
- BIC only gets vendor ID through I2C from retimer once time and records it. If other threads need this information, get the record data and not ask the device directly.

# Motivation
- Two threads ask for the vendor ID at the same time, causing conflict.

# Test plan
- Build code: Pass
- Get retimer temperature: Pass
- Get retimer version: Pass
- AC stress: Pass

# Log
1. Get retimer version. root@bmc-oob:~# fw-util slot1 --version 1ou_retimer 1OU Retimer Version: Astera Labs v2_8_9472

2. Get retimer temperature. root@bmc-oob:~# sensor-util slot1 | grep 1OU_RETIMER
1OU_RETIMER_TEMP_C           (0x61) :  68.400 C     | (ok)