### PR TITLE
yv4: sd: Support get blade configuration by IPMI command

### DIFF
--- a/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
@@ -134,6 +134,12 @@ void OEM_GET_CHASSIS_POSITION(ipmi_msg *msg)
 
 	uint8_t slot_id = get_slot_id();
 
+	uint8_t blade_config = BLADE_CONFIG_UNKNOWN;
+	if (get_blade_config(&blade_config) == false) {
+		LOG_ERR("Failed to get the blade configuration");
+		return;
+	}
+
 	/*   msg->data[0] format:
 	 *
 	 *   Slot Present (Bit 7):
@@ -149,7 +155,7 @@ void OEM_GET_CHASSIS_POSITION(ipmi_msg *msg)
 	 *       1000: Slot 8
 	 */
 
-	msg->data[0] = SLOT_PRESENT + slot_id;
+	msg->data[0] = SLOT_PRESENT + blade_config + slot_id;
 	return;
 }
 

--- a/meta-facebook/yv4-sd/src/platform/plat_class.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_class.c
@@ -77,6 +77,23 @@ uint8_t get_slot_id()
 	return slot_id;
 }
 
+bool get_blade_config(uint8_t *blade_config)
+{
+	float voltage = 0.0f;
+
+	if (get_adc_voltage(ADC_CHANNEL_12, &voltage) == false) {
+		*blade_config = BLADE_CONFIG_UNKNOWN;
+		return false;
+	}
+
+	if (voltage <= 1.02f && voltage >= 0.98f) {
+		*blade_config = BLADE_CONFIG_T1C;
+	} else {
+		*blade_config = BLADE_CONFIG_T1M;
+	}
+	return true;
+}
+
 bool get_board_rev(uint8_t *board_rev)
 {
 	int retry = 5;
@@ -160,10 +177,10 @@ void init_platform_config()
 
 	i3c_msg.bus = 0;
 
-	bool success = get_adc_voltage(CHANNEL_13, &voltage);
+	bool success = get_adc_voltage(ADC_CHANNEL_13, &voltage);
 
 	if (success) {
-		success = get_adc_voltage(CHANNEL_2, &p3v3_stby_voltage);
+		success = get_adc_voltage(ADC_CHANNEL_2, &p3v3_stby_voltage);
 		p3v3_stby_voltage *= 2; // voltage division is 0.5
 		if (!success) {
 			LOG_ERR("Fail to get 3v3 standby voltage. Set to default value.");

--- a/meta-facebook/yv4-sd/src/platform/plat_class.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_class.h
@@ -4,9 +4,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define CHANNEL_2 2
-#define CHANNEL_13 13
-#define NUMBER_OF_ADC_CHANNEL 16
 #define AST1030_ADC_BASE_ADDR 0x7e6e9000
 
 enum SLOT_EID {
@@ -39,10 +36,24 @@ enum BOARD_REV_ID {
 	BOARD_REV_MP = 0x06,
 };
 
+enum ADC_CHANNEL {
+	ADC_CHANNEL_2 = 2,
+	ADC_CHANNEL_12 = 12,
+	ADC_CHANNEL_13 = 13,
+	NUMBER_OF_ADC_CHANNEL = 16,
+};
+
+enum BLADE_CONFIG {
+	BLADE_CONFIG_T1M = 0x00,
+	BLADE_CONFIG_T1C = 0x10,
+	BLADE_CONFIG_UNKNOWN = 0xff,
+};
+
 bool get_adc_voltage(int channel, float *voltage);
 bool get_board_rev(uint8_t *board_rev);
 uint8_t get_slot_eid();
 uint8_t get_slot_id();
+bool get_blade_config(uint8_t *blade_config);
 void init_platform_config();
 
 #endif


### PR DESCRIPTION
# Description:
    1. Identify the blade configuration by EXAMAX_TYPE(ADC12).
        - If the value is 1V, the blade configuration is T1C. Otherwise, it is T1M.
    2. Display blade configuration in the result of IPMI command CMD_OEM_GET_CHASSIS_POSITION(netfn: 0x30 cmd: 0x7E).
        - Bit 4 is 1 : T1C
        - Bit 4 is 0 : T1M
# Motivation:
    Support the IPMI command CMD_OEM_GET_CHASSIS_POSITION(netfn: 0x30 cmd: 0x7E) to display blade configuration.

# Test log:
    Check the blade configuration from host:
        T1C:
        [OemPei]: OemCheckSlotID gEfiPeiIpmiTransportPpiGuid Status: Success
        [PeiIpmiInitialize]: EfiIpmiSendCommand - InterfaceType = 1.
        [PeiIpmiInitialize]: EfiIpmiSendCommand - gIpmiSendCommand[0] Status = Success.
        [PeiIpmiInitialize]:  IPMI Req. = [ C0 7E[PeiIpmiInitialize]:  ]
        [PeiIpmiInitialize]:  IPMI Res. = [ C0 7E[PeiIpmiInitialize]:  00[PeiIpmiInitialize]:  94[PeiIpmiInitialize]:  ]
        [OemPei]: OemCheckSlotID Slot ID: 4
        [OemPei]: OemCheckSlotID Slot Config: 1
        [OemPei]: OemCheckSlotID SendIpmiCommand Status: Success
        [OemPei]: OemPei_Init exit

        T1M:
        [00000015][OemPei]: OemPei_Init start
        [OemPei]: OemCheckSlotID gEfiPeiIpmiTransportPpiGuid Status: Success
        [PeiIpmiInitialize]: EfiIpmiSendCommand - InterfaceType = 1.
        [PeiIpmiInitialize]: EfiIpmiSendCommand - gIpmiSendCommand[0] Status = Success.
        [PeiIpmiInitialize]:  IPMI Req. = [ C0 7E[PeiIpmiInitialize]:  ]
        [PeiIpmiInitialize]:  IPMI Res. = [ C0 7E[PeiIpmiInitialize]:  00[PeiIpmiInitialize]:  82[PeiIpmiInitialize]:  ]
        [OemPei]: OemCheckSlotID Slot ID: 2
        [OemPei]: OemCheckSlotID Slot Config: 0
        [OemPei]: OemCheckSlotID SendIpmiCommand Status: Success
        [OemPei]: OemPei_Init exit
     Check the blade configuration from BIC:
        T1C:
        uart:~$ platform ipmi raw 0x30 0x7e
        BIC self command netfn:0x30 cmd:0x7e response with cc 0x0
        00000000: 93 // Bit 4 is 1

        T1M:
        uart:~$ platform ipmi raw 0x30 0x7e
        BIC self command netfn:0x30 cmd:0x7e response with cc 0x0
        00000000: 83 // Bit 4 is 0