### PR TITLE
Artemis:acb: hard fix for clk gen ssc

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_dev.h
+++ b/meta-facebook/at-cb/src/platform/plat_dev.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include "sensor.h"
 
+#define CLOCK_GEN_ADDR (0xD0 >> 1)
 #define FREYA_STATUS_BLOCK_OFFSET 0x00
 #define FREYA_STATUS_BLOCK_LENGTH 0x08
 #define FREYA_READY_STATUS_BIT BIT(6)
@@ -123,5 +124,6 @@ void get_switch_error_status(uint8_t sensor_num, uint8_t bus, uint8_t addr, uint
 bool init_vr_write_protect(uint8_t bus, uint8_t addr, uint8_t default_val);
 int atm_fw_update(uint8_t bus, uint8_t addr, uint32_t offset, uint8_t *msg_buf, uint16_t buf_len,
 		  uint32_t image_size, bool is_end_package);
+void init_clk_gen_spread_spectrum_control_register();
 
 #endif

--- a/meta-facebook/at-cb/src/platform/plat_isr.c
+++ b/meta-facebook/at-cb/src/platform/plat_isr.c
@@ -462,6 +462,7 @@ void ISR_POWER_STATUS_CHANGE()
 {
 	get_acb_power_status();
 	if (get_acb_power_good_flag()) {
+		init_clk_gen_spread_spectrum_control_register();
 		k_work_schedule_for_queue(&plat_work_q, &check_accl_card_pwr_good_work,
 					  K_MSEC(NORMAL_POWER_GOOD_CHECK_DELAY_MS));
 	} else {


### PR DESCRIPTION
# Description:
- ACB PEX0/PEX1 SYS_REF Clock SSC function should be turn off
- Release a hard fix for this issue.

# Motivation:
- Adjust incorrect SSC for PESW

# Test Plan:
- build code : pass
- power cycle : pass

# log:
root@bmc-oob:~# power-util mb cycle
Power cycling fru 1...

uart:~$ i2c read I2C_2 0x68 0x0
00000000: 01 06 f6 ff 5f 40 31 02  01 36 00 40 00 55 55 55 |...._@1. .6.@.UUU|