### PR TITLE
common: Add adc max11617 in common sensors table

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -125,6 +125,7 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(bmr351)
 	sensor_name_to_num(cx7)
 	sensor_name_to_num(vistara)
+	sensor_name_to_num(max11617)
 };
 // clang-format on
 
@@ -183,6 +184,7 @@ SENSOR_DRIVE_INIT_DECLARE(cx7);
 #ifdef ENABLE_VISTARA
 SENSOR_DRIVE_INIT_DECLARE(vistara);
 #endif
+SENSOR_DRIVE_INIT_DECLARE(max11617);
 
 // The sequence needs to same with SENSOR_DEV ID
 sensor_drive_api sensor_drive_tbl[] = {
@@ -233,6 +235,7 @@ sensor_drive_api sensor_drive_tbl[] = {
 #else
 	SENSOR_DRIVE_TYPE_UNUSE(vistara),
 #endif
+	SENSOR_DRIVE_TYPE_INIT_MAP(max11617),
 };
 
 static void init_sensor_num(void)


### PR DESCRIPTION
Summary:
Description:
- Add max11617 config in common sensors table

Motivation:
- Support fby4-wf cxl2 adc sensor reading

Test Plan:
- Get corresponding sensor reading

Test Log:
root@bmc:/usr/libexec/phosphor-state-manager# busctl tree xyz.openbmc_project.PLDM|grep WF_ADC
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P0V75_ASIC1_VOLT_V_43_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P0V75_ASIC2_VOLT_V_54_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V2_ASIC1_VOLT_V_37_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V2_ASIC2_VOLT_V_48_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V2_STBY_VOLT_V_36_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V8_ASIC1_VOLT_V_38_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V8_ASIC2_VOLT_V_49_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P3V3_E1S_0_VOLT_V_35_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_P3V3_STBY_VOLT_V_34_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_AB_ASIC1_VOLT_V_44_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_AB_ASIC2_VOLT_V__55_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_CD_ASIC1_VOLT_V_45_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_CD_ASIC2_VOLT_V__56_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_AB_ASIC1_VOLT_V_46_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_AB_ASIC2_VOLT_V__57_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_CD_ASIC1_VOLT_V_47_1
        |- /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_CD_ASIC2_VOLT_V__58_1
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_P0V75_ASIC2_VOLT_V_54_1 ...
.Value                                                property  d         0.754                                    emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V2_ASIC2_VOLT_V_48_1
...
.Value                                                property  d         1.2009                                   emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_P1V8_ASIC2_VOLT_V_49_1
...
.Value                                                property  d         1.80299                                  emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_AB_ASIC2_VOLT_V__55_1
...
.Value                                                property  d         2.5                                      emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_PVPP_CD_ASIC2_VOLT_V__56_1
...
.Value                                                property  d         2.51                                     emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_AB_ASIC2_VOLT_V__57_1
...
.Value                                                property  d         0.597                                    emits-change writable
...
root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/voltage/WF_ADC_PVTT_CD_ASIC2_VOLT_V__58_1
...
.Value                                                property  d         0.597                                    emits-change writable
...