### PR TITLE
fby4: wf: Support two CXLs update through SPI

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
@@ -24,9 +24,13 @@
 #include "plat_pldm_fw_update.h"
 #include "plat_i2c.h"
 #include "plat_pldm_sensor.h"
+#include "plat_isr.h"
+#include "plat_gpio.h"
 #include "power_status.h"
 #include "mctp_ctrl.h"
 #include "xdpe12284c.h"
+#include "ioexp_tca9555.h"
+#include "util_spi.h"
 
 LOG_MODULE_REGISTER(plat_fwupdate);
 
@@ -34,6 +38,9 @@ static bool plat_pldm_vr_i2c_info_get(int comp_identifier, uint8_t *bus, uint8_t
 static uint8_t plat_pldm_pre_vr_update(void *fw_update_param);
 static uint8_t plat_pldm_post_vr_update(void *fw_update_param);
 static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len);
+static uint8_t plat_pldm_pre_cxl_update(void *fw_update_param);
+static uint8_t plat_pldm_post_cxl_update(void *fw_update_param);
+static uint8_t pldm_cxl_update(void *fw_update_param);
 
 enum FIRMWARE_COMPONENT {
 	WF_COMPNT_BIC,
@@ -41,6 +48,8 @@ enum FIRMWARE_COMPONENT {
 	WF_COMPNT_VR_PVDDQ_CD_ASIC1,
 	WF_COMPNT_VR_PVDDQ_AB_ASIC2,
 	WF_COMPNT_VR_PVDDQ_CD_ASIC2,
+	WF_COMPNT_CXL1,
+	WF_COMPNT_CXL2,
 };
 
 /* PLDM FW update table */
@@ -109,6 +118,32 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = plat_get_vr_fw_version,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = WF_COMPNT_CXL1,
+		.comp_classification_index = 0x00,
+		.pre_update_func = plat_pldm_pre_cxl_update,
+		.update_func = pldm_cxl_update,
+		.pos_update_func = plat_pldm_post_cxl_update,
+		.inf = COMP_UPDATE_VIA_SPI,
+		.activate_method = COMP_ACT_DC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = WF_COMPNT_CXL2,
+		.comp_classification_index = 0x00,
+		.pre_update_func = plat_pldm_pre_cxl_update,
+		.update_func = pldm_cxl_update,
+		.pos_update_func = plat_pldm_post_cxl_update,
+		.inf = COMP_UPDATE_VIA_SPI,
+		.activate_method = COMP_ACT_DC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = NULL,
 	},
 };
 
@@ -310,4 +345,114 @@ static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 	ret = true;
 
 	return ret;
