### PR TITLE
fby4: sd: Update threshold on sensor table ver_20240229

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -130,7 +130,7 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00, //uint8_t sensor_init;
 			0x01, //uint8_t sensor_auxiliary_names_pdr;
 			0x05, //uint8_t base_unit;
-			-3, //int8_t unit_modifier;
+			-2, //int8_t unit_modifier;
 			0x00, //uint8_t rate_unit;
 			0x00, //uint8_t base_oem_unit_handle;
 			0x00, //uint8_t aux_unit;
@@ -159,8 +159,8 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00000000, //uint32_t normal_min;
 			0x00000000, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000000, //uint32_t critical_high;
-			0x00000000, //uint32_t critical_low;
+			0x000000BC, //uint32_t critical_high;
+			0x000000AC, //uint32_t critical_low;
 			0x00000000, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 		},
@@ -227,10 +227,10 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00000000, //uint32_t normal_min;
 			0x00056496, //uint32_t warning_high;
 			0x0004B01E, //uint32_t warning_low;
-			0x00057279, //uint32_t critical_high;
+			0x0005721F, //uint32_t critical_high;
 			0x0004A3DF, //uint32_t critical_low;
-			0x0005D750, //uint32_t fatal_high;
-			0x00040740, //uint32_t fatal_low;
+			0x000617C4, //uint32_t fatal_high;
+			0x00038658, //uint32_t fatal_low;
 		},
 		.update_time = 0,
 		{
@@ -336,7 +336,7 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00, //uint8_t sensor_init;
 			0x01, //uint8_t sensor_auxiliary_names_pdr;
 			0x05, //uint8_t base_unit;
-			-3, //int8_t unit_modifier;
+			-2, //int8_t unit_modifier;
 			0x00, //uint8_t rate_unit;
 			0x00, //uint8_t base_oem_unit_handle;
 			0x00, //uint8_t aux_unit;
@@ -365,8 +365,8 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00000000, //uint32_t normal_min;
 			0x00000000, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000000, //uint32_t critical_high;
-			0x00000000, //uint32_t critical_low;
+			0x0000015B, //uint32_t critical_high;
+			0x00000138, //uint32_t critical_low;
 			0x00000000, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 		},
@@ -431,9 +431,9 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00000000, //uint32_t nominal_value;
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
-			0x0000DB24, //uint32_t warning_high;
+			0x0000D12E, //uint32_t warning_high;
 			0x0000B5D6, //uint32_t warning_low;
-			0x0000DD4A, //uint32_t critical_high;
+			0x0000D33B, //uint32_t critical_high;
 			0x0000B3FB, //uint32_t critical_low;
 			0x0000E290, //uint32_t fatal_high;
 			0x00009C40, //uint32_t fatal_low;
@@ -472,7 +472,7 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00, //uint8_t sensor_init;
 			0x01, //uint8_t sensor_auxiliary_names_pdr;
 			0x05, //uint8_t base_unit;
-			-0x03, //int8_t unit_modifier;
+			-2, //int8_t unit_modifier;
 			0x00, //uint8_t rate_unit;
 			0x00, //uint8_t base_oem_unit_handle;
 			0x00, //uint8_t aux_unit;
