### PR TITLE
fby4: sd: Support BIC resets BMC by IPMI command

### DIFF
--- a/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
@@ -14,10 +14,21 @@
  * limitations under the License.
  */
 
-#include "libutil.h"
+#include <stdio.h>
+#include <stdlib.h>
 #include <logging/log.h>
+
+#include "libutil.h"
+#include "ipmb.h"
 #include "ipmi.h"
 #include "plat_ipmi.h"
+#include "plat_sys.h"
+
+enum THREAD_STATUS {
+	THREAD_SUCCESS = 0,
+	// If k_work_schedule_for_queue() is running, return 1
+	THREAD_RUNNING = 1,
+};
 
 LOG_MODULE_REGISTER(plat_ipmi);
 
@@ -27,7 +38,8 @@ bool pal_request_msg_to_BIC_from_HOST(uint8_t netfn, uint8_t cmd)
 		if ((cmd == CMD_APP_SET_ACPI_POWER) || (cmd == CMD_APP_GET_DEVICE_GUID) ||
 		    (cmd == CMD_APP_GET_BMC_GLOBAL_ENABLES) ||
 		    (cmd == CMD_APP_CLEAR_MESSAGE_FLAGS) || (cmd == CMD_APP_GET_CAHNNEL_INFO) ||
-		    (cmd == CMD_APP_GET_DEVICE_ID) || (cmd == CMD_APP_GET_SELFTEST_RESULTS)) {
+		    (cmd == CMD_APP_GET_DEVICE_ID) || (cmd == CMD_APP_GET_SELFTEST_RESULTS) ||
+		    (cmd == CMD_APP_COLD_RESET)) {
 			return true;
 		}
 	} else if (netfn == NETFN_DCMI_REQ) {
@@ -65,5 +77,38 @@ void APP_CLEAR_MESSAGE_FLAGS(ipmi_msg *msg)
 	CHECK_NULL_ARG(msg);
 
 	msg->completion_code = CC_SUCCESS;
+	return;
+}
+
+// Reset BMC
+void APP_COLD_RESET(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	switch (pal_submit_bmc_cold_reset()) {
+	case -EBUSY:
+		msg->completion_code = CC_NODE_BUSY;
+		break;
+	case -EINVAL:
+		msg->completion_code = CC_INVALID_PARAM;
+		break;
+	case -ENODEV:
+		msg->completion_code = CC_SENSOR_NOT_PRESENT;
+		break;
+	case THREAD_RUNNING:
+	case THREAD_SUCCESS:
+		msg->completion_code = CC_SUCCESS;
+		break;
+	default:
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
+		break;
+	}
+
+	msg->data_len = 0;
 	return;
 }

--- a/meta-facebook/yv4-sd/src/lib/plat_sys.c
+++ b/meta-facebook/yv4-sd/src/lib/plat_sys.c
@@ -24,10 +24,13 @@
 
 void BMC_reset_handler()
 {
-	/*TODO :
-        1. set GPIO "RST_BMC_R_N" LOW
-        2. k_msleep(10)
-        3. set GPIO "RST_BMC_R_N" HIGH
-    */
-	return;
+	gpio_set(RST_BMC_R_N, GPIO_LOW);
+	k_msleep(BMC_COLD_RESET_PULL_GPIO_INTERVAL_MS);
+	gpio_set(RST_BMC_R_N, GPIO_HIGH);
+}
+
+K_WORK_DELAYABLE_DEFINE(BMC_reset_work, BMC_reset_handler);
+int pal_submit_bmc_cold_reset()
+{
+	return k_work_schedule(&BMC_reset_work, K_MSEC(BMC_COLD_RESET_DELAY_MS));
 }

--- a/meta-facebook/yv4-sd/src/lib/plat_sys.h
+++ b/meta-facebook/yv4-sd/src/lib/plat_sys.h
@@ -17,4 +17,9 @@
 #ifndef PLAT_SYS_H
 #define PLAT_SYS_H
 
+#define BMC_COLD_RESET_DELAY_MS 1000
+#define BMC_COLD_RESET_PULL_GPIO_INTERVAL_MS 10
+
+int pal_submit_bmc_cold_reset();
+
 #endif


### PR DESCRIPTION
# Description:
Add support for the IPMI command "mc reset" (netfn: 0x06, cmd: 0x02), which resets BMC by pulling the GPIO "RST_BMC_R_N."

# Motivation:
This change aims to support BIC in resetting the BMC.

# Test Plan:
1. BMC reset by sending the IPMI command to BIC: Pass
2. BMC reset by sending the IPMI command to Host: Pass

# Test log:
1. Send the IPMI command to BIC uart:~$ platform ipmi raw 0x6 0x2 BIC self command netfn:0x6 cmd:0x2 response with cc 0x0 /*Reboot BMC*/

2. Send the IPMI command to Host

    2-1. raw command "0x6, 0x2"
    [root@20231109-643fbk1rc21 ~]# ipmitool raw 0x6 0x2
    /*Reboot BMC*/

    2-2. standard command "mc reset cold"
    [root@20231109-643fbk1rc21 ~]# ipmitool mc reset cold
    Sent cold reset command to MC
    /*Reboot BMC*/