### PR TITLE
Artemis:CB:check the cached flag before send ready status to BMC

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_pldm_monitor.c
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_monitor.c
@@ -218,15 +218,21 @@ void plat_send_event_pre_work()
 	uint8_t index = 0;
 	uint8_t status = 0;
 	for (index = 0; index < ASIC_CARD_COUNT; ++index) {
-		status = ((accl_freya_info[index].freya1_fw_info.is_freya_ready == FREYA_READY) ?
-				  PLDM_STATE_SET_OEM_DEVICE_NVME_READY :
-				  PLDM_STATE_SET_OEM_DEVICE_NVME_NOT_READY);
-		plat_asic_nvme_status_event(index, PCIE_DEVICE_ID1, status);
+		if (accl_freya_info[index].is_cache_freya1_info) {
+			status = ((accl_freya_info[index].freya1_fw_info.is_freya_ready ==
+				   FREYA_READY) ?
+					  PLDM_STATE_SET_OEM_DEVICE_NVME_READY :
+					  PLDM_STATE_SET_OEM_DEVICE_NVME_NOT_READY);
+			plat_asic_nvme_status_event(index, PCIE_DEVICE_ID1, status);
+		}
 
-		status = ((accl_freya_info[index].freya2_fw_info.is_freya_ready == FREYA_READY) ?
-				  PLDM_STATE_SET_OEM_DEVICE_NVME_READY :
-				  PLDM_STATE_SET_OEM_DEVICE_NVME_NOT_READY);
-		plat_asic_nvme_status_event(index, PCIE_DEVICE_ID2, status);
+		if (accl_freya_info[index].is_cache_freya2_info) {
+			status = ((accl_freya_info[index].freya2_fw_info.is_freya_ready ==
+				   FREYA_READY) ?
+					  PLDM_STATE_SET_OEM_DEVICE_NVME_READY :
+					  PLDM_STATE_SET_OEM_DEVICE_NVME_NOT_READY);
+			plat_asic_nvme_status_event(index, PCIE_DEVICE_ID2, status);
+		}
 	}
 }
 


### PR DESCRIPTION
# Description
- BIC will send the wrong nvme status to bmc when BIC boot up.
- Checking the cached flag before send the status to BMC.

# Motivation
- Prevent send unexpected nvme status to BMC

# Test Plan
- Build code :Pass
- Update BIC : 1900 times pass