### PR TITLE
Artemis: cb: Fix PEX1 FW version might not be updated after BIC update

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_init.c
+++ b/meta-facebook/at-cb/src/platform/plat_init.c
@@ -45,6 +45,8 @@ void pal_pre_init()
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
 	init_asic_jtag_select_ioexp();
 	check_accl_device_presence_status_via_ioexp();
+	get_acb_power_status();
+	init_sw_heartbeat_work();
 	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
 }
 
@@ -72,8 +74,6 @@ void pal_device_init()
 
 void pal_set_sys_status()
 {
-	get_acb_power_status();
-	init_sw_heartbeat_work();
 	gpio_set(ACB_BIC_READY_N, GPIO_LOW);
 	return;
 }

--- a/meta-facebook/at-cb/src/platform/plat_isr.c
+++ b/meta-facebook/at-cb/src/platform/plat_isr.c
@@ -461,7 +461,6 @@ void ISR_FIO_BUTTON()
 void ISR_POWER_STATUS_CHANGE()
 {
 	get_acb_power_status();
-	init_sw_heartbeat_work();
 	if (get_acb_power_good_flag()) {
 		k_work_schedule_for_queue(&plat_work_q, &check_accl_card_pwr_good_work,
 					  K_MSEC(NORMAL_POWER_GOOD_CHECK_DELAY_MS));

--- a/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.c
@@ -306,13 +306,13 @@ static bool get_pex_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 		return false;
 	}
 
-	uint8_t unit_idx = ((pex89000_unit *)(cfg->priv_data))->idx;
 	if (cfg->pre_sensor_read_hook) {
 		if (cfg->pre_sensor_read_hook(cfg, cfg->pre_sensor_read_args) == false) {
 			LOG_ERR("PEX%d pre-read fail", pex_id);
 			return false;
 		}
 	}
+	uint8_t unit_idx = ((pex89000_unit *)(cfg->priv_data))->idx;
 
 	if (pex_access_engine(cfg->port, cfg->target_addr, unit_idx, pex_access_sbr_ver,
 			      &reading)) {


### PR DESCRIPTION
 # Description:
 - Currently, BMC will ask FW description after BIC update. However, PEX1 has not inited yet.

   Order: PEX0 initial -> BMC get FW version -> PEX1 initial
   0.9 sec            1.2 sec            1.9 sec

   Use CB power good for PEX ready while init stage and use PEX heartbeat for PEX ready then.

 - This commit also remove PEX ready abort function to avoid the mutex_lock while accessing CPLD register.

 # Motivation:
 - To avoid PEX1 has not finished initializtion while BMC asking FW.

 # Test Plan:
 - Upgrade and downgrade BIC version and check if PEX version can show correctly - pass

 Log:
 ```
 root@bmc-oob:~# fw-util cb --force --update bic ./ATCB.bin

Raw image detected.
updating fw on bus 3
updated: 100 %
Elapsed time:  15   sec.
Force upgrade of cb : bic succeeded
root@bmc-oob:~# fw-util cb --version
CB BIC Version: cb2024.09.02
CB CPLD Version: 00040304
CB PESW0 Version: 53.11.0b-00
CB PESW1 Version: 53.11.0b-01
CB PESW_VR Version: MPS 9d072a02, Remaining Write: 100
root@bmc-oob:~#
 ```