+}
+
+static uint8_t plat_pldm_pre_cxl_update(void *fw_update_param)
+{
+	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, 1);
+
+	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
+	uint8_t cxl_comp_id = p->comp_id;
+	uint8_t value = 0;
+
+	if (get_ioe_value(ADDR_IOE1, TCA9555_OUTPUT_PORT_REG_0, &value) != 0) {
+		return 1;
+	}
+
+	switch (cxl_comp_id) {
+	case WF_COMPNT_CXL1:
+		// Switch SPI1 MUX to BIC
+		value = SETBIT(value, IOE_P05);
+		break;
+	case WF_COMPNT_CXL2:
+		// Switch SPI2 MUX to BIC
+		value = SETBIT(value, IOE_P06);
+		break;
+	default:
+		LOG_ERR("Unknown CXL component ID %d", cxl_comp_id);
+		return 1;
+	}
+
+	set_ioe_value(ADDR_IOE1, TCA9555_OUTPUT_PORT_REG_0, value);
+
+	return 0;
+}
+
+static uint8_t plat_pldm_post_cxl_update(void *fw_update_param)
+{
+	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, 1);
+
+	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
+	uint8_t cxl_comp_id = p->comp_id;
+	uint8_t value = 0;
+
+	if (get_ioe_value(ADDR_IOE1, TCA9555_OUTPUT_PORT_REG_0, &value) != 0) {
+		return 1;
+	}
+
+	switch (cxl_comp_id) {
+	case WF_COMPNT_CXL1:
+		// Switch SPI1 MUX to CXL
+		value = CLEARBIT(value, IOE_P05);
+		break;
+	case WF_COMPNT_CXL2:
+		// Switch SPI2 MUX to CXL
+		value = CLEARBIT(value, IOE_P06);
+		break;
+	default:
+		LOG_ERR("Unknown CXL component ID %d", cxl_comp_id);
+		return 1;
+	}
+
+	set_ioe_value(ADDR_IOE1, TCA9555_OUTPUT_PORT_REG_0, value);
+
+	return 0;
+}
+
+static uint8_t pldm_cxl_update(void *fw_update_param)
+{
+	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, 1);
+
+	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
+
+	CHECK_NULL_ARG_WITH_RETURN(p->data, 1);
+
+	uint8_t update_flag = 0;
+
+	// Prepare next data offset and length
+	p->next_ofs = p->data_ofs + p->data_len;
+	p->next_len = fw_update_cfg.max_buff_size;
+
+	if (p->next_ofs < fw_update_cfg.image_size) {
+		if (p->next_ofs + p->next_len > fw_update_cfg.image_size)
+			p->next_len = fw_update_cfg.image_size - p->next_ofs;
+
+		if (((p->next_ofs % SECTOR_SZ_64K) + p->next_len) > SECTOR_SZ_64K)
+			p->next_len = SECTOR_SZ_64K - (p->next_ofs % SECTOR_SZ_64K);
+	} else {
+		// Current data is the last packet
+		// Set the next data length to 0 to inform the update completely
+		p->next_len = 0;
+		update_flag = (SECTOR_END_FLAG | NO_RESET_FLAG);
+	}
+
+	uint8_t cxl_comp_id = p->comp_id;
+	uint8_t spi_device = 0xFF;
+	switch (cxl_comp_id) {
+	case WF_COMPNT_CXL1:
+		spi_device = DEVSPI_SPI1_CS0;
+		break;
+	case WF_COMPNT_CXL2:
+		spi_device = DEVSPI_SPI2_CS0;
+		break;
+	default:
+		LOG_ERR("Unknown CXL component ID %d", cxl_comp_id);
+		return 1;
+	}
+
+	uint8_t ret = fw_update(p->data_ofs, p->data_len, p->data, update_flag, spi_device);
+
+	CHECK_PLDM_FW_UPDATE_RESULT_WITH_RETURN(p->comp_id, p->data_ofs, p->data_len, ret, 1);
+
+	return 0;
 }


### PR DESCRIPTION
# Description
- Support update CXL1 and CXL2 through SPI.

# Motivation
- Support a way to OOB update CXL1 and CXL2.

# Test plan
- Build code: Pass
- CXL1 update: Pass
- CXL2 update: Pass

# Log:
1. Update CXL1. root@bmc:~# cxl-fw-update version -m 54
Get Firmware Info for EID: 54
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.5-b5d9fe65c
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:

root@bmc:~# cxl-fw-update.sh 5 1 pldm_wf_cxl_2.0.7 software_id = 3648103133
Waiting for updating... 389 sec
Update done.
Update done. Please conduct DC cycle to load the new firmware.

root@bmc:~# cxl-fw-update version -m 54
Get Firmware Info for EID: 54
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.5-b5d9fe65c
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:

root@bmc:~# busctl set-property xyz.openbmc_project.State.Host5 /xyz/openbmc_project/state/host5 xyz.openbmc_project.State.Host RequestedHostTransition s "xyz.openbmc_project.State.Host.Transition.Reboot"

root@bmc:~# cxl-fw-update version -m 54
Get Firmware Info for EID: 54
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.7-465f8f505
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:

2. Update CXL2. root@bmc:~# cxl-fw-update version -m 55
Get Firmware Info for EID: 55
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.5-b5d9fe65c
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:
root@bmc:~# cxl-fw-update.sh 5 2 pldm_wf_cxl_2.0.7 software_id = 3648103133
Waiting for updating... 393 sec
Update done.
Update done. Please conduct DC cycle to load the new firmware.

root@bmc:~# cxl-fw-update version -m 55
Get Firmware Info for EID: 55
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.5-b5d9fe65c
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:

root@bmc:~# busctl set-property xyz.openbmc_project.State.Host5 /xyz/openbmc_project/state/host5 xyz.openbmc_project.State.Host RequestedHostTransition s "xyz.openbmc_project.State.Host.Transition.Reboot"

root@bmc:~# cxl-fw-update version -m 55
Get Firmware Info for EID: 55
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.7-465f8f505
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision: