### PR TITLE
Artemis: cb: Support to update boot1 firmware when nvme not ready

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_dev.c
+++ b/meta-facebook/at-cb/src/platform/plat_dev.c
@@ -61,6 +61,7 @@ k_tid_t sw_heartbeat_tid;
 #define PAYLOAD_HEADER_UID2 0xE2BC907E
 #define PAYLOAD_HEADER_SIZE 0x10
 #define PAYLOAD_HEADER_VER 0x02
+#define PAYLOAD_HEADER_TYPE_BOOT1 0x01
 #define PAYLOAD_HEADER_TYPE_QSPI 0x16
 #define PAYLOAD_HEADER_TYPE_PSOC 0x1C
 
@@ -71,6 +72,7 @@ k_tid_t sw_heartbeat_tid;
 #define TRANSFER_MEM_INFO_LEN 8
 #define BLOCK_DATA_COUNT 32
 #define WAIT_FIRMWARE_READY_DELAY_TIMEOUT_S 5
+#define WAIT_BOOT1_FIRMWARE_UPDATE_COMPLETE_TIMEOUT_S 20
 #define WAIT_QSPI_FIRMWARE_UPDATE_COMPLETE_TIMEOUT_S 15
 #define WAIT_PSOC_FIRMWARE_UPDATE_COMPLETE_TIMEOUT_S 60
 #define FW_ABORT_UPDATE_RETURN_VAL -2
@@ -78,6 +80,7 @@ k_tid_t sw_heartbeat_tid;
 #define FW_EXEC_STATUS_RUNNING_RETURN_VAL 1
 
 #define CHECK_IS_PROGRESS_DELAY_MS 1000
