### PR TITLE
yv4: sd: Define EVT WF_BIC_READY GPIO

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_gpio.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_gpio.c
@@ -290,6 +290,8 @@ bool pal_load_gpio_config(void)
 		plat_gpio_cfg[EVT_MEDUSA_HSC_R_PG].is_init = ENABLE;
 		gpio_name[EVT_MEDUSA_HSC_R_PG] = "MEDUSA_HSC_R_PG";
 		plat_gpio_cfg[EVT_Reserve_GPIOM3].is_init = DISABLE;
+		plat_gpio_cfg[EVT_BIC_READY_FRONT_EXP].is_init = ENABLE;
+		gpio_name[EVT_BIC_READY_FRONT_EXP] = "BIC_READY_FRONT_EXP";
 	}
 
 	memcpy(&gpio_cfg[0], &plat_gpio_cfg[0], sizeof(plat_gpio_cfg));


### PR DESCRIPTION
# Description:
The WF_BIC_READY pin is GPIOJ4 in EVT stage, and it will change to GPIOF4 in DVT stage.

# Motivation:
The GPIO definition had been change to DVT. Add EVT definition so it is also work on EVT machine.

# Test Plan:
Check with `platform gpio list_all` - Pass
uart:~$ platform gpio list_all
[0  ] FM_CPU_BIC_SLP_S5_N                : OD  | input (I) | 1(1)
[1  ] FM_CPU_BIC_SLP_S3_N                : OD  | input (I) | 1(1)
[2  ] RST_RSMRST_BMC_N                   : OD  | input (I) | 1(1)
...
[76 ] BIC_READY_FRONT_EXP                : OD  | input (I) | 1(1)