### PR TITLE
fby4: sd: Support to read DIMM PMIC power

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_dimm.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_dimm.h
@@ -26,6 +26,13 @@
 #define DIMM_SPD_E_K_ADDR (0xA8 >> 1)
 #define DIMM_SPD_F_L_ADDR (0xAA >> 1)
 
+#define DIMM_PMIC_A_G_ADDR 0x48
+#define DIMM_PMIC_B_H_ADDR 0x49
+#define DIMM_PMIC_C_I_ADDR 0x4A
+#define DIMM_PMIC_D_J_ADDR 0x4B
+#define DIMM_PMIC_E_K_ADDR 0x4C
+#define DIMM_PMIC_F_L_ADDR 0x4D
+
 #define CPLD_ADDR 0x21
 
 #define MAX_LEN_I3C_GET_PMIC_PWR 1
@@ -44,6 +51,7 @@ typedef struct dimm_info {
 	uint8_t is_present;
 	bool is_ready_monitor;
 	uint8_t spd_temp_data[MAX_LEN_I3C_GET_SPD_TEMP];
+	uint8_t pmic_pwr_data[MAX_LEN_I3C_GET_PMIC_PWR];
 } dimm_info;
 
 enum NUMBER_DIMM_TEMP {
@@ -59,6 +67,21 @@ enum NUMBER_DIMM_TEMP {
 	NUM_DIMM_J_TEMP,
 	NUM_DIMM_K_TEMP,
 	NUM_DIMM_L_TEMP,
+};
+
+enum NUMBER_DIMM_PMIC_PWR {
+	NUM_DIMM_A_PMIC_PWR = 0x0056,
+	NUM_DIMM_B_PMIC_PWR,
+	NUM_DIMM_C_PMIC_PWR,
+	NUM_DIMM_D_PMIC_PWR,
+	NUM_DIMM_E_PMIC_PWR,
+	NUM_DIMM_F_PMIC_PWR,
+	NUM_DIMM_G_PMIC_PWR,
+	NUM_DIMM_H_PMIC_PWR,
+	NUM_DIMM_I_PMIC_PWR,
+	NUM_DIMM_J_PMIC_PWR,
+	NUM_DIMM_K_PMIC_PWR,
+	NUM_DIMM_L_PMIC_PWR,
 };
 
 enum DIMM_ID {
@@ -86,10 +109,10 @@ enum DIMM_PRSNT_STATUS {
 void start_get_dimm_info_thread();
 void get_dimm_info_handler();
 uint8_t sensor_num_map_dimm_id(uint8_t sensor_num);
-void get_spd_temp_raw_data(int dimm_index, uint8_t *data);
 int pal_get_spd_temp(uint8_t sensor_num, uint8_t *data);
+int pal_get_pmic_pwr(uint8_t sensor_num, uint8_t *data);
 void clear_unaccessible_dimm_data(uint8_t dimm_id);
-int switch_i3c_dimm_mux(uint8_t i3c_mux_switch_data);
+int switch_i3c_dimm_mux(uint8_t i3c_ctrl_mux_data);
 int all_brocast_ccc(I3C_MSG *i3c_msg);
 void init_dimm_prsnt_status();
 uint8_t get_dimm_present(uint8_t dimm_id);

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -4449,8 +4449,834 @@ pldm_sensor_info plat_pldm_sensor_dimm_table[] = {
 			.pre_sensor_read_hook = pre_dimm_i3c_read,
 		},
 	},
+	{
+		{
+			// DIMMA_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
 
-	// TODO: support DIMM PMIC PWR
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_A_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x000D, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_A_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_A_G_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
+	{
+		{
+			// DIMMB_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_B_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x000E, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_B_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_B_H_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
+	{
+		{
+			// DIMMC_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_C_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x000F, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_C_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_C_I_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
+	{
+		{
+			// DIMMD_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_D_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x0010, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_D_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_D_J_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
+	{
+		{
+			// DIMME_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_E_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x0011, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_E_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_E_K_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
+	{
+		{
+			// DIMMF_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_F_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x0012, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_F_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_F_L_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
+	{
+		{
+			// DIMMG_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_G_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x0013, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_G_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_A_G_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
+	{
+		{
+			// DIMMH_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_H_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x0014, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_H_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_B_H_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
+	{
+		{
+			// DIMMI_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_I_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x0015, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_I_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_C_I_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
+	{
+		{
+			// DIMMJ_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_J_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x0016, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_J_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_D_J_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
+	{
+		{
+			// DIMMK_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_K_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x0017, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_K_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_E_K_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
+	{
+		{
+			// DIMML_PMIC_PWR_W
+			/*** PDR common header***/
+			{
+				0x00000000, //uint32_t record_handle
+				0x01, //uint8_t PDR_header_version
+				PLDM_NUMERIC_SENSOR_PDR, //uint8_t PDR_type
+				0x0000, //uint16_t record_change_number
+				0x0000, //uint16_t data_length
+			},
+
+			/***numeric sensor format***/
+			0x0000, //uint16_t PLDM_terminus_handle;
+			NUM_DIMM_L_PMIC_PWR, //uint16_t sensor_id;
+			0x8E, //uint16_t entity_type;
+			0x0018, //uint16_t entity_instance_number;
+			0x0000, //uint16_t container_id;
+			0x00, //uint8_t sensor_init;
+			0x01, //uint8_t sensor_auxiliary_names_pdr;
+			0x07, //uint8_t base_unit;
+			-2, //int8_t unit_modifier;
+			0x00, //uint8_t rate_unit;
+			0x00, //uint8_t base_oem_unit_handle;
+			0x00, //uint8_t aux_unit;
+			0x00, //int8_t aux_unit_modifier;
+			0x00, //uint8_t auxrate_unit;
+			0x00, //uint8_t rel;
+			0x00, //uint8_t aux_oem_unit_handle;
+			0x00, //uint8_t is_linear;
+			0x4, //uint8_t sensor_data_size;
+			1, //real32_t resolution;
+			0, //real32_t offset;
+			0x0000, //uint16_t accuracy;
+			0x00, //uint8_t plus_tolerance;
+			0x00, //uint8_t minus_tolerance;
+			0x00000000, //uint32_t hysteresis;
+			0xFF, //uint8_t supported_thresholds;
+			0x00, //uint8_t threshold_and_hysteresis_volatility;
+			0, //real32_t state_transition_interval;
+			UPDATE_INTERVAL_1S, //real32_t update_interval;
+			0x0000639C, //uint32_t max_readable;
+			0x00000000, //uint32_t min_readable;
+			0x04, //uint8_t range_field_format;
+			0xFF, //uint8_t range_field_support;
+			0x00000000, //uint32_t nominal_value;
+			0x00000000, //uint32_t normal_max;
+			0x00000000, //uint32_t normal_min;
+			0x00000C1A, //uint32_t warning_high;
+			0x00000000, //uint32_t warning_low;
+			0x00000C37, //uint32_t critical_high;
+			0x00000000, //uint32_t critical_low;
+			0x00000000, //uint32_t fatal_high;
+			0x00000000, //uint32_t fatal_low;
+		},
+		.update_time = 0,
+		{
+			.num = NUM_DIMM_L_PMIC_PWR,
+			.type = sensor_dev_i3c_dimm,
+			.port = I3C_BUS3,
+			.target_addr = DIMM_PMIC_F_L_ADDR,
+			.offset = DIMM_PMIC_SWA_PWR,
+			.access_checker = post_access,
+			.sample_count = SAMPLE_COUNT_DEFAULT,
+			.cache = 0,
+			.cache_status = PLDM_SENSOR_INITIALIZING,
+			.pre_sensor_read_hook = pre_dimm_i3c_read,
+		},
+	},
 };
 
 PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
@@ -4533,7 +5359,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0005,
+		.sensor_id = NUM_DIMM_A_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -4550,7 +5376,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0006,
+		.sensor_id = NUM_DIMM_B_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -4567,7 +5393,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0007,
+		.sensor_id = NUM_DIMM_C_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -4584,7 +5410,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0008,
+		.sensor_id = NUM_DIMM_D_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -4601,7 +5427,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0009,
+		.sensor_id = NUM_DIMM_E_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -4618,7 +5444,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x000A,
+		.sensor_id = NUM_DIMM_F_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -4635,7 +5461,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x000B,
+		.sensor_id = NUM_DIMM_G_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -4652,7 +5478,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x000C,
+		.sensor_id = NUM_DIMM_H_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -4669,7 +5495,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x000D,
+		.sensor_id = NUM_DIMM_I_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -4686,7 +5512,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x000E,
+		.sensor_id = NUM_DIMM_J_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -4703,7 +5529,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x000F,
+		.sensor_id = NUM_DIMM_K_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -4720,7 +5546,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0010,
+		.sensor_id = NUM_DIMM_L_TEMP,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5485,7 +6311,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0056,
+		.sensor_id = NUM_DIMM_A_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5502,7 +6328,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0057,
+		.sensor_id = NUM_DIMM_B_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5519,7 +6345,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0058,
+		.sensor_id = NUM_DIMM_C_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5536,7 +6362,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0059,
+		.sensor_id = NUM_DIMM_D_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5553,7 +6379,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x005A,
+		.sensor_id = NUM_DIMM_E_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5570,7 +6396,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x005B,
+		.sensor_id = NUM_DIMM_F_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5587,7 +6413,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x005C,
+		.sensor_id = NUM_DIMM_G_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5604,7 +6430,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x005D,
+		.sensor_id = NUM_DIMM_H_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5621,7 +6447,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x005E,
+		.sensor_id = NUM_DIMM_I_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5638,7 +6464,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x005F,
+		.sensor_id = NUM_DIMM_J_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5655,7 +6481,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0060,
+		.sensor_id = NUM_DIMM_K_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
@@ -5672,7 +6498,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 			.data_length = 0x0000,
 		},
 		.terminus_handle = 0x0000,
-		.sensor_id = 0x0061,
+		.sensor_id = NUM_DIMM_L_PMIC_PWR,
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",


### PR DESCRIPTION
# Description:
    BIC can monitor DIMMs' PMIC power and BMC can read them.

# Motivation:
    1. Add the feature of reading PMIC power within the "Get DIMM information" thread.
    2. Add PMIC sensors' information to the "numeric sensor table" and "aux sensor names PDR table".
    3. Spread SRAM space according to AST1030 data sheet "SCUA50".

# Test plan:
    Get PMIC power information by Redfish: Pass

# Test log:
Get PMIC power information by Redfish:
    /*Installed DIMM*/
    jeff@ber300-f5a-dhcp:~/Image/YV4/BIC/Test$ curl -u root:0penBmc -k https://192.168.88.127/redfish/v1/Chassis/PLDM_Device_40/Sensors/power_MB_DIMM_I_PWR_W_94_40
    {
    "@odata.id": "/redfish/v1/Chassis/PLDM_Device_40/Sensors/power_MB_DIMM_I_PWR_W_94_40",
    "@odata.type": "#Sensor.v1_2_0.Sensor",
    "Id": "power_MB_DIMM_I_PWR_W_94_40",
    "Name": "MB DIMM I PWR W 94 40",
    "Reading": 1.37,
    "ReadingRangeMax": 255.0,
    "ReadingRangeMin": 0.0,
    "ReadingType": "Power",
    "ReadingUnits": "W",
    "Status": {
        "Health": "Warning",
        "State": "Enabled"
    },
    "Thresholds": {
        "LowerCaution": {
        "Reading": 0.0
        },
        "LowerCritical": {
        "Reading": 0.0
        },
        "UpperCaution": {
        "Reading": 0.0
        },
        "UpperCritical": {
        "Reading": 30.98
        }
    }
    /*Other DIMMs*/
    jeff@ber300-f5a-dhcp:~/Image/YV4/BIC/Test$  curl -u root:0penBmc -k https://192.168.88.127/redfish/v1/Chassis/PLDM_Device_40/Sensors/power_MB_DIMM_J_PWR_W_95_40
    {
    "@odata.id": "/redfish/v1/Chassis/PLDM_Device_40/Sensors/power_MB_DIMM_J_PWR_W_95_40",
    "@odata.type": "#Sensor.v1_2_0.Sensor",
    "Id": "power_MB_DIMM_J_PWR_W_95_40",
    "Name": "MB DIMM J PWR W 95 40",
    "Reading": null,
    "ReadingRangeMax": 255.0,
    "ReadingRangeMin": 0.0,
    "ReadingType": "Power",
    "ReadingUnits": "W",
    "Status": {
        "Health": "OK",
        "State": "UnavailableOffline"
    },
    "Thresholds": {
        "LowerCaution": {
        "Reading": 0.0
        },
        "LowerCritical": {
        "Reading": 0.0
        },
        "UpperCaution": {
        "Reading": 0.0
        },
        "UpperCritical": {
        "Reading": 30.98
        }
    }