### PR TITLE
oby4: sd: Reset USB hub when BIC is ready

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_gpio.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_gpio.c
@@ -25,6 +25,8 @@
 #include "plat_isr.h"
 #include "plat_class.h"
 
+LOG_MODULE_REGISTER(plat_gpio);
+
 #define gpio_name_to_num(x) #x,
 char *gpio_name[] = {
 	name_gpioA name_gpioB name_gpioC name_gpioD name_gpioE name_gpioF name_gpioG name_gpioH
@@ -54,7 +56,7 @@ GPIO_CFG plat_gpio_cfg[] = {
 	{ CHIP_GPIO, 4, ENABLE, DISABLE, GPIO_INPUT, GPIO_HIGH, OPEN_DRAIN, GPIO_INT_DISABLE, NULL },
 	{ CHIP_GPIO, 5, ENABLE, DISABLE, GPIO_OUTPUT, GPIO_LOW, PUSH_PULL, GPIO_INT_DISABLE, NULL },
 	{ CHIP_GPIO, 6, ENABLE, DISABLE, GPIO_INPUT, GPIO_HIGH, OPEN_DRAIN, GPIO_INT_DISABLE, NULL },
-	{ CHIP_GPIO, 7, ENABLE, DISABLE, GPIO_OUTPUT, GPIO_HIGH, OPEN_DRAIN, GPIO_INT_DISABLE, NULL },
+	{ CHIP_GPIO, 7, ENABLE, DISABLE, GPIO_OUTPUT, GPIO_LOW, PUSH_PULL, GPIO_INT_DISABLE, NULL },
 
 	/** Group B: 08-15 **/
 	{ CHIP_GPIO, 8, ENABLE, DISABLE, GPIO_INPUT, GPIO_HIGH, OPEN_DRAIN, GPIO_INT_DISABLE, NULL },
@@ -298,4 +300,14 @@ void sync_bmc_ready_pin()
 {
 	uint8_t gpio_val = gpio_get(FM_CPLD_BMC_BIC_READY);
 	gpio_set(BMC_READY, gpio_val);
+}
+
+void reset_usb_hub()
+{
+	if (gpio_get(BIC_READY_R) == HIGH_ACTIVE) {
+		gpio_set(RST_USB_HUB_R_N, HIGH_ACTIVE);
+		LOG_INF("Reset USB Hub");
+	} else {
+		LOG_ERR("Failed to reset USB Hub because BIC_READY_R is not active");
+	}
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_gpio.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_gpio.h
@@ -269,4 +269,5 @@ extern enum _GPIO_NUMS_ GPIO_NUMS;
 extern char *gpio_name[];
 
 void sync_bmc_ready_pin();
+void reset_usb_hub();
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -103,6 +103,8 @@ void pal_set_sys_status()
 	set_DC_on_delayed_status();
 	set_post_status(FM_BIOS_POST_CMPLT_BIC_N);
 	sync_bmc_ready_pin();
+	set_sys_ready_pin(BIC_READY_R);
+	reset_usb_hub();
 
 	if (get_post_status()) {
 		apml_recovery();


### PR DESCRIPTION
# Description:
    Pull RST_USB_HUB_R_N high to reset USB hub after BIC is ready.

# Motivation:
    In WF borads, the USB DN/DP will have an abnormal high pulse which would cause MB's USB hub to disable the downstream port. It would lead WF BIC/ASIC USB lost detection. Therefore, BIC need to reset USB hub to avoid any abnormal USB signal behavior during WF BIC is booting up.

# Test plan:
    Check that USB will be re-linked and the abnormal signal on USB during WF BIC booting up: Pass