### PR TITLE
Artemis: Remove BIC image size check

### DIFF
--- a/meta-facebook/at-cb/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/at-cb/src/ipmi/plat_ipmi.c
@@ -396,11 +396,6 @@ void OEM_1S_FW_UPDATE(ipmi_msg *msg)
 	switch (target) {
 	case CB_COMPNT_BIC:
 	case (CB_COMPNT_BIC | IS_SECTOR_END_MASK):
-		// Expect BIC firmware size not bigger than 320k
-		if (offset > BIC_UPDATE_MAX_OFFSET) {
-			msg->completion_code = CC_PARAM_OUT_OF_RANGE;
-			return;
-		}
 		if (offset == 0) {
 			// Set default fw update retry count at first package
 			set_default_retry_count(FW_UPDATE_RETRY_MAX_COUNT);

--- a/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/at-mc/src/ipmi/plat_ipmi.c
@@ -695,11 +695,6 @@ void OEM_1S_FW_UPDATE(ipmi_msg *msg)
 	switch (component) {
 	case MC_COMPNT_BIC:
 	case (MC_COMPNT_BIC | IS_SECTOR_END_MASK):
-		// Expect BIC firmware size not bigger than 320k
-		if (offset > BIC_UPDATE_MAX_OFFSET) {
-			msg->completion_code = CC_PARAM_OUT_OF_RANGE;
-			return;
-		}
 		if (offset == 0) {
 			// Set default fw update retry count at first package
 			set_default_retry_count(FW_UPDATE_RETRY_MAX_COUNT);


### PR DESCRIPTION
# Description
- The BIC image size will exceed 320K when we implement the ASIC update.

# Motivation:
- Fix BIC force update fail when the image size large than 320K

# Test Plan
- Build code: Pass
- Force Update BIC : Pass
- Recovery update BIC : Pass

# Log
root@bmc-oob:~# fw-util cb --force --update bic ATCB.bin Raw image detected.
updating fw on bus 3
updated: 100 %
Elapsed time:  16   sec.
Force upgrade of cb : bic succeeded

root@bmc-oob:~# fw-util mc --force --update bic ATMC.bin Raw image detected.
updating fw on bus 9
updated: 100 %
Elapsed time:  16   sec.
Force upgrade of cb : bic succeeded