### PR TITLE
fby4: sd: Switch I2C bus of APML by board revision

### DIFF
--- a/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
@@ -59,6 +59,12 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
 
+&i2c9 {
+	pinctrl-0 = <&pinctrl_i2c9_default>;
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
 &i3c_gr {
 	status = "okay";
 	pull-up-resistor-ohm = <2000>, <2000>, <2000>, <2000>, <2000>, <2000>;
@@ -219,7 +225,7 @@
 	* It is currently written as 24KB, and Aspeed will correct to 32KB in the next version.
 	* 0xa0000 is the starting offset of the non-cacheable area.
 	*/
-	reg = <0 DT_SIZE_K(640)>, <0xa0000 DT_SIZE_K(128)>;
+	reg = <0 DT_SIZE_K(672)>, <0xa8000 DT_SIZE_K(96)>;
 };
 
 &pcc {

--- a/meta-facebook/yv4-sd/src/platform/plat_class.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_class.h
@@ -31,7 +31,16 @@ enum SLOT_PID {
 	SLOT8_PID = 0x0023,
 };
 
+enum BOARD_REV_ID {
+	BOARD_REV_POC = 0x00,
+	BOARD_REV_EVT = 0x01,
+	BOARD_REV_DVT = 0x03,
+	BOARD_REV_PVT = 0x05,
+	BOARD_REV_MP = 0x06,
+};
+
 bool get_adc_voltage(int channel, float *voltage);
+bool get_board_rev(uint8_t *board_rev);
 uint8_t get_slot_eid();
 uint8_t get_slot_id();
 void init_platform_config();

--- a/meta-facebook/yv4-sd/src/platform/plat_i2c.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_i2c.h
@@ -27,10 +27,12 @@
 #define I2C_BUS4 3
 #define I2C_BUS5 4
 #define I2C_BUS6 5
+#define I2C_BUS10 9
 #define I2C_BUS14 13
 
 #define CPLD_IO_I2C_BUS I2C_BUS5
 #define CPLD_IO_I2C_ADDR 0x21
+#define CPLD_REG_BOARD_REVISION_ID 0x08
 
 #define I2C_BUS_MAX_NUM 14
 


### PR DESCRIPTION
# Description:
    - Enable I2C_10 in "ast1030.overlay".
    - According to Board revision, set APML's bus I2C_14(<= EVT) or I2C_10(>= DVT).
    - Spread SRAM space according to AST1030 data sheet "SCUA50".

# Motivation:
    To following Schematic "yosemitev4_dvt_sentinel dome_20240304", BIC
need to switch I2C bus of APML by board revision.

# Test Plan:
    1. Check I2C_10 & I2C_14 are available: Pass
    2. BIC gets the correct board revision: Pass
    3. BIC reads CPU temperature through APML: Pass

# Test Log:
1.
     uart:~$ i2c scan I2C_9
          0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
     00:             -- -- -- -- -- -- -- -- -- -- -- --
     10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
     20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
     30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
     40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
     50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
     60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
     70: -- -- -- -- -- -- -- --
     0 devices found on I2C_9

     uart:~$ i2c scan I2C_13
          0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
     00:             -- -- -- -- -- -- -- -- -- -- -- --
     10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
     20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
     30: -- -- -- -- -- -- -- -- -- -- -- -- 3c -- -- --
     40: -- -- -- -- -- -- -- -- -- -- -- -- 4c -- -- --
     50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
     60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
     70: -- -- -- -- -- -- -- --
     2 devices found on I2C_13
2.
     EVT board:
     [00:26:18.362,000] <wrn> power_status: POST_COMPLETE: yes
     [00:26:18.363,000] <inf> plat_class: Board revision 0x1 // EVT
     DVT board:
     [00:26:18.362,000] <wrn> power_status: POST_COMPLETE: yes
     [00:26:18.363,000] <inf> plat_class: Board revision 0x3 // DVT
3.
     root@bmc:/usr/libexec/phosphor-state-manager# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/temperature/MB_CPU_TEMP_C_4_40
     NAME                                                  TYPE      SIGNATURE RESULT/VALUE                             FLAGS
     org.freedesktop.DBus.Introspectable                   interface -         -                                        -
     .Introspect                                           method    -         s                                        -

     .Value                                                property  d         65.625                                   emits-change writable