### PR TITLE
Common: Support to query device/downstream identifier

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.c
@@ -68,6 +68,9 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = pldm_bic_activate,
 		.get_fw_version_fn = NULL,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+
 	},
 	{
 		.enable = true,
@@ -81,6 +84,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_cpld_user_code,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -94,6 +99,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -107,6 +114,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_DC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_pex_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -120,12 +129,14 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_DC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_pex_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 };
 
 static uint8_t pldm_pre_cpld_update(void *fw_update_param)
 {
-	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, 1);
+	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, PLDM_FW_UPDATE_ERROR);
 
 	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
 
@@ -134,7 +145,7 @@ static uint8_t pldm_pre_cpld_update(void *fw_update_param)
 		p->addr = CPLD_BUS_5_ADDR;
 	}
 
-	return 0;
+	return PLDM_FW_UPDATE_SUCCESS;
 }
 
 static bool get_cpld_user_code(void *info_p, uint8_t *buf, uint8_t *len)
@@ -206,11 +217,11 @@ static bool get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 
 static uint8_t pldm_pre_pex_update(void *fw_update_param)
 {
-	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, 1);
+	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, PLDM_FW_UPDATE_ERROR);
 
 	if (is_acb_power_good() == false) {
 		LOG_WRN("Can't update switch firmware because ACB dc off");
-		return 1;
+		return PLDM_FW_UPDATE_ERROR;
 	}
 
 	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
@@ -260,7 +271,7 @@ static uint8_t pldm_pex_update(void *fw_update_param)
 
 static uint8_t pldm_post_pex_update(void *fw_update_param)
 {
-	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, 1);
+	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, PLDM_FW_UPDATE_ERROR);
 
 	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
 	uint8_t pex_id = p->comp_id - CB_COMPNT_PCIE_SWITCH0;

--- a/meta-facebook/at-mc/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/at-mc/src/platform/plat_pldm_fw_update.c
@@ -54,6 +54,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = pldm_bic_activate,
 		.get_fw_version_fn = NULL,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -67,12 +69,14 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_cpld_user_code,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 };
 
 static uint8_t pldm_pre_cpld_update(void *fw_update_param)
 {
-	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, 1);
+	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, PLDM_FW_UPDATE_ERROR);
 
 	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
 
@@ -81,7 +85,7 @@ static uint8_t pldm_pre_cpld_update(void *fw_update_param)
 		p->addr = CPLD_BUS_13_ADDR;
 	}
 
-	return 0;
+	return PLDM_FW_UPDATE_SUCCESS;
 }
 
 static bool get_cpld_user_code(void *info_p, uint8_t *buf, uint8_t *len)

--- a/meta-facebook/at-mc/src/platform/plat_pldm_fw_update.h
+++ b/meta-facebook/at-mc/src/platform/plat_pldm_fw_update.h
@@ -21,6 +21,9 @@
 #include <stdint.h>
 #include "pldm_firmware_update.h"
 
+#define PLDM_FW_UPDATE_SUCCESS 0
+#define PLDM_FW_UPDATE_ERROR 1
+
 void load_pldmupdate_comp_config(void);
 void clear_pending_version(uint8_t activate_method);
 

--- a/meta-facebook/gt-cc/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/gt-cc/src/platform/plat_pldm_fw_update.c
@@ -64,6 +64,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = pldm_bic_activate,
 		.get_fw_version_fn = NULL,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -77,6 +79,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -90,6 +94,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -103,6 +109,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_DC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_pex_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -116,6 +124,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_DC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_pex_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -129,6 +139,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_DC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_pex_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -142,6 +154,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_DC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_pex_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -155,6 +169,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = get_fpga_user_code,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 };
 

--- a/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-ff/src/platform/plat_pldm_fw_update.c
@@ -55,6 +55,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = pldm_bic_activate,
 		.get_fw_version_fn = NULL,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -68,6 +70,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = plat_get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -81,6 +85,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = plat_get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 };
 

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
@@ -78,6 +78,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = pldm_bic_activate,
 		.get_fw_version_fn = NULL,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -91,6 +93,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = plat_get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -104,6 +108,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = plat_get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -117,6 +123,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_AC_PWR_CYCLE,
 		.self_act_func = NULL,
 		.get_fw_version_fn = plat_get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -130,6 +138,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = NULL,
 		.get_fw_version_fn = plat_get_retimer_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,
@@ -143,6 +153,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = NULL,
 		.get_fw_version_fn = plat_get_retimer_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 };
 

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
@@ -57,6 +57,8 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = pldm_bic_activate,
 		.get_fw_version_fn = NULL,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
 	},
 	{
 		.enable = true,


### PR DESCRIPTION
# Description
- Support PLDM command to query device/downstream identifier.
- Add apply work function to allow each device to perform platform work in the apply_state.
- Add component version string to compare firmware information.
- Add function to set/get progress percent.

# Motivation
- Support PLDM command to query device/downstream identifier.
- Add apply work function to allow each device to perform platform work in the apply_state.
- Add component version string to compare firmware information.
- Add function to set/get progress percent.
- Initialize GT/YV4 project PLDM firmware update self_apply_work_func and comp_version_str parameter.

# Test Plan
- Build code: Pass in Artemis CB/MC, GT, YV4 FF/SD/WF platform
- BIC PLDM firmware update: Pass