### PR TITLE
fby4: wf: Revise IOE configuration and support for proper CXL LED ope…

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_gpio.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_gpio.h
@@ -270,4 +270,9 @@ enum IOE_PIN_NUM {
 	IOE_P17 = 7,
 };
 
+int get_ioe_value(uint8_t ioe_addr, uint8_t ioe_reg, uint8_t *value);
+int set_ioe_value(uint8_t ioe_addr, uint8_t ioe_reg, uint8_t value);
+void init_ioe_config();
+int check_ioe4_e1s_prsnt_pin();
+
 #endif

--- a/meta-facebook/yv4-wf/src/platform/plat_init.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_init.c
@@ -42,7 +42,7 @@ void pal_set_sys_status()
 	set_mb_dc_status(FM_POWER_EN_R);
 	set_DC_status(PG_CARD_OK);
 	set_DC_on_delayed_status();
-	set_ioe_init();
+	init_ioe_config();
 	if (gpio_get(PG_CARD_OK) == POWER_ON) {
 		k_work_schedule(&cxl_ready_check, K_SECONDS(CXL_READY_SECONDS));
 	}
@@ -62,8 +62,8 @@ void pal_pre_init()
 	uint8_t ioe2_output_value = 0;
 	if (get_ioe_value(ADDR_IOE2, TCA9555_OUTPUT_PORT_REG_0, &ioe2_output_value) == 0) {
 		// BIC starts monitoring VR only after the PMIC mux is switched to BIC.
-		if ((GETBIT(ioe2_output_value, IOE_P00) == 0) ||
-		    (GETBIT(ioe2_output_value, IOE_P02) == 0)) {
+		if ((GETBIT(ioe2_output_value, IOE_P00) == 0) || // SEL_SMB_HOST_MUX_PMIC1_IN_R
+		    (GETBIT(ioe2_output_value, IOE_P02) == 0)) { // SEL_SMB_HOST_MUX_PMIC2_IN_R
 			set_vr_monitor_status(false);
 		}
 	}

--- a/meta-facebook/yv4-wf/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_isr.c
@@ -21,221 +21,65 @@
 #include "plat_gpio.h"
 #include "plat_power_seq.h"
 #include "plat_isr.h"
-#include "plat_i2c.h"
 
 LOG_MODULE_REGISTER(plat_isr);
 
-IOE_CFG ioe_cfg[] = {
-	{ ADDR_IOE1, TCA9555_CONFIG_REG_0, 0x18, TCA9555_OUTPUT_PORT_REG_0, 0x18 },
-	{ ADDR_IOE1, TCA9555_CONFIG_REG_1, 0xC0, TCA9555_OUTPUT_PORT_REG_1, 0xFE },
-	{ ADDR_IOE2, TCA9555_CONFIG_REG_0, 0xF0, TCA9555_OUTPUT_PORT_REG_0, 0xF0 },
-	{ ADDR_IOE2, TCA9555_CONFIG_REG_1, 0xC0, TCA9555_OUTPUT_PORT_REG_1, 0x78 },
-	{ ADDR_IOE3, TCA9555_CONFIG_REG_0, 0xFF, TCA9555_OUTPUT_PORT_REG_0, 0xFF },
-	{ ADDR_IOE3, TCA9555_CONFIG_REG_1, 0xF0, TCA9555_OUTPUT_PORT_REG_1, 0xF4 },
-	{ ADDR_IOE4, TCA9555_CONFIG_REG_0, 0x12, TCA9555_OUTPUT_PORT_REG_0, 0x3F },
-	{ ADDR_IOE4, TCA9555_CONFIG_REG_1, 0x04, TCA9555_OUTPUT_PORT_REG_1, 0xBE },
-};
-
-int get_ioe_value(uint8_t ioe_addr, uint8_t ioe_reg, uint8_t *value)
+void enable_e1s_pe_reset()
 {
-	int ret = 0;
-	uint8_t retry = 5;
-	I2C_MSG msg = { 0 };
+	if (check_ioe4_e1s_prsnt_pin() == 0) {
+		uint8_t ioe_reg_value = 0;
+		int ret = 0;
 
-	msg.bus = I2C_BUS6;
-	msg.target_addr = ioe_addr;
-	msg.tx_len = 1;
-	msg.rx_len = 1;
-	msg.data[0] = ioe_reg;
-
-	ret = i2c_master_read(&msg, retry);
-
-	if (ret != 0) {
-		LOG_ERR("Failed to read value from IOE(0x%X)", ioe_addr);
-		return -1;
-	}
-
-	*value = msg.data[0];
-
-	return 0;
-}
-
-int set_ioe_value(uint8_t ioe_addr, uint8_t ioe_reg, uint8_t value)
-{
-	int ret = 0;
-	uint8_t retry = 5;
-	I2C_MSG msg = { 0 };
-
-	msg.bus = I2C_BUS6;
-	msg.target_addr = ioe_addr;
-	msg.tx_len = 2;
-	msg.rx_len = 1;
-	msg.data[0] = ioe_reg;
-	msg.data[1] = value;
-
-	ret = i2c_master_write(&msg, retry);
-
-	if (ret != 0) {
-		LOG_ERR("Failed to write value(0x%X) into IOE(0x%X)", value, ioe_addr);
-		return -1;
-	}
-
-	return 0;
-}
-
-int set_ioe4_control(int cmd)
-{
-	int ret = 0;
-	uint8_t retry = 5;
-	uint8_t io_output_status = 0;
-	I2C_MSG msg = { 0 };
-
-	msg.bus = I2C_BUS6;
-	msg.target_addr = ADDR_IOE4;
-	msg.rx_len = 1;
-	msg.tx_len = 1;
-	msg.data[0] = TCA9555_OUTPUT_PORT_REG_1;
-
-	ret = i2c_master_read(&msg, retry);
-	if (ret != 0) {
-		LOG_ERR("Unable to read ioexp bus when setting IOE4: %u addr: 0x%02x", msg.bus,
-			msg.target_addr);
-		return -1;
-	}
-
-	io_output_status = msg.data[0];
-
-	memset(&msg, 0, sizeof(I2C_MSG));
-
-	msg.bus = I2C_BUS6;
-	msg.target_addr = ADDR_IOE4;
-	msg.tx_len = 2;
-	msg.data[0] = TCA9555_OUTPUT_PORT_REG_1;
-
-	switch (cmd) {
-	case SET_CLK:
-		msg.data[1] = ((io_output_status & (~ASIC_CLK_BIT)) & (~E1S_CLK_BIT));
-		break;
-	case SET_PE_RST:
-		msg.data[1] = (io_output_status | E1S_PE_RESET_BIT);
-		break;
-	default:
-		LOG_ERR("Unknown command to set IOE4. cmd: %d", cmd);
-		return -1;
-	}
-
-	ret = i2c_master_write(&msg, retry);
-
-	if (ret != 0) {
-		LOG_ERR("Unable to write ioexp bus when setting IOE4: %u addr: 0x%02x", msg.bus,
-			msg.target_addr);
-		return -1;
-	}
-
-	return 0;
-}
-
-int check_e1s_present_status()
-{
-	int ret = 0;
-	uint8_t retry = 5;
-	uint8_t e1s_present_status = 0;
-	I2C_MSG msg = { 0 };
-
-	memset(&msg, 0, sizeof(I2C_MSG));
-	msg.bus = I2C_BUS6;
-	msg.target_addr = ADDR_IOE4;
-	msg.rx_len = 1;
-	msg.tx_len = 1;
-	msg.data[0] = TCA9555_INPUT_PORT_REG_1;
-
-	ret = i2c_master_read(&msg, retry);
-
-	if (ret != 0) {
-		LOG_ERR("Unable to read ioexp bus when checking E1S present: %u addr: 0x%02x",
-			msg.bus, msg.target_addr);
-		return -1;
-	}
-
-	e1s_present_status = msg.data[0] & TCA9555_PORT_2;
-
-	if (e1s_present_status != 0) { // e1s is not present when present pin is low.
-		LOG_WRN("E1S is not present");
-		return -1;
-	} else {
-		return 0;
-	}
-}
-
-void set_ioe_init()
-{
-	int ret = 0;
-	uint8_t retry = 5;
-	I2C_MSG msg = { 0 };
-	msg.bus = I2C_BUS6;
-	msg.tx_len = 2;
-	msg.rx_len = 1;
-
-	for (int i = 0; i < ARRAY_SIZE(ioe_cfg); i++) {
-		msg.target_addr = ioe_cfg[i].addr;
-		msg.data[0] = ioe_cfg[i].conf_reg;
-		msg.data[1] = ioe_cfg[i].conf_dir;
-		ret = i2c_master_write(&msg, retry);
-		if (ret != 0) {
-			LOG_ERR("Unable to write ioexp bus when initializing IOE, addr: 0x%02x",
-				msg.target_addr);
-			return;
-		}
-
-		if ((ioe_cfg[i].addr == ADDR_IOE4) &&
-		    (ioe_cfg[i].output_reg == TCA9555_OUTPUT_PORT_REG_1)) {
-			msg.tx_len = 1;
-			ret = i2c_master_read(&msg, retry);
-			if (ret != 0) {
-				LOG_ERR("Unable to read ioexp bus when checking E1S present: %u addr: 0x%02x",
-					msg.bus, msg.target_addr);
-				return;
-			}
-
-			msg.tx_len = 2;
-			msg.data[1] = (ioe_cfg[i].output_val & 0xCF) | (msg.data[0] & 0x30);
-			msg.data[0] = TCA9555_OUTPUT_PORT_REG_1;
-			ret = i2c_master_write(&msg, retry);
-
-		} else if ((ioe_cfg[i].addr == ADDR_IOE2) &&
-			   (ioe_cfg[i].output_reg == TCA9555_OUTPUT_PORT_REG_0) &&
-			   (gpio_get(PG_CARD_OK) == HIGH_ACTIVE)) { // If all CXL have been already.
-			msg.data[0] = ioe_cfg[i].output_reg;
-			msg.data[1] = (ioe_cfg[i].output_val |
-				       IOE_SWITCH_MUX_TO_BIC); // Enable P0~P3 to switch mux to BIC.
-			ret = i2c_master_write(&msg, retry);
-
-		} else {
-			msg.data[0] = ioe_cfg[i].output_reg;
-			msg.data[1] = ioe_cfg[i].output_val;
-			ret = i2c_master_write(&msg, retry);
-		}
+		ret = get_ioe_value(ADDR_IOE4, TCA9555_OUTPUT_PORT_REG_1, &ioe_reg_value);
 
 		if (ret != 0) {
-			LOG_ERR("Unable to write ioexp bus when initializing IOE, addr: 0x%02x",
-				msg.target_addr);
-			return;
+			LOG_ERR("Failed to enable E1S PE reset while reading IOE4 register");
 		}
-	}
 
-	return;
-}
+		ioe_reg_value = (ioe_reg_value | E1S_PE_RESET_BIT);
 
-void check_ioexp_status()
-{
-	if (check_e1s_present_status() == 0) {
-		set_ioe4_control(SET_PE_RST);
+		ret = set_ioe_value(ADDR_IOE4, TCA9555_OUTPUT_PORT_REG_1, ioe_reg_value);
+
+		if (ret != 0) {
+			LOG_ERR("Failed to enable E1S PE reset while writing IOE4 register");
+		}
 	}
 }
 
 void set_asic_and_e1s_clk_handler()
 {
-	set_ioe4_control(SET_CLK);
+	uint8_t ioe_reg_value = 0;
+	int ret = 0;
+
+	ret = get_ioe_value(ADDR_IOE4, TCA9555_OUTPUT_PORT_REG_1, &ioe_reg_value);
+
+	if (ret != 0) {
+		LOG_ERR("Failed to get ASIC and E1S clock while reading IOE4 register");
+	}
+
+	ioe_reg_value = ((ioe_reg_value & (~ASIC_CLK_BIT)) & (~E1S_CLK_BIT));
+
+	ret = set_ioe_value(ADDR_IOE4, TCA9555_OUTPUT_PORT_REG_1, ioe_reg_value);
+
+	if (ret != 0) {
+		LOG_ERR("Failed to set ASIC and E1S clock while writing IOE4 register");
+	}
+}
+
+void set_cxl_led()
+{
+	uint8_t ioe_reg_value = 0;
+
+	get_ioe_value(ADDR_IOE3, TCA9555_OUTPUT_PORT_REG_1, &ioe_reg_value);
+
+	if ((gpio_get(PWRGD_PVTT_CD_ASIC1) == HIGH_ACTIVE) &&
+	    (gpio_get(PWRGD_PVTT_CD_ASIC2) == HIGH_ACTIVE)) {
+		ioe_reg_value = (ioe_reg_value | CXL_LED_BIT);
+	} else { // If any of the ASIC is not powered up, turn off the CXL LED
+		ioe_reg_value = (ioe_reg_value & (~CXL_LED_BIT));
+	}
+
+	set_ioe_value(ADDR_IOE3, TCA9555_OUTPUT_PORT_REG_1, ioe_reg_value);
 }
 
 K_WORK_DEFINE(cxl_power_on_work, execute_power_on_sequence);
@@ -254,7 +98,7 @@ void ISR_MB_DC_STAGUS_CHAGNE()
 	}
 }
 
-K_WORK_DEFINE(ioe_power_on_work, check_ioexp_status);
+K_WORK_DEFINE(_enable_e1s_pe_reset, enable_e1s_pe_reset);
 
 void ISR_MB_PCIE_RST()
 {
@@ -262,7 +106,7 @@ void ISR_MB_PCIE_RST()
 	gpio_set(PERST_ASIC2_N_R, gpio_get(RST_PCIE_MB_EXP_N));
 
 	if (gpio_get(RST_PCIE_MB_EXP_N) == GPIO_HIGH) {
-		k_work_submit(&ioe_power_on_work);
+		k_work_submit(&_enable_e1s_pe_reset);
 	}
 }
 
@@ -271,4 +115,11 @@ K_WORK_DEFINE(e1s_pwr_on_work, set_asic_and_e1s_clk_handler);
 void ISR_E1S_PWR_ON()
 {
 	k_work_submit(&e1s_pwr_on_work);
+}
+
+K_WORK_DEFINE(_set_cxl_led, set_cxl_led);
+
+void ISR_SET_CXL_LED()
+{
+	k_work_submit(&_set_cxl_led);
 }

--- a/meta-facebook/yv4-wf/src/platform/plat_isr.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_isr.h
@@ -29,7 +29,7 @@
 #define ASIC_CLK_BIT BIT(4)
 #define E1S_CLK_BIT BIT(5)
 #define E1S_PE_RESET_BIT BIT(6)
-
+#define CXL_LED_BIT BIT(2)
 // Only switch VR MUX
 #define IOE_SWITCH_MUX_TO_BIC 0x05
 
@@ -52,9 +52,6 @@ void ISR_MB_DC_STAGUS_CHAGNE();
 void ISR_MB_PCIE_RST();
 void ISR_E1S_PWR_ON();
 void ISR_CXL_PG_ON();
-
-void set_ioe_init();
-int get_ioe_value(uint8_t ioe_addr, uint8_t ioe_reg, uint8_t *value);
-int set_ioe_value(uint8_t ioe_addr, uint8_t ioe_reg, uint8_t value);
+void ISR_SET_CXL_LED();
 
 #endif


### PR DESCRIPTION
…ration.

Description:
	1. Configure IOE following GPIO table 20240131.
	2. Refactor the code about IOE initialization, get&set, and interrupt handling.
	3. After BIC verifies all CXL readiness, turn on the CXL LED power.

Motivation:
	1. Follow the lastest GPIO table 20240131.
	2. Refactor the code to make it more readable and maintainable.
	3. Support for proper CXL LED operation.

Test plan:
	1. Check all IOE configuration: Pass
	2. CXL LED is workable: Pass

Test log:
	1. Check all IOE configuration: uart:~$ i2c read I2C_5 0x20 0x6 0x1		//IOE1's direction register
		00000000: 18                                               |.                |
		uart:~$ i2c read I2C_5 0x20 0x7 0x1		//IOE1's statue register
		00000000: c0                                               |.                |
		uart:~$ i2c read I2C_5 0x21 0x6 0x1		//IOE2's direction register
		00000000: f0                                               |.                |
		uart:~$ i2c read I2C_5 0x21 0x7 0x1
		00000000: c0                                               |.                |
		uart:~$ i2c read I2C_5 0x22 0x6 0x1
		00000000: e7                                               |~                |
		uart:~$ i2c read I2C_5 0x22 0x7 0x1
		00000000: f0                                               |.                |
		uart:~$ i2c read I2C_5 0x23 0x6 0x1
		00000000: 10                                               |.                |
		uart:~$ i2c read I2C_5 0x23 0x7 0x1
		00000000: 04                                               |.                |
		uart:~$ i2c read I2C_5 0x20 0x2 0x1
		00000000: 00                                               |.                |
		uart:~$ i2c read I2C_5 0x20 0x3 0x1
		00000000: fe                                               |.                |
		uart:~$ i2c read I2C_5 0x21 0x2 0x1
		00000000: 00                                               |.                |
		uart:~$ i2c read I2C_5 0x21 0x3 0x1
		00000000: 00                                               |.                |
		uart:~$ i2c read I2C_5 0x22 0x2 0x1
		00000000: 18                                               |.                |
		uart:~$ i2c read I2C_5 0x22 0x3 0x1
		00000000: 00                                               |.                |
		uart:~$ i2c read I2C_5 0x23 0x2 0x1
		00000000: 3f                                               |?                |
		uart:~$ i2c read I2C_5 0x23 0x3 0x1
		00000000: 3e                                               |>                |