### PR TITLE
fby4: sd: Fix attach/detach function unexpected

### DIFF
--- a/common/hal/hal_i3c.c
+++ b/common/hal/hal_i3c.c
@@ -125,13 +125,19 @@ int i3c_attach(I3C_MSG *msg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
 
-	int ret = 0;
-	struct i3c_dev_desc *desc;
+	int ret = 0, pos = 0;
+	struct i3c_dev_desc *desc = NULL;
 
 	if (!dev_i3c[msg->bus]) {
 		LOG_ERR("Failed to attach address 0x%x due to undefined bus%u", msg->target_addr,
 			msg->bus);
 		return -ENODEV;
+	}
+
+	desc = find_matching_desc(dev_i3c[msg->bus], msg->target_addr, &pos);
+	if (desc != NULL) {
+		LOG_INF("addr 0x%x already attach", msg->target_addr);
+		return -ret;
 	}
 
 	desc = &i3c_desc_table[i3c_desc_count];
@@ -204,8 +210,8 @@ int i3c_brocast_ccc(I3C_MSG *msg, uint8_t ccc_id, uint8_t ccc_addr)
 
 	ret = i3c_master_send_ccc(dev_i3c[msg->bus], &ccc);
 	if (ret != 0) {
-		LOG_ERR("Failed to broadcast ccc 0x%x to addresses 0x%x due to undefined bus%u",
-			ccc_id, ccc_addr, ret);
+		LOG_ERR("Failed to broadcast ccc 0x%x to addresses 0x%x bus%u, ret%d",
+                       ccc_id, ccc_addr, msg->bus, ret);
 	}
 
 	return -ret;

--- a/meta-facebook/yv4-sd/src/platform/plat_dimm.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_dimm.h
@@ -114,7 +114,7 @@ int pal_get_pmic_pwr(uint8_t sensor_num, uint8_t *data);
 void clear_unaccessible_dimm_data(uint8_t dimm_id);
 int switch_i3c_dimm_mux(uint8_t i3c_ctrl_mux_data);
 int all_brocast_ccc(I3C_MSG *i3c_msg);
-void init_dimm_prsnt_status();
+int init_dimm_prsnt_status();
 uint8_t get_dimm_present(uint8_t dimm_id);
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <zephyr.h>
+#include <soc.h>
 #include "hal_gpio.h"
 #include "hal_peci.h"
 #include "power_status.h"
@@ -46,6 +48,7 @@ SCU_CFG scu_cfg[] = {
 void pal_pre_init()
 {
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
+	aspeed_print_sysrst_info();
 	apml_init();
 
 	/* init i2c target */


### PR DESCRIPTION
# Description
- Check if already attached before run attach function.
- Add mutex lock of DIMM in present check function.
- Add function to check BIC reset reason.

# Motivation
- Log term stress, BIC will unexpected crash.

# Test plan
- Build code: Pass
- DC cycle stress: 93 run Pass