### PR TITLE
fby4: sd: Modify SRAM to be aligned with 32KB

### DIFF
--- a/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
@@ -213,7 +213,13 @@
 };
 
 &sram0 {
-	reg = <0 DT_SIZE_K(642)>, <DT_SIZE_K(642) DT_SIZE_K(126)>;
+	/*
+	* The cacheable/non-cacheable memory regions should be aligned to 32KB.
+	* Refer to the AST1030 data sheet section of "SCUA50: CM4F Cacheable Area Statement".
+	* It is currently written as 24KB, and Aspeed will correct to 32KB in the next version.
+	* 0xa0000 is the starting offset of the non-cacheable area.
+	*/
+	reg = <0 DT_SIZE_K(640)>, <0xa0000 DT_SIZE_K(128)>;
 };
 
 &pcc {


### PR DESCRIPTION
# Summary:
Description:
- The cacheable/non-cacheable memory regions should be aligned to 32KB

# Motivation:
- If SRAM is not aligned to 32KB, it will cause unexpected cache behavior, like some postcode missing.

# Test case:
1. Get the complete postcode, without missing

a0 40 00 41 00 42 ee 43 a3 40 00 41 00 42 ee 43
a2 40 00 41 00 42 ee 43 a2 40 00 41 00 42 ee 43
b4 40 00 41 00 42 ee 43 a5 40 00 41 00 42 ee 43
ee 40 00 41 00 42 ee 43 ee 40 00 41 00 42 ee 43
ee 40 00 41 00 42 ee 43 ee 40 00 41 00 42 ee 43
ee 40 00 41 00 42 ee 43 ee 40 00 41 00 42 ee 43
ee 40 00 41 00 42 ee 43 ee 40 00 41 00 42 ee 43
a6 40 00 41 00 42 ee 43 e9 40 00 41 00 42 ee 43
ea 40 00 41 00 42 ee 43 eb 40 00 41 00 42 ee 43
ec 40 00 41 00 42 ee 43 ed 40 00 41 00 42 ee 43
ee 40 00 41 00 42 ee 43 ab 40 00 41 00 42 ee 43
e4 40 00 41 00 42 ee 43 e6 40 00 41 00 42 ee 43
ac 40 00 41 00 42 ee 43 cf 40 00 41 00 42 ee 43
b7 40 00 41 00 42 ee 43 af 40 00 41 00 42 ee 43
fc 40 e0 41 00 42 ea 43 00 40 00 41 00 42 00 43
00 40 00 41 00 42 00 43 c1 40 ab 41 00 42 ea 43
0b 40 e6 41 00 42 ea 43 0c 40 e6 41 00 42 ea 43
e1 40 ab 41 00 42 ea 43 e2 40 ab 41 00 42 ea 43
e4 40 ab 41 00 42 ea 43 e5 40 ab 41 00 42 ea 43
eb 40 ab 41 00 42 ea 43 ec 40 ab 41 00 42 ea 43
ed 40 ab 41 00 42 ea 43 ee 40 ab 41 00 42 ea 43
ef 40 ab 41 00 42 ea 43 b1 40 e0 41 00 42 ea 43
98 40 e0 41 00 42 ea 43 99 40 e0 41 00 42 ea 43
f0 40 ab 41 00 42 ea 43 12 40 e1 41 00 42 ea 43
13 40 e1 41 00 42 ea 43 f2 40 ab 41 00 42 ea 43
b7 40 e0 41 00 42 ea 43 0c 40 e6 41 00 42 ea 43
0c 40 e6 41 00 42 ea 43 00 40 ea 41 00 42 ea 43
01 40 e0 41 00 42 ea 43 46 40 e0 41 00 42 ea 43
10 40 e3 41 00 42 ea 43 16 40 e3 41 00 42 ea 43

md 0xa0000 100

[000a0000] 410040a0 43ee4200 410040a3 43ee4200
[000a0010] 410040a2 43ee4200 410040a2 43ee4200
[000a0020] 410040b4 43ee4200 410040a5 43ee4200
[000a0030] 410040ee 43ee4200 410040ee 43ee4200
[000a0040] 410040ee 43ee4200 410040ee 43ee4200
[000a0050] 410040ee 43ee4200 410040ee 43ee4200
[000a0060] 410040ee 43ee4200 410040ee 43ee4200
[000a0070] 410040a6 43ee4200 410040e9 43ee4200
[000a0080] 410040ea 43ee4200 410040eb 43ee4200
[000a0090] 410040ec 43ee4200 410040ed 43ee4200
[000a00a0] 410040ee 43ee4200 410040ab 43ee4200
[000a00b0] 410040e4 43ee4200 410040e6 43ee4200
[000a00c0] 410040ac 43ee4200 410040cf 43ee4200
[000a00d0] 410040b7 43ee4200 410040af 43ee4200
[000a00e0] 41e040fc 43ea4200 41004000 43004200
[000a00f0] 41004000 43004200 41ab40c1 43ea4200
[000a0100] 41e6400b 43ea4200 41e6400c 43ea4200
[000a0110] 41ab40e1 43ea4200 41ab40e2 43ea4200
[000a0120] 41ab40e4 43ea4200 41ab40e5 43ea4200
[000a0130] 41ab40eb 43ea4200 41ab40ec 43ea4200
[000a0140] 41ab40ed 43ea4200 41ab40ee 43ea4200
[000a0150] 41ab40ef 43ea4200 41e040b1 43ea4200
[000a0160] 41e04098 43ea4200 41e04099 43ea4200
[000a0170] 41ab40f0 43ea4200 41e14012 43ea4200
[000a0180] 41e14013 43ea4200 41ab40f2 43ea4200
[000a0190] 41e040b7 43ea4200 41e6400c 43ea4200
[000a01a0] 41e6400c 43ea4200 41ea4000 43ea4200
[000a01b0] 41e04001 43ea4200 41e04046 43ea4200
[000a01c0] 41e34010 43ea4200 41e34016 43ea4200
[000a01d0] 00000000 00000000 00000000 00000000
[000a01e0] 00000000 00000000 00000000 00000000