### PR TITLE
common: support send BIOS version when post code complete

### DIFF
--- a/common/service/pldm/pldm_oem.h
+++ b/common/service/pldm/pldm_oem.h
@@ -34,6 +34,7 @@ extern "C" {
 
 enum cmd_type {
 	POST_CODE = 0x00,
+	BIOS_VERSION = 0x01,
 };
 
 struct _cmd_echo_req {


### PR DESCRIPTION
Summary:
# Description:
Send OEM command Write File IO: BIOS version when post code complete.

# Motivation:
BMC should keep BIOS version when BIC reset.

# Test Plan:
Build code: pass
The command is successfully sent to BMC: pass

# Test Log:
```
[Init state]
root@bmc:/tmp# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
pldmtool: Tx: 80 01 05 00 00 00 00 00 00 00 00
pldmtool: Rx: 00 01 05 00 00 00 00 00 05 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

[power on the Host, wait for postcode complete]
root@bmc:~# pldmtool raw -m 40 -v -d 0x80 0x01 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
pldmtool: Tx: 80 01 05 00 00 00 00 00 00 00 00
pldmtool: Rx: 00 01 05 00 00 00 00 00 05 00 12 00 00 01 02 00 00 03 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 4e 2f 41 00 59 34 31 30 34 00 4e 2f 41 00 00

[The version is synced to Settingsd]
root@bmc:/tmp# busctl get-property xyz.openbmc_project.Settings  /xyz/openbmc_project/software/host4/bios_version xyz.openbmc_project.Software.Version Version
s "Y4104"
```