### PR TITLE
fby35: ji: Support sensor reading

### DIFF
--- a/common/dev/include/nvidia.h
+++ b/common/dev/include/nvidia.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NVIDIA_H
+#define NVIDIA_H
+
+#include "plat_def.h"
+#ifdef ENABLE_NVIDIA
+
+#include <stdint.h>
+#include "pldm_monitor.h"
+
+enum nv_satmc_sensor_num_table {
+	/* numeric sensor */
+	NV_SATMC_SENSOR_NUM_PWR_VDD_CPU = 0x0010,
+	NV_SATMC_SENSOR_NUM_VOL_VDD_CPU,
+	NV_SATMC_SENSOR_NUM_PWR_VDD_SOC = 0x0020,
+	NV_SATMC_SENSOR_NUM_VOL_VDD_SOC,
+	NV_SATMC_SENSOR_NUM_PWR_MODULE = 0x0030,
+	NV_SATMC_SENSOR_NUM_ENG_MODULE,
+	NV_SATMC_SENSOR_NUM_PWR_GRACE = 0x0040,
+	NV_SATMC_SENSOR_NUM_ENG_GRACE,
+	NV_SATMC_SENSOR_NUM_PWR_TOTAL_MODULE,
+	NV_SATMC_SENSOR_NUM_ENG_TOTAL_MODULE,
+	NV_SATMC_SENSOR_NUM_CNT_PAGE_RETIRE = 0x0050,
+	NV_SATMC_SENSOR_NUM_TMP_GRACE = 0x00A0,
+	NV_SATMC_SENSOR_NUM_TMP_GRACE_LIMIT,
+	NV_SATMC_SENSOR_NUM_FRQ_MEMORY = 0x00B0,
+	NV_SATMC_SENSOR_NUM_FRQ_MAX_CPU = 0x00C0,
+
+	/* state sensor */
+	NV_SATMC_SENSOR_NUM_CPU_THROT_STATE = 0x0210,
+	NV_SATMC_SENSOR_NUM_POWER_BREAK = 0x0240,
+	NV_SATMC_SENSOR_NUM_SPARE_CH_PRESENCE = 0x0250,
+};
+
+/* Y = (mX + b) * 10^r */
+struct nv_satmc_sensor_parm {
+	uint16_t nv_satmc_sensor_id;
+	pldm_sensor_pdr_parm cal_parm;
+};
+
+extern struct nv_satmc_sensor_parm satmc_sensor_cfg_list[];
+extern const int SATMC_SENSOR_CFG_LIST_SIZE;
+
+#endif /* ENABLE_NVIDIA */
+#endif /* NVIDIA_H */