@@ -499,12 +499,12 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00000000, //uint32_t nominal_value;
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
-			0x000036FC, //uint32_t warning_high;
-			0x0000270C, //uint32_t warning_low;
-			0x00003786, //uint32_t critical_high;
-			0x000026A6, //uint32_t critical_low;
-			0x00000000, //uint32_t fatal_high;
-			0x00000000, //uint32_t fatal_low;
+			0x00000528, //uint32_t warning_high;
+			0x00000438, //uint32_t warning_low;
+			0x0000053A, //uint32_t critical_high;
+			0x0000042C, //uint32_t critical_low;
+			0x0000059A, //uint32_t fatal_high;
+			0x000003F0, //uint32_t fatal_low;
 		},
 		.update_time = 0,
 		{
@@ -540,7 +540,7 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00, //uint8_t sensor_init;
 			0x01, //uint8_t sensor_auxiliary_names_pdr;
 			0x05, //uint8_t base_unit;
-			-0x03, //int8_t unit_modifier;
+			-2, //int8_t unit_modifier;
 			0x00, //uint8_t rate_unit;
 			0x00, //uint8_t base_oem_unit_handle;
 			0x00, //uint8_t aux_unit;
@@ -567,12 +567,12 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00000000, //uint32_t nominal_value;
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
-			0x000036FC, //uint32_t warning_high;
-			0x0000270C, //uint32_t warning_low;
-			0x00003786, //uint32_t critical_high;
-			0x000026A6, //uint32_t critical_low;
-			0x00000000, //uint32_t fatal_high;
-			0x00000000, //uint32_t fatal_low;
+			0x00000528, //uint32_t warning_high;
+			0x00000438, //uint32_t warning_low;
+			0x0000053A, //uint32_t critical_high;
+			0x0000042C, //uint32_t critical_low;
+			0x0000059A, //uint32_t fatal_high;
+			0x000003F0, //uint32_t fatal_low;
 		},
 		.update_time = 0,
 		{
@@ -676,7 +676,7 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00, //uint8_t sensor_init;
 			0x01, //uint8_t sensor_auxiliary_names_pdr;
 			0x05, //uint8_t base_unit;
-			-4, //int8_t unit_modifier;
+			-5, //int8_t unit_modifier;
 			0x00, //uint8_t rate_unit;
 			0x00, //uint8_t base_oem_unit_handle;
 			0x00, //uint8_t aux_unit;
@@ -703,12 +703,12 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00000000, //uint32_t nominal_value;
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
-			0x00004B4E, //uint32_t warning_high;
-			0x00004176, //uint32_t warning_low;
-			0x00004C0B, //uint32_t critical_high;
-			0x000040CB, //uint32_t critical_low;
-			0x00005190, //uint32_t fatal_high;
-			0x00003840, //uint32_t fatal_low;
+			0x0002E64A, //uint32_t warning_high;
+			0x00029580, //uint32_t warning_low;
+			0x0002ED91, //uint32_t critical_high;
+			0x00028EC0, //uint32_t critical_low;
+			0x00032FA0, //uint32_t fatal_high;
+			0x00023280, //uint32_t fatal_low;
 		},
 		.update_time = 0,
 		{
@@ -2812,7 +2812,7 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
 			0x01, //uint8_t sensor_auxiliary_names_pdr;
 			0x06, //uint8_t base_unit;
-			-4, //int8_t unit_modifier;
+			-5, //int8_t unit_modifier;
 			0x00, //uint8_t rate_unit;
 			0x00, //uint8_t base_oem_unit_handle;
 			0x00, //uint8_t aux_unit;
@@ -2841,9 +2841,9 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			0x00000000, //uint32_t nominal_value;
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
-			0x00000000, //uint32_t warning_high;
+			0x000187B3, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000000, //uint32_t critical_high;
+			0x00019A5A, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
 			0x00000000, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
@@ -2910,9 +2910,9 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			0x00000000, //uint32_t nominal_value;
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
-			0x00000000, //uint32_t warning_high;
+			0x00004383, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000000, //uint32_t critical_high;
+			0x000046BA, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
 			0x00000000, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
@@ -2952,7 +2952,7 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
 			0x01, //uint8_t sensor_auxiliary_names_pdr;
 			0x07, //uint8_t base_unit;
-			-4, //int8_t unit_modifier;
+			-5, //int8_t unit_modifier;
 			0x00, //uint8_t rate_unit;
 			0x00, //uint8_t base_oem_unit_handle;
 			0x00, //uint8_t aux_unit;
@@ -2979,11 +2979,11 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			0x00000000, //uint32_t nominal_value;
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
-			0x00000000, //uint32_t warning_high;
+			0x00100D7C, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000000, //uint32_t critical_high;
+			0x001035C6, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x00000000, //uint32_t fatal_high;
+			0x00105E10, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 
 		},
@@ -3021,7 +3021,7 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			PDR_SENSOR_USEINIT_PDR, //uint8_t sensor_init;
 			0x01, //uint8_t sensor_auxiliary_names_pdr;
 			0x07, //uint8_t base_unit;
