### PR TITLE
fby4: sd: Support raa229621 VR sensor reading

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -27,8 +27,11 @@
 #include "plat_i2c.h"
 #include "plat_pldm_sensor.h"
 #include "plat_dimm.h"
+#include "plat_gpio.h"
 
 LOG_MODULE_REGISTER(plat_pldm_sensor);
+
+void plat_pldm_sensor_change_vr_dev();
 
 static struct pldm_sensor_thread pal_pldm_sensor_thread[MAX_SENSOR_THREAD_ID] = {
 	// thread id, thread name
@@ -5775,6 +5778,7 @@ pldm_sensor_info *plat_pldm_sensor_load(int thread_id)
 	case ADC_SENSOR_THREAD_ID:
 		return plat_pldm_sensor_adc_table;
 	case VR_SENSOR_THREAD_ID:
+		plat_pldm_sensor_change_vr_dev();
 		return plat_pldm_sensor_vr_table;
 	case MB_TEMP_SENSOR_THREAD_ID:
 		return plat_pldm_sensor_mb_temp_table;
@@ -5881,4 +5885,61 @@ void plat_load_aux_sensor_names_pdr_table(PDR_sensor_auxiliary_names *aux_sensor
 {
 	memcpy(aux_sensor_name_table, &plat_pdr_sensor_aux_names_table,
 	       sizeof(plat_pdr_sensor_aux_names_table));
+}
+
+void plat_pldm_sensor_change_vr_dev()
+{
+	uint8_t vr_dev = VR_DEVICE_UNKNOWN;
+	if (plat_pldm_sensor_get_vr_dev(&vr_dev) != GET_VR_DEV_SUCCESS) {
+		LOG_ERR("Unable to change the VR device due to its unknown status.");
+		return;
+	}
+
+	for (int index = 0; index < plat_pldm_sensor_get_sensor_count(VR_SENSOR_THREAD_ID);
+	     index++) {
+		plat_pldm_sensor_vr_table[index].pldm_sensor_cfg.type = vr_dev;
+	}
+}
+
+uint8_t plat_pldm_sensor_get_vr_dev(uint8_t *vr_dev)
+{
+	/*
+	 * GPIO VR_TYPE_0 and VR_TYPE_1 are used to determine the VR type.
+	 * 
+	 * VR_TYPE[1:0]
+	 * 00 - MPS
+	 * 10 - RNS
+	 * 01 - IFX
+	 * 11 - TI
+	 */
+
+	int high_byte = gpio_get(VR_TYPE_1);
+	int low_byte = gpio_get(VR_TYPE_0);
+
+	if (high_byte == HIGH_ACTIVE) {
+		if (low_byte == HIGH_ACTIVE) {
+			*vr_dev = sensor_dev_tps53689;
+		} else if (low_byte == HIGH_INACTIVE) {
+			*vr_dev = sensor_dev_raa229621;
+		} else {
+			goto error_exit;
+		}
+	} else if (high_byte == HIGH_INACTIVE) {
+		if (low_byte == HIGH_ACTIVE) {
+			*vr_dev = sensor_dev_xdpe19283b;
+		} else if (low_byte == HIGH_INACTIVE) {
+			*vr_dev = sensor_dev_mp2856gut;
+		} else {
+			goto error_exit;
+		}
+	} else {
+		goto error_exit;
+	}
+	return GET_VR_DEV_SUCCESS;
+
+error_exit:
+	LOG_ERR("Unable to get VR device due to unknown VR_TYPE_1:%d VR_TYPE_0:%d", high_byte,
+		low_byte);
+	*vr_dev = VR_DEVICE_UNKNOWN;
+	return GET_VR_DEV_FAILED;
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
@@ -44,6 +44,8 @@
 #define UPDATE_INTERVAL_1S 1
 #define UPDATE_INTERVAL_3S 3
 
+#define VR_DEVICE_UNKNOWN 0xFF
+
 enum SENSOR_THREAD_LIST {
 	ADC_SENSOR_THREAD_ID = 0,
 	VR_SENSOR_THREAD_ID,
@@ -54,8 +56,14 @@ enum SENSOR_THREAD_LIST {
 	MAX_SENSOR_THREAD_ID,
 };
 
+enum GET_VR_DEV_STATUS {
+	GET_VR_DEV_SUCCESS = 0,
+	GET_VR_DEV_FAILED,
+};
+
 int plat_pldm_sensor_get_sensor_count(int thread_id);
 void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
 					     PDR_numeric_sensor *numeric_sensor_table);
+uint8_t plat_pldm_sensor_get_vr_dev(uint8_t *vr_dev);
 
 #endif


### PR DESCRIPTION
# Description:
- Determine the VR model through GPIO "VR_TYPE_1" and "VR_TYPE_0".

# Motivation:
- Support to read sensors of raa229621 device.

# Test Plan:
- Read raa229621's sensors: Pass

# Test Log:
MB_VR_CPU0_CURR_A_64_40            |1        |nan      |0        |0        |0        |230      |nan
MB_VR_CPU1_CURR_A_66_40            |2        |nan      |0        |0        |0        |230      |nan
MB_VR_PVDD11_CURR_A_68_40          |1        |nan      |0        |0        |0        |80       |nan
MB_VR_PVDDIO_CURR_A_67_40          |6        |nan      |0        |0        |0        |140      |nan
MB_VR_SOC_CURR_A_65_40             |11       |nan      |0        |0        |0        |130      |nan
MB_VR_CPU0_PWR_W_80_40             |2        |nan      |0        |0        |0        |393.3    |nan
MB_VR_CPU1_PWR_W_82_40             |2        |nan      |0        |0        |0        |393.3    |nan
MB_VR_PVDD11_PWR_W_84_40           |2        |nan      |0        |0        |0        |93.6     |nan
MB_VR_PVDDIO_PWR_W_83_40           |7        |nan      |0        |0        |0        |180.6    |nan
MB_VR_SOC_PWR_W_81_40              |11       |nan      |0        |0        |0        |176.8    |nan
MB_VR_CPU0_TEMP_C_19_40            |52       |nan      |0        |0        |0        |100      |nan
MB_VR_CPU1_TEMP_C_21_40            |54       |nan      |0        |0        |0        |100      |nan
MB_VR_PVDD11_TEMP_C_23_40          |52       |nan      |0        |0        |0        |100      |nan
MB_VR_PVDDIO_TEMP_C_22_40          |53       |nan      |0        |0        |0        |100      |nan
MB_VR_SOC_TEMP_C_20_40             |53       |nan      |0        |0        |0        |100      |nan
MB_VR_CPU0_VOLT_V_45_40            |0.9129   |nan      |0.37     |0        |0        |1.71     |nan
MB_VR_CPU1_VOLT_V_47_40            |0.9079   |nan      |0.37     |0        |0        |1.71     |nan
MB_VR_PVDD11_VOLT_V_49_40          |1.1      |nan      |1.04     |0        |0        |1.17     |nan
MB_VR_PVDDIO_VOLT_V_48_40          |1.1      |nan      |0.81     |0        |0        |1.29     |nan
MB_VR_SOC_VOLT_V_46_40             |0.8989   |nan      |0.59     |0        |0        |1.36     |nan