### PR TITLE
fby35: ji: Support ssif channel from host

### DIFF
--- a/common/dev/include/sbmr.h
+++ b/common/dev/include/sbmr.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SBMR_H
+#define SBMR_H
+
+#include "plat_def.h"
+#ifdef ENABLE_SBMR
+
+#include <stdint.h>
+#include "ipmb.h"
+typedef struct __attribute__((packed)) {
+	union {
+		struct {
+			uint8_t type;
+			uint16_t rsvd;
+			uint8_t severity;
+		} __attribute__((packed));
+		uint32_t status_code;
+	};
+	union {
+		struct {
+			uint16_t operation;
+			uint8_t sub_class;
+			uint8_t class;
+		} __attribute__((packed));
+		uint32_t efi_status_code;
+	};
+	uint8_t inst;
+} sbmr_boot_progress_code_t;
+
+#define SBMR_POSTCODE_SIZE sizeof(sbmr_boot_progress_code_t)
+
+struct sbmr_cmd_send_boot_progress_code_req {
+	uint8_t group_ext_def_body;
+	sbmr_boot_progress_code_t code;
+} __attribute__((packed));
+
+struct sbmr_cmd_send_boot_progress_code_resp {
+	uint8_t completion_code;
+	uint8_t group_ext_def_body;
+} __attribute__((packed));
+
+struct sbmr_cmd_get_boot_progress_code_req {
+	uint8_t group_ext_def_body;
+} __attribute__((packed));
+
+struct sbmr_cmd_get_boot_progress_code_resp {
+	uint8_t completion_code;
+	uint8_t group_ext_def_body;
+	sbmr_boot_progress_code_t code;
+} __attribute__((packed));
+
+uint16_t copy_sbmr_read_buffer(uint16_t start, uint16_t length, uint8_t *buffer,
+			       uint16_t buffer_len);
+void sbmr_postcode_insert(sbmr_boot_progress_code_t boot_progress_code);
+void reset_sbmr_postcode_buffer();
+bool sbmr_get_9byte_postcode_ok();
+void sbmr_reset_9byte_postcode_ok();
+bool smbr_cmd_handler(ipmi_msg *msg);
+
+#endif /* ENABLE_SBMR */
+
+#endif /* SBMR_H */

