### PR TITLE
common: Send SEL to BMC via PLDM

### DIFF
--- a/common/service/pldm/pldm_monitor.c
+++ b/common/service/pldm/pldm_monitor.c
@@ -356,7 +356,7 @@ uint8_t pldm_platform_event_message_req(void *mctp_inst, mctp_ext_params ext_par
 
 	req.event_class = event_class;
 	req.format_version = 0x01;
-	req.tid = DEFAULT_TID;
+	req.tid = plat_pldm_get_tid();
 
 	memcpy(&req.event_data, event_data, event_data_length);
 


### PR DESCRIPTION
# Description:
Send SEL to BMC via PLDM. Utilize PlatformEventMessage command with OEM event class 0xFB.

# Motivation:
Validation team needs these events to confirm if the system is functioning properly.

# Test Plan:
Teste on YV4 system - pass