### PR TITLE
common: patch: Add error handling for I3C IBI

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0059-i3c-Add-max_payload_size-to-specify-the-max-IBI-payl.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0059-i3c-Add-max_payload_size-to-specify-the-max-IBI-payl.patch
@@ -1,0 +1,61 @@
+From efe6c10c807d94a2997757a756c3f9eda99f27fe Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Wed, 29 Mar 2023 13:48:18 +0800
+Subject: [PATCH] i3c: Add max_payload_size to specify the max IBI payload size
+
+Add max_payload_size as a configuration in the application to specify
+the max IBI payload size. This will make the I3C platform driver to
+filter out IBIs with illegal payload sizes and avoid data corruption.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: I9d06b629bc573ee1730c5ab1c829bbbd9933e68e
+---
+ drivers/i3c/i3c_aspeed.c       | 6 ++++++
+ include/drivers/i3c/i3c.h      | 1 +
+ tests/boards/ast1030/src/i3c.c | 1 +
+ 3 files changed, 8 insertions(+)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 32e44a1bff..1fe49c2d06 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -877,6 +877,12 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 
+ 		nbytes = ibi_status.length;
+ 		nwords = nbytes >> 2;
++		if ((payload->size + ibi_status.length) > payload->max_payload_size) {
++			LOG_ERR("IBI length exceeds the max size (%d bytes)\n",
++				payload->max_payload_size);
++			goto out;
++		}
++
+ 		for (j = 0; j < nwords; j++) {
+ 			dst[j] = i3c_register->ibi_queue_status.value;
+ 		}
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index 576dd34bff..3f4a2bf369 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -113,6 +113,7 @@ struct i3c_dev_desc {
+ #define IBI_MDB_ASPEED			IBI_MDB_ID(IBI_MDB_GRP_PENDING_READ_NOTIF, 0x1f)
+ 
+ struct i3c_ibi_payload {
++	int max_payload_size;
+ 	int size;
+ 	uint8_t *buf;
+ };
+diff --git a/tests/boards/ast1030/src/i3c.c b/tests/boards/ast1030/src/i3c.c
+index 7badc00a40..d500889e14 100644
+--- a/tests/boards/ast1030/src/i3c.c
++++ b/tests/boards/ast1030/src/i3c.c
+@@ -41,6 +41,7 @@ static struct i3c_ibi_payload *test_ibi_write_requested(struct i3c_dev_desc *des
+ {
+ 	i3c_payload.buf = test_data_rx;
+ 	i3c_payload.size = 0;
++	i3c_payload.max_payload_size = MAX_DATA_SIZE;
+ 
+ 	return &i3c_payload;
+ }
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0060-i3c-aspeed-drop-the-problematic-and-unsupported-IBI-.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0060-i3c-aspeed-drop-the-problematic-and-unsupported-IBI-.patch
@@ -1,0 +1,91 @@
+From 16d31fce64446b591e4b32db41231d6c947ce402 Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Wed, 29 Mar 2023 13:20:39 +0800
+Subject: [PATCH] i3c: aspeed: drop the problematic and unsupported IBI
+ payloads
+
+In I3C bus controller mode, drop the problematic and unsupported IBI
+payloads.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: Id9bd16804dfd0ef3f34be3f23d493084e8462075
+---
+ drivers/i3c/i3c_aspeed.c | 27 ++++++++++++++++++++++-----
+ 1 file changed, 22 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index dad66b7b2f..32e44a1bff 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -833,8 +833,9 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 	struct i3c_aspeed_dev_priv *priv;
+ 	struct i3c_ibi_status ibi_status;
+ 	struct i3c_ibi_payload *payload;
+-	uint32_t i, j, nstatus, nbytes, nwords, pos;
++	uint32_t i, j, nstatus, nbytes, nwords, pos, tmp;
+ 	uint32_t *dst;
++	bool data_consumed;
+ 
+ 	nstatus = i3c_register->queue_status_level.fields.ibi_status_cnt;
+ 	if (!nstatus) {
+@@ -843,19 +844,26 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 
+ 	for (i = 0; i < nstatus; i++) {
+ 		obj->ibi_status_parser(i3c_register->ibi_queue_status.value, &ibi_status);
++		data_consumed = false;
+ 		if (ibi_status.ibi_status) {
+ 			LOG_WRN("IBI NACK\n");
++			goto out;
+ 		}
+ 
+ 		if (ibi_status.error) {
+ 			LOG_ERR("IBI error\n");
++			goto out;
++		}
++
++		if (ibi_status.id == (0x2 << 1)) {
++			LOG_INF("Receive Hot-join event (Not supported for now)\n");
++			goto out;
+ 		}
+ 
+ 		pos = i3c_aspeed_get_pos(obj, ibi_status.id >> 1);
+ 		if (pos < 0) {
+ 			LOG_ERR("unregistered IBI source: 0x%x\n", ibi_status.id >> 1);
+-			i3c_register->reset_ctrl.fields.ibi_queue_reset = 1;
+-			continue;
++			goto out;
+ 		}
+ 
+ 		i3cdev = obj->dev_descs[pos];
+@@ -874,10 +882,10 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 		}
+ 
+ 		if (nbytes & 0x3) {
+-			uint32_t tmp = i3c_register->ibi_queue_status.value;
+-
++			tmp = i3c_register->ibi_queue_status.value;
+ 			memcpy((uint8_t *)dst + (nbytes & ~0x3), &tmp, nbytes & 3);
+ 		}
++		data_consumed = true;
+ 
+ 		payload->size += nbytes;
+ 		priv->ibi.incomplete = payload;
+@@ -885,6 +893,15 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 			priv->ibi.callbacks->write_done(priv->ibi.context);
+ 			priv->ibi.incomplete = NULL;
+ 		}
++out:
++		if (data_consumed == false) {
++			nbytes = ibi_status.length;
++			/* rounding up the bytes into words */
++			nwords = (nbytes + 3) >> 2;
++			for (j = 0; j < nwords; j++) {
++				tmp = i3c_register->ibi_queue_status.value;
++			}
++		}
+ 	}
+ }
+ 
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0061-i3c-aspeed-Generate-the-t-bits-low-to-stop-the-ibi-s.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0061-i3c-aspeed-Generate-the-t-bits-low-to-stop-the-ibi-s.patch
@@ -1,0 +1,117 @@
+From e97844b11318d20b70966fd6abe9ef197790010b Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Wed, 29 Mar 2023 17:53:14 +0800
+Subject: [PATCH] i3c: aspeed: Generate the t-bits low to stop the ibi storm.
+
+Under certain conditions, such as when an IBI interrupt is received and
+SDA remains high after the address phase, the i3c master may enter an
+infinite loop while trying to read data until the t-bit low appears.
+This commit addresses the issue by gerenating the fake t-bit low to stop
+the IBI storm when receiving an IBI with an unrecognized address or when
+the received data length of IBI is larger than the maximum IBI payload.
+This issue can't be solved by abort function, because it doesn't work when
+i3c fsm at Servicing IBI Transfer (0xe) and Clock extension state (0x12).
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I87e6c7d06ad3040a5f2f577f8edf6ac0f2f4be71
+---
+ drivers/i3c/i3c_aspeed.c     | 37 ++++++++++++++++++++++++++++++++++++
+ soc/arm/aspeed/aspeed_util.h | 20 +++++++++++++++++++
+ 2 files changed, 57 insertions(+)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 3e075f4667..5886ed7bf3 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -276,6 +276,7 @@ union i3c_present_state_s {
+ 		volatile uint32_t current_master : 1;		/* bit[2] */
+ 		volatile uint32_t reserved0 : 5;		/* bit[7:3] */
+ #define CM_TFR_STS_SLAVE_HALT	0x6
++#define CM_TFR_STS_MASTER_SERV_IBI	0xe
+ 		volatile uint32_t cm_tfr_sts : 6;		/* bit[13:8] */
+ 		volatile uint32_t reserved1 : 2;		/* bit[15:14] */
+ 		volatile uint32_t cm_tfr_st_sts : 6;		/* bit[21:16] */
+@@ -579,6 +580,39 @@ void i3c_aspeed_isolate_scl_sda(int inst_id, bool iso)
+ 	}
+ }
+ 
++static bool aspeed_i3c_fsm_is_idle(struct i3c_register_s *i3c_register)
++{
++	uint32_t temp;
++
++	/*
++	 * Clear the IBI queue to enable the hardware to generate SCL and
++	 * begin detecting the T-bit low to stop reading IBI data.
++	 */
++	temp = i3c_register->ibi_queue_status.value;
++	if (i3c_register->present_state.fields.cm_tfr_sts)
++		return false;
++	return true;
++}
++
++void i3c_aspeed_gen_tbits_low(struct i3c_aspeed_obj *obj)
++{
++	struct i3c_aspeed_config *config = obj->config;
++	struct i3c_register_s *i3c_register = config->base;
++	uint32_t i3c_gr = DT_REG_ADDR(DT_NODELABEL(i3c_gr));
++	uint32_t value;
++	int ret;
++
++	i3c_aspeed_isolate_scl_sda(config->inst_id, true);
++	value = sys_read32(i3c_gr + I3CG_REG1(config->inst_id));
++	value &= ~SDA_IN_SW_MODE_VAL;
++	sys_write32(value, i3c_gr + I3CG_REG1(config->inst_id));
++	ret = readx_poll_timeout(aspeed_i3c_fsm_is_idle, i3c_register, 0, 2000);
++	i3c_aspeed_isolate_scl_sda(config->inst_id, false);
++
++	if (ret)
++		LOG_ERR("Failed to recovery the i3c fsm from %x to idle: %d",
++			i3c_register->present_state.fields.cm_tfr_sts, ret);
++}
+ void i3c_aspeed_toggle_scl_in(int inst_id)
+ {
+ 	uint32_t i3c_gr = DT_REG_ADDR(DT_NODELABEL(i3c_gr));
+@@ -907,6 +941,9 @@ out:
+ 			for (j = 0; j < nwords; j++) {
+ 				tmp = i3c_register->ibi_queue_status.value;
+ 			}
++			if (i3c_register->present_state.fields.cm_tfr_sts ==
++			    CM_TFR_STS_MASTER_SERV_IBI)
++				i3c_aspeed_gen_tbits_low(obj);
+ 		}
+ 	}
+ }
+diff --git a/soc/arm/aspeed/aspeed_util.h b/soc/arm/aspeed/aspeed_util.h
+index 66f72241cc..6063970407 100644
+--- a/soc/arm/aspeed/aspeed_util.h
++++ b/soc/arm/aspeed/aspeed_util.h
+@@ -68,6 +68,26 @@
+ 		__ret;								    \
+ 	})
+ 
++#define readx_poll_timeout(op, args, sleep_us, timeout_ms)			    \
++	({									    \
++		uint32_t __timeout_tick = Z_TIMEOUT_MS(timeout_ms).ticks;	    \
++		uint32_t __start = sys_clock_tick_get_32();			    \
++		int __ret = 0;							    \
++		for (;;) {							    \
++			if (op(args)) {						    \
++				break;						    \
++			}							    \
++			if ((sys_clock_tick_get_32() - __start) > __timeout_tick) { \
++				__ret = -ETIMEDOUT;				    \
++				break;						    \
++			}							    \
++			if (sleep_us) {						    \
++				k_usleep(sleep_us);				    \
++			}							    \
++		}								    \
++		__ret;								    \
++	})
++
+ /* Common reset control device name for all ASPEED SOC family */
+ #define ASPEED_RST_CTRL_NAME DT_INST_RESETS_LABEL(0)
+ 
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0062-drivers-i3c-fix-calling-unregistered-callback-functi.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0062-drivers-i3c-fix-calling-unregistered-callback-functi.patch
@@ -1,0 +1,72 @@
+From c6645dc196dbc1f09eee919eac5cfbcbafd6ce13 Mon Sep 17 00:00:00 2001
+From: Jamin Lin <jamin_lin@aspeedtech.com>
+Date: Tue, 4 Jul 2023 15:27:54 +0800
+Subject: [PATCH] drivers:i3c: fix calling unregistered callback function
+
+It set the data type of pos "uint32_t".
+However, i3c_aspeed_get_pos function return status is "int".
+If the slave address did not be found in i3c_aspeed_get_pos
+function, this function returned "-1". Due to the incorrect
+data type of pos, the value of pos would be "0xffffffff"
+
+The max i3c device descriptor was 32, so it got the NULL
+i3c device descriptor and called unregistered callback
+function and it caused system crash.
+
+Signed-off-by: Jamin Lin <jamin_lin@aspeedtech.com>
+Change-Id: I9a49a9f784526c13c73b103ff8261cb8678a7c75
+---
+ drivers/i3c/i3c_aspeed.c | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 244ddad079..4a572b0312 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -877,9 +877,10 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 	struct i3c_aspeed_dev_priv *priv;
+ 	struct i3c_ibi_status ibi_status;
+ 	struct i3c_ibi_payload *payload;
+-	uint32_t i, j, nstatus, nbytes, nwords, pos, tmp;
++	uint32_t i, j, nstatus, nbytes, nwords, tmp;
+ 	uint32_t *dst;
+ 	bool data_consumed;
++	int pos;
+ 
+ 	nstatus = i3c_register->queue_status_level.fields.ibi_status_cnt;
+ 	if (!nstatus) {
+@@ -899,7 +900,12 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 			goto out;
+ 		}
+ 
+-		if (ibi_status.id == (0x2 << 1)) {
++		if ((ibi_status.id >> 1) != 0x2 && !(ibi_status.id & 0x1)) {
++			LOG_INF("Receive Controller Role Request event (Not supported for now)\n");
++			goto out;
++		}
++
++		if ((ibi_status.id >> 1) == 0x2 && !(ibi_status.id & 0x1)) {
+ 			LOG_INF("Receive Hot-join event (Not supported for now)\n");
+ 			goto out;
+ 		}
+@@ -910,7 +916,17 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 			goto out;
+ 		}
+ 
++		if (pos > ARRAY_SIZE(obj->dev_descs)) {
++			LOG_ERR("pos(%d) exceeds the max device(%ld)\n", pos, ARRAY_SIZE(obj->dev_descs));
++			goto out;
++		}
++
+ 		i3cdev = obj->dev_descs[pos];
++		if (!i3cdev) {
++			LOG_ERR("device descriptor not found\n");
++			goto out;
++		}
++
+ 		priv = DESC_PRIV(i3cdev);
+ 		if (priv->ibi.incomplete) {
+ 			payload = priv->ibi.incomplete;
+-- 
+2.25.1
+


### PR DESCRIPTION
# Description
- In I3C bus controller mode, drop the problematic and unsupported IBI payloads.
- Add max_payload_size as a configuration in the application to specify the max IBI payload size. This will make the I3C platform driver to filter out IBIs with illegal payload sizes and avoid data corruption.
- Under certain conditions, such as when an IBI interrupt is received and SDA remains high after the address phase, the i3c master may enter an infinite loop while trying to read data until the t-bit low appears. This commit addresses the issue by gerenating the fake t-bit low to stop the IBI storm when receiving an IBI with an unrecognized address or when the received data length of IBI is larger than the maximum IBI payload. This issue can't be solved by abort function, because it doesn't work when i3c fsm at Servicing IBI Transfer (0xe) and Clock extension state (0x12).
- It set the data type of pos "uint32_t". However, i3c_aspeed_get_pos function return status is "int". If the slave address did not be found in i3c_aspeed_get_pos function, this function returned "-1". Due to the incorrect data type of pos, the value of pos would be "0xffffffff" The max i3c device descriptor was 32, so it got the NULL i3c device descriptor and called unregistered callback function and it caused system crash.

# Motivation
- Current I3C driver of RX function doesn't have error handling.