### PR TITLE
Artemis: cb: remove the runtime asic present check for EVT2 system

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_init.c
+++ b/meta-facebook/at-cb/src/platform/plat_init.c
@@ -64,7 +64,10 @@ void pal_post_init()
 			plat_accl_power_cable_present_check();
 		}
 	}
-	init_accl_presence_check_work();
+
+	if (board_revision > EVT2_STAGE) {
+		init_accl_presence_check_work();
+	}
 }
 
 void pal_device_init()


### PR DESCRIPTION
# Description
- EVT2 asic present logic is different from DVT or later.
- The runtime checking will cause EVT2 system show not present.

# Motivation
- Fix EVT2 module not present.

# Test Plan
- Build code: pass
- Sensor : Pass