### PR TITLE
op2: op: Revise the criteria for monitoring parts of sensors.

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_power_seq.c
+++ b/meta-facebook/op2-op/src/platform/plat_power_seq.c
@@ -159,6 +159,26 @@ bool get_e1s_power_good(uint8_t index)
 	return power_good;
 }
 
+bool get_edge_power_good()
+{
+	uint8_t card_type = get_card_type();
+	bool power_good = false;
+
+	switch (card_type) {
+	case CARD_TYPE_OPA:
+		power_good = gpio_get(OPA_PWRGD_P12V_MAIN);
+		break;
+	case CARD_TYPE_OPB:
+		power_good = gpio_get(OPB_PWRGD_P12V_MAIN);
+		break;
+	default:
+		LOG_ERR("UNKNOWN CARD TYPE");
+		break;
+	}
+
+	return power_good;
+}
+
 uint8_t get_e1s_pcie_reset_status(uint8_t index)
 {
 	uint8_t card_type = get_card_type();

--- a/meta-facebook/op2-op/src/platform/plat_power_seq.h
+++ b/meta-facebook/op2-op/src/platform/plat_power_seq.h
@@ -92,6 +92,7 @@ extern e1s_power_control_gpio opb_e1s_power_control_gpio[];
 
 bool get_e1s_present(uint8_t index);
 bool get_e1s_power_good(uint8_t index);
+bool get_edge_power_good();
 uint8_t get_e1s_pcie_reset_status(uint8_t index);
 void init_sequence_status();
 void set_sequence_status(uint8_t index, bool status);

--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.c
@@ -32,6 +32,7 @@ LOG_MODULE_REGISTER(plat_sensor);
 
 bool e1s_access(uint8_t sensor_num);
 bool retimer_access(uint8_t sensor_num);
+bool edge_access(uint8_t sensor_num);
 
 sensor_cfg plat_sensor_config[] = {
 	/*  number,
@@ -55,19 +56,19 @@ sensor_cfg plat_sensor_config[] = {
 
 	//INA233 VOL
 	{ SENSOR_NUM_1OU_P12V_EDGE_VOLT, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
-	  INA233_VOLT_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_VOLT_OFFSET, edge_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[5] },
 
 	//INA233 CURR
 	{ SENSOR_NUM_1OU_P12V_EDGE_CURR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
-	  INA233_CURR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_CURR_OFFSET, edge_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[5] },
 
 	//INA233 PWR
 	{ SENSOR_NUM_1OU_P12V_EDGE_PWR, sensor_dev_ina233, I2C_BUS3, INA233_EXPA_MAIN_ADDR,
-	  INA233_PWR_OFFSET, dc_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  INA233_PWR_OFFSET, edge_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
 	  &ina233_init_args[5] },
 };
@@ -633,5 +634,10 @@ bool e1s_access(uint8_t sensor_num)
 		LOG_ERR("Unsupported sensor device for e1s checking.");
 		break;
 	}
-	return get_e1s_present(e1s_index) && get_DC_on_delayed_status();
+	return get_e1s_present(e1s_index) && get_e1s_power_good(e1s_index);
+}
+
+bool edge_access(uint8_t sensor_num)
+{
+	return get_DC_on_delayed_status() && get_edge_power_good();
 }


### PR DESCRIPTION
# Description:
    Monitor "XOU_E1S_SSDX_P12V_VOLT_V" and "XOU_BIC_MAIN_P12V_VOLT_V" after their power good are ready.

# Motivation:
    BIC monitors “XOU_E1S_SSDX_P12V_VOLT_V“ and “XOU_BIC_MAIN_P12V_VOLT_V“ too early.

# Test plan:
    Check these sensors are normal after power-cycle: Pass

# Test log:
    Before:
    root@bmc-oob:~# power-util slot1 cycle; sensor-util all | grep 2OU_E1S_SSD0_P12V_VOLT_V; sensor-util all | grep 2OU_BIC_MAIN_P12V_VOLT_V
    Power cycling fru 1...
    2OU_E1S_SSD0_P12V_VOLT_V     (0x71) :   9.896 Volts | (lnr)
    2OU_BIC_MAIN_P12V_VOLT_V     (0x76) :  10.930 Volts | (lnr)
    // The sensors returns to normal for a period of time.
    root@bmc-oob:~#sensor-util all | grep 2OU_E1S_SSD0_P12V_VOLT_V; sensor-util all | grep 2OU_BIC_MAIN_P12V_VOLT_V
    2OU_E1S_SSD0_P12V_VOLT_V     (0x71) :  12.477 Volts | (ok)
    2OU_BIC_MAIN_P12V_VOLT_V     (0x76) :  12.378 Volts | (ok)
After:
    root@bmc-oob:~# power-util slot1 cycle; sensor-util all | grep 2OU_E1S_SSD0_P12V_VOLT_V; sensor-util all | grep 2OU_BIC_MAIN_P12V_VOLT_V
    Power cycling fru 1...
    2OU_E1S_SSD0_P12V_VOLT_V     (0x71) :  12.477 Volts | (ok)
    2OU_BIC_MAIN_P12V_VOLT_V     (0x76) :  12.378 Volts | (ok)