### PR TITLE
yv4: sd: support PLDM Downstream Device including BIOS

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_device_identifier.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_device_identifier.c
@@ -1,0 +1,189 @@
+#include "libutil.h"
+#include "pldm_firmware_update.h"
+#include "plat_pldm_device_identifier.h"
+
+struct pldm_descriptor_string PLDM_VR_PVDDCR_CPU1_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "SentinelDome",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"4d50535f565200000000000000000000000000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "31000000000000000000",
+	},
+};
+
+struct pldm_descriptor_string PLDM_VR_PVDD11_S3_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "SentinelDome",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"4d50535f565200000000000000000000000000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "32000000000000000000",
+	},
+};
+
+struct pldm_descriptor_string PLDM_VR_PVDDCR_CPU0_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "SentinelDome",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"4d50535f565200000000000000000000000000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "33000000000000000000",
+	},
+};
+
+struct pldm_descriptor_string PLDM_RETIMER_X16_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "SentinelDome",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"4153544552414c41425f526574696d65720000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "31000000000000000000",
+	},
+};
+
+struct pldm_descriptor_string PLDM_RETIMER_X8_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "SentinelDome",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"4153544552414c41425f526574696d65720000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "32000000000000000000",
+	},
+};
+
+struct pldm_descriptor_string PLDM_BIOS_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "SentinelDome",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"42494f53000000000000000000000000000000000000000000000000000000000000000000000000",
+	},
+};
+
+struct pldm_downstream_identifier_table downstream_table[] = {
+	{ .descriptor = PLDM_VR_PVDDCR_CPU1_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_VR_PVDDCR_CPU1_DESCRIPTORS) },
+	{ .descriptor = PLDM_VR_PVDD11_S3_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_VR_PVDD11_S3_DESCRIPTORS) },
+	{ .descriptor = PLDM_VR_PVDDCR_CPU0_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_VR_PVDDCR_CPU0_DESCRIPTORS) },
+	{ .descriptor = PLDM_RETIMER_X16_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_RETIMER_X16_DESCRIPTORS) },
+	{ .descriptor = PLDM_RETIMER_X8_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_RETIMER_X8_DESCRIPTORS) },
+	{ .descriptor = PLDM_BIOS_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_BIOS_DESCRIPTORS) },
+};
+
+const uint8_t downstream_devices_count = ARRAY_SIZE(downstream_table);

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_device_identifier.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_device_identifier.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _PLAT_PLDM_DEVICE_IDENTIFIER_H_
+#define _PLAT_PLDM_DEVICE_IDENTIFIER_H_
+
+#include "pldm_firmware_update.h"
+
+extern const uint8_t downstream_devices_count;
+
+extern struct pldm_downstream_identifier_table downstream_table[];
+
+#endif

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
@@ -31,6 +31,7 @@
 #include "pt5161l.h"
 #include "raa229621.h"
 #include "plat_class.h"
+#include "plat_pldm_device_identifier.h"
 
 LOG_MODULE_REGISTER(plat_fwupdate);
 
@@ -39,6 +40,7 @@ static uint8_t plat_pldm_post_vr_update(void *fw_update_param);
 static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len);
 static uint8_t plat_pldm_pre_retimer_update(void *fw_update_param);
 static bool plat_get_retimer_fw_version(void *info_p, uint8_t *buf, uint8_t *len);
