### PR TITLE
Artemis: cb: Adjust the PESW version string

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.c
@@ -334,16 +334,18 @@ static bool get_pex_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 
 	uint8_t tmp_buf[4] = { 0 };
 	uint8_t idx = 0;
-	uint8_t i = 0;
 
 	memcpy(tmp_buf, &reading, sizeof(reading));
 	reverse_array(tmp_buf, sizeof(reading));
-	for (i = 0; i < ARRAY_SIZE(tmp_buf) - 1; i++) {
-		idx += bin2hex(&tmp_buf[i], 1, &buf[idx], 2);
-		buf[idx++] = '.';
-	}
 
-	idx += bin2hex(&tmp_buf[i], 1, &buf[idx], 2);
+	idx += bin2hex(&tmp_buf[0], 1, &buf[idx], 2);
+	buf[idx++] = '.';
+	idx += bin2hex(&tmp_buf[1], 1, &buf[idx], 2);
+	buf[idx++] = '.';
+	idx += bin2hex(&tmp_buf[3], 1, &buf[idx], 2);
+	//Append the config id into the version string
+	buf[idx++] = '-';
+	idx += bin2hex(&tmp_buf[2], 1, &buf[idx], 2);
 	*len = idx;
 	return true;
 }


### PR DESCRIPTION
# Description
- The PCIe Switch FW is reporting 2 different versions even though we load same blob FW image on both.
- https://metainfra.atlassian.net/jira/software/projects/T17GTART/issues/T17GTART-593

# Motivation
- Move the config ID to the end of the string for version string comparing.

# Test Plan:
- Build code: Pass
- Check the output of fw-util: Pass

# Log
root@bmc-oob:~# fw-util cb --version
CB BIC Version: cb2024.04.01
CB CPLD Version: 00040304
CB PESW0 Version: 53.11.0b-00
CB PESW1 Version: 53.11.0b-01
CB PESW_VR Version: Infineon 47f8bf91, Remaining Write: 20