### PR TITLE
fby35: ji: Fix BIOS update failed problem

### DIFF
--- a/meta-facebook/yv35-ji/src/lib/plat_spi.c
+++ b/meta-facebook/yv35-ji/src/lib/plat_spi.c
@@ -39,7 +39,7 @@ bool pal_switch_bios_spi_mux(int gpio_status)
 	msg.target_addr = (CPLD_I2C_ADDR >> 1);
 	msg.tx_len = 2;
 	msg.data[0] = CPLD_REG_SPI_MUX;
-	msg.data[1] = (gpio_status == GPIO_HIGH) ? 0:1;
+	msg.data[1] = (gpio_status == GPIO_HIGH) ? 0 : 1;
 
 	int ret = i2c_master_write(&msg, retry);
 	if (ret) {

--- a/meta-facebook/yv35-ji/src/lib/plat_spi.c
+++ b/meta-facebook/yv35-ji/src/lib/plat_spi.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hal_gpio.h"
+#include "hal_i2c.h"
+#include "plat_gpio.h"
+#include "plat_i2c.h"
+#include "util_spi.h"
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(plat_spi);
+
+#define CPLD_REG_SPI_MUX 0x0B
+
+int pal_get_bios_flash_position()
+{
+	return DEVSPI_SPI1_CS0;
+}
+
+bool pal_switch_bios_spi_mux(int gpio_status)
+{
+	I2C_MSG msg = { 0 };
+	int retry = 3;
+
+	msg.bus = I2C_BUS1;
+	msg.target_addr = (CPLD_I2C_ADDR >> 1);
+	msg.tx_len = 2;
+	msg.data[0] = CPLD_REG_SPI_MUX;
+	msg.data[1] = (gpio_status == GPIO_HIGH) ? 0:1;
+
+	int ret = i2c_master_write(&msg, retry);
+	if (ret) {
+		LOG_ERR("Failed to switch spi mux, ret: %d", ret);
+		return false;
+	}
+
+	return true;
+}


### PR DESCRIPTION
Summary:
- Add bios pre-update function

Test Plan:
- Build Code: PASS
- BIOS update via BMC: PASS

Log:
- BMC console:
```
root@bmc-oob:~# fw-util slot1 --force --update bios F0EJ1A01.03.BIN
Checking if the server is ready...
slot_id: 1, comp: c, intf: 0, img: /F0EJ1A01.03.BIN, force: 1
Checksum function is unavailable, disabling deduplication and verification.
Updating BIOS, dedup is off, verification is off.
809 blocks (809 written, 0 skipped)...finished.
Elapsed time:  218   sec.
There is no valid platform signature in image. 
Init libusb Successful!
1d6b:0104 (bus 1, device 64) path: 1.1.3
Manufactured : ZEPHYR
Product : Zephyr CDC ACM
----------------------------------------
Device Descriptors:
Vendor ID : 1d6b
Product ID : 104
Serial Number : 3
Size of Device Descriptor : 18
Type of Descriptor : 1
USB Specification Release Number : 512
Device Release Number : 518
Device Class : 0
Device Sub-Class : 0
Device Protocol : 0
Max. Packet Size : 64
No. of Configuraions : 1
Configured value : 1
Claimed Interface: 1, EP addr: 0x03
-----------------------------------

Interface Descriptors:
  Number of Interfaces : 0x2
  Length : 0x9
  Desc_Type : 0x2
  Config_index : 0x0
  Total length : 75
  Configuration Value  : 0x1
  Configuration Attributes : 0xc0
  MaxPower(mA) : 50
    Interface:
      bInterfaceNumber:   0
      bAlternateSetting:  0
      bNumEndpoints:      1
      bInterfaceClass:    2
      bInterfaceSubClass: 2
      bInterfaceProtocol: 0
      iInterface:         0

      EndPoint Descriptors:
        bLength: 7
        bDescriptorType: 0x5
        bEndpointAddress: 0x81
        Maximum Packet Size: 0x10
        bmAttributes: 0x3
        bInterval: 0xa
-----------------------------------
    Interface:
      bInterfaceNumber:   1
      bAlternateSetting:  0
      bNumEndpoints:      2
      bInterfaceClass:    10
      bInterfaceSubClass: 0
      bInterfaceProtocol: 0
      iInterface:         0

      EndPoint Descriptors:
        bLength: 7
        bDescriptorType: 0x5
        bEndpointAddress: 0x82
        Maximum Packet Size: 0x40
        bmAttributes: 0x2
        bInterval: 0x0
      EndPoint Descriptors:
        bLength: 7
        bDescriptorType: 0x5
        bEndpointAddress: 0x3
        Maximum Packet Size: 0x40
        bmAttributes: 0x2
        bInterval: 0x0
-----------------------------------
Power-cycling the server...
Force upgrade of slot1 : bios succeeded
```
