### PR TITLE
fby4: wf: Change PWR_ON_RST_N_R and SYS_RST_N_R sequence

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
@@ -23,7 +23,7 @@
 #define CXL_READY_SECONDS 30
 #define CHK_PWR_DELAY_MSEC 100
 #define SYS_CLK_STABLE_DELAY_MSEC 25
-#define PWR_ON_RST_DELAY_MSEC 25
+#define PWR_RST_DELAY_MSEC 25
 #define P1V8_POWER_OFF_DELAY_MSEC 3500
 
 #define POWER_SEQ_CTRL_STACK_SIZE 1000
@@ -87,8 +87,8 @@ enum POWER_OFF_STAGE {
 };
 
 void set_mb_dc_status(uint8_t gpio_num);
-void enable_asic1_power_on_rst();
-void enable_asic2_power_on_rst();
+void enable_asic1_rst();
+void enable_asic2_rst();
 bool is_power_controlled(int cxl_id, int power_pin, uint8_t check_power_status, char *power_name);
 int check_powers_enabled(int cxl_id, int pwr_stage);
 int check_powers_disabled(int cxl_id, int pwr_stage);


### PR DESCRIPTION
# Description
- Change the PWR_ON_RST_N_R and SYS_RST_N_R power-on sequence. Control those power on after PVTT_CD is power good.

# Motivation
- According to section 11.1 Reset Timing of Broadcom 2TV6 spec., adjust the power sequence.

# Test plan:
- Build code: Pass
- Check CXL power: Pass

# Log
1. Check CXL power on successful. [BMC console]
root@bmc:~# cxl-fw-update version -m 44
Get Firmware Info for EID: 44
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.8-0dc0bf094
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:
root@bmc:~# cxl-fw-update version -m 45
Get Firmware Info for EID: 45
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.8-0dc0bf094
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:
root@bmc:~# busctl set-property xyz.openbmc_project.State.Host4 /xyz/openbmc_project/state/host4 xyz.openbmc_project.State.Hos   t RequestedHostTransition s "xyz.openbmc_project.State.Host.Transition.Reboot"
root@bmc:~# gpioget $(basename ""/sys/bus/i2c/devices/3-0023/""*gpiochip*) 16
0
root@bmc:~# gpioget $(basename ""/sys/bus/i2c/devices/3-0023/""*gpiochip*) 16
1
root@bmc:~# cxl-fw-update version -m 44
Get Firmware Info for EID: 44
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.8-0dc0bf094
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:
root@bmc:~# cxl-fw-update version -m 45
Get Firmware Info for EID: 45
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.8-0dc0bf094
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:

[BIC console]
...
[00:02:28.686,000] <inf> plat_power_seq: CXL 1 power on success [00:02:29.211,000] <inf> plat_power_seq: CXL 2 power on success [00:02:29.211,000] <wrn> power_status: DC_STATUS: on ...
[00:02:59.212,000] <inf> plat_power_seq: CXL1 is ready [00:02:59.212,000] <inf> plat_power_seq: CXL2 is ready