### PR TITLE
op2: gl: Modify UCR of CPU temperature

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
@@ -254,7 +254,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x5B, // UCT
+		0x54, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT


### PR DESCRIPTION
# Description
- Modify UCR of MB_SOC_CPU_TEMP_C from 91 to 84.

# Motivation
- In the CPU spec., the new CPU throttle target value dcrease. From 92 (EVT QS1 CPU) to 86 (DVT QS2 CPU), so need to change the sensor threshold.

# Test plan
- Build code: Pass
- Get UCR: Pass

# Log
1. Check threshold of MB_SOC_CPU_TEMP_C.
- Before root@bmc-oob:~# sensor-util slot1 --thre | grep MB | grep CPU
MB_SOC_CPU_TEMP_C            (0x4) :  38.000 C     | (ok) | UCR: 91.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA

- After root@bmc-oob:~# sensor-util slot1 --thre | grep MB | grep CPU
MB_SOC_CPU_TEMP_C            (0x4) :  40.000 C     | (ok) | UCR: 84.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA