### PR TITLE
fby4: Add new Descriptor for updating single blade BIC

### DIFF
--- a/meta-facebook/yv4-ff/src/platform/plat_mctp.h
+++ b/meta-facebook/yv4-ff/src/platform/plat_mctp.h
@@ -38,5 +38,6 @@ uint8_t plat_get_mctp_port_count();
 mctp_port *plat_get_mctp_port(uint8_t index);
 void plat_update_mctp_routing_table(uint8_t eid);
 int load_mctp_support_types(uint8_t *type_len, uint8_t *types);
+uint8_t plat_get_eid();
 
 #endif /* _PLAT_MCTP_h */

--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.c
@@ -101,12 +101,15 @@ uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uin
 		(struct pldm_query_device_identifiers_resp *)resp;
 
 	resp_p->completion_code = PLDM_SUCCESS;
-	resp_p->descriptor_count = 0x02;
+	resp_p->descriptor_count = 0x03;
 
 	uint8_t iana[PLDM_FWUP_IANA_ENTERPRISE_ID_LENGTH] = { 0x00, 0x00, 0xA0, 0x15 };
 
 	// Set the device id for ff bic
-	uint8_t deviceId[PLDM_FWUP_IANA_ENTERPRISE_ID_LENGTH] = { 0x00, 0x01 };
+	uint8_t deviceId[PLDM_PCI_DEVICE_ID_LENGTH] = { 0x00, 0x01 };
+
+	uint8_t slotNumber = plat_get_eid() / 10;
+	uint8_t slot[PLDM_ASCII_MODEL_NUMBER_SHORT_STRING_LENGTH] = { (char)(slotNumber + '0') };
 
 	uint8_t total_size_of_iana_descriptor =
 		sizeof(struct pldm_descriptor_tlv) + sizeof(iana) - 1;
@@ -114,8 +117,11 @@ uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uin
 	uint8_t total_size_of_device_id_descriptor =
 		sizeof(struct pldm_descriptor_tlv) + sizeof(deviceId) - 1;
 