+#define BOOT1_COMPLETE_BIT BIT(7)
 
 enum ATM_FW_UPDATE_REG_OFFSET {
 	SB_CMD_FW_SMBUS_ERROR_CODE = 0x82,
@@ -86,10 +89,10 @@ enum ATM_FW_UPDATE_REG_OFFSET {
 	SB_CMD_FW_UPDATE_EXT = 0x87,
 	SB_CMD_FW_UPDATE_ERROR_CODE = 0x94,
 	TRANSFER_MEM_START = 0xA4,
+	LCS_STATE = 0xBF,
 	TRANSFER_HEADER_PAGE = 0xC1,
 	TRANSFER_DATA_PACKET = 0xC7,
-	EXEC_STATUS = 0xEB,
-	EXEC_RESULT = 0xED,
+	SB_PAYLOAD_EXEC_T = 0xE9,
 };
 
 enum ATM_SB_CMD_FW_UPDATE_BIT {
@@ -172,7 +175,19 @@ typedef struct _sb_transferdata_packet {
 	uint8_t pec;
 } __attribute__((__packed__)) sb_transferdata_packet;
 
+typedef struct _sb_payload_exec_t {
+	uint8_t length;
+	uint8_t exec_id;
+	uint8_t exec_status;
+	uint8_t exec_state;
+	uint8_t exec_result;
+	uint8_t forced_state_fail;
+	uint8_t abort;
+	uint8_t pec;
+} __attribute__((__packed__)) sb_payload_exec_t;
+
 wait_fw_update_status_info atm_wait_fw_info = { .is_init = false,
+						.type = UNKNOWN_TYPE,
 						.is_work_done = false,
 						.status = EXEC_STATUS_DEFAULT,
 						.result = EXEC_RESULT_DEFAULT };
@@ -593,6 +608,59 @@ bool init_vr_write_protect(uint8_t bus, uint8_t addr, uint8_t default_val)
 	return true;
 }
 
+int check_error_status(uint8_t bus, uint8_t addr, uint32_t *error_code, uint8_t *smbus_error_code)
+{
+	CHECK_NULL_ARG_WITH_RETURN(error_code, -1);
+	CHECK_NULL_ARG_WITH_RETURN(smbus_error_code, -1);
+
+	int ret = 0;
+	int retry = 5;
+	uint8_t offset = SB_CMD_FW_UPDATE_ERROR_CODE;
+	I2C_MSG msg = { 0 };
+
+	msg = construct_i2c_message(bus, addr, 1, &offset, sizeof(uint32_t));
+
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Get error code value fail, bus: 0x%x, addr: 0x%x", bus, addr);
+		return ret;
+	}
+
+	memcpy(error_code, &msg.data[0], sizeof(uint32_t));
+
+	offset = SB_CMD_FW_SMBUS_ERROR_CODE;
+	msg = construct_i2c_message(bus, addr, 1, &offset, sizeof(uint8_t));
+
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Get smbus error code value fail, bus: 0x%x, addr: 0x%x", bus, addr);
+		return ret;
+	}
+
+	*smbus_error_code = msg.data[0];
+	return ret;
+}
+
+int get_boot1_complete_bit(uint8_t bus, uint8_t addr, uint8_t *bit)
+{
+	CHECK_NULL_ARG_WITH_RETURN(bit, -1);
+
+	int ret = 0;
+	int retry = 5;
+	uint8_t offset = LCS_STATE;
+	I2C_MSG msg = { 0 };
+
+	msg = construct_i2c_message(bus, addr, 1, &offset, 1);
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Get boot1 complete bit fail, bus: 0x%x, addr: 0x%x", bus, addr);
+		return ret;
+	}
+
+	*bit = (msg.data[0] & BOOT1_COMPLETE_BIT);
+	return ret;
+}
+
 int sb_cmd_fw_update_bit_operation(uint8_t bus, uint8_t addr, uint8_t optional, uint8_t bit_value)
 {
 	int ret = 0;
@@ -663,6 +731,11 @@ int check_fw_update_bit_operation(uint8_t bus, uint8_t addr, uint8_t optional, u
 			return ret;
 		}
 
+		if (bit_value == SB_CMD_FW_UPDATE_INITIATE_DOWNLOAD_BIT) {
+			//wait bit operation finish
+			k_msleep(300);
+		}
+
 		ret = sb_cmd_fw_update_bit_operation(bus, addr, BIT_GET, bit_value);
 		if (ret < 0) {
 			LOG_ERR("Checking: Fail to get bit val: 0x%x", bit_value);
@@ -671,6 +744,16 @@ int check_fw_update_bit_operation(uint8_t bus, uint8_t addr, uint8_t optional, u
 
 		expected_val = ((optional == BIT_SET) ? bit_value : 0);
 		if (ret != expected_val) {
+			uint32_t error_code = 0;
+			uint8_t smbus_error_code = 0;
+			// read back error status to unlock SMbus write.
+			ret = check_error_status(bus, addr, &error_code, &smbus_error_code);
+			if (ret != 0) {
+				LOG_ERR("Checking bit operation:Fail read error status, bus: 0x%x, addr: 0x%x",
+					bus, addr);
+				return ret;
+			}
+
 			// Retry
 			ret = sb_cmd_fw_update_bit_operation(bus, addr, optional, bit_value);
 			if (ret != 0) {
@@ -723,39 +806,6 @@ int get_atm_transfer_info(uint8_t bus, uint8_t addr, uint32_t *transfer_mem_star
 	return ret;
 }
 
-int check_error_status(uint8_t bus, uint8_t addr, uint32_t *error_code, uint8_t *smbus_error_code)
-{
-	CHECK_NULL_ARG_WITH_RETURN(error_code, -1);
-	CHECK_NULL_ARG_WITH_RETURN(smbus_error_code, -1);
-
-	int ret = 0;
-	int retry = 5;
-	uint8_t offset = SB_CMD_FW_UPDATE_ERROR_CODE;
-	I2C_MSG msg = { 0 };
-
-	msg = construct_i2c_message(bus, addr, 1, &offset, sizeof(uint32_t));
-
-	ret = i2c_master_read(&msg, retry);
-	if (ret != 0) {
-		LOG_ERR("Get error code value fail, bus: 0x%x, addr: 0x%x", bus, addr);
-		return ret;
-	}
-
-	memcpy(error_code, &msg.data[0], sizeof(uint32_t));
-
-	offset = SB_CMD_FW_SMBUS_ERROR_CODE;
-	msg = construct_i2c_message(bus, addr, 1, &offset, sizeof(uint8_t));
-
-	ret = i2c_master_read(&msg, retry);
-	if (ret != 0) {
-		LOG_ERR("Get smbus error code value fail, bus: 0x%x, addr: 0x%x", bus, addr);
-		return ret;
-	}
-
-	*smbus_error_code = msg.data[0];
-	return ret;
-}
-
 int pre_atm_fw_update_check(uint8_t *msg_buf, uint16_t buf_len, hbin_header *h_header,
 			    payload_header *p_header)
 {
@@ -795,7 +845,8 @@ int pre_atm_fw_update_check(uint8_t *msg_buf, uint16_t buf_len, hbin_header *h_h
 	}
 
 	if ((p_header->type != PAYLOAD_HEADER_TYPE_QSPI) &&
-	    (p_header->type != PAYLOAD_HEADER_TYPE_PSOC)) {
+	    (p_header->type != PAYLOAD_HEADER_TYPE_PSOC) &&
+	    (p_header->type != PAYLOAD_HEADER_TYPE_BOOT1)) {
 		LOG_ERR("Invalid payload header type: 0x%x", p_header->type);
 		return -1;
 	}
@@ -932,30 +983,20 @@ int check_exec_status(uint8_t bus, uint8_t addr, uint8_t *status, uint8_t *resul
 
 	int ret = 0;
 	int retry = 5;
-	uint8_t offset = 0;
+	uint8_t offset = SB_PAYLOAD_EXEC_T;
 	I2C_MSG msg = { 0 };
 
-	offset = EXEC_STATUS;
-	msg = construct_i2c_message(bus, addr, 1, &offset, 1);
-
+	msg = construct_i2c_message(bus, addr, 1, &offset, sizeof(sb_payload_exec_t));
 	ret = i2c_master_read(&msg, retry);
 	if (ret != 0) {
-		LOG_ERR("Check exec_status fail, bus: 0x%x, addr: 0x%x", bus, addr);
+		LOG_ERR("Read sb_payload_exec_t data fail, bus: 0x%x, addr: 0x%x", bus, addr);
 		return ret;
 	}
 
-	*status = msg.data[0];
+	sb_payload_exec_t *arg = (sb_payload_exec_t *)&msg.data[0];
 
-	offset = EXEC_RESULT;
-	msg = construct_i2c_message(bus, addr, 1, &offset, 1);
-
-	ret = i2c_master_read(&msg, retry);
-	if (ret != 0) {
-		LOG_ERR("Check exec_result fail, bus: 0x%x, addr: 0x%x", bus, addr);
-		return ret;
-	}
-
-	*result = msg.data[0];
+	*status = arg->exec_status;
+	*result = arg->exec_result;
 	return ret;
 }
 
@@ -967,30 +1008,52 @@ void wait_firmware_work_handler(struct k_work *work_item)
 
 	int ret = -1;
 	int index = 0;
+	uint8_t bit = 0;
 
 	for (index = 0; index < work_info->timeout_s; ++index) {
 		k_sleep(K_SECONDS(WAIT_FIRMWARE_READY_DELAY_S));
 
-		ret = check_exec_status(work_info->bus, work_info->addr, &work_info->status,
-					&work_info->result);
-		if (ret != 0) {
-			LOG_WRN("Check exec status fail on waiting firmware work, current time: 0x%x",
-				index + 1);
-			continue;
-		}
-
-		if (work_info->status == EXEC_STATUS_COMPLETE) {
-			if (work_info->result != EXEC_RESULT_PASS) {
-				LOG_ERR("Error: exec result is %s",
-					(work_info->result == EXEC_RESULT_ABORTED ? "aborted" :
-										    "fail"));
+		if (work_info->type == PAYLOAD_HEADER_TYPE_BOOT1) {
+			ret = get_boot1_complete_bit(work_info->bus, work_info->addr, &bit);
+			if (ret < 0) {
+				LOG_WRN("Get boot1 complete bit fail on waiting firmware work, current time: 0x%x",
+					index + 1);
+				continue;
 			}
+
+			if (bit == 0) {
+				continue;
+			}
+
+			LOG_INF("Boot1 complete");
+			work_info->status = EXEC_STATUS_COMPLETE;
+			work_info->result = EXEC_RESULT_PASS;
 			work_info->is_work_done = true;
 			return;
+		} else {
+			ret = check_exec_status(work_info->bus, work_info->addr, &work_info->status,
+						&work_info->result);
+			if (ret != 0) {
+				LOG_WRN("Check exec status fail on waiting firmware work, current time: 0x%x",
+					index + 1);
+				continue;
+			}
+
+			if (work_info->status == EXEC_STATUS_COMPLETE) {
+				if (work_info->result != EXEC_RESULT_PASS) {
+					LOG_ERR("Error: exec result is %s",
+						(work_info->result == EXEC_RESULT_ABORTED ?
+							 "aborted" :
+							 "fail"));
+				}
+				work_info->is_work_done = true;
+				return;
+			}
 		}
 	}
 
-	LOG_ERR("Wait firmware exec status timeout, total wait: %d seconds", work_info->timeout_s);
+	LOG_ERR("Wait firmware exec status timeout, total wait: %d seconds, type: 0x%x",
+		work_info->timeout_s, work_info->type);
 	work_info->status = EXEC_STATUS_TIMEOUT;
 	work_info->is_work_done = true;
 	return;
@@ -1159,16 +1222,31 @@ int atm_fw_update(uint8_t bus, uint8_t addr, uint32_t offset, uint8_t *msg_buf, 
 		}
 
 		/* Step 9: Check error_code, exec_status, exec_result */
+		if (p_header.type == PAYLOAD_HEADER_TYPE_BOOT1) {
+			uint8_t bit = 0;
+			ret = get_boot1_complete_bit(bus, addr, &bit);
+			if (ret < 0) {
+				LOG_ERR("Get boot1 complete bit fail on Step 9");
+			}
+
+			if (bit != 0) {
+				LOG_WRN("Boot1 complete bit should be 0");
+			}
+		}
+
 		ret = check_error_status(bus, addr, &error_code, &smbus_error_code);
 		if (ret != 0) {
 			LOG_ERR("Get error code fail on Step 9, bus: 0x%x, addr: 0x%x", bus, addr);
 			goto exit;
 		}
 
-		ret = check_exec_status(bus, addr, &exec_status, &exec_result);
-		if (ret != 0) {
-			LOG_ERR("Get exec status fail on Step 9, bus: 0x%x, addr: 0x%x", bus, addr);
-			goto exit;
+		if (p_header.type != PAYLOAD_HEADER_TYPE_BOOT1) {
+			ret = check_exec_status(bus, addr, &exec_status, &exec_result);
+			if (ret != 0) {
+				LOG_ERR("Get exec status fail on Step 9, bus: 0x%x, addr: 0x%x",
+					bus, addr);
+				goto exit;
+			}
 		}
 
 		LOG_INF("Error code: 0x%x, smbus error code: 0x%x, exec status: 0x%x, exec_result: 0x%x after firmware update complete",
@@ -1182,9 +1260,14 @@ int atm_fw_update(uint8_t bus, uint8_t addr, uint32_t offset, uint8_t *msg_buf, 
 
 		atm_wait_fw_info.bus = bus;
 		atm_wait_fw_info.addr = addr;
-		atm_wait_fw_info.timeout_s = (p_header.type == PAYLOAD_HEADER_TYPE_QSPI ?
-						      WAIT_QSPI_FIRMWARE_UPDATE_COMPLETE_TIMEOUT_S :
-						      WAIT_PSOC_FIRMWARE_UPDATE_COMPLETE_TIMEOUT_S);
+		atm_wait_fw_info.type = p_header.type;
+		if (p_header.type == PAYLOAD_HEADER_TYPE_QSPI) {
+			atm_wait_fw_info.timeout_s = WAIT_QSPI_FIRMWARE_UPDATE_COMPLETE_TIMEOUT_S;
+		} else if (p_header.type == PAYLOAD_HEADER_TYPE_PSOC) {
+			atm_wait_fw_info.timeout_s = WAIT_PSOC_FIRMWARE_UPDATE_COMPLETE_TIMEOUT_S;
+		} else {
+			atm_wait_fw_info.timeout_s = WAIT_BOOT1_FIRMWARE_UPDATE_COMPLETE_TIMEOUT_S;
+		}
 
 		k_work_schedule_for_queue(&plat_work_q, &atm_wait_fw_info.wait_firmware_work,
 					  K_NO_WAIT);

--- a/meta-facebook/at-cb/src/platform/plat_dev.h
+++ b/meta-facebook/at-cb/src/platform/plat_dev.h
@@ -39,7 +39,8 @@
 #define FREYA_FIRMWARE_VERSION_LENGTH 5
 #define FREYA_NOT_READY_RET_CODE -2
 #define FREYA_NOT_SUPPORT_MODULE_IDENTIFIER_RET_CODE -3
-#define WAIT_FIRMWARE_READY_DELAY_S 3
+#define WAIT_FIRMWARE_READY_DELAY_S 1
+#define UNKNOWN_TYPE 0xFF
 
 typedef struct _freya_fw_info {
 	uint8_t is_freya_ready;
@@ -84,6 +85,7 @@ typedef struct _wait_fw_update_status_info {
 	bool is_work_done;
 	uint8_t bus;
 	uint8_t addr;
+	uint8_t type;
 	uint8_t status;
 	uint8_t result;
 	uint8_t timeout_s;
@@ -110,6 +112,7 @@ extern vr_fw_info cb_vr_fw_info;
 extern switch_error_check_info sw_error_check_info[];
 extern wait_fw_update_status_info atm_wait_fw_info;
 
+int get_boot1_complete_bit(uint8_t bus, uint8_t addr, uint8_t *bit);
 void clear_freya_cache_flag(uint8_t card_id);
 void clear_accl_cable_power_fault_flag();
 int get_freya_fw_info(uint8_t bus, uint8_t addr, freya_fw_info *fw_info);

--- a/meta-facebook/at-cb/src/platform/plat_pldm_device_identifier.c
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_device_identifier.c
@@ -125,15 +125,62 @@ struct pldm_descriptor_string ASIC_QSPI_DESCRIPTOR_TABLE[] = {
 	},
 };
 
+struct pldm_descriptor_string ASIC_BOOT1_DESCRIPTOR_TABLE[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Artemis",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "ColterBay",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Stage",
+		.descriptor_data = "PVT",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"62726f6164636f6d5f61736963000000000000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "33000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_PCI_VENDOR_ID,
+		.title_string = NULL,
+		.descriptor_data = "1D9B",
+	},
+	{
+		.descriptor_type = PLDM_PCI_DEVICE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0201",
+	},
+};
+
 const uint8_t bic_descriptors_count = ARRAY_SIZE(PLDM_DEVICE_DESCRIPTOR_TABLE);
 const uint8_t asic_psoc_descriptors_count = ARRAY_SIZE(ASIC_PSOC_DESCRIPTOR_TABLE);
 const uint8_t asic_qspi_descriptors_count = ARRAY_SIZE(ASIC_QSPI_DESCRIPTOR_TABLE);
+const uint8_t asic_boot1_descriptors_count = ARRAY_SIZE(ASIC_BOOT1_DESCRIPTOR_TABLE);
 
 struct pldm_downstream_identifier_table downstream_table[] = {
 	{ .descriptor = ASIC_PSOC_DESCRIPTOR_TABLE,
 	  .descriptor_count = asic_psoc_descriptors_count },
 	{ .descriptor = ASIC_QSPI_DESCRIPTOR_TABLE,
 	  .descriptor_count = asic_qspi_descriptors_count },
+	{ .descriptor = ASIC_BOOT1_DESCRIPTOR_TABLE,
+	  .descriptor_count = asic_boot1_descriptors_count },
 };
 
 const uint8_t downstream_table_count = ARRAY_SIZE(downstream_table);

--- a/meta-facebook/at-cb/src/platform/plat_pldm_device_identifier.h
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_device_identifier.h
@@ -22,12 +22,14 @@
 extern const uint8_t bic_descriptors_count;
 extern const uint8_t asic_psoc_descriptors_count;
 extern const uint8_t asic_qspi_descriptors_count;
+extern const uint8_t asic_boot1_descriptors_count;
 
 extern const uint8_t downstream_table_count;
 
 extern struct pldm_descriptor_string PLDM_DEVICE_DESCRIPTOR_TABLE[];
 extern struct pldm_descriptor_string ASIC_PSOC_DESCRIPTOR_TABLE[];
 extern struct pldm_descriptor_string ASIC_QSPI_DESCRIPTOR_TABLE[];
+extern struct pldm_descriptor_string ASIC_BOOT1_DESCRIPTOR_TABLE[];
 
 extern struct pldm_downstream_identifier_table downstream_table[];
 

--- a/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/at-cb/src/platform/plat_pldm_fw_update.c
@@ -59,6 +59,7 @@ static uint8_t pldm_pre_vr_update(void *fw_update_param);
 static uint8_t pldm_post_vr_update(void *fw_update_param);
 static uint8_t plat_pldm_vr_update(void *fw_update_param);
 static uint8_t pldm_pre_atm_update(void *fw_update_param);
+static uint8_t pldm_pre_boot1_update(void *fw_update_param);
 static uint8_t pldm_post_atm_update(void *fw_update_param);
 static uint8_t pldm_atm_update(void *fw_update_param);
 static uint8_t pldm_atm_apply_work();
@@ -171,6 +172,21 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.get_fw_version_fn = get_atm_fw_version,
 		.self_apply_work_func = pldm_atm_apply_work,
 		.comp_version_str = "qspi",
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = CB_COMPNT_ACCL1_CH1_FREYA,
+		.comp_classification_index = 0x00,
+		.pre_update_func = pldm_pre_boot1_update,
+		.update_func = pldm_atm_update,
+		.pos_update_func = pldm_post_atm_update,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_atm_fw_version,
+		.self_apply_work_func = pldm_atm_apply_work,
+		.comp_version_str = "boot1",
 	},
 };
 
@@ -545,16 +561,81 @@ static bool get_atm_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 	}
 }
 
+static uint8_t pldm_pre_boot1_update(void *fw_update_param)
+{
+	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, PLDM_FW_UPDATE_ERROR);
+
+	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
+	uint8_t card_id = (p->comp_id - CB_COMPNT_ACCL1_CH1_FREYA) / 2;
+	uint8_t device_id = ((p->comp_id - CB_COMPNT_ACCL1_CH1_FREYA) % 2);
+
+	if (is_time_to_poll_card_sensor(card_id) != true) {
+		LOG_ERR("Artemis module power status not ready, card id: 0x%x", card_id);
+		return PLDM_FW_UPDATE_ERROR;
+	}
+
+	if (device_id == PCIE_DEVICE_ID1) {
+		if (accl_freya_info[card_id].freya1_fw_info.is_freya_ready != FREYA_NOT_READY) {
+			LOG_ERR("Not support boot1 firmware update when nvme ready, card id: 0x%x, device id: 0x%x",
+				card_id, device_id);
+			return PLDM_FW_UPDATE_ERROR;
+		}
+	} else {
+		if (accl_freya_info[card_id].freya2_fw_info.is_freya_ready != FREYA_NOT_READY) {
+			LOG_ERR("Not support boot1 firmware update when nvme ready, card id: 0x%x, device id: 0x%x",
+				card_id, device_id);
+			return PLDM_FW_UPDATE_ERROR;
+		}
+	}
+
+	/* Stop sensor polling at first package */
+	if (p->data_ofs == 0) {
+		disable_sensor_poll();
+		k_msleep(DISABLE_SENSOR_POLLING_DELAY_MS);
+	}
+
+	mux_config accl_mux = { 0 };
+	if (get_accl_mux_config(card_id, &accl_mux) != true) {
+		LOG_ERR("Fail to get ACCL card mux config, card id: 0x%x", card_id);
+		return PLDM_FW_UPDATE_ERROR;
+	}
+
+	if (set_mux_channel(accl_mux, MUTEX_LOCK_ENABLE) == false) {
+		LOG_ERR("ACCL switch card mux fail, card id: 0x%x", card_id);
+		return PLDM_FW_UPDATE_ERROR;
+	}
+
+	p->bus = ((card_id < (ASIC_CARD_COUNT / 2)) ? I2C_BUS8 : I2C_BUS7);
+	p->addr = (p->comp_id % 2 ? ACCL_ARTEMIS_MODULE_2_ADDR : ACCL_ARTEMIS_MODULE_1_ADDR);
+
+	return PLDM_FW_UPDATE_SUCCESS;
+}
+
 static uint8_t pldm_pre_atm_update(void *fw_update_param)
 {
 	CHECK_NULL_ARG_WITH_RETURN(fw_update_param, PLDM_FW_UPDATE_ERROR);
 
 	pldm_fw_update_param_t *p = (pldm_fw_update_param_t *)fw_update_param;
 	uint8_t card_id = (p->comp_id - CB_COMPNT_ACCL1_CH1_FREYA) / 2;
+	uint8_t device_id = ((p->comp_id - CB_COMPNT_ACCL1_CH1_FREYA) % 2);
 
 	if (is_time_to_poll_card_sensor(card_id) != true) {
 		LOG_ERR("Artemis module power status not ready, card id: 0x%x", card_id);
 		return PLDM_FW_UPDATE_ERROR;
+	}
+
+	if (device_id == PCIE_DEVICE_ID1) {
+		if (accl_freya_info[card_id].freya1_fw_info.is_freya_ready != FREYA_READY) {
+			LOG_ERR("ACCL card: 0x%x, device id: 0x%x nvme not ready", card_id,
+				device_id);
+			return PLDM_FW_UPDATE_ERROR;
+		}
+	} else {
+		if (accl_freya_info[card_id].freya2_fw_info.is_freya_ready != FREYA_READY) {
+			LOG_ERR("ACCL card: 0x%x, device id: 0x%x nvme not ready", card_id,
+				device_id);
+			return PLDM_FW_UPDATE_ERROR;
+		}
 	}
 
 	mux_config accl_mux = { 0 };

--- a/scripts/signing/pldm_fw_package/platform/cfg_at_cb_asic_psoc_qspi.json
+++ b/scripts/signing/pldm_fw_package/platform/cfg_at_cb_asic_psoc_qspi.json
@@ -95,6 +95,51 @@
                     "DescriptorData": "0201"
                 }
             ]
+        },
+        {
+            "DeviceUpdateOptionFlags": [0],
+            "ComponentImageSetVersionString": "PLDM_UPDATE_SUPPORTED_DEVICE",
+            "ApplicableComponents": [0],
+            "Descriptors": [
+                {
+                    "DescriptorType": 1,
+                    "DescriptorData": "0000A015"
+                },
+                {
+                    "DescriptorType" : 65535,
+                    "VendorDefinedDescriptorTitleStringType" : 2,
+                    "VendorDefinedDescriptorTitleString" : "Platform",
+                    "VendorDefinedDescriptorData" : "Artemis"
+                },
+                {
+                    "DescriptorType" : 65535,
+                    "VendorDefinedDescriptorTitleStringType" : 2,
+                    "VendorDefinedDescriptorTitleString" : "Board",
+                    "VendorDefinedDescriptorData" : "ColterBay"
+                },
+                {
+                    "DescriptorType" : 65535,
+                    "VendorDefinedDescriptorTitleStringType" : 2,
+                    "VendorDefinedDescriptorTitleString" : "Stage",
+                    "VendorDefinedDescriptorData" : "PVT"
+                },
+                {
+                    "DescriptorType": 262,
+                    "DescriptorData": "62726f6164636f6d5f61736963000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "DescriptorType": 263,
+                    "DescriptorData": "33000000000000000000"
+                },
+                {
+                    "DescriptorType": 0,
+                    "DescriptorData": "1D9B"
+                },
+                {
+                    "DescriptorType": 256,
+                    "DescriptorData": "0201"
+                }
+            ]
         }
     ],
     "ComponentImageInformationArea": [
@@ -103,14 +148,21 @@
             "ComponentIdentifier": 0,
             "ComponentOptions": [0],
             "RequestedComponentActivationMethod": [0],
-            "ComponentVersionString": "psoc v12.100"
+            "ComponentVersionString": "psoc v17.100"
         },
         {
             "ComponentClassification": 65535,
             "ComponentIdentifier": 0,
             "ComponentOptions": [0],
             "RequestedComponentActivationMethod": [0],
-            "ComponentVersionString": "qspi v10"
+            "ComponentVersionString": "qspi v12"
+        },
+        {
+            "ComponentClassification": 65535,
+            "ComponentIdentifier": 0,
+            "ComponentOptions": [0],
+            "RequestedComponentActivationMethod": [0],
+            "ComponentVersionString": "boot1 v3.5"
         }
     ]
 }


### PR DESCRIPTION
# Description:
- Support to update boot1 firmware when nvme not ready.
  - Because the currently supported QSPI/PSOC firmware update is when boot1 is loaded, if the OS can't be booted but the Artemis module has power, we need to load boot1 through SMbus to update the QSPI/PSOC firmware.

# Motivation:
- Support to update boot1 firmware when nvme not ready.

# Test Plan:
- Build code: Pass
- Update boot1 firmware when nvme not ready:

# Log:

root@bmc-oob:~# fw-util cb_accl7 --update dev1_boot1 at_cb_psoc_qspi_boot1.pldm Note: Host can't be used to load boot1 during the update process. RequestUpdate Success.
PassComponentTable Success.
UpdateComponent Success.
Download offset : 0x00024800/0x00024880, size : 0x00000080 TransferComplete.
VerifyComplete.
Wait for loading firmware, no more than 20s...
ApplyComplete.
ActivateFirmwareComplete.
Upgrade of cb_accl7 : dev1_boot1 succeeded