### PR TITLE
oby4: wf: Support VR MP2971 sensor reading

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.h
@@ -61,8 +61,14 @@ enum SENSOR_THREAD_LIST {
 	MAX_SENSOR_THREAD_ID,
 };
 
+enum GET_VR_DEV_STATUS {
+	GET_VR_DEV_SUCCESS = 0,
+	GET_VR_DEV_FAILED,
+};
+
 int plat_pldm_sensor_get_sensor_count(int thread_id);
 void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
 					     PDR_numeric_sensor *numeric_sensor_table);
+uint8_t plat_pldm_sensor_get_vr_dev(uint8_t *vr_dev);
 
 #endif


### PR DESCRIPTION
# Description:
    - Determine the VR model through IO expander P14.
        - If P14 is high, the VR type is MP2971.
        - If P14 is low, the VR type is xdpe12284c.
# Motivation:
    - Support to read sensors of MP2971 device.
# Test plan:
    Read VR sensors: Pass
# Test log:
    root@bmc:/tmp# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/current/WF_VR_P0V85_ASIC1_CURR_A_68_72
    NAME                                                  TYPE      SIGNATURE RESULT/VALUE                             FLAGS
    ```
    .Value                                                property  d         3.5                                      emits-change writable
    xyz.openbmc_project.State.Decorator.Availability      interface -         -                                        -
    ```