### PR TITLE
op2: gl: Change VR EHV temperature reading

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sensor_table.c
@@ -123,7 +123,7 @@ sensor_cfg plat_sensor_config[] = {
 	  &xdpe15284_pre_read_args[0], NULL, NULL, NULL },
 	{ SENSOR_NUM_MB_VR_EHV_TEMP_C, sensor_dev_xdpe15284, I2C_BUS5, EHV_ADDR, VR_TEMP_OFFSET,
 	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_pre_read_args[1], NULL, NULL, NULL },
+	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_pre_read_args[0], NULL, NULL, NULL },
 	{ SENSOR_NUM_MB_VR_FIVRA_TEMP_C, sensor_dev_xdpe15284, I2C_BUS5, FIVRA_ADDR, VR_TEMP_OFFSET,
 	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, pre_xdpe15284_read, &xdpe15284_pre_read_args[0], NULL, NULL, NULL },


### PR DESCRIPTION
# Description
- Correct VR EHV temperature sensor reading. Read the same VR page with VCCIN.

# Motivation
- According to the block diagram, the temperature sensors of EHV and VCCIN are connected together. Their temperature is reported form the same VR page.

# Test plan
- Build code: Pass
- Read VR temperature: Pass

# Log
1. Check VR EHV and
- Before change root@bmc-oob:~# sensor-util slot1 | grep VR | grep TEMP
MB_VR_VCCIN_TEMP_C           (0xF) :  35.000 C     | (ok)
MB_VR_EHV_TEMP_C             (0x10) :  0.000 C     | (ok)
MB_VR_FIVRA_TEMP_C           (0x11) :  32.000 C     | (ok)
MB_VR_VCCINF_TEMP_C          (0x12) :  30.000 C     | (ok)
MB_VR_VCCD0_TEMP_C           (0x13) :  25.000 C     | (ok)
MB_VR_VCCD1_TEMP_C           (0x14) :  27.000 C     | (ok)

- After change root@bmc-oob:~# sensor-util slot1 | grep VR | grep TEMP
MB_VR_VCCIN_TEMP_C           (0xF) :  31.000 C     | (ok)
MB_VR_EHV_TEMP_C             (0x10) :  31.000 C     | (ok)
MB_VR_FIVRA_TEMP_C           (0x11) :  27.000 C     | (ok)
MB_VR_VCCINF_TEMP_C          (0x12) :  27.000 C     | (ok)
MB_VR_VCCD0_TEMP_C           (0x13) :  23.000 C     | (ok)
MB_VR_VCCD1_TEMP_C           (0x14) :  22.000 C     | (ok)