-			-4, //int8_t unit_modifier;
+			-5, //int8_t unit_modifier;
 			0x00, //uint8_t rate_unit;
 			0x00, //uint8_t base_oem_unit_handle;
 			0x00, //uint8_t aux_unit;
@@ -3048,11 +3048,11 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			0x00000000, //uint32_t nominal_value;
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
-			0x00000000, //uint32_t warning_high;
+			0x001BADD0, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000000, //uint32_t critical_high;
+			0x001BF348, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x00000000, //uint32_t fatal_high;
+			0x001C38C0, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 		},
 		.update_time = 0,
@@ -3089,7 +3089,7 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			0x00, //uint8_t sensor_init;
 			0x01, //uint8_t sensor_auxiliary_names_pdr;
 			0x05, //uint8_t base_unit;
-			-2, //int8_t unit_modifier;
+			-3, //int8_t unit_modifier;
 			0x00, //uint8_t rate_unit;
 			0x00, //uint8_t base_oem_unit_handle;
 			0x00, //uint8_t aux_unit;
@@ -3116,12 +3116,12 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			0x00000000, //uint32_t nominal_value;
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
-			0x00000540, //uint32_t warning_high;
-			0x00000420, //uint32_t warning_low;
-			0x0000054C, //uint32_t critical_high;
-			0x00000414, //uint32_t critical_low;
-			0x00000599, //uint32_t fatal_high;
-			0x000003F1, //uint32_t fatal_low;
+			0x00003480, //uint32_t warning_high;
+			0x00002940, //uint32_t warning_low;
+			0x000034F8, //uint32_t critical_high;
+			0x000028C8, //uint32_t critical_low;
+			0x000037FD, //uint32_t fatal_high;
+			0x0000276B, //uint32_t fatal_low;
 		},
 		.update_time = 0,
 		{
@@ -3157,7 +3157,7 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			0x00, //uint8_t sensor_init;
 			0x01, //uint8_t sensor_auxiliary_names_pdr;
 			0x05, //uint8_t base_unit;
-			-2, //int8_t unit_modifier;
+			-3, //int8_t unit_modifier;
 			0x00, //uint8_t rate_unit;
 			0x00, //uint8_t base_oem_unit_handle;
 			0x00, //uint8_t aux_unit;
@@ -3184,12 +3184,13 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			0x00000000, //uint32_t nominal_value;
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
-			0x00000540, //uint32_t warning_high;
-			0x00000420, //uint32_t warning_low;
-			0x0000054C, //uint32_t critical_high;
-			0x00000414, //uint32_t critical_low;
-			0x00000599, //uint32_t fatal_high;
-			0x000003F1, //uint32_t fatal_low;
+			0x00003480, //uint32_t warning_high;
+			0x00002940, //uint32_t warning_low;
+			0x000034F8, //uint32_t critical_high;
+			0x000028C8, //uint32_t critical_low;
+			0x000037FD, //uint32_t fatal_high;
+			0x0000276B, //uint32_t fatal_low;
+
 		},
 		.update_time = 0,
 		{


### PR DESCRIPTION
Summary:
# Description:
Update sensor threshold by following sensor table ver_20240229

# Motivation:
Sensor table threhold have been tuned since ver_20240229

# Test Plan:
Get sensor reading by mfg-tool: pass

# Test Log:
root@bmc:/tmp# mfg-tool sensor-display
    "MB_ADC_PVDD18_S5_VOLT_V_33_50": {
        "critical": {
            "high": 1.8800000000000001,
            "low": 1.72
        },
        "max": 0.0,
        "min": 0.0,
        "status": "warning",
        "unit": "Volts",
        "value": 1.8,
        "warning": {
            "high": 0.0,
            "low": 0.0
        }
    },
    "MB_ADC_PVDD33_S5_VOLT_V_36_50": {
        "critical": {
            "high": 3.47,
            "low": 3.12
        },
        "max": 0.0,
        "min": 0.0,
        "status": "warning",
        "unit": "Volts",
        "value": 3.2800000000000002,
        "warning": {
            "high": 0.0,
            "low": 0.0
        }
    },