+static bool plat_get_bios_fw_version(void *info_p, uint8_t *buf, uint8_t *len);
 
 enum FIRMWARE_COMPONENT {
 	SD_COMPNT_BIC,
@@ -47,6 +49,7 @@ enum FIRMWARE_COMPONENT {
 	SD_COMPNT_VR_PVDDCR_CPU0,
 	SD_COMPNT_X16_RETIMER,
 	SD_COMPNT_X8_RETIMER,
+	SD_COMPNT_BIOS,
 };
 
 uint8_t MCTP_SUPPORTED_MESSAGES_TYPES[] = {
@@ -157,6 +160,21 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.self_apply_work_func = NULL,
 		.comp_version_str = NULL,
 	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = SD_COMPNT_BIOS,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_SPI,
+		.activate_method = COMP_ACT_SYS_REBOOT,
+		.self_act_func = NULL,
+		.get_fw_version_fn = plat_get_bios_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
 };
 
 uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uint8_t *resp,
@@ -250,6 +268,183 @@ uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uin
 	*resp_len = sizeof(struct pldm_query_device_identifiers_resp) +
 		    total_size_of_iana_descriptor + total_size_of_device_id_descriptor +
 		    total_size_of_slot_descriptor;
+
+	return PLDM_SUCCESS;
+}
+
+uint8_t plat_pldm_query_downstream_devices(const uint8_t *buf, uint16_t len, uint8_t *resp,
+					   uint16_t *resp_len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, false);
+	CHECK_NULL_ARG_WITH_RETURN(resp, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, PLDM_ERROR);
+
+	struct pldm_query_downstream_devices_resp *resp_p =
+		(struct pldm_query_downstream_devices_resp *)resp;
+
+	resp_p->completion_code = PLDM_SUCCESS;
+	resp_p->downstream_device_update_supported = PLDM_FW_UPDATE_SUPPORT_DOWNSTREAM_DEVICES;
+	resp_p->number_of_downstream_devices = 5;
+	resp_p->max_number_of_downstream_devices = 5;
+
+	resp_p->capabilities.dynamically_attached = 0;
+	resp_p->capabilities.dynamically_removed = 0;
+	resp_p->capabilities.support_update_simultaneously = 0;
+
+	*resp_len = sizeof(struct pldm_query_downstream_devices_resp);
+
+	return PLDM_SUCCESS;
+}
+
+static uint8_t get_returned_devices_start_index(struct pldm_query_downstream_identifier_req *req,
+						uint32_t *index)
+{
+	switch (req->transferoperationflag) {
+	case PLDM_FW_UPDATE_GET_FIRST_PART:
+		*(index) = 0;
+		break;
+	case PLDM_FW_UPDATE_GET_NEXT_PART:
+		if (req->datatransferhandle >= downstream_devices_count) {
+			LOG_ERR("%s:%s:%d: Invalid data transfer handle: 0x%x", __FILE__, __func__,
+				__LINE__, req->datatransferhandle);
+			return PLDM_FW_UPDATE_CC_INVALID_TRANSFER_HANDLE;
+		}
+		*(index) = req->datatransferhandle;
+		break;
+	default:
+		LOG_ERR("%s:%s:%d: Invalid transfer operation flag: 0x%x", __FILE__, __func__,
+			__LINE__, req->transferoperationflag);
+		return PLDM_FW_UPDATE_CC_INVALID_TRANSFER_OPERATION_FLAG;
+	}
+
+	return PLDM_SUCCESS;
+}
+
+static size_t calculate_descriptors_size(struct pldm_descriptor_string *descriptors, uint8_t count)
+{
+	size_t size = 0;
+	for (size_t i = 0; i < count; i++) {
+		size += strlen(descriptors[i].descriptor_data);
+		switch (descriptors[i].descriptor_type) {
+		case PLDM_FWUP_VENDOR_DEFINED:
+			size += sizeof(struct pldm_vendor_defined_descriptor_tlv) +
+						descriptors[i].title_string ?
+					strlen(descriptors[i].title_string) :
+					0;
+			break;
+		default:
+			size += sizeof(struct pldm_descriptor_tlv);
+			break;
+		}
+	}
+
+	return size;
+}
+
+static bool remaining_data_can_be_returned_in_one_transaction(uint32_t start_index,
+							      uint32_t *next_transaction_index)
+{
+	size_t total_size = sizeof(pldm_hdr) + sizeof(struct pldm_query_downstream_identifier_resp);
+	uint32_t i = start_index;
+	while (i < downstream_devices_count) {
+		total_size += sizeof(struct pldm_downstream_device) +
+			      calculate_descriptors_size(downstream_table[i].descriptor,
+							 downstream_table[i].descriptor_count);
+		if (total_size >= PLDM_MAX_DATA_SIZE) {
+			*next_transaction_index = i;
+			return false;
+		}
+
+		i++;
+	}
+	*next_transaction_index = 0;
+
+	return true;
+}
+
+uint8_t plat_pldm_query_downstream_identifiers(const uint8_t *buf, uint16_t len, uint8_t *resp,
+					       uint16_t *resp_len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, PLDM_ERROR);
+
+	uint8_t rc = PLDM_ERROR;
+
+	struct pldm_query_downstream_identifier_req *req_p =
+		(struct pldm_query_downstream_identifier_req *)buf;
+	struct pldm_query_downstream_identifier_resp *resp_p =
+		(struct pldm_query_downstream_identifier_resp *)resp;
+
+	resp_p->completion_code = PLDM_ERROR;
+
+	uint32_t start_index = 0;
+	rc = get_returned_devices_start_index(req_p, &start_index);
+	if (rc) {
+		LOG_ERR("%s:%s:%d: Failed to get returning devices start index.", __FILE__,
+			__func__, __LINE__);
+		return rc;
+	}
+
+	uint32_t next_transaction_index = 0;
+	if (remaining_data_can_be_returned_in_one_transaction(start_index,
+							      &next_transaction_index)) {
+		resp_p->nextdatatransferhandle = 0;
+		resp_p->numbwerofdownstreamdevice = downstream_devices_count - start_index;
+		switch (req_p->transferoperationflag) {
+		case PLDM_FW_UPDATE_GET_FIRST_PART:
+			resp_p->transferflag = PLDM_FW_UPDATE_TRANSFER_START_AND_END;
+			break;
+		case PLDM_FW_UPDATE_GET_NEXT_PART:
+			resp_p->transferflag = PLDM_FW_UPDATE_TRANSFER_END;
+			break;
+		}
+	} else {
+		resp_p->nextdatatransferhandle = next_transaction_index;
+		resp_p->numbwerofdownstreamdevice = resp_p->nextdatatransferhandle - start_index;
+		switch (req_p->transferoperationflag) {
+		case PLDM_FW_UPDATE_GET_FIRST_PART:
+			resp_p->transferflag = PLDM_FW_UPDATE_TRANSFER_START;
+			break;
+		case PLDM_FW_UPDATE_GET_NEXT_PART:
+			resp_p->transferflag = PLDM_FW_UPDATE_TRANSFER_MIDDLE;
+			break;
+		}
+	}
+
+	uint32_t downstream_devices_length = 0;
+	uint8_t curr_descriptor_length = 0;
+	struct pldm_downstream_device *curr_device =
+		(struct pldm_downstream_device
+			 *)(resp + sizeof(struct pldm_query_downstream_identifier_resp));
+	struct pldm_descriptor_string *curr_descriptors_tbl;
+
+	for (uint32_t i = start_index; i < start_index + resp_p->numbwerofdownstreamdevice; i++) {
+		curr_descriptors_tbl = downstream_table[i].descriptor;
+		curr_device->downstreamdeviceindex = i + 1;
+		curr_device->downstreamdescriptorcount = downstream_table[i].descriptor_count;
+		downstream_devices_length += sizeof(struct pldm_downstream_device);
+		uint8_t *descriptor_ptr = curr_device->downstreamdescriptors;
+		for (uint32_t j = 0; j < downstream_table[i].descriptor_count; j++) {
+			rc = fill_descriptor_into_buf(&curr_descriptors_tbl[j], descriptor_ptr,
+						      &curr_descriptor_length,
+						      downstream_devices_length);
+			if (rc) {
+				LOG_ERR("%s:%s:%d: Fill device descriptor into buffer fail.",
+					__FILE__, __func__, __LINE__);
+				return PLDM_ERROR;
+			}
+			downstream_devices_length += curr_descriptor_length;
+			descriptor_ptr += curr_descriptor_length;
+		}
+
+		curr_device = (struct pldm_downstream_device *)descriptor_ptr;
+	}
+
+	resp_p->downstreamdevicelength = downstream_devices_length;
+	*resp_len =
+		sizeof(struct pldm_query_downstream_identifier_resp) + downstream_devices_length;
+	resp_p->completion_code = PLDM_SUCCESS;
 
 	return PLDM_SUCCESS;
 }