--- a/common/dev/sbmr.c
+++ b/common/dev/sbmr.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plat_def.h"
+#ifdef ENABLE_SBMR
+
+#include <zephyr.h>
+#include <stdlib.h>
+#include "libutil.h"
+#include <logging/log.h>
+#include "ipmi.h"
+#include "ipmb.h"
+#include "sensor.h"
+#include "sbmr.h"
+
+LOG_MODULE_REGISTER(sbmr);
+
+#define SBMR_POSTCODE_LEN 128
+#define PROCESS_POSTCODE_STACK_SIZE 2048
+
+#define SMBR_CC_ERR 0x80
+#define SMBR_GROUP_DEF_BODE_CODE 0xAE
+
+static sbmr_boot_progress_code_t sbmr_read_buffer[SBMR_POSTCODE_LEN];
+static uint16_t sbmr_read_len = 0, sbmr_read_index = 0;
+static bool sbmr_proc_9byte_postcode_ok = false;
+
+uint16_t copy_sbmr_read_buffer(uint16_t start, uint16_t length, uint8_t *buffer,
+			       uint16_t buffer_len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buffer, 0);
+
+	if (buffer_len < (length * SBMR_POSTCODE_SIZE))
+		return 0;
+
+	uint16_t current_index, i = 0;
+	uint16_t current_read_len = sbmr_read_len;
+	uint16_t current_read_index = sbmr_read_index;
+	if (start < current_read_index) {
+		current_index = current_read_index - start - 1;
+	} else {
+		current_index = current_read_index + SBMR_POSTCODE_LEN - start - 1;
+	}
+
+	for (; (i < length) && ((i + start) < current_read_len); i++) {
+		memcpy(&buffer[SBMR_POSTCODE_SIZE * i], (uint8_t *)&sbmr_read_buffer[current_index],
+		       SBMR_POSTCODE_SIZE);
+
+		if (current_index == 0) {
+			current_index = SBMR_POSTCODE_LEN - 1;
+		} else {
+			current_index--;
+		}
+	}
+	return SBMR_POSTCODE_SIZE * i;
+}
+
+void sbmr_postcode_insert(sbmr_boot_progress_code_t boot_progress_code)
+{
+	sbmr_proc_9byte_postcode_ok = true;
+
+	LOG_INF("* [POSTCODE] inst: %02d status:0x%04x code:0x%04x", boot_progress_code.inst,
+		boot_progress_code.status_code, boot_progress_code.efi_status_code);
+
+	sbmr_read_buffer[sbmr_read_index] = boot_progress_code;
+
+	if (sbmr_read_len < SBMR_POSTCODE_LEN)
+		sbmr_read_len++;
+
+	sbmr_read_index++;
+	if (sbmr_read_index == SBMR_POSTCODE_LEN)
+		sbmr_read_index = 0;
+}
+
+void reset_sbmr_postcode_buffer()
+{
+	sbmr_read_len = 0;
+	return;
+}
+
+bool sbmr_get_9byte_postcode_ok()
+{
+	return sbmr_proc_9byte_postcode_ok;
+}
+
+void sbmr_reset_9byte_postcode_ok()
+{
+	sbmr_proc_9byte_postcode_ok = false;
+}
+
+__weak bool SBMR_SEND_BOOT_PROGRESS_CODE(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+
+	msg->completion_code = SMBR_CC_ERR;
+
+	if (msg->data_len != sizeof(struct sbmr_cmd_send_boot_progress_code_req)) {
+		LOG_ERR("Get invalid data length 0x%x -- 0x%x", msg->data_len,
+			sizeof(struct sbmr_cmd_send_boot_progress_code_req));
+		goto exit;
+	}
+
+	struct sbmr_cmd_send_boot_progress_code_req *req =
+		(struct sbmr_cmd_send_boot_progress_code_req *)msg->data;
+
+	if (req->group_ext_def_body != SMBR_GROUP_DEF_BODE_CODE) {
+		LOG_ERR("Get invalid group_ext_def_body 0x%x", req->group_ext_def_body);
+		goto exit;
+	}
+
+	sbmr_postcode_insert(req->code);
+
+	msg->data[0] = SMBR_GROUP_DEF_BODE_CODE;
+	msg->data_len = 1;
+
+	msg->completion_code = CC_SUCCESS;
+
+exit:
+	return true;
+}
+
+__weak bool SBMR_GET_BOOT_PROGRESS_CODE(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+
+	msg->completion_code = SMBR_CC_ERR;
+
+	if (msg->data_len != sizeof(struct sbmr_cmd_get_boot_progress_code_req)) {
+		msg->data_len = 0;
+		LOG_ERR("Get invalid data length");
+		goto exit;
+	}
+
+	struct sbmr_cmd_get_boot_progress_code_req *req =
+		(struct sbmr_cmd_get_boot_progress_code_req *)msg->data;
+
+	if (req->group_ext_def_body != SMBR_GROUP_DEF_BODE_CODE) {
+		LOG_ERR("Get invalid group_ext_def_body 0x%x", req->group_ext_def_body);
+		msg->data_len = 0;
+		goto exit;
+	}
+
+	msg->data[0] = SMBR_GROUP_DEF_BODE_CODE;
+	msg->data_len = 1;
+
+	if (!sbmr_read_len)
+		memset(&msg->data[1], 0, sizeof(sbmr_boot_progress_code_t));
+	else
+		memcpy(&msg->data[1], (uint8_t *)&sbmr_read_buffer[sbmr_read_len],
+		       sizeof(sbmr_boot_progress_code_t));
+
+	msg->data_len += sizeof(sbmr_boot_progress_code_t);
+	msg->completion_code = CC_SUCCESS;
+
+exit:
+	return true;
+}
+
+bool smbr_cmd_handler(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+
+	switch (msg->cmd) {
+	case CMD_DCMI_SEND_BOOT_PROGRESS_CODE:
+		if (SBMR_SEND_BOOT_PROGRESS_CODE(msg) == false)
+			return false;
+		break;
+
+	case CMD_DCMI_GET_BOOT_PROGRESS_CODE:
+		if (SBMR_GET_BOOT_PROGRESS_CODE(msg) == false)
+			return false;
+		break;
+
+	default:
+		return false;
+	}
+
+	msg->netfn = (msg->netfn + 1) << 2;
+
+	return true;
+}
+
+#endif

