### PR TITLE
fby4: sd: Correct response self-test result

### DIFF
--- a/common/service/host/kcs.c
+++ b/common/service/host/kcs.c
@@ -220,26 +220,6 @@ static void kcs_read_task(void *arvg0, void *arvg1, void *arvg2)
 					SAFE_FREE(kcs_buff);
 				} while (0);
 			}
-#ifdef ENABLE_PLDM
-			/*
-			Bios needs get self test and get system info before getting set system info
-			*/
-			if ((req->netfn == NETFN_APP_REQ) &&
-			    (req->cmd == CMD_APP_GET_SELFTEST_RESULTS)) {
-				uint8_t *kcs_buff;
-				kcs_buff = malloc(4);
-				if (kcs_buff == NULL) {
-					LOG_ERR("Memory allocation failed");
-					continue;
-				}
-				kcs_buff[0] = req->netfn;
-				kcs_buff[1] = req->cmd;
-				kcs_buff[2] = 0x00;
-				kcs_buff[3] = 0x55;
-				kcs_write(kcs_inst->index, kcs_buff, 4);
-				SAFE_FREE(kcs_buff);
-			}
-#endif
 			if ((req->netfn == NETFN_APP_REQ) &&
 			    (req->cmd == CMD_APP_SET_SYS_INFO_PARAMS) &&
 			    (req->data[0] == CMD_SYS_INFO_FW_VERSION)) {

--- a/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
@@ -124,6 +124,7 @@ void APP_COLD_RESET(ipmi_msg *msg)
 	msg->data_len = 0;
 	return;
 }
+
 void OEM_GET_CHASSIS_POSITION(ipmi_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
@@ -149,5 +150,24 @@ void OEM_GET_CHASSIS_POSITION(ipmi_msg *msg)
 	 */
 
 	msg->data[0] = SLOT_PRESENT + slot_id;
+	return;
+}
+
+void APP_GET_SELFTEST_RESULTS(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	// Bios needs get self test and get system info before getting set system info
+	// Using hardcode directly response
+	msg->data[0] = 0x55;
+	msg->data[1] = 0x00;
+	msg->data_len = 2;
+	msg->completion_code = CC_SUCCESS;
+
 	return;
 }


### PR DESCRIPTION
# Description
- Correct the self-test result to 0x55 0x00 and respond to BIOS.

# Motivation
- We respond to self-test results on the wrong path. That causes BIOS to get the error data and the host console to show "ERROR: Class:0; Subclass:20000".

# Test plan
- Build code: Pass
- Check log of Power on host: Pass
- Check BIOS version: Pass

# Log:
1. Check power on log of the host.
- Before fix [00000015][00000033][00000032][0000003B][0000004F][00000060][00000061]ERROR: Class:0; Subclass:20000; Operation: 1009 ERROR: Class:0; Subclass:20000; Operation: 1008
ERROR: Class:0; Subclass:20000; Operation: 1006
ERROR: Class:0; Subclass:20000; Operation: 1005
ERROR: Class:0; Subclass:20000; Operation: 1001
][00000062][00000063][00000068][00000069]...

- After fix [00000015][00000033][00000032][0000003B][0000004F][00000060][00000061][0000009A][00000062][00000063][00000068][00000069][0000006A][00000070][00000079][00000090][00000091][00000092][00000094][00000094][00000094][00000094][00000094][00000094][00000094][00000094][00000094][00000094][00000094][00000094][00000094][00000094][00000094][00000095][00000096][00000092][00000092][00000092][00000092][00000092][00000092][00000099][00000091][00000092][00000092][00000092][00000092][00000092][00000092][00000092][00000097] ...

2. Check BIOS version. root@bmc:~# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 pldmtool: Tx: 80 01 05 00 00 00 00 00 00 00 00
pldmtool: Rx: 00 01 05 00 00 00 00 00 05 00 12 00 00 01 02 00 00 03 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 4e 2f 41 00 59 34 30 30 35 00 4e 2f 41 00 00