@@ -452,6 +647,27 @@ static bool plat_get_retimer_fw_version(void *info_p, uint8_t *buf, uint8_t *len
 	memcpy(buf_p, version, RETIMER_PT5161L_FW_VER_LEN);
 	*len += bin2hex(version, 4, buf_p, 8);
 	buf_p += 8;
+
+	return ret;
+}
+
+static bool plat_get_bios_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(info_p, false);
+	CHECK_NULL_ARG_WITH_RETURN(buf, false);
+	CHECK_NULL_ARG_WITH_RETURN(len, false);
+
+	bool ret = false;
+	const char *bios_version = pldm_smbios_get_bios_version();
+	if (!bios_version) {
+		memcpy(buf, "N/A", 3);
+		*len = 3;
+	} else {
+		memcpy(buf, bios_version, strlen(bios_version));
+	}
+
+	ret = true;
+	*len = strlen(bios_version);
 
 	return ret;
 }


### PR DESCRIPTION
Summary:
# Description:
- Add support of PLDM Downstream Devices in yv4 sd.
- Add BIOS as a Downstream Device and query its version.

# Motivation:
- BMC should be able to query Downstream Devices version.

# Test Plan:
- Build code: pass
- BMC successfully get information of Downstream Devices: pass

# Test Log:
```
[BMC query Downstream Devices and generate DBus Objects]
root@bmc:~# busctl tree xyz.openbmc_project.PLDM |grep inventory
    ├─ /xyz/openbmc_project/inventory
    │ ├─ /xyz/openbmc_project/inventory/Item
    │ │ └─ /xyz/openbmc_project/inventory/Item/Board
    │ │   └─ /xyz/openbmc_project/inventory/Item/Board/PLDM_Device_50
    │ └─ /xyz/openbmc_project/inventory/system
    │   └─ /xyz/openbmc_project/inventory/system/board
    │     └─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5
    │       └─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC
    │         ├─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/ASTERALAB_Retimer_1
    │         │ ├─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/ASTERALAB_Retimer_1/active_version
    │         │ └─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/ASTERALAB_Retimer_1/pending_version
    │         ├─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/ASTERALAB_Retimer_2
    │         │ ├─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/ASTERALAB_Retimer_2/active_version
    │         │ └─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/ASTERALAB_Retimer_2/pending_version
    │         ├─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/BIOS
    │         │ ├─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/BIOS/active_version
    │         │ └─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/BIOS/pending_version
    │         ├─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/MPS_VR_1
    │         │ ├─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/MPS_VR_1/active_version
    │         │ └─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/MPS_VR_1/pending_version
    │         ├─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/MPS_VR_2
    │         │ ├─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/MPS_VR_2/active_version
    │         │ └─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/MPS_VR_2/pending_version
    │         └─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/MPS_VR_3
    │           ├─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/MPS_VR_3/active_version
    │           └─ /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/MPS_VR_3/pending_version

[Get BIOS version]
root@bmc:~# busctl get-property xyz.openbmc_project.PLDM
    /xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_Slot_5/BIC/BIOS/active_version
        xyz.openbmc_project.Software.Version Version
 s "Y4002"

```