+	uint8_t total_size_of_slot_descriptor =
+		sizeof(struct pldm_descriptor_tlv) + sizeof(slot) - 1;
+
 	if (sizeof(struct pldm_query_device_identifiers_resp) + total_size_of_iana_descriptor +
-		    total_size_of_device_id_descriptor >
+		    total_size_of_device_id_descriptor + total_size_of_slot_descriptor >
 	    PLDM_MAX_DATA_SIZE) {
 		LOG_ERR("QueryDeviceIdentifiers data length is over PLDM_MAX_DATA_SIZE define size %d",
 			PLDM_MAX_DATA_SIZE);
@@ -154,11 +160,27 @@ uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uin
 	memcpy(end_of_id_ptr, tlv_ptr, total_size_of_device_id_descriptor);
 	free(tlv_ptr);
 
-	resp_p->device_identifiers_len =
-		total_size_of_iana_descriptor + total_size_of_device_id_descriptor;
+	tlv_ptr = malloc(total_size_of_slot_descriptor);
+	if (tlv_ptr == NULL) {
+		LOG_ERR("Memory allocation failed!");
+		return PLDM_ERROR;
+	}
+
+	tlv_ptr->descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING;
+	tlv_ptr->descriptor_length = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING_LENGTH;
+	memcpy(tlv_ptr->descriptor_data, slot, sizeof(slot));
+
+	end_of_id_ptr += total_size_of_device_id_descriptor;
+	memcpy(end_of_id_ptr, tlv_ptr, total_size_of_slot_descriptor);
+	free(tlv_ptr);
+
+	resp_p->device_identifiers_len = total_size_of_iana_descriptor +
+					 total_size_of_device_id_descriptor +
+					 total_size_of_slot_descriptor;
 
 	*resp_len = sizeof(struct pldm_query_device_identifiers_resp) +
-		    total_size_of_iana_descriptor + total_size_of_device_id_descriptor;
+		    total_size_of_iana_descriptor + total_size_of_device_id_descriptor +
+		    total_size_of_slot_descriptor;
 
 	return PLDM_SUCCESS;
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
@@ -30,6 +30,7 @@
 #include "mp2971.h"
 #include "pt5161l.h"
 #include "raa229621.h"
+#include "plat_class.h"
 
 LOG_MODULE_REGISTER(plat_fwupdate);
 
@@ -169,12 +170,15 @@ uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uin
 		(struct pldm_query_device_identifiers_resp *)resp;
 
 	resp_p->completion_code = PLDM_SUCCESS;
-	resp_p->descriptor_count = 0x02;
+	resp_p->descriptor_count = 0x03;
 
 	uint8_t iana[PLDM_FWUP_IANA_ENTERPRISE_ID_LENGTH] = { 0x00, 0x00, 0xA0, 0x15 };
 
 	// Set the device id for sd bic
-	uint8_t deviceId[PLDM_FWUP_IANA_ENTERPRISE_ID_LENGTH] = { 0x00, 0x00 };
+	uint8_t deviceId[PLDM_PCI_DEVICE_ID_LENGTH] = { 0x00, 0x00 };
+
+	uint8_t slotNumber = get_slot_eid() / 10;
+	uint8_t slot[PLDM_ASCII_MODEL_NUMBER_SHORT_STRING_LENGTH] = { (char)(slotNumber + '0') };
 
 	uint8_t total_size_of_iana_descriptor =
 		sizeof(struct pldm_descriptor_tlv) + sizeof(iana) - 1;
@@ -182,8 +186,11 @@ uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uin
 	uint8_t total_size_of_device_id_descriptor =
 		sizeof(struct pldm_descriptor_tlv) + sizeof(deviceId) - 1;
 
+	uint8_t total_size_of_slot_descriptor =
+		sizeof(struct pldm_descriptor_tlv) + sizeof(slot) - 1;
+
 	if (sizeof(struct pldm_query_device_identifiers_resp) + total_size_of_iana_descriptor +
-		    total_size_of_device_id_descriptor >
+		    total_size_of_device_id_descriptor + total_size_of_slot_descriptor >
 	    PLDM_MAX_DATA_SIZE) {
 		LOG_ERR("QueryDeviceIdentifiers data length is over PLDM_MAX_DATA_SIZE define size %d",
 			PLDM_MAX_DATA_SIZE);
@@ -222,11 +229,27 @@ uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uin
 	memcpy(end_of_id_ptr, tlv_ptr, total_size_of_device_id_descriptor);
 	free(tlv_ptr);
 
-	resp_p->device_identifiers_len =
-		total_size_of_iana_descriptor + total_size_of_device_id_descriptor;
+	tlv_ptr = malloc(total_size_of_slot_descriptor);
+	if (tlv_ptr == NULL) {
+		LOG_ERR("Memory allocation failed!");
+		return PLDM_ERROR;
+	}
+
+	tlv_ptr->descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING;
+	tlv_ptr->descriptor_length = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING_LENGTH;
+	memcpy(tlv_ptr->descriptor_data, slot, sizeof(slot));
+
+	end_of_id_ptr += total_size_of_device_id_descriptor;
+	memcpy(end_of_id_ptr, tlv_ptr, total_size_of_slot_descriptor);
+	free(tlv_ptr);
+
+	resp_p->device_identifiers_len = total_size_of_iana_descriptor +
+					 total_size_of_device_id_descriptor +
+					 total_size_of_slot_descriptor;
 
 	*resp_len = sizeof(struct pldm_query_device_identifiers_resp) +
-		    total_size_of_iana_descriptor + total_size_of_device_id_descriptor;
+		    total_size_of_iana_descriptor + total_size_of_device_id_descriptor +
+		    total_size_of_slot_descriptor;
 
 	return PLDM_SUCCESS;
 }

--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.h
@@ -10,5 +10,6 @@ uint8_t plat_get_mctp_port_count();
 mctp_port *plat_get_mctp_port(uint8_t index);
 void send_cmd_to_dev_handler(struct k_work *work);
 void send_cmd_to_dev(struct k_timer *timer);
+uint8_t plat_get_eid();
 
 #endif /* _PLAT_MCTP_h */

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
@@ -160,12 +160,15 @@ uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uin
 		(struct pldm_query_device_identifiers_resp *)resp;
 
 	resp_p->completion_code = PLDM_SUCCESS;
-	resp_p->descriptor_count = 0x02;
+	resp_p->descriptor_count = 0x03;
 
 	uint8_t iana[PLDM_FWUP_IANA_ENTERPRISE_ID_LENGTH] = { 0x00, 0x00, 0xA0, 0x15 };
 
 	// Set the device id for ff bic
-	uint8_t deviceId[PLDM_FWUP_IANA_ENTERPRISE_ID_LENGTH] = { 0x00, 0x02 };
+	uint8_t deviceId[PLDM_PCI_DEVICE_ID_LENGTH] = { 0x00, 0x02 };
+
+	uint8_t slotNumber = plat_get_eid() / 10;
+	uint8_t slot[PLDM_ASCII_MODEL_NUMBER_SHORT_STRING_LENGTH] = { (char)(slotNumber + '0') };
 
 	uint8_t total_size_of_iana_descriptor =
 		sizeof(struct pldm_descriptor_tlv) + sizeof(iana) - 1;
@@ -173,8 +176,11 @@ uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uin
 	uint8_t total_size_of_device_id_descriptor =
 		sizeof(struct pldm_descriptor_tlv) + sizeof(deviceId) - 1;
 
+	uint8_t total_size_of_slot_descriptor =
+		sizeof(struct pldm_descriptor_tlv) + sizeof(slot) - 1;
+
 	if (sizeof(struct pldm_query_device_identifiers_resp) + total_size_of_iana_descriptor +
-		    total_size_of_device_id_descriptor >
+		    total_size_of_device_id_descriptor + total_size_of_slot_descriptor >
 	    PLDM_MAX_DATA_SIZE) {
 		LOG_ERR("QueryDeviceIdentifiers data length is over PLDM_MAX_DATA_SIZE define size %d",
 			PLDM_MAX_DATA_SIZE);
@@ -213,11 +219,27 @@ uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uin
 	memcpy(end_of_id_ptr, tlv_ptr, total_size_of_device_id_descriptor);
 	free(tlv_ptr);
 
-	resp_p->device_identifiers_len =
-		total_size_of_iana_descriptor + total_size_of_device_id_descriptor;
+	tlv_ptr = malloc(total_size_of_slot_descriptor);
+	if (tlv_ptr == NULL) {
+		LOG_ERR("Memory allocation failed!");
+		return PLDM_ERROR;
+	}
+
+	tlv_ptr->descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING;
+	tlv_ptr->descriptor_length = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING_LENGTH;
+	memcpy(tlv_ptr->descriptor_data, slot, sizeof(slot));
+
+	end_of_id_ptr += total_size_of_device_id_descriptor;
+	memcpy(end_of_id_ptr, tlv_ptr, total_size_of_slot_descriptor);
+	free(tlv_ptr);
+
+	resp_p->device_identifiers_len = total_size_of_iana_descriptor +
+					 total_size_of_device_id_descriptor +
+					 total_size_of_slot_descriptor;
 
 	*resp_len = sizeof(struct pldm_query_device_identifiers_resp) +
-		    total_size_of_iana_descriptor + total_size_of_device_id_descriptor;
+		    total_size_of_iana_descriptor + total_size_of_device_id_descriptor +
+		    total_size_of_slot_descriptor;
 
 	return PLDM_SUCCESS;
 }


### PR DESCRIPTION
Summary:
# Description
- Support update single blade SD/FF/WF BIC.

# Motivation
- User unable to update single blade BIC FW by BMC, BMC will update for all available blades together.

# Test Plan
- Check new Descriptor is added, and be able to update single blade BIC.

# Test Log

[Update single blade SD BIC]

[Recovery]
root@bmc:~# bic-update.sh sd --rcvy 5 /tmp/uart_Y4BSD.bin /tmp/pldm_sd_bic_image_with_slot Start to Recovery slot 5 sd BIC
UART is ttyS5
i2c bus is 4
Setting BIC boot from UART
Doing the recovery update...
Recovery BIC is finished.
Restart MCTP/PLDM daemon
`- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/mctp
      `- /xyz/openbmc_project/mctp/1
        |- /xyz/openbmc_project/mctp/1/50
        `- /xyz/openbmc_project/mctp/1/8
Start to Update BIC
software_id = 3207297738
Waiting for updating... 14 sec
Update done.
slot5: Do 12V cycle
Done

[BIC console]
[00:00:36.312,000] <inf> pldm: package loaded: 88% [00:00:36.459,000] <inf> pldm: package loaded: 89% [00:00:36.610,000] <inf> pldm: package loaded: 90% [00:00:36.743,000] <inf> pldm: package loaded: 91% [00:00:36.873,000] <inf> pldm: package loaded: 92% [00:00:37.005,000] <inf> pldm: package loaded: 93% [00:00:37.146,000] <inf> pldm: package loaded: 94% [00:00:37.304,000] <inf> pldm: package loaded: 95% [00:00:37.453,000] <inf> pldm: package loaded: 96% [00:00:37.602,000] <inf> pldm: package loaded: 97% [00:00:37.738,000] <inf> pldm: package loaded: 98% [00:00:37.896,000] <inf> pldm: package loaded: 99% [00:00:38.032,000] <inf> pldm: package loaded: 100% [00:00:38.064,000] <inf> util_spi: Update success
[00:00:38.074,000] <inf> pldm: Component 0 update success! [00:00:38.074,000] <inf> pldm: Transfer complete
[00:00:38.076,000] <inf> pldm: Verify complete
[00:00:38.078,000] <inf> pldm: Apply complete
[00:00:38.082,000] <inf> pldm: Activate firmware

[Update Single blade SD BIC]
root@bmc:~/chris# ./bic-update.sh sd 5 ./pldm_sd_bic_image_with_slot `- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/mctp
      `- /xyz/openbmc_project/mctp/1
        |- /xyz/openbmc_project/mctp/1/50
        `- /xyz/openbmc_project/mctp/1/8
Start to Update BIC
software_id = 3207297738
Waiting for updating... 14 sec
Update done.
Done

(BIC console was checked to make sure only slot 5 is updated)

[Update all SD BICs]
root@bmc:~/chris# bic-update.sh sd pldm_sd_bic_image_main WARNING! This will automatically update all BICs.
Continue? [y/N] y
`- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/mctp
      `- /xyz/openbmc_project/mctp/1
        |- /xyz/openbmc_project/mctp/1/50
        `- /xyz/openbmc_project/mctp/1/8
Start to Update BIC
software_id = 3207297738
Waiting for updating... 17 sec
Update done.
Done

(BIC console was checked to make sure all slots are updated)

[Check Desciptors]
root@bmc:~# pldmtool fw_update QueryDeviceIdentifiers -m 50 -v pldmtool: Tx: 80 05 01
pldmtool: Rx: 00 05 01 00 1c 00 00 00 03 01 00 04 00 00 00 a0 15 00 01 02 00 00 00 07 01 0a 00 35 00 00 00 00 00 00 00 00 00 Unknown descriptor type, type=263
{
    "EID": 50,
    "Descriptors": [
        {
            "Type": "IANA Enterprise ID",
            "Value": [
                "0000a015"
            ]
        },
        {
            "Type": "PCI Device ID",
            "Value": [
                "0000"
            ]
        }
    ]
}

[WF BIC]

[Recovery]
root@bmc:~# bic-update.sh wf --rcvy 5 ~/chris/uart_Y4BWF_with_slot.bin ~/chris/pldm_wf_bic_image_with_slot Start to Recovery slot 5 wf BIC
Check Power : On
UART is ttyS5
i2c bus is 4
Setting BIC boot from UART
Doing the recovery update...
Recovery BIC is finished.
pldmtool: Tx: 80 02 39 01 01 01 01 01
pldmtool: Rx: 00 02 39 00
Restart MCTP/PLDM daemon
`- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/mctp
      `- /xyz/openbmc_project/mctp/1
        |- /xyz/openbmc_project/mctp/1/50
        |- /xyz/openbmc_project/mctp/1/51
        |- /xyz/openbmc_project/mctp/1/52
        |- /xyz/openbmc_project/mctp/1/53
        `- /xyz/openbmc_project/mctp/1/8
Start to Update BIC
software_id = 3648103133
Waiting for updating... 20 sec
Update done.
slot5: Do 12V cycle
Done

[DC on to make sure WF BIC is online]
root@bmc:~# busctl set-property xyz.openbmc_project.State.Host${slot} /xyz/openbmc_project/state/host${slot} xyz.openbmc_project.State.Host RequestedHostTransition s "xyz.openbmc_project.State.Host.Transition.On" root@bmc:~# systemctl restart mctpd
root@bmc:~# busctl tree xyz.openbmc_project.MCTP
`- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/mctp
      `- /xyz/openbmc_project/mctp/1
        |- /xyz/openbmc_project/mctp/1/50
        |- /xyz/openbmc_project/mctp/1/51
        |- /xyz/openbmc_project/mctp/1/52
        `- /xyz/openbmc_project/mctp/1/8

[Update single blade of WF BIC]
root@bmc:~# bic-update.sh wf 5 ~/chris/pldm_wf_bic_image_with_slot `- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/mctp
      `- /xyz/openbmc_project/mctp/1
        |- /xyz/openbmc_project/mctp/1/50
        |- /xyz/openbmc_project/mctp/1/51
        |- /xyz/openbmc_project/mctp/1/52
        `- /xyz/openbmc_project/mctp/1/8
Start to Update BIC
software_id = 3648103133
Waiting for updating... 16 sec
Update done.
Done

root@bmc:~# pldmtool fw_update QueryDeviceIdentifiers -m 52 -v pldmtool: Tx: 80 05 01
pldmtool: Rx: 00 05 01 00 1c 00 00 00 03 01 00 04 00 00 00 a0 15 00 01 02 00 00 02 07 01 0a 00 35 00 00 00 00 00 00 00 00 00 Unknown descriptor type, type=263
{
    "EID": 52,
    "Descriptors": [
        {
            "Type": "IANA Enterprise ID",
            "Value": [
                "0000a015"
            ]
        },
        {
            "Type": "PCI Device ID",
            "Value": [
                "0002"
            ]
        }
    ]
}

[FF BIC]
[Recovery]

root@bmc:~# bic-update.sh ff --rcvy 5 ~/chris/uart_Y4BFF_with_slot.bin ~/chris/pldm_ff_bic_image_with_slot Start to Recovery slot 5 ff BIC
Check Power : On
UART is ttyS5
i2c bus is 4
Setting BIC boot from UART
Doing the recovery update...
Recovery BIC is finished.
pldmtool: Tx: 80 02 39 01 01 01 01 01
pldmtool: Rx: 00 02 39 00
Restart MCTP/PLDM daemon
`- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/mctp
      `- /xyz/openbmc_project/mctp/1
        |- /xyz/openbmc_project/mctp/1/50
        |- /xyz/openbmc_project/mctp/1/51
        |- /xyz/openbmc_project/mctp/1/52
        |- /xyz/openbmc_project/mctp/1/54
        `- /xyz/openbmc_project/mctp/1/8
Start to Update BIC
software_id = 3463480235
Waiting for updating... 115 sec
Update done.
slot5: Do 12V cycle
Done

[DC on to make sure FF BIC is online]
root@bmc:~# busctl set-property xyz.openbmc_project.State.Host${slot} /xyz/openbmc_project/state/host${slot} xyz.openbmc_project.State.Host RequestedHostTransition s "xyz.openbmc_project.State.Host.Transition.On" root@bmc:~# systemctl restart mctpd
root@bmc:~# busctl tree xyz.openbmc_project.MCTP
`- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/mctp
      `- /xyz/openbmc_project/mctp/1
        |- /xyz/openbmc_project/mctp/1/50
        |- /xyz/openbmc_project/mctp/1/51
        |- /xyz/openbmc_project/mctp/1/52
        `- /xyz/openbmc_project/mctp/1/8

[Update single blade of FF BIC]
root@bmc:~# bic-update.sh ff 5 ~/chris/pldm_ff_bic_image_with_slot `- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/mctp
      `- /xyz/openbmc_project/mctp/1
        |- /xyz/openbmc_project/mctp/1/50
        |- /xyz/openbmc_project/mctp/1/51
        |- /xyz/openbmc_project/mctp/1/52
        |- /xyz/openbmc_project/mctp/1/54
        |- /xyz/openbmc_project/mctp/1/55
        `- /xyz/openbmc_project/mctp/1/8
Start to Update BIC
software_id = 3463480235
Waiting for updating... 16 sec
Update done.
Done

root@bmc:~# pldmtool fw_update QueryDeviceIdentifiers -m 51 -v pldmtool: Tx: 80 05 01
pldmtool: Rx: 00 05 01 00 1c 00 00 00 03 01 00 04 00 00 00 a0 15 00 01 02 00 00 01 07 01 0a 00 35 00 00 00 00 00 00 00 00 00 Unknown descriptor type, type=263
{
    "EID": 51,
    "Descriptors": [
        {
            "Type": "IANA Enterprise ID",
            "Value": [
                "0000a015"
            ]
        },
        {
            "Type": "PCI Device ID",
            "Value": [
                "0001"
            ]
        }
    ]
}