### PR TITLE
yv4: sd: Monitor sensors after 12V-on

### DIFF
--- a/common/service/sensor/pldm_sensor.c
+++ b/common/service/sensor/pldm_sensor.c
@@ -54,6 +54,10 @@ bool pldm_sensor_is_interval_ready(pldm_sensor_info *pldm_sensor_list)
 {
 	CHECK_NULL_ARG_WITH_RETURN(pldm_sensor_list, false);
 
+	if (pldm_sensor_list->update_time == 0) { // First time to read sensor
+		return true;
+	}
+
 	uint32_t current_time = 0, diff_time = 0;
 
 	current_time = k_uptime_get_32() / 1000;


### PR DESCRIPTION
# Description:
    Monitor all SD sensors when 12V-on.

# Motivation:
    After 12V-off, all sensors' cache values will be cleared. Therefore, upon 12V-on, all sensors should be read once, and then sensor values updated according to their update interval times.

# Test plan:
  - BMC can read "ADC_P3V_BAT_VOLT_V" after 12V-on: Pass

# Test log:
  /* after 12V-cycle */
  root@bmc:~# busctl introspect xyz.openbmc_project.PLDM  /xyz/openbmc_project/sensors/voltage/MB_ADC_P3V_BAT_VOLT_V_35_10
  NAME                                                  TYPE      SIGNATURE RESULT/VALUE                             FLAGS                                 -
  ```
  .Value                                                property  d         3.147                                    emits-change writable
  xyz.openbmc_project.State.Decorator.Availability      interface -         -                                        -
  .Available                                            property  b         true                                     emits-change writable
  xyz.openbmc_project.State.Decorator.OperationalStatus interface -         -                                        -
  .Functional                                           property  b         true                                     emits-change writable