### PR TITLE
yv4: wf: Revise CXL ready monitoring

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_init.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_init.c
@@ -52,8 +52,8 @@ void pal_set_sys_status()
 	set_DC_on_delayed_status();
 	init_ioe_config();
 	if (gpio_get(PG_CARD_OK) == POWER_ON) {
-		k_work_schedule(&cxl1_ready_check, K_SECONDS(CXL_READY_INTERVAL_SECONDS));
-		k_work_schedule(&cxl2_ready_check, K_SECONDS(CXL_READY_INTERVAL_SECONDS));
+		set_cxl_ready_status(CXL_ID_0, true);
+		set_cxl_ready_status(CXL_ID_1, true);
 	}
 	set_sys_ready_pin(BIC_READY_R);
 }

--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
@@ -105,6 +105,7 @@ void execute_power_on_sequence();
 void execute_power_off_sequence();
 void cxl1_ready_handler();
 void cxl2_ready_handler();
+void set_cxl_ready_status(uint8_t cxl_id, bool value);
 bool get_cxl_ready_status(uint8_t cxl_id);
 bool cxl_ready_access(uint8_t sensor_num);
 void set_cxl_vr_access(uint8_t cxl_id, bool value);


### PR DESCRIPTION
# Description:
- Revise CXL ready status initialization. Set CXL ready if we get DC status ON.
- Revise CXL ready thread for making it run asynchronously.

# Motivation:
- The CXL should be ready if the DC status is ON when BIC booting up, so we don't need to check it.
- These two thread should run asynchronously.

# Test Plan:
Tested on yv4 system - pass