### PR TITLE
fby4: sd: Add delay between dimm i3c transfer

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_dimm.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_dimm.c
@@ -374,6 +374,7 @@ int init_dimm_prsnt_status()
 			continue;
 		}
 
+		k_msleep(I3C_TRANSFER_DELAY_TIME_MS);
 		i3c_msg.bus = I3C_BUS3;
 		i3c_msg.target_addr = spd_i3c_addr_list[dimm_id % (DIMM_ID_MAX / 2)];
 		i3c_attach(&i3c_msg);
@@ -387,6 +388,7 @@ int init_dimm_prsnt_status()
 			continue;
 		}
 
+		k_msleep(I3C_TRANSFER_DELAY_TIME_MS);
 		// Read SPD vender to check dimm present
 		i3c_msg.tx_len = 1;
 		i3c_msg.rx_len = 1;
@@ -402,6 +404,7 @@ int init_dimm_prsnt_status()
 			dimm_data[dimm_id].is_present = DIMM_PRSNT;
 		}
 		i3c_detach(&i3c_msg);
+		k_msleep(I3C_TRANSFER_DELAY_TIME_MS);
 	}
 
 	if (k_mutex_unlock(&i3c_dimm_mutex)) {

--- a/meta-facebook/yv4-sd/src/platform/plat_dimm.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_dimm.h
@@ -46,6 +46,7 @@
 #define I3C_DIMM_MUTEX_TIMEOUT_MS 1000
 #define GET_DIMM_INFO_TIME_MS 1000
 #define GET_DIMM_INFO_STACK_SIZE 2304
+#define I3C_TRANSFER_DELAY_TIME_MS 200
 
 typedef struct dimm_info {
 	uint8_t is_present;

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -49,7 +49,6 @@ void pal_pre_init()
 {
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
 	aspeed_print_sysrst_info();
-	apml_init();
 
 	/* init i2c target */
 	for (int index = 0; index < MAX_TARGET_NUM; index++) {
@@ -108,6 +107,7 @@ void pal_set_sys_status()
 	sync_bmc_ready_pin();
 	set_sys_ready_pin(BIC_READY_R);
 	reset_usb_hub();
+	apml_init();
 
 	if (get_post_status()) {
 		apml_recovery();


### PR DESCRIPTION
# Description:
1. This is a shortterm workaround for BIC crash when BIC continiously send i3c command to check DIMM info in very short time.
2. Modify the time of APML should be inited.

# Motivation:
1. To do workaround for BIC crash issue.
2. Fix APML will fail after BIC reset.

# Test Plan:
1. Build and test pass on YV4 system. pass

2. BIC reset stress test pass.