--- a/common/dev/nv_satmc.c
+++ b/common/dev/nv_satmc.c
@@ -31,28 +31,28 @@
 LOG_MODULE_REGISTER(nv_satmc);
 
 struct nv_satmc_sensor_parm satmc_sensor_cfg_list[] = {
-	{NV_SATMC_SENSOR_NUM_PWR_VDD_CPU, {1, 0, -3}},
-	{NV_SATMC_SENSOR_NUM_VOL_VDD_CPU, {1, 0, -3}},
-	{NV_SATMC_SENSOR_NUM_PWR_VDD_SOC, {1, 0, -3}},
-	{NV_SATMC_SENSOR_NUM_VOL_VDD_SOC, {1, 0, -3}},
-	{NV_SATMC_SENSOR_NUM_PWR_MODULE, {1, 0, -3}},
-	{NV_SATMC_SENSOR_NUM_ENG_MODULE, {1, 0, 0}},
-	{NV_SATMC_SENSOR_NUM_PWR_GRACE, {1, 0, -3}},
-	{NV_SATMC_SENSOR_NUM_ENG_GRACE, {1, 0, 0}},
-	{NV_SATMC_SENSOR_NUM_PWR_TOTAL_MODULE, {1, 0, -3}},
-	{NV_SATMC_SENSOR_NUM_ENG_TOTAL_MODULE, {1, 0, 0}},
-	{NV_SATMC_SENSOR_NUM_CNT_PAGE_RETIRE, {1, 0, 0}},
-	{NV_SATMC_SENSOR_NUM_TMP_GRACE, {1, 0, -3}},
-	{NV_SATMC_SENSOR_NUM_TMP_GRACE_LIMIT, {1, 0, -3}},
-	{NV_SATMC_SENSOR_NUM_FRQ_MEMORY, {1, 0, 3}},
-	{NV_SATMC_SENSOR_NUM_FRQ_MAX_CPU, {1, 0, 0}},
+	{ NV_SATMC_SENSOR_NUM_PWR_VDD_CPU, { 1, 0, -3 } },
+	{ NV_SATMC_SENSOR_NUM_VOL_VDD_CPU, { 1, 0, -3 } },
+	{ NV_SATMC_SENSOR_NUM_PWR_VDD_SOC, { 1, 0, -3 } },
+	{ NV_SATMC_SENSOR_NUM_VOL_VDD_SOC, { 1, 0, -3 } },
+	{ NV_SATMC_SENSOR_NUM_PWR_MODULE, { 1, 0, -3 } },
+	{ NV_SATMC_SENSOR_NUM_ENG_MODULE, { 1, 0, 0 } },
+	{ NV_SATMC_SENSOR_NUM_PWR_GRACE, { 1, 0, -3 } },
+	{ NV_SATMC_SENSOR_NUM_ENG_GRACE, { 1, 0, 0 } },
+	{ NV_SATMC_SENSOR_NUM_PWR_TOTAL_MODULE, { 1, 0, -3 } },
+	{ NV_SATMC_SENSOR_NUM_ENG_TOTAL_MODULE, { 1, 0, 0 } },
+	{ NV_SATMC_SENSOR_NUM_CNT_PAGE_RETIRE, { 1, 0, 0 } },
+	{ NV_SATMC_SENSOR_NUM_TMP_GRACE, { 1, 0, -3 } },
+	{ NV_SATMC_SENSOR_NUM_TMP_GRACE_LIMIT, { 1, 0, -3 } },
+	{ NV_SATMC_SENSOR_NUM_FRQ_MEMORY, { 1, 0, 3 } },
+	{ NV_SATMC_SENSOR_NUM_FRQ_MAX_CPU, { 1, 0, 0 } },
 };
 
 const int SATMC_SENSOR_CFG_LIST_SIZE = ARRAY_SIZE(satmc_sensor_cfg_list);
 
 pldm_sensor_pdr_parm *find_sensor_parm_by_id(uint16_t sensor_id)
 {
-	for (int i=0; i<SATMC_SENSOR_CFG_LIST_SIZE; i++) {
+	for (int i = 0; i < SATMC_SENSOR_CFG_LIST_SIZE; i++) {
 		if (satmc_sensor_cfg_list[i].nv_satmc_sensor_id == sensor_id)
 			return &satmc_sensor_cfg_list[i].cal_parm;
 	}
@@ -85,25 +85,25 @@ uint8_t nv_satmc_read(sensor_cfg *cfg, int *reading)
 		return SENSOR_FAIL_TO_ACCESS;
 	}
 
-	if ((init_arg->sensor_id == NV_SATMC_SENSOR_NUM_CPU_THROT_STATE) || 
-		(init_arg->sensor_id == NV_SATMC_SENSOR_NUM_POWER_BREAK) ||
-		(init_arg->sensor_id == NV_SATMC_SENSOR_NUM_SPARE_CH_PRESENCE)) {
+	if ((init_arg->sensor_id == NV_SATMC_SENSOR_NUM_CPU_THROT_STATE) ||
+	    (init_arg->sensor_id == NV_SATMC_SENSOR_NUM_POWER_BREAK) ||
+	    (init_arg->sensor_id == NV_SATMC_SENSOR_NUM_SPARE_CH_PRESENCE)) {
 		req_len = sizeof(struct pldm_get_state_sensor_reading_req);
-		struct pldm_get_state_sensor_reading_req req = {0};
+		struct pldm_get_state_sensor_reading_req req = { 0 };
 		req.sensor_id = init_arg->sensor_id;
 
-		uint16_t resp_len =
-		pldm_platform_monitor_read(mctp_inst, ext_params,
-					   PLDM_MONITOR_CMD_CODE_GET_STATE_SENSOR_READING,
-					   (uint8_t *)&req, req_len, resp_buf, sizeof(resp_buf));
+		uint16_t resp_len = pldm_platform_monitor_read(
+			mctp_inst, ext_params, PLDM_MONITOR_CMD_CODE_GET_STATE_SENSOR_READING,
+			(uint8_t *)&req, req_len, resp_buf, sizeof(resp_buf));
 
 		if (resp_len == 0) {
 			LOG_ERR("Failed to get SatMC sensor #0x%x reading", init_arg->sensor_id);
 			return SENSOR_FAIL_TO_ACCESS;
 		}
 
-		struct pldm_get_state_sensor_reading_resp *res = (struct pldm_get_state_sensor_reading_resp *)resp_buf;
-		
+		struct pldm_get_state_sensor_reading_resp *res =
+			(struct pldm_get_state_sensor_reading_resp *)resp_buf;
+
 		if (res->completion_code != PLDM_SUCCESS) {
 			LOG_ERR("Get SatMC sensor #%04x with bad cc 0x%x", init_arg->sensor_id,
 				res->completion_code);
@@ -111,7 +111,8 @@ uint8_t nv_satmc_read(sensor_cfg *cfg, int *reading)
 		}
 
 		if (init_arg->state_sensor_idx >= res->composite_sensor_count) {
-			LOG_ERR("Failed to get SatMC sensor #0x%x state with index %d", init_arg->sensor_id, init_arg->state_sensor_idx);
+			LOG_ERR("Failed to get SatMC sensor #0x%x state with index %d",
+				init_arg->sensor_id, init_arg->state_sensor_idx);
 			return SENSOR_UNSPECIFIED_ERROR;
 		}
 
@@ -167,13 +168,15 @@ uint8_t nv_satmc_read(sensor_cfg *cfg, int *reading)
 	LOG_DBG("SatMC sensor#0x%04x", init_arg->sensor_id);
 	LOG_HEXDUMP_DBG(res->present_reading, resp_len - 7, "");
 
-	val = pldm_sensor_cal(res->present_reading, resp_len - 7, res->sensor_data_size, init_arg->parm);
+	val = pldm_sensor_cal(res->present_reading, resp_len - 7, res->sensor_data_size,
+			      init_arg->parm);
 
 exit:
 	sval->integer = (int)val & 0xFFFF;
 	sval->fraction = (val - sval->integer) * 1000;
 
-	LOG_DBG("SatMC sensor #0x%04x --> %d.%03d", init_arg->sensor_id, sval->integer, sval->fraction);
+	LOG_DBG("SatMC sensor #0x%04x --> %d.%03d", init_arg->sensor_id, sval->integer,
+		sval->fraction);
 
 	return SENSOR_READ_SUCCESS;
 }

--- a/common/dev/nv_satmc.c
+++ b/common/dev/nv_satmc.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "plat_def.h"
+#ifdef ENABLE_NVIDIA
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <logging/log.h>
+#include "libutil.h"
+#include "sensor.h"
+#include "pldm.h"
+#include "hal_i2c.h"
+#include "nvidia.h"
+#include "pdr.h"
+
+LOG_MODULE_REGISTER(nv_satmc);
+
+struct nv_satmc_sensor_parm satmc_sensor_cfg_list[] = {
+	{NV_SATMC_SENSOR_NUM_PWR_VDD_CPU, {1, 0, -3}},
+	{NV_SATMC_SENSOR_NUM_VOL_VDD_CPU, {1, 0, -3}},
+	{NV_SATMC_SENSOR_NUM_PWR_VDD_SOC, {1, 0, -3}},
+	{NV_SATMC_SENSOR_NUM_VOL_VDD_SOC, {1, 0, -3}},
+	{NV_SATMC_SENSOR_NUM_PWR_MODULE, {1, 0, -3}},
+	{NV_SATMC_SENSOR_NUM_ENG_MODULE, {1, 0, 0}},
+	{NV_SATMC_SENSOR_NUM_PWR_GRACE, {1, 0, -3}},
+	{NV_SATMC_SENSOR_NUM_ENG_GRACE, {1, 0, 0}},
+	{NV_SATMC_SENSOR_NUM_PWR_TOTAL_MODULE, {1, 0, -3}},
+	{NV_SATMC_SENSOR_NUM_ENG_TOTAL_MODULE, {1, 0, 0}},
+	{NV_SATMC_SENSOR_NUM_CNT_PAGE_RETIRE, {1, 0, 0}},
+	{NV_SATMC_SENSOR_NUM_TMP_GRACE, {1, 0, -3}},
+	{NV_SATMC_SENSOR_NUM_TMP_GRACE_LIMIT, {1, 0, -3}},
+	{NV_SATMC_SENSOR_NUM_FRQ_MEMORY, {1, 0, 3}},
+	{NV_SATMC_SENSOR_NUM_FRQ_MAX_CPU, {1, 0, 0}},
+};
+
+const int SATMC_SENSOR_CFG_LIST_SIZE = ARRAY_SIZE(satmc_sensor_cfg_list);
+
+pldm_sensor_pdr_parm *find_sensor_parm_by_id(uint16_t sensor_id)
+{
+	for (int i=0; i<SATMC_SENSOR_CFG_LIST_SIZE; i++) {
+		if (satmc_sensor_cfg_list[i].nv_satmc_sensor_id == sensor_id)
+			return &satmc_sensor_cfg_list[i].cal_parm;
+	}
+
+	return NULL;
+}
+
+uint8_t nv_satmc_read(sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(cfg->init_args, SENSOR_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("sensor num: 0x%x is invalid", cfg->num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	nv_satmc_init_arg *init_arg = (nv_satmc_init_arg *)cfg->init_args;
+
+	sensor_val *sval = (sensor_val *)reading;
+	uint8_t resp_buf[256] = { 0 };
+	uint8_t req_len = 0;
+	float val = 0;
+
+	mctp *mctp_inst = NULL;
+	mctp_ext_params ext_params = { 0 };
+	if (get_mctp_info_by_eid(init_arg->endpoint, &mctp_inst, &ext_params) == false) {
+		LOG_ERR("Failed to get mctp info by eid 0x%x", init_arg->endpoint);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	if ((init_arg->sensor_id == NV_SATMC_SENSOR_NUM_CPU_THROT_STATE) || 
+		(init_arg->sensor_id == NV_SATMC_SENSOR_NUM_POWER_BREAK) ||
+		(init_arg->sensor_id == NV_SATMC_SENSOR_NUM_SPARE_CH_PRESENCE)) {
+		req_len = sizeof(struct pldm_get_state_sensor_reading_req);
+		struct pldm_get_state_sensor_reading_req req = {0};
+		req.sensor_id = init_arg->sensor_id;
+
+		uint16_t resp_len =
+		pldm_platform_monitor_read(mctp_inst, ext_params,
+					   PLDM_MONITOR_CMD_CODE_GET_STATE_SENSOR_READING,
+					   (uint8_t *)&req, req_len, resp_buf, sizeof(resp_buf));
+
+		if (resp_len == 0) {
+			LOG_ERR("Failed to get SatMC sensor #0x%x reading", init_arg->sensor_id);
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+
+		struct pldm_get_state_sensor_reading_resp *res = (struct pldm_get_state_sensor_reading_resp *)resp_buf;
+		
+		if (res->completion_code != PLDM_SUCCESS) {
+			LOG_ERR("Get SatMC sensor #%04x with bad cc 0x%x", init_arg->sensor_id,
+				res->completion_code);
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+
+		if (init_arg->state_sensor_idx >= res->composite_sensor_count) {
+			LOG_ERR("Failed to get SatMC sensor #0x%x state with index %d", init_arg->sensor_id, init_arg->state_sensor_idx);
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+
+		if (res->field[init_arg->state_sensor_idx].sensor_op_state != PLDM_SENSOR_ENABLED) {
+			LOG_WRN("SatMC sensor #%04x in abnormal op state 0x%x", init_arg->sensor_id,
+				res->field[init_arg->state_sensor_idx].sensor_op_state);
+			return SENSOR_NOT_ACCESSIBLE;
+		}
+
+		val = (float)res->field[init_arg->state_sensor_idx].present_state;
+		goto exit;
+	}
+
+	if (init_arg->is_init == false) {
+		pldm_sensor_pdr_parm *parm_cfg = find_sensor_parm_by_id(init_arg->sensor_id);
+		if (!parm_cfg) {
+			LOG_WRN("SatMC sensor #0x%x PDR not ready", init_arg->sensor_id);
+			return SENSOR_UNSPECIFIED_ERROR;
+		}
+		init_arg->parm = *parm_cfg;
+		init_arg->is_init = true;
+	}
+
+	req_len = sizeof(struct pldm_get_sensor_reading_req);
+	struct pldm_get_sensor_reading_req req = { 0 };
+	req.sensor_id = init_arg->sensor_id;
+	req.rearm_event_state = 0;
+
+	uint16_t resp_len =
+		pldm_platform_monitor_read(mctp_inst, ext_params,
+					   PLDM_MONITOR_CMD_CODE_GET_SENSOR_READING,
+					   (uint8_t *)&req, req_len, resp_buf, sizeof(resp_buf));
+
+	if (resp_len == 0) {
+		LOG_ERR("Failed to get SatMC sensor #0x%x reading", init_arg->sensor_id);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	struct pldm_get_sensor_reading_resp *res = (struct pldm_get_sensor_reading_resp *)resp_buf;
+
+	if (res->completion_code != PLDM_SUCCESS) {
+		LOG_ERR("Get SatMC sensor #%04x with bad cc 0x%x", init_arg->sensor_id,
+			res->completion_code);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	if (res->sensor_operational_state != PLDM_SENSOR_ENABLED) {
+		LOG_WRN("SatMC sensor #%04x in abnormal op state 0x%x", init_arg->sensor_id,
+			res->sensor_operational_state);
+		return SENSOR_NOT_ACCESSIBLE;
+	}
+
+	LOG_DBG("SatMC sensor#0x%04x", init_arg->sensor_id);
+	LOG_HEXDUMP_DBG(res->present_reading, resp_len - 7, "");
+
+	val = pldm_sensor_cal(res->present_reading, resp_len - 7, res->sensor_data_size, init_arg->parm);
+
+exit:
+	sval->integer = (int)val & 0xFFFF;
+	sval->fraction = (val - sval->integer) * 1000;
+
+	LOG_DBG("SatMC sensor #0x%04x --> %d.%03d", init_arg->sensor_id, sval->integer, sval->fraction);
+
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t nv_satmc_init(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	cfg->read = nv_satmc_read;
+	return SENSOR_INIT_SUCCESS;
+}
+
+#endif

--- a/common/service/pldm/pldm_monitor.h
+++ b/common/service/pldm/pldm_monitor.h
@@ -27,6 +27,7 @@ extern "C" {
 /* command number of pldm type 0x02 : PLDM for platform monitor and control */
 typedef enum pldm_platform_monitor_commands {
 	PLDM_MONITOR_CMD_CODE_GET_SENSOR_READING = 0x11,
+	PLDM_MONITOR_CMD_CODE_GET_STATE_SENSOR_READING = 0x21,
 	PLDM_MONITOR_CMD_CODE_SET_EVENT_RECEIVER = 0x04,
 	PLDM_MONITOR_CMD_CODE_PLATFORM_EVENT_MESSAGE = 0x0A,
 	PLDM_MONITOR_CMD_CODE_EVENT_MESSAGE_BUFF_SIZE = 0x0D,
@@ -199,8 +200,8 @@ enum pldm_entity_types {
 
 /* Y = (mX + b) * 10^r */
 typedef struct _pldm_sensor_pdr_parm {
-	float resolution; // from PDR (m)
-	float ofst; // from PDR (b)
+	int64_t resolution; // from PDR (m)
+	int64_t ofst; // from PDR (b)
 	int8_t unit_modifier; // from PDR (r)
 } pldm_sensor_pdr_parm;
 
@@ -364,6 +365,25 @@ struct pldm_event_message_buffer_size_req {
 struct pldm_event_message_buffer_size_resp {
 	uint8_t completion_code;
 	uint16_t term_max_buff_size;
+} __attribute__((packed));
+
+typedef struct state_field_state_sensor_reading_get {
+	uint8_t sensor_op_state;
+	uint8_t present_state;
+	uint8_t previous_state;
+	uint8_t event_state;
+} __attribute__((packed)) state_sensor_reading_state_field_t;
+
+struct pldm_get_state_sensor_reading_req {
+	uint16_t sensor_id;
+	uint8_t sensor_rearm;
+	uint8_t rsv;
+} __attribute__((packed));
+
+struct pldm_get_state_sensor_reading_resp {
+	uint8_t completion_code;
+	uint8_t composite_sensor_count;
+	state_sensor_reading_state_field_t field[8];
 } __attribute__((packed));
 
 enum pldm_get_pdr_transfer_flag {

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -126,6 +126,7 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(cx7)
 	sensor_name_to_num(vistara)
 	sensor_name_to_num(max11617)
+	sensor_name_to_num(nv_satmc)
 };
 // clang-format on
 
@@ -185,6 +186,9 @@ SENSOR_DRIVE_INIT_DECLARE(cx7);
 SENSOR_DRIVE_INIT_DECLARE(vistara);
 #endif
 SENSOR_DRIVE_INIT_DECLARE(max11617);
+#ifdef ENABLE_NVIDIA
+SENSOR_DRIVE_INIT_DECLARE(nv_satmc);
+#endif
 
 // The sequence needs to same with SENSOR_DEV ID
 sensor_drive_api sensor_drive_tbl[] = {
@@ -236,6 +240,11 @@ sensor_drive_api sensor_drive_tbl[] = {
 	SENSOR_DRIVE_TYPE_UNUSE(vistara),
 #endif
 	SENSOR_DRIVE_TYPE_INIT_MAP(max11617),
+#ifdef ENABLE_NVIDIA
+	SENSOR_DRIVE_TYPE_INIT_MAP(nv_satmc),
+#else
+	SENSOR_DRIVE_TYPE_UNUSE(nv_satmc),
+#endif
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -23,6 +23,7 @@
 
 #include "plat_def.h"
 #include "sdr.h"
+#include "pldm_monitor.h"
 #include "libutil.h"
 #include "sensor_shell.h"
 
@@ -156,6 +157,7 @@ enum SENSOR_DEV {
 	sensor_dev_cx7 = 0x2E,
 	sensor_dev_vistara = 0x2F,
 	sensor_dev_max11617 = 0x30,
+	sensor_dev_nv_satmc = 0x31,
 	sensor_dev_max
 };
 
@@ -699,6 +701,14 @@ typedef struct _max11617_init_arg {
 	uint8_t config_byte;
 	float scalefactor[12];
 } max11617_init_arg;
+
+typedef struct _nv_satmc_init_arg {
+	bool is_init;
+	uint8_t endpoint;
+	uint16_t sensor_id;
+	uint8_t state_sensor_idx; //only used for state sensor
+	pldm_sensor_pdr_parm parm; //only used for numeric sensor
+} nv_satmc_init_arg;
 
 extern bool enable_sensor_poll_thread;
 extern sensor_cfg *sensor_config;

--- a/meta-facebook/yv35-ji/src/platform/plat_def.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_def.h
@@ -24,5 +24,6 @@
 #define ENABLE_SSIF
 #define ENABLE_SSIF_RSP_PEC
 #define ENABLE_SBMR
+#define ENABLE_NVIDIA
 
 #endif

--- a/meta-facebook/yv35-ji/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_hook.c
@@ -71,16 +71,34 @@ ina230_init_arg ina230_init_args[] = {
 #ifdef ENABLE_NVIDIA
 nv_satmc_init_arg satmc_init_args[] = {
 	/* numeric sensor */
-	[0] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_TMP_GRACE },
-	[1] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_PWR_VDD_CPU },
-	[2] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_VOL_VDD_CPU },
-	[3] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_PWR_VDD_SOC },
-	[4] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_VOL_VDD_SOC },
-	[5] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_PWR_GRACE },
+	[0] = { .is_init = false,
+		.endpoint = MCTP_EID_SATMC,
+		.sensor_id = NV_SATMC_SENSOR_NUM_TMP_GRACE },
+	[1] = { .is_init = false,
+		.endpoint = MCTP_EID_SATMC,
+		.sensor_id = NV_SATMC_SENSOR_NUM_PWR_VDD_CPU },
+	[2] = { .is_init = false,
+		.endpoint = MCTP_EID_SATMC,
+		.sensor_id = NV_SATMC_SENSOR_NUM_VOL_VDD_CPU },
+	[3] = { .is_init = false,
+		.endpoint = MCTP_EID_SATMC,
+		.sensor_id = NV_SATMC_SENSOR_NUM_PWR_VDD_SOC },
+	[4] = { .is_init = false,
+		.endpoint = MCTP_EID_SATMC,
+		.sensor_id = NV_SATMC_SENSOR_NUM_VOL_VDD_SOC },
+	[5] = { .is_init = false,
+		.endpoint = MCTP_EID_SATMC,
+		.sensor_id = NV_SATMC_SENSOR_NUM_PWR_GRACE },
 	/* state sensor */
-	[6] = { .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_CPU_THROT_STATE, .state_sensor_idx = 0 },
-	[7] = { .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_POWER_BREAK, .state_sensor_idx = 0 },
-	[8] = { .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_SPARE_CH_PRESENCE, .state_sensor_idx = 0 },
+	[6] = { .endpoint = MCTP_EID_SATMC,
+		.sensor_id = NV_SATMC_SENSOR_NUM_CPU_THROT_STATE,
+		.state_sensor_idx = 0 },
+	[7] = { .endpoint = MCTP_EID_SATMC,
+		.sensor_id = NV_SATMC_SENSOR_NUM_POWER_BREAK,
+		.state_sensor_idx = 0 },
+	[8] = { .endpoint = MCTP_EID_SATMC,
+		.sensor_id = NV_SATMC_SENSOR_NUM_SPARE_CH_PRESENCE,
+		.state_sensor_idx = 0 },
 };
 #endif
 
@@ -88,12 +106,15 @@ nv_satmc_init_arg satmc_init_args[] = {
  *  PRE-HOOK/POST-HOOK ARGS
  **************************************************************************************************/
 struct tca9548 mux_conf_addr_0xe0[4] = {
-	[0] = { .addr = 0xe0, .chan = 0 }, [1] = { .addr = 0xe0, .chan = 1 },
-	[2] = { .addr = 0xe0, .chan = 2 }, [3] = { .addr = 0xe0, .chan = 3 },
+	[0] = { .addr = 0xe0, .chan = 0 },
+	[1] = { .addr = 0xe0, .chan = 1 },
+	[2] = { .addr = 0xe0, .chan = 2 },
+	[3] = { .addr = 0xe0, .chan = 3 },
 };
 
 struct tca9548 mux_conf_addr_0xe2[2] = {
-	[0] = { .addr = 0xe2, .chan = 0 }, [1] = { .addr = 0xe2, .chan = 1 },
+	[0] = { .addr = 0xe2, .chan = 0 },
+	[1] = { .addr = 0xe2, .chan = 1 },
 };
 
 /**************************************************************************************************

--- a/meta-facebook/yv35-ji/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_hook.c
@@ -32,8 +32,8 @@
 #include "plat_mctp.h"
 #endif
 
-#define ADJUST_MP5990_CURRENT(x) (x)
-#define ADJUST_MP5990_POWER(x) (x)
+#define ADJUST_MP5990_CURRENT(x) (x * 1) // temporary set
+#define ADJUST_MP5990_POWER(x) (x * 1) // temporary set
 
 LOG_MODULE_REGISTER(plat_hook);
 

--- a/meta-facebook/yv35-ji/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_hook.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "sensor.h"
+#include "plat_def.h"
+#include "plat_i2c.h"
+#include "plat_gpio.h"
+#include "plat_hook.h"
+#include "plat_sensor_table.h"
+#include "i2c-mux-tca9548.h"
+#include "logging/log.h"
+#include "libipmi.h"
+#include "ipmi.h"
+#include "power_status.h"
+#ifdef ENABLE_NVIDIA
+#include "nvidia.h"
+#include "plat_mctp.h"
+#endif
+
+#define ADJUST_MP5990_CURRENT(x) (x)
+#define ADJUST_MP5990_POWER(x) (x)
+
+LOG_MODULE_REGISTER(plat_hook);
+
+/**************************************************************************************************
+ * INIT ARGS
+**************************************************************************************************/
+adc_asd_init_arg ast_adc_init_args[] = { [0] = { .is_init = false } };
+
+mp5990_init_arg mp5990_init_args[] = {
+	[0] = { .is_init = false,
+		.iout_cal_gain = 0xFFFF,
+		.iout_oc_fault_limit = 0xFFFF,
+		.ocw_sc_ref = 0xFFFF },
+};
+
+ina230_init_arg ina230_init_args[] = {
+	[0] = { .is_init = false,
+		.config =
+			{
+				.MODE = 0b111, // Measure voltage of shunt resistor and bus(default).
+				.VSH_CT = 0b100, // The Vshunt conversion time is 1.1ms(default).
+				.VBUS_CT = 0b100, // The Vbus conversion time is 1.1ms(default).
+				.AVG = 0b000, // Average number is 1(default).
+			},
+		.alt_cfg =
+			{
+				.LEN = 1, // Alert Latch enabled.
+				.BOL = 1,
+			},
+		.r_shunt = 0.01,
+		.alert_value = 13.2, // Unit: Watt, // Unit: Watt
+		.i_max = 16.384 },
+};
+
+#ifdef ENABLE_NVIDIA
+nv_satmc_init_arg satmc_init_args[] = {
+	/* numeric sensor */
+	[0] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_TMP_GRACE },
+	[1] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_PWR_VDD_CPU },
+	[2] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_VOL_VDD_CPU },
+	[3] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_PWR_VDD_SOC },
+	[4] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_VOL_VDD_SOC },
+	[5] = { .is_init = false, .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_PWR_GRACE },
+	/* state sensor */
+	[6] = { .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_CPU_THROT_STATE, .state_sensor_idx = 0 },
+	[7] = { .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_POWER_BREAK, .state_sensor_idx = 0 },
+	[8] = { .endpoint = MCTP_EID_SATMC, .sensor_id = NV_SATMC_SENSOR_NUM_SPARE_CH_PRESENCE, .state_sensor_idx = 0 },
+};
+#endif
+
+/**************************************************************************************************
+ *  PRE-HOOK/POST-HOOK ARGS
+ **************************************************************************************************/
+struct tca9548 mux_conf_addr_0xe0[4] = {
+	[0] = { .addr = 0xe0, .chan = 0 }, [1] = { .addr = 0xe0, .chan = 1 },
+	[2] = { .addr = 0xe0, .chan = 2 }, [3] = { .addr = 0xe0, .chan = 3 },
+};
+
+struct tca9548 mux_conf_addr_0xe2[2] = {
+	[0] = { .addr = 0xe2, .chan = 0 }, [1] = { .addr = 0xe2, .chan = 1 },
+};
+
+/**************************************************************************************************
+ *  PRE-HOOK/POST-HOOK FUNC
+ **************************************************************************************************/
+bool pre_vol_bat3v_read(sensor_cfg *cfg, void *args)
+{
+	ARG_UNUSED(args);
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+
+	if (cfg->num == SENSOR_NUM_VOL_ADC4_P3V_BAT) {
+		gpio_set(P3V_BAT_SCALED_EN_R, GPIO_HIGH);
+		k_msleep(1);
+	}
+
+	return true;
+}
+
+bool post_vol_bat3v_read(sensor_cfg *cfg, void *args, int *reading)
+{
+	ARG_UNUSED(args);
+	ARG_UNUSED(reading);
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+
+	if (cfg->num == SENSOR_NUM_VOL_ADC4_P3V_BAT) {
+		gpio_set(P3V_BAT_SCALED_EN_R, GPIO_LOW);
+		k_msleep(1);
+	}
+
+	return true;
+}
+
+bool post_mp5990_cur_read(sensor_cfg *cfg, void *args, int *reading)
+{
+	ARG_UNUSED(args);
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	if (!reading) {
+		return check_reading_pointer_null_is_allowed(cfg);
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	float val = sval->integer + (sval->fraction * 0.001);
+	val = ADJUST_MP5990_CURRENT(val);
+	sval->integer = (int16_t)val;
+	sval->fraction = (val - sval->integer) * 1000;
+
+	return true;
+}
+
+bool post_mp5990_pwr_read(sensor_cfg *cfg, void *args, int *reading)
+{
+	ARG_UNUSED(args);
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	if (!reading) {
+		return check_reading_pointer_null_is_allowed(cfg);
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	float val = sval->integer + (sval->fraction * 0.001);
+	val = ADJUST_MP5990_POWER(val);
+	sval->integer = (int16_t)val;
+	sval->fraction = (val - sval->integer) * 1000;
+
+	return true;
+}
+
+bool pre_tmp451_read(sensor_cfg *cfg, void *args)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(args, false);
+
+	gpio_set(BIC_TMP_LVSFT_EN, GPIO_HIGH);
+
+	struct tca9548 *p = (struct tca9548 *)args;
+
+	uint8_t retry = 200; //workaround for poc board
+	I2C_MSG msg = { 0 };
+
+	msg.bus = cfg->port;
+	/* change address to 7-bit */
+	msg.target_addr = ((p->addr) >> 1);
+	msg.tx_len = 2;
+	msg.data[0] = 0x00;
+	msg.data[1] = (1 << (p->chan));
+
+	if (i2c_master_write(&msg, retry)) {
+		LOG_ERR("I2C master write failed");
+		return false;
+	}
+
+	return true;
+}
+
+bool pre_tmp75_read(sensor_cfg *cfg, void *args)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(args, false);
+
+	struct tca9548 *p = (struct tca9548 *)args;
+
+	uint8_t retry = 200; //workaround for poc board
+	I2C_MSG msg = { 0 };
+
+	msg.bus = cfg->port;
+	/* change address to 7-bit */
+	msg.target_addr = ((p->addr) >> 1);
+	msg.tx_len = 2;
+	msg.data[0] = 0x00;
+	msg.data[1] = (1 << (p->chan));
+
+	if (i2c_master_write(&msg, retry)) {
+		LOG_ERR("I2C master write failed");
+		return false;
+	}
+
+	return true;
+}

--- a/meta-facebook/yv35-ji/src/platform/plat_hook.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_hook.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_HOOK_H
+#define PLAT_HOOK_H
+
+#include "sensor.h"
+#include "plat_def.h"
+
+/**************************************************************************************************
+ * INIT ARGS
+**************************************************************************************************/
+extern adc_asd_init_arg ast_adc_init_args[];
+extern mp5990_init_arg mp5990_init_args[];
+extern ina230_init_arg ina230_init_args[];
+#ifdef ENABLE_NVIDIA
+extern nv_satmc_init_arg satmc_init_args[];
+#endif
+
+/**************************************************************************************************
+ *  PRE-HOOK/POST-HOOK ARGS
+ **************************************************************************************************/
+extern struct tca9548 mux_conf_addr_0xe0[];
+extern struct tca9548 mux_conf_addr_0xe2[];
+
+/**************************************************************************************************
+ *  PRE-HOOK/POST-HOOK FUNC
+ **************************************************************************************************/
+bool pre_nvme_read(sensor_cfg *cfg, void *args);
+bool pre_vol_bat3v_read(sensor_cfg *cfg, void *args);
+bool post_vol_bat3v_read(sensor_cfg *cfg, void *args, int *reading);
+bool post_mp5990_cur_read(sensor_cfg *cfg, void *args, int *reading);
+bool post_mp5990_pwr_read(sensor_cfg *cfg, void *args, int *reading);
+bool pre_tmp451_read(sensor_cfg *cfg, void *args);
+bool pre_tmp75_read(sensor_cfg *cfg, void *args);
+
+#endif

--- a/meta-facebook/yv35-ji/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sdr_table.c
@@ -21,6 +21,7 @@
 
 #include "sdr.h"
 #include "sensor.h"
+#include "plat_def.h"
 #include "plat_class.h"
 #include "plat_ipmb.h"
 #include "plat_sensor_table.h"
@@ -28,7 +29,2221 @@
 
 LOG_MODULE_REGISTER(plat_sdr_table);
 
-SDR_Full_sensor plat_sdr_table[] = {};
+SDR_Full_sensor plat_sdr_table[] = {
+	/* =============================== TEMPARUTURE SENSOR =============================== */
+	{
+		// TMP451_IN temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_TMP451_IN, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_INLET_TEMP_C",
+	},
+	{
+		// TMP451_OUT temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_TMP451_OUT, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_OUTLET_TEMP_C",
+	},
+	{
+		// TMP75_FIO temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_TMP75_FIO, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_FIO_FRONT_TEMP_C",
+	},
+#ifdef ENABLE_NVIDIA
+	{
+		// CPU temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_CPU, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_SOC_CPU_TEMP_C",
+	},
+#endif
+	{
+		// FPGA temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_FPGA, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_FPGA_TEMP_C",
+	},
+	{
+		// E1S_SSD temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_E1S_SSD, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_E1S_SSD_TEMP_C",
+	},
+	{
+		// HSC temperature
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_TEMP_HSC, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_TEMPERATURE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x01, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x50, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_HSC_TEMP_C",
+	},
+
+	/* =============================== VOLTAGE SENSOR =============================== */
+	{
+		// HSC Input Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_HSCIN, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_HSC_INPUT_VOLT_V",
+	},
+	{
+		// ADC0 - P12V_STBY Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC0_P12V_STBY, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_P12V_STBY_VOLT_V",
+	},
+	{
+		// ADC1 - VDD_1V8 Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC1_VDD_1V8, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_VDD_1V8_VOLT_V",
+	},
+	{
+		// ADC2 - P3V3_STBY Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC2_P3V3_STBY, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_P3V3_STBY_VOLT_V",
+	},
+	{
+		// ADC3 - SOCVDD Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC3_SOCVDD, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_SOCVDD_VOLT_V",
+	},
+	{
+		// ADC4 - P3V_BAT Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC4_P3V_BAT, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_P3V_BAT_VOLT_V",
+	},
+	{
+		// ADC5 - CPUVDD Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC5_CPUVDD, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_CPUVDD_VOLT_V",
+	},
+	{
+		// ADC6 - FPGA_VCC_AO Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC6_FPGA_VCC_AO, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_FPGA_VCC_AO_VOLT_V",
+	},
+	{
+		// ADC7 - 1V2 Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC7_1V2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_1V2_VOLT_V",
+	},
+	{
+		// ADC9 - VDD_M2 Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC9_VDD_M2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_VDD_M2_VOLT_V",
+	},
+	{
+		// ADC10 - P1V2_STBY Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC10_P1V2_STBY, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_P1V2_STBY_VOLT_V",
+	},
+	{
+		// ADC11 - FBVDDQ Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC11_FBVDDQ, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_FBVDDQ_VOLT_V",
+	},
+	{
+		// ADC12 - FBVDDP2 Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC12_FBVDDP2, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_FBVDDP2_VOLT_V",
+	},
+	{
+		// ADC13 - FBVDD1 Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC13_FBVDD1, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_FBVDD1_VOLT_V",
+	},
+	{
+		// ADC14 - P5V_STBY Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC14_P5V_STBY, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_P5V_STBY_VOLT_V",
+	},
+	{
+		// ADC15 - CPU_DVDD Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_ADC15_CPU_DVDD, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_ADC_CPU_DVDD_VOLT_V",
+	},
+	{
+		// INA230 Voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_E1S, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_E1S_VOLT_V",
+	},
+#ifdef ENABLE_NVIDIA
+	{
+		// CPU_VDD voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_CPUVDD, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_CPUVDD_VOLT_V",
+	},
+	{
+		// SOC_VDD voltage
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_VOL_SOCVDD, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_VOLTAGE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_VOL, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_SOCVDD_VOLT_V",
+	},
+#endif
+
+	/* =============================== CURRENT SENSOR =============================== */
+	{
+		// HSC Output Current
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_CUR_HSCOUT, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_CURRENT, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_HSC_OUTPUT_CURR_A",
+	},
+	{
+		// INA230 E1.S Current
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_CUR_E1S, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_CURRENT, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_AMP, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_E1S_CURR_A",
+	},
+
+	/* =============================== POWER SENSOR =============================== */
+	{
+		// HSC Input Power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_PWR_HSCIN, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_OTHER_UNIT_BASE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_HSC_INPUT_PWR_W",
+	},
+	{
+		// INA230 E1.S Power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_PWR_E1S, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_OTHER_UNIT_BASE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_E1S_PWR_W",
+	},
+#ifdef ENABLE_NVIDIA
+	{
+		// CPU power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_PWR_CPU, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_OTHER_UNIT_BASE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_CPU_PWR_W",
+	},
+	{
+		// CPU_VDD power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_PWR_CPUVDD, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_OTHER_UNIT_BASE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_CPUVDD_PWR_W",
+	},
+	{
+		// SOC_VDD power
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_PWR_SOCVDD, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_OTHER_UNIT_BASE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_WATT, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_SOCVDD_PWR_W",
+	},
+#endif
+
+/* =============================== STATE SENSOR =============================== */
+#ifdef ENABLE_NVIDIA
+	{
+		// CPU THROTTLE state
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_OTH_CPU_THROTTLE, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_OTHER_UNIT_BASE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_UNSPECIFIED, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_CPU_THROTTLE_STA",
+	},
+	{
+		// POWER BREAK state
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_OTH_POWER_BREAK, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_OTHER_UNIT_BASE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_UNSPECIFIED, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_PWR_BREAK_STA",
+	},
+	{
+		// CPU THROTTLE state
+		0x00,
+		0x00, // record ID
+		IPMI_SDR_VER_15, // SDR ver
+		IPMI_SDR_FULL_SENSOR, // record type
+		IPMI_SDR_FULL_SENSOR_MIN_LEN, // size of struct
+
+		SELF_I2C_ADDRESS << 1, // owner id
+		0x00, // owner lun
+		SENSOR_NUM_OTH_SPARE_CHANNEL, // sensor number
+
+		IPMI_SDR_ENTITY_ID_SYS_BOARD, // entity id
+		0x00, // entity instance
+		IPMI_SDR_SENSOR_INIT_SCAN | IPMI_SDR_SENSOR_INIT_EVENT |
+			IPMI_SDR_SENSOR_INIT_THRESHOLD | IPMI_SDR_SENSOR_INIT_TYPE |
+			IPMI_SDR_SENSOR_INIT_DEF_EVENT |
+			IPMI_SDR_SENSOR_INIT_DEF_SCAN, // sensor init
+		IPMI_SDR_SENSOR_CAP_THRESHOLD_RW |
+			IPMI_SDR_SENSOR_CAP_EVENT_CTRL_NO, // sensor capabilities
+		IPMI_SDR_SENSOR_TYPE_OTHER_UNIT_BASE, // sensor type
+		IPMI_SDR_EVENT_TYPE_THRESHOLD, // event/reading type
+		0x00, // assert event mask
+		IPMI_SDR_CMP_RETURN_LCT | IPMI_SDR_ASSERT_MASK_UCT_HI |
+			IPMI_SDR_ASSERT_MASK_LCT_LO, // assert threshold reading mask
+		0x00, // deassert event mask
+		IPMI_SDR_CMP_RETURN_UCT | IPMI_SDR_DEASSERT_MASK_UCT_LO |
+			IPMI_SDR_DEASSERT_MASK_LCT_HI, // deassert threshold reading mask
+		0x00, // discrete reading mask/ settable
+		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
+			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
+		0x00, // sensor unit
+		IPMI_SENSOR_UNIT_UNSPECIFIED, // base unit
+		0x00, // modifier unit
+		IPMI_SDR_LINEAR_LINEAR, // linearization
+		0x00, // [7:0] M bits
+		0x00, // [9:8] M bits, tolerance
+		0x00, // [7:0] B bits
+		0x00, // [9:8] B bits, tolerance
+		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
+		0x00, // Rexp, Bexp
+		0x00, // analog characteristic
+		0x00, // nominal reading
+		0x00, // normal maximum
+		0x00, // normal minimum
+		0x00, // sensor maximum reading
+		0x00, // sensor minimum reading
+		0x00, // UNRT
+		0x00, // UCT
+		0x00, // UNCT
+		0x00, // LNRT
+		0x00, // LCT
+		0x00, // LNCT
+		0x00, // positive-going threshold
+		0x00, // negative-going threshold
+		0x00, // reserved
+		0x00, // reserved
+		0x00, // OEM
+		IPMI_SDR_STRING_TYPE_ASCII_8, // ID len, should be same as "size of struct"
+		"MB_SPARE_CH_STA",
+	},
+#endif
+};
 
 const int SDR_TABLE_SIZE = ARRAY_SIZE(plat_sdr_table);
 

--- a/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
@@ -21,6 +21,12 @@
 #include <string.h>
 
 #include "sensor.h"
+#include "ast_adc.h"
+#include "pmbus.h"
+#include "plat_def.h"
+#include "tmp461.h"
+#include "plat_class.h"
+#include "plat_hook.h"
 #include "plat_i2c.h"
 #include "plat_i3c.h"
 #include "libutil.h"
@@ -29,11 +35,230 @@
 
 LOG_MODULE_REGISTER(plat_sensor_table);
 
+sensor_poll_time_cfg diff_poll_time_sensor_table[] = {
+	// sensor_number, last_access_time
+	{ SENSOR_NUM_VOL_ADC4_P3V_BAT, 0 },
+};
+
 sensor_cfg plat_sensor_config[] = {
 	/* number,                  type,       port,      address,      offset,
 	   access check arg0, arg1, sample_count, cache, cache_status, mux_ADDRess, mux_offset,
 	   pre_sensor_read_fn, pre_sensor_read_args, post_sensor_read_fn, post_sensor_read_fn  */
+
+	/* NVME */
+	{ SENSOR_NUM_TEMP_E1S_SSD, sensor_dev_nvme, I2C_BUS10, E1S_SSD_ADDR, SSD_TEMP_OFFSET,
+	  post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
+
+	/* adc voltage */
+	{ SENSOR_NUM_VOL_ADC0_P12V_STBY, sensor_dev_ast_adc, ADC_PORT0, NONE, NONE, stby_access, 66,
+	  10, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC1_VDD_1V8, sensor_dev_ast_adc, ADC_PORT1, NONE, NONE, stby_access, 1, 1,
+	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC2_P3V3_STBY, sensor_dev_ast_adc, ADC_PORT2, NONE, NONE, stby_access, 2,
+	  1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC3_SOCVDD, sensor_dev_ast_adc, ADC_PORT3, NONE, NONE, stby_access, 1, 1,
+	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC4_P3V_BAT, sensor_dev_ast_adc, ADC_PORT4, NONE, NONE, stby_access, 301,
+	  100, SAMPLE_COUNT_DEFAULT, POLL_TIME_BAT3V, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  pre_vol_bat3v_read, NULL, post_vol_bat3v_read, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC5_CPUVDD, sensor_dev_ast_adc, ADC_PORT5, NONE, NONE, stby_access, 1, 1,
+	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC6_FPGA_VCC_AO, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, stby_access,
+	  1, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC7_1V2, sensor_dev_ast_adc, ADC_PORT7, NONE, NONE, stby_access, 1, 1,
+	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC9_VDD_M2, sensor_dev_ast_adc, ADC_PORT9, NONE, NONE, stby_access, 2, 1,
+	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC10_P1V2_STBY, sensor_dev_ast_adc, ADC_PORT10, NONE, NONE, stby_access,
+	  1, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC11_FBVDDQ, sensor_dev_ast_adc, ADC_PORT11, NONE, NONE, stby_access, 1,
+	  1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC12_FBVDDP2, sensor_dev_ast_adc, ADC_PORT12, NONE, NONE, stby_access, 1,
+	  1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC13_FBVDD1, sensor_dev_ast_adc, ADC_PORT13, NONE, NONE, stby_access, 1,
+	  1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC14_P5V_STBY, sensor_dev_ast_adc, ADC_PORT14, NONE, NONE, stby_access,
+	  711, 200, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+	{ SENSOR_NUM_VOL_ADC15_CPU_DVDD, sensor_dev_ast_adc, ADC_PORT15, NONE, NONE, stby_access, 1,
+	  1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
+	  NULL, NULL, NULL, NULL, &ast_adc_init_args[0] },
+
+	// INA230
+	{ SENSOR_NUM_PWR_E1S, sensor_dev_ina230, I2C_BUS2, INA230_ADDR, INA230_PWR_OFFSET,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &ina230_init_args[0] },
+	{ SENSOR_NUM_CUR_E1S, sensor_dev_ina230, I2C_BUS2, INA230_ADDR, INA230_CUR_OFFSET,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &ina230_init_args[0] },
+	{ SENSOR_NUM_VOL_E1S, sensor_dev_ina230, I2C_BUS2, INA230_ADDR, INA230_BUS_VOL_OFFSET,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &ina230_init_args[0] },
+
+	// TMP
+	{ SENSOR_NUM_TEMP_TMP451_IN, sensor_dev_tmp461, I2C_BUS12, TMP451_ADDR,
+	  TMP461_REMOTE_TEMPERATRUE, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_tmp451_read, &mux_conf_addr_0xe0[0],
+	  NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_TMP451_OUT, sensor_dev_tmp461, I2C_BUS12, TMP451_ADDR,
+	  TMP461_REMOTE_TEMPERATRUE, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_tmp451_read, &mux_conf_addr_0xe0[1],
+	  NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_FPGA, sensor_dev_tmp461, I2C_BUS12, TMP451_ADDR,
+	  TMP461_REMOTE_TEMPERATRUE, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_tmp451_read, &mux_conf_addr_0xe0[2],
+	  NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_TMP75_FIO, sensor_dev_tmp75, I2C_BUS2, TMP75_ADDR, TMP75_TEMP_OFFSET,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tmp75_read, &mux_conf_addr_0xe2[0], NULL, NULL, NULL },
+
+#ifdef ENABLE_NVIDIA
+	/* SatMC */
+	{ SENSOR_NUM_TEMP_CPU, sensor_dev_nv_satmc, MCTP_I2C_SATMC_BUS, (MCTP_I2C_SATMC_ADDR >> 1),
+	  NONE, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING,
+	  0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &satmc_init_args[0] },
+	{ SENSOR_NUM_VOL_CPUVDD, sensor_dev_nv_satmc, MCTP_I2C_SATMC_BUS,
+	  (MCTP_I2C_SATMC_ADDR >> 1), NONE, post_access, 0, 0, SAMPLE_COUNT_DEFAULT,
+	  POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &satmc_init_args[2] },
+	{ SENSOR_NUM_VOL_SOCVDD, sensor_dev_nv_satmc, MCTP_I2C_SATMC_BUS,
+	  (MCTP_I2C_SATMC_ADDR >> 1), NONE, post_access, 0, 0, SAMPLE_COUNT_DEFAULT,
+	  POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &satmc_init_args[4] },
+	{ SENSOR_NUM_PWR_CPUVDD, sensor_dev_nv_satmc, MCTP_I2C_SATMC_BUS,
+	  (MCTP_I2C_SATMC_ADDR >> 1), NONE, post_access, 0, 0, SAMPLE_COUNT_DEFAULT,
+	  POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &satmc_init_args[1] },
+	{ SENSOR_NUM_PWR_SOCVDD, sensor_dev_nv_satmc, MCTP_I2C_SATMC_BUS,
+	  (MCTP_I2C_SATMC_ADDR >> 1), NONE, post_access, 0, 0, SAMPLE_COUNT_DEFAULT,
+	  POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &satmc_init_args[3] },
+	{ SENSOR_NUM_PWR_CPU, sensor_dev_nv_satmc, MCTP_I2C_SATMC_BUS, (MCTP_I2C_SATMC_ADDR >> 1),
+	  NONE, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING,
+	  0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &satmc_init_args[5] },
+	{ SENSOR_NUM_OTH_CPU_THROTTLE, sensor_dev_nv_satmc, MCTP_I2C_SATMC_BUS,
+	  (MCTP_I2C_SATMC_ADDR >> 1), NONE, post_access, 0, 0, SAMPLE_COUNT_DEFAULT,
+	  POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &satmc_init_args[6] },
+	{ SENSOR_NUM_OTH_POWER_BREAK, sensor_dev_nv_satmc, MCTP_I2C_SATMC_BUS,
+	  (MCTP_I2C_SATMC_ADDR >> 1), NONE, post_access, 0, 0, SAMPLE_COUNT_DEFAULT,
+	  POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &satmc_init_args[7] },
+	{ SENSOR_NUM_OTH_SPARE_CHANNEL, sensor_dev_nv_satmc, MCTP_I2C_SATMC_BUS,
+	  (MCTP_I2C_SATMC_ADDR >> 1), NONE, post_access, 0, 0, SAMPLE_COUNT_DEFAULT,
+	  POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &satmc_init_args[8] },
+#endif
 };
+
+sensor_cfg mp5990_sensor_config_table[] = {
+	{ SENSOR_NUM_VOL_HSCIN, sensor_dev_mp5990, I2C_BUS2, MP5990_ADDR, PMBUS_READ_VIN,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
+	{ SENSOR_NUM_CUR_HSCOUT, sensor_dev_mp5990, I2C_BUS2, MP5990_ADDR, PMBUS_READ_IOUT,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, post_mp5990_cur_read, NULL, &mp5990_init_args[0] },
+	{ SENSOR_NUM_PWR_HSCIN, sensor_dev_mp5990, I2C_BUS2, MP5990_ADDR, PMBUS_READ_PIN,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, post_mp5990_pwr_read, NULL, &mp5990_init_args[0] },
+};
+
+sensor_cfg mp5990_temp_sensor_config_table[] = {
+	{ SENSOR_NUM_TEMP_HSC, sensor_dev_mp5990, I2C_BUS2, MP5990_ADDR, PMBUS_READ_TEMPERATURE_1,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &mp5990_init_args[0] },
+};
+
+void pal_extend_sensor_config()
+{
+	uint8_t sensor_count = 0;
+	uint8_t hsc_module = get_hsc_module();
+
+	/* Determine which HSC module is used */
+	switch (hsc_module) {
+	case HSC_MODULE_MP5990:
+		LOG_INF("HSC vendor: MP5990");
+		sensor_count = ARRAY_SIZE(mp5990_sensor_config_table);
+		for (int index = 0; index < sensor_count; index++) {
+			add_sensor_config(mp5990_sensor_config_table[index]);
+		}
+		/* MP5990 can read HSC temperature */
+		add_sensor_config(mp5990_temp_sensor_config_table[0]);
+		break;
+	case HSC_MODULE_RS31380R:
+		LOG_INF("HSC vendor: RS31380R");
+		LOG_WRN("RS31380R HSC module is not supported yet");
+		break;
+	default:
+		LOG_ERR("Unsupported HSC module, HSC module: 0x%x", hsc_module);
+		break;
+	}
+
+	if (sensor_config_count != sdr_count) {
+		LOG_ERR("Extend sensor SDR and config table not match, sdr size: 0x%x, sensor config size: 0x%x",
+			sdr_count, sensor_config_count);
+	}
+}
+
+uint8_t pal_get_extend_sensor_config()
+{
+	uint8_t extend_sensor_config_size = 0;
+	uint8_t hsc_module = get_hsc_module();
+	switch (hsc_module) {
+	case HSC_MODULE_MP5990:
+		LOG_INF("HSC vendor: MP5990");
+		extend_sensor_config_size += ARRAY_SIZE(mp5990_sensor_config_table);
+		/* MP5990 can read HSC temperature */
+		extend_sensor_config_size += ARRAY_SIZE(mp5990_temp_sensor_config_table);
+		break;
+	case HSC_MODULE_RS31380R:
+		LOG_INF("HSC vendor: RS31380R");
+		LOG_WRN("RS31380R HSC module is not supported yet");
+		break;
+	default:
+		LOG_ERR("Unsupported HSC module, HSC module: 0x%x", hsc_module);
+		break;
+	}
+
+	return extend_sensor_config_size;
+}
+
+bool pal_is_time_to_poll(uint8_t sensor_num, int poll_time)
+{
+	int i = 0;
+	int table_size = sizeof(diff_poll_time_sensor_table) / sizeof(sensor_poll_time_cfg);
+
+	for (i = 0; i < table_size; i++) {
+		if (sensor_num == diff_poll_time_sensor_table[i].sensor_num) {
+			int64_t current_access_time = k_uptime_get();
+			int64_t last_access_time = diff_poll_time_sensor_table[i].last_access_time;
+			int64_t diff_time = (current_access_time - last_access_time) / 1000;
+			if ((last_access_time != 0) && (diff_time < poll_time)) {
+				return false;
+			} else {
+				diff_poll_time_sensor_table[i].last_access_time =
+					current_access_time;
+				return true;
+			}
+		}
+	}
+
+	LOG_ERR("Can't find sensor 0x%x last access time", sensor_num);
+	return true;
+}
 
 const int SENSOR_CONFIG_SIZE = ARRAY_SIZE(plat_sensor_config);
 
@@ -41,4 +266,6 @@ void load_sensor_config(void)
 {
 	memcpy(sensor_config, plat_sensor_config, sizeof(plat_sensor_config));
 	sensor_config_count = ARRAY_SIZE(plat_sensor_config);
+
+	pal_extend_sensor_config();
 }

--- a/meta-facebook/yv35-ji/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_sensor_table.h
@@ -19,10 +19,86 @@
 
 #include <stdint.h>
 #include "sensor.h"
+#include "plat_def.h"
 
-/*  define config for sensors  */
+/* SENSOR POLLING TIME(second) */
+#define POLL_TIME_BAT3V 3600
 
-/*  threshold sensor number, 1 based  */
+/* SENSOR ADDRESS(7-bit)/OFFSET */
+#define E1S_SSD_ADDR (0xD4 >> 1)
+#define FPGA_ADDR (0xC0 >> 1)
+#define TEMP_HSC_ADDR (0x98 >> 1)
+#define MP5990_ADDR (0xA0 >> 1)
+#define INA230_ADDR (0x8A >> 1)
+#define INA3221_ADDR (0x80 >> 1)
+#define TMP451_ADDR (0x98 >> 1)
+#define TMP75_ADDR (0x90 >> 1)
+
+/* SENSOR OFFSET */
+#define SSD_TEMP_OFFSET 0x00
+#define TMP75_TEMP_OFFSET 0x00
+
+/*  threshold sensor number, 1 based - temperature */
+#define SENSOR_NUM_TEMP_TMP451_IN 0x1
+#define SENSOR_NUM_TEMP_TMP451_OUT 0x2
+#define SENSOR_NUM_TEMP_TMP75_FIO 0x3
+#define SENSOR_NUM_TEMP_CPU 0x4
+#define SENSOR_NUM_TEMP_FPGA 0x5
+#define SENSOR_NUM_TEMP_E1S_SSD 0x6
+#define SENSOR_NUM_TEMP_HSC 0x7
+#define SENSOR_NUM_TEMP_CPUDVDD 0x8
+#define SENSOR_NUM_TEMP_CPUVDD 0x9
+#define SENSOR_NUM_TEMP_SOCVDD 0xA
+
+/* SENSOR NUMBER(1 based) - voltage */
+#define SENSOR_NUM_VOL_HSCIN 0x10
+#define SENSOR_NUM_VOL_ADC0_P12V_STBY 0x11
+#define SENSOR_NUM_VOL_ADC1_VDD_1V8 0x12
+#define SENSOR_NUM_VOL_ADC2_P3V3_STBY 0x13
+#define SENSOR_NUM_VOL_ADC3_SOCVDD 0x14
+#define SENSOR_NUM_VOL_ADC4_P3V_BAT 0x15
+#define SENSOR_NUM_VOL_ADC5_CPUVDD 0x16
+#define SENSOR_NUM_VOL_ADC6_FPGA_VCC_AO 0x17
+#define SENSOR_NUM_VOL_ADC7_1V2 0x18
+#define SENSOR_NUM_VOL_ADC9_VDD_M2 0x19
+#define SENSOR_NUM_VOL_ADC10_P1V2_STBY 0x1A
+#define SENSOR_NUM_VOL_ADC11_FBVDDQ 0x1B
+#define SENSOR_NUM_VOL_ADC12_FBVDDP2 0x1C
+#define SENSOR_NUM_VOL_ADC13_FBVDD1 0x1D
+#define SENSOR_NUM_VOL_ADC14_P5V_STBY 0x1E
+#define SENSOR_NUM_VOL_ADC15_CPU_DVDD 0x1F
+#define SENSOR_NUM_VOL_E1S 0x20
+#define SENSOR_NUM_VOL_CPUDVDD 0x21
+#define SENSOR_NUM_VOL_CPUVDD 0x22
+#define SENSOR_NUM_VOL_SOCVDD 0x23
+
+/* SENSOR NUMBER(1 based) - current */
+#define SENSOR_NUM_CUR_HSCOUT 0x25
+#define SENSOR_NUM_CUR_E1S 0x26
+#define SENSOR_NUM_CUR_CPUDVDD 0x27
+#define SENSOR_NUM_CUR_CPUVDD 0x28
+#define SENSOR_NUM_CUR_SOCVDD 0x29
+
+/* SENSOR NUMBER(1 based) - power */
+#define SENSOR_NUM_PWR_CPU 0x30
+#define SENSOR_NUM_PWR_HSCIN 0x31
+#define SENSOR_NUM_PWR_E1S 0x32
+#define SENSOR_NUM_PWR_CPUDVDD 0x33
+#define SENSOR_NUM_PWR_CPUVDD 0x34
+#define SENSOR_NUM_PWR_SOCVDD 0x35
+
+/* SENSOR NUMBER(1 based) - state */
+#define SENSOR_NUM_OTH_CPU_THROTTLE 0x40
+#define SENSOR_NUM_OTH_POWER_BREAK 0x41
+#define SENSOR_NUM_OTH_SPARE_CHANNEL 0x42
+
+/* SENSOR NUMBER - sel */
+#define SENSOR_NUM_SYSTEM_STATUS 0x10
+#define SENSOR_NUM_POWER_ERROR 0x56
+#define SENSOR_NUM_PROC_FAIL 0x65
+#define SENSOR_NUM_CPU_FAULT 0xC0
+
+#define IPMI_EVENT_OFFSET_SYS_E1S_ALERT 0x86
 
 uint8_t plat_get_config_size();
 void load_sensor_config(void);


### PR DESCRIPTION
Summary:
- Support Nvidia SatMC sensor reading.
- Support sensor MP5990/INA230/TMP75/TMP451/ADC/NVME/SATMC monitor.

Test Plan:
- Build Code: PASS
- Get sensor reading from BMC and BIC: PASS

Log:
- BMC console
```
root@bmc-oob:~# sensor-util slot1
slot1:
MB_INLET_TEMP_C              (0x1) :  42.625 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :  31.375 C     | (ok)
MB_FIO_FRONT_TEMP_C          (0x3) :  29.000 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x4) :  48.312 C     | (ok)
MB_FPGA_TEMP_C               (0x5) :  35.062 C     | (ok)
MB_E1S_SSD_TEMP_C            (0x6) :  39.000 C     | (ok)
MB_HSC_TEMP_C                (0x7) :  41.000 C     | (ok)
MB_HSC_INPUT_VOLT_V          (0x10) :  11.968 Volts | (ok)
MB_ADC_P12V_STBY_VOLT_V      (0x11) :  12.144 Volts | (ok)
MB_ADC_VDD_1V8_VOLT_V        (0x12) :   1.826 Volts | (ok)
MB_ADC_P3V3_STBY_VOLT_V      (0x13) :   3.348 Volts | (ok)
MB_ADC_SOCVDD_VOLT_V         (0x14) :   0.866 Volts | (ok)
MB_ADC_P3V_BAT_VOLT_V        (0x15) :   3.268 Volts | (ok)
MB_ADC_CPUVDD_VOLT_V         (0x16) :   1.027 Volts | (ok)
MB_ADC_FPGA_VCC_AO_VOLT_V    (0x17) :   0.910 Volts | (ok)
MB_ADC_1V2_VOLT_V            (0x18) :   1.228 Volts | (ok)
MB_ADC_VDD_M2_VOLT_V         (0x19) :   3.320 Volts | (ok)
MB_ADC_P1V2_STBY_VOLT_V      (0x1A) :   1.191 Volts | (ok)
MB_ADC_FBVDDQ_VOLT_V         (0x1B) :   0.515 Volts | (ok)
MB_ADC_FBVDDP2_VOLT_V        (0x1C) :   1.047 Volts | (ok)
MB_ADC_FBVDD1_VOLT_V         (0x1D) :   1.794 Volts | (ok)
MB_ADC_P5V_STBY_VOLT_V       (0x1E) :   4.937 Volts | (ok)
MB_ADC_CPU_DVDD_VOLT_V       (0x1F) :   0.905 Volts | (ok)
MB_E1S_VOLT_V                (0x20) :  12.015 Volts | (ok)
MB_HSC_OUTPUT_CURR_A         (0x25) :   5.750 Amps  | (ok)
MB_E1S_CURR_A                (0x26) :   0.236 Amps  | (ok)
MB_CPU_PWR_W                 (0x30) :  51.736 Watts | (ok)
MB_HSC_INPUT_PWR_W           (0x31) :  66.000 Watts | (ok)
MB_E1S_PWR_W                 (0x32) :   2.825 Watts | (ok)
```
- BIC console
```
uart:~$ platform sensor list_all_sensor 
---------------------------------------------------------------------------------
Table name: common sensor table | index: 0x0  | sensor count: 0x24 | access[O]

[0x6 ] MB_E1S_SSD_TEMP_C        : nvme       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    39.000
[0x11] MB_ADC_P12V_STBY_VOLT_V  : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.130
[0x12] MB_ADC_VDD_1V8_VOLT_V    : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.826
[0x13] MB_ADC_P3V3_STBY_VOLT_V  : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.348
[0x14] MB_ADC_SOCVDD_VOLT_V     : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.866
[0x15] MB_ADC_P3V_BAT_VOLT_V    : adc        | access[O] | poll[O] 3600 sec | 4byte_acur_read_success   |     3.268
[0x16] MB_ADC_CPUVDD_VOLT_V     : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.027
[0x17] MB_ADC_FPGA_VCC_AO_VOLT_V: adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.910
[0x18] MB_ADC_1V2_VOLT_V        : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.228
[0x19] MB_ADC_VDD_M2_VOLT_V     : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.320
[0x1a] MB_ADC_P1V2_STBY_VOLT_V  : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.191
[0x1b] MB_ADC_FBVDDQ_VOLT_V     : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.517
[0x1c] MB_ADC_FBVDDP2_VOLT_V    : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.047
[0x1d] MB_ADC_FBVDD1_VOLT_V     : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.794
[0x1e] MB_ADC_P5V_STBY_VOLT_V   : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.937
[0x1f] MB_ADC_CPU_DVDD_VOLT_V   : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.905
[0x32] MB_E1S_PWR_W             : ina230     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.825
[0x26] MB_E1S_CURR_A            : ina230     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.236
[0x20] MB_E1S_VOLT_V            : ina230     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.008
[0x1 ] MB_INLET_TEMP_C          : tmp461     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    42.750
[0x2 ] MB_OUTLET_TEMP_C         : tmp461     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    31.250
[0x5 ] MB_FPGA_TEMP_C           : tmp461     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    35.062
[0x3 ] MB_FIO_FRONT_TEMP_C      : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    29.000
[0x4 ] MB_SOC_CPU_TEMP_C        : nv_satmc   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    48.280
[0x22] MB_CPUVDD_VOLT_V         : nv_satmc   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.006
[0x23] MB_SOCVDD_VOLT_V         : nv_satmc   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.856
[0x34] MB_CPUVDD_PWR_W          : nv_satmc   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    31.472
[0x35] MB_SOCVDD_PWR_W          : nv_satmc   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     8.817
[0x30] MB_CPU_PWR_W             : nv_satmc   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    51.632
[0x40] MB_CPU_THROTTLE_STA      : nv_satmc   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.000
[0x41] MB_PWR_BREAK_STA         : nv_satmc   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.000
[0x42] MB_SPARE_CH_STA          : nv_satmc   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.000
[0x10] MB_HSC_INPUT_VOLT_V      : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    11.968
[0x25] MB_HSC_OUTPUT_CURR_A     : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     5.750
[0x31] MB_HSC_INPUT_PWR_W       : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    66.000
[0x7 ] MB_HSC_TEMP_C            : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.000
---------------------------------------------------------------------------------
```