### PR TITLE
Artemis:cb:Prevent module power leakage on system

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_class.c
+++ b/meta-facebook/at-cb/src/platform/plat_class.c
@@ -568,3 +568,61 @@ void init_accl_presence_check_work()
 					     CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
 	k_thread_name_set(&presence_check_thread_handler, "presence_check_thread");
 }
+
+void init_asic_jtag_select_ioexp()
+{
+	int ret = 0;
+	int retry = 5;
+	uint8_t tx_len = 2;
+	uint8_t output_0_value = 0;
+	uint8_t output_1_value = 0;
+	uint8_t config_0_value = 0;
+	uint8_t config_1_value = 0;
+	uint8_t data[tx_len];
+	I2C_MSG msg = { 0 };
+	memset(data, 0, sizeof(uint8_t) * tx_len);
+
+	/** Write U233 ioexp output 0 register **/
+	data[0] = PCA9555_OUTPUT_PORT_REG_0;
+	data[1] = output_0_value;
+	msg = construct_i2c_message(I2C_BUS13, IOEXP_U233_ADDR, tx_len, data, 0);
+
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Unable to write ioexp output 0 register bus: %u addr: 0x%02x", msg.bus,
+			msg.target_addr);
+	}
+
+	/** Write U233 ioexp output 1 register **/
+	data[0] = PCA9555_OUTPUT_PORT_REG_1;
+	data[1] = output_1_value;
+	msg = construct_i2c_message(I2C_BUS13, IOEXP_U233_ADDR, tx_len, data, 0);
+
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Unable to write ioexp output 1 register bus: %u addr: 0x%02x", msg.bus,
+			msg.target_addr);
+	}
+
+	/** Write U233 ioexp config 0 register **/
+	data[0] = PCA9555_CONFIG_REG_0;
+	data[1] = config_0_value;
+	msg = construct_i2c_message(I2C_BUS13, IOEXP_U233_ADDR, tx_len, data, 0);
+
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Unable to write ioexp config 0 register bus: %u addr: 0x%02x", msg.bus,
+			msg.target_addr);
+	}
+
+	/** Write U233 ioexp config 1 register **/
+	data[0] = PCA9555_CONFIG_REG_1;
+	data[1] = config_1_value;
+	msg = construct_i2c_message(I2C_BUS13, IOEXP_U233_ADDR, tx_len, data, 0);
+
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Unable to write ioexp config 1 register bus: %u addr: 0x%02x", msg.bus,
+			msg.target_addr);
+	}
+}

--- a/meta-facebook/at-cb/src/platform/plat_class.h
+++ b/meta-facebook/at-cb/src/platform/plat_class.h
@@ -65,6 +65,7 @@
 #define IOEXP_U228_ADDR (0x40 >> 1)
 #define IOEXP_U229_ADDR (0x42 >> 1)
 #define IOEXP_U230_ADDR (0x44 >> 1)
+#define IOEXP_U233_ADDR (0x46 >> 1)
 #define IOEXP_CARD_PRESENCE_COUNT 4
 #define IOEXP_CARD_PRESENCE_PIN_COUNT 4
 #define IOEXP_CARD_PRESENCE_MAP_VAL 0x0F
@@ -191,5 +192,6 @@ bool get_acb_power_status();
 bool get_acb_power_good_flag();
 int get_cpld_register(uint8_t offset, uint8_t *value);
 void init_accl_presence_check_work();
+void init_asic_jtag_select_ioexp();
 
 #endif

--- a/meta-facebook/at-cb/src/platform/plat_init.c
+++ b/meta-facebook/at-cb/src/platform/plat_init.c
@@ -43,6 +43,7 @@ void pal_pre_init()
 	}
 
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
+	init_asic_jtag_select_ioexp();
 	check_accl_device_presence_status_via_ioexp();
 	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
 }


### PR DESCRIPTION
# Description
- The JTAG is in the STBY domain on the ACB board. However, on the Artemis module, the JTAG is in the normal power domain.
- When the system is AC on, there may be power leakage during the system's normal power off state.
- https://metainfra.atlassian.net/browse/TGGAW-6

# Motivation
- Prevent power leakage during the system power off.
- Setting ioexp low when BIC boot up.

# Test Plan:
- Build code: Pass
- EE checking power leakage : Pass