### PR TITLE
common: i3c: Add IBI max size

### DIFF
--- a/common/hal/hal_i3c.c
+++ b/common/hal/hal_i3c.c
@@ -446,6 +446,7 @@ static struct i3c_ibi_payload *ibi_write_requested(struct i3c_dev_desc *desc)
 	if (idx < 0) {
 		LOG_ERR("%s: find dev i3c idx failed. idx = %d", __func__, idx);
 	}
+	i3c_ibi_dev_table[idx].i3c_payload.max_payload_size = I3C_MAX_DATA_SIZE;
 	i3c_ibi_dev_table[idx].i3c_payload.size = 0;
 	i3c_ibi_dev_table[idx].i3c_payload.buf = i3c_ibi_dev_table[idx].data_rx;
 


### PR DESCRIPTION
# Description
- Add IBI max_payload_size.

# Monitvation
- Zephyr code add some ibi error handle patch, application code need to define.

# Test plan
- Build code: Pass

# Log
- Get WF to check I3C IBI is workable. root@bmc:~# busctl tree xyz.openbmc_project.MCTP
└─ /xyz
  └─ /xyz/openbmc_project └─ /xyz/openbmc_project/mctp └─ /xyz/openbmc_project/mctp/1 ├─ /xyz/openbmc_project/mctp/1/50 ├─ /xyz/openbmc_project/mctp/1/60 ├─ /xyz/openbmc_project/mctp/1/62 ├─ /xyz/openbmc_project/mctp/1/64 ├─ /xyz/openbmc_project/mctp/1/70 └─ /xyz/openbmc_project/mctp/1/8