### PR TITLE
common: Improve checksum check process

### DIFF
--- a/scripts/signing/pldm_fw_package/pldm_update_pkg_gen.py
+++ b/scripts/signing/pldm_fw_package/pldm_update_pkg_gen.py
@@ -6,9 +6,8 @@ import lib.json_cfg as json_lib
 from lib.common_lib import Common_msg, Common_file, System_ctrl
 
 APP_NAME = "PLDM UPDATE PACKAGE GENERATOR"
-APP_AUTH = "Mouchen"
-APP_RELEASE_VER = "1.7"
-APP_RELEASE_DATE = "2023/07/27"
+APP_RELEASE_VER = "1.8"
+APP_RELEASE_DATE = "2024/04/19"
 
 PLATFORM_PATH = "./platform"
 CONFIG_FILE = "pldm_cfg.json"
@@ -60,7 +59,6 @@ else:
 def APP_HEADER():
     msg_hdr_print("n", "========================================================")
     msg_hdr_print("n", "* APP name:    "+APP_NAME)
-    msg_hdr_print("n", "* APP auth:    "+APP_AUTH)
     msg_hdr_print("n", "* APP version: "+APP_RELEASE_VER)
     msg_hdr_print("n", "* APP date:    "+APP_RELEASE_DATE)
     msg_hdr_print("n", "* NOTE: This APP is based on pldm_fwup_pkg_creator.py")
@@ -81,7 +79,7 @@ def PLAT_CheckVRChecksum(str, byte_num):
         return False
 
     focus_str = str[0:byte_num*2]
-    print(focus_str)
+
     for c in focus_str:
         try:
             int(c, 16)
@@ -142,8 +140,14 @@ if __name__ == '__main__':
                     found_verify_flag = 1
 
                     if comp["CheckSum"] == "y":
-                        if PLAT_CheckVRChecksum(given_subfix, 4) == False:
-                            msg_hdr_print('e', "Component #" + str(select_comp_id_lst[i]) + " sub version string [" + given_subfix + "] need CheckSum in front!")
+                        img_checksum = given_subfix.split('_')[0]
+                        # checksum should be even
+                        if len(img_checksum) % 2 != 0:
+                            msg_hdr_print('e', "Component #" + str(select_comp_id_lst[i]) + " checksum [" + img_checksum + "] byte count should be even!")
+                            sys.exit(1)
+                        checksum_byte_cnt = int(len(img_checksum)/2)
+                        if PLAT_CheckVRChecksum(img_checksum, checksum_byte_cnt) == False:
+                            msg_hdr_print('e', "Component #" + str(select_comp_id_lst[i]) + " sub version string [" + given_subfix + "] need CheckSum in front with format <checksum_version>!")
                             sys.exit(1)
                     break
         


### PR DESCRIPTION
Summary:
- If "CheckSum": "y", the version format should be <device checksum_version>.
- Checksum string could be any length but should be even byte count.

TestPlan:
- Generate pldm image: PASS

Log:
```
mouchen@mouchen-System-Product-Name:~/Documents/BIC/GIT_CODE/OpenBIC/scripts/signing/pldm_fw_package$ python pldm_update_pkg_gen.py -p yv35 -b ji -s evt -c 3 -v 'mpq8746 0000199015_test' -i vr_image.txt 
========================================================
* APP name:    PLDM UPDATE PACKAGE GENERATOR
* APP version: 1.8
* APP date:    2024/04/19
* NOTE: This APP is based on pldm_fwup_pkg_creator.py
========================================================
[STEP0] Calculate image(s) MD5
Get MD5: 41eb51432cbff92667e048139189e459
--> SUCCESS!

[STEP1] Generate pldm config file
PLDM json file [pldm_cfg.json] has been created!
--> SUCCESS!

[STEP2] Generate pldm package file
Using package file name [yv35_ji_mpq8746_0000199015_test.pldm].
============================================================================================
* APP name:     PLDM FWUPDATE PACKAGE CREATOR
* APP auth:     opensource
* APP version:  1.1.0
* APP date:     2023/03/21
* OEM features:
  1. Support string type for data in vendor defined descriptors.
* NOTE: 
* 1. More detail, please check [https://github.com/openbmc/pldm/tree/master/tools/fw-update]
============================================================================================
Please look for pldm package file [yv35_ji_mpq8746_0000199015_test.pldm]
--> SUCCESS!
```