--- a/common/service/host/ssif.c
+++ b/common/service/host/ssif.c
@@ -321,6 +321,7 @@ static bool ssif_data_handle(ssif_dev *ssif_inst, ssif_action_t action, uint8_t 
 		/* Message to BIC */
 		if (pal_request_msg_to_BIC_from_HOST(ssif_inst->current_ipmi_msg.buffer.netfn,
 						     ssif_inst->current_ipmi_msg.buffer.cmd)) {
+			bool skip_ipmi_handle = false;
 #ifdef ENABLE_SBMR
 			if (ssif_inst->current_ipmi_msg.buffer.netfn == NETFN_DCMI_REQ) {
 				if (smbr_cmd_handler(&ssif_inst->current_ipmi_msg.buffer) == true) {
@@ -329,9 +330,12 @@ static bool ssif_data_handle(ssif_dev *ssif_inst, ssif_action_t action, uint8_t 
 						LOG_ERR("Failed to write ssif response data");
 					}
 				}
-				goto exit;
+				skip_ipmi_handle = true;
 			}
 #endif
+			if (skip_ipmi_handle)
+				goto exit;
+
 			while (k_msgq_put(&ipmi_msgq, &ssif_inst->current_ipmi_msg, K_NO_WAIT) !=
 			       0) {
 				k_msgq_purge(&ipmi_msgq);
@@ -398,7 +402,7 @@ static bool ssif_data_handle(ssif_dev *ssif_inst, ssif_action_t action, uint8_t 
 				if (!pal_is_interface_use_ipmb(IPMB_inf_index_map[BMC_IPMB])) {
 					msg.InF_target = PLDM;
 					// Send request to MCTP/PLDM thread to ask BMC
-					int ret = pldm_send_ipmi_request(&msg);
+					ret = pldm_send_ipmi_request(&msg);
 					if (ret < 0) {
 						LOG_ERR("SSIF[%d] Failed to send SSIF msg to BMC via PLDM with ret: 0x%x",
 							ssif_inst->index, ret);
@@ -416,7 +420,7 @@ static bool ssif_data_handle(ssif_dev *ssif_inst, ssif_action_t action, uint8_t 
 #else
 				msg.InF_target = PLDM;
 				// Send request to MCTP/PLDM thread to ask BMC
-				int ret = pldm_send_ipmi_request(&msg);
+				ret = pldm_send_ipmi_request(&msg);
 				if (ret < 0) {
 					LOG_ERR("SSIF[%d] Failed to send SSIF msg to BMC via PLDM with ret: 0x%x",
 						ssif_inst->index, ret);

--- a/common/service/ipmi/include/ipmi.h
+++ b/common/service/ipmi/include/ipmi.h
@@ -190,8 +190,9 @@ enum {
 	CMD_STORAGE_ADD_SEL = 0x44,
 };
 
-// DCMI Command Codes (0x2C)
+// Application Extension Code (0x2c)
 enum {
+	CMD_DCMI_GET_PICMG_PROPERTIES = 0x00,
 	CMD_DCMI_SEND_BOOT_PROGRESS_CODE = 0x02,
 	CMD_DCMI_GET_BOOT_PROGRESS_CODE = 0x03,
 };

--- a/common/service/ipmi/include/ipmi.h
+++ b/common/service/ipmi/include/ipmi.h
@@ -190,9 +190,10 @@ enum {
 	CMD_STORAGE_ADD_SEL = 0x44,
 };
 
-// Application Extension Code (0x2c)
+// DCMI Command Codes (0x2C)
 enum {
-	CMD_DCMI_GET_PICMG_PROPERTIES = 0x00,
+	CMD_DCMI_SEND_BOOT_PROGRESS_CODE = 0x02,
+	CMD_DCMI_GET_BOOT_PROGRESS_CODE = 0x03,
 };
 
 // OEM NM Command Codes (0x2E)
@@ -203,6 +204,8 @@ enum {
 // OEM Command Codes (0x30)
 enum {
 	CMD_OEM_GET_BOARD_ID = 0x37,
+	CMD_OEM_POST_START = 0x73,
+	CMD_OEM_POST_END = 0x74,
 	CMD_OEM_CABLE_DETECTION = 0xCB,
 	CMD_OEM_NM_SENSOR_READ = 0xE2,
 	CMD_OEM_SET_SYSTEM_GUID = 0xEF,

--- a/meta-facebook/yv35-ji/src/platform/plat_init.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_init.c
@@ -19,6 +19,7 @@
 #include "plat_class.h"
 #include "plat_gpio.h"
 #include "plat_mctp.h"
+#include "plat_ssif.h"
 #include "util_worker.h"
 #include "power_status.h"
 #include <stdio.h>
@@ -51,6 +52,7 @@ void pal_pre_init()
 void pal_post_init()
 {
 	plat_mctp_init();
+	ssif_init();
 }
 
 void pal_device_init()

--- a/meta-facebook/yv35-ji/src/platform/plat_ssif.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_ssif.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include <logging/log.h>
+#include "plat_ssif.h"
+#include "plat_i2c.h"
+#include "plat_gpio.h"
+#include "plat_mctp.h"
+#include "power_status.h"
+#include "ssif.h"
+
+LOG_MODULE_REGISTER(plat_ssif);
+
+struct ssif_init_cfg ssif_cfg_table[] = {
+	{ SSIF_I2C_BUS, SSIF_I2C_ADDR, 0x0A },
+};
+
+void pal_ssif_alert_trigger(uint8_t status)
+{
+	LOG_DBG("trigger %d", status);
+	gpio_set(I2C_SSIF_ALERT_L, status);
+}
+
+void ssif_init(void)
+{
+	ssif_device_init(ssif_cfg_table, ARRAY_SIZE(ssif_cfg_table));
+
+	if (ssif_inst_get_by_bus(SSIF_I2C_BUS))
+		LOG_WRN("SSIF ready!");
+}
+
+K_TIMER_DEFINE(send_cmd_timer, send_cmd_to_dev, NULL);
+
+void pal_bios_post_complete()
+{
+	k_timer_start(&send_cmd_timer, K_MSEC(3000), K_NO_WAIT);
+	set_post_complete(true);
+}

--- a/meta-facebook/yv35-ji/src/platform/plat_ssif.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_ssif.h
@@ -14,15 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef PLAT_DEF_H
-#define PLAT_DEF_H
+#ifndef PLAT_SSIF_H
+#define PLAT_SSIF_H
 
-#define BMC_USB_PORT "CDC_ACM_0"
-
-#define WORKER_STACK_SIZE 4096
-#define ENABLE_MCTP_I3C
-#define ENABLE_SSIF
-#define ENABLE_SSIF_RSP_PEC
-#define ENABLE_SBMR
+void ssif_init(void);
 
 #endif


### PR DESCRIPTION
Summary:
- Enable SSIF channel between BIC and HOST.

Test Plan:
- Build code: pass
- Send ipmi command from host: PASS

Log:
- HOST log:
```
[root@localhost ~]# ipmitool raw 0x06 0x01
 20 81 18 15 02 bf 15 a0 00 46 31 02 00 00 00
```