### PR TITLE
fby4: sd: Change definitions of APML bus after EVT

### DIFF
--- a/common/service/apml/apml.h
+++ b/common/service/apml/apml.h
@@ -29,6 +29,8 @@
 #define SBRMI_CMD_CODE_LEN_TWO_BYTE 2
 #define SBRMI_REV_BRTH 0x21
 
+#define APML_BUS_UNKNOWN 0xFF
+
 enum APML_MSG_TYPE {
 	APML_MSG_TYPE_MAILBOX,
 	APML_MSG_TYPE_CPUID,
@@ -142,6 +144,8 @@ void apml_init();
 void fatal_error_happened();
 void apml_recovery();
 int pal_check_sbrmi_command_code_length();
+uint8_t pal_get_apml_bus();
+uint8_t apml_get_bus();
 int set_sbrmi_command_code_len(uint8_t value);
 
 #endif

--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -1835,10 +1835,12 @@ __weak void OEM_1S_APML_READ(ipmi_msg *msg)
 		return;
 	}
 
+	uint8_t apml_bus = apml_get_bus();
+
 	uint8_t read_data;
 	switch (msg->data[0]) {
 	case 0x00: /* RMI */
-		if (apml_read_byte(APML_BUS, SB_RMI_ADDR, msg->data[1], &read_data)) {
+		if (apml_read_byte(apml_bus, SB_RMI_ADDR, msg->data[1], &read_data)) {
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 		} else {
 			msg->data[0] = read_data;
@@ -1847,7 +1849,7 @@ __weak void OEM_1S_APML_READ(ipmi_msg *msg)
 		}
 		break;
 	case 0x01: /* TSI */
-		if (apml_read_byte(APML_BUS, SB_TSI_ADDR, msg->data[1], &read_data)) {
+		if (apml_read_byte(apml_bus, SB_TSI_ADDR, msg->data[1], &read_data)) {
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 		} else {
 			msg->data[0] = read_data;
@@ -1871,16 +1873,18 @@ __weak void OEM_1S_APML_WRITE(ipmi_msg *msg)
 		return;
 	}
 
+	uint8_t apml_bus = apml_get_bus();
+
 	switch (msg->data[0]) {
 	case 0x00: /* RMI */
-		if (apml_write_byte(APML_BUS, SB_RMI_ADDR, msg->data[1], msg->data[2])) {
+		if (apml_write_byte(apml_bus, SB_RMI_ADDR, msg->data[1], msg->data[2])) {
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 		} else {
 			msg->completion_code = CC_SUCCESS;
 		}
 		break;
 	case 0x01: /* TSI */
-		if (apml_write_byte(APML_BUS, SB_TSI_ADDR, msg->data[1], msg->data[2])) {
+		if (apml_write_byte(apml_bus, SB_TSI_ADDR, msg->data[1], msg->data[2])) {
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 		} else {
 			msg->completion_code = CC_SUCCESS;
@@ -1904,6 +1908,7 @@ __weak void OEM_1S_SEND_APML_REQUEST(ipmi_msg *msg)
 	}
 
 	static uint8_t index = 0;
+	uint8_t apml_bus = apml_get_bus();
 	apml_msg apml_data = { 0 };
 
 	switch (msg->data[0]) {
@@ -1933,7 +1938,7 @@ __weak void OEM_1S_SEND_APML_REQUEST(ipmi_msg *msg)
 		return;
 	}
 	apml_data.msg_type = msg->data[0];
-	apml_data.bus = APML_BUS;
+	apml_data.bus = apml_bus;
 	apml_data.target_addr = SB_RMI_ADDR;
 	apml_data.cb_fn = apml_request_callback;
 	apml_data.ui32_arg = index;

--- a/meta-facebook/yv35-hd/src/platform/plat_apml.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_apml.c
@@ -66,6 +66,11 @@ void set_tsi_threshold()
 	is_threshold_set = true;
 }
 
+uint8_t pal_get_apml_bus()
+{
+	return APML_BUS;
+}
+
 static void read_cpuid_callback(apml_msg *msg)
 {
 	CHECK_NULL_ARG(msg);

--- a/meta-facebook/yv4-sd/src/platform/plat_apml.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_apml.c
@@ -94,6 +94,23 @@ int pal_check_sbrmi_command_code_length()
 	return ret;
 }
 
+uint8_t pal_get_apml_bus()
+{
+	uint8_t board_rev = APML_BUS_UNKNOWN;
+
+	if (get_board_rev(&board_rev) == false) {
+		LOG_ERR("Failed to get board revision");
+		return APML_BUS_UNKNOWN;
+	}
+
+	if (board_rev <= BOARD_REV_EVT) {
+		return I2C_BUS14;
+	} else {
+		// For DVT and later, the hardware design was changed to I2C_BUS10
+		return I2C_BUS10;
+	}
+}
+
 bool get_tsi_status()
 {
 	return is_threshold_set;
@@ -107,13 +124,14 @@ void reset_tsi_status()
 void set_tsi_threshold()
 {
 	uint8_t read_data;
+	uint8_t apml_bus = apml_get_bus();
 	// Set high temperature threshold
-	if (apml_read_byte(APML_BUS, SB_TSI_ADDR, SBTSI_HIGH_TEMP_INTEGER_THRESHOLD, &read_data)) {
+	if (apml_read_byte(apml_bus, SB_TSI_ADDR, SBTSI_HIGH_TEMP_INTEGER_THRESHOLD, &read_data)) {
 		LOG_ERR("Failed to read high temperature threshold.");
 		return;
 	}
 	if (read_data != TSI_HIGH_TEMP_THRESHOLD) {
-		if (apml_write_byte(APML_BUS, SB_TSI_ADDR, SBTSI_HIGH_TEMP_INTEGER_THRESHOLD,
+		if (apml_write_byte(apml_bus, SB_TSI_ADDR, SBTSI_HIGH_TEMP_INTEGER_THRESHOLD,
 				    TSI_HIGH_TEMP_THRESHOLD)) {
 			LOG_ERR("Failed to set TSI temperature threshold.");
 			return;
@@ -121,12 +139,12 @@ void set_tsi_threshold()
 	}
 
 	// Set the frequency of the high/low temperature comparison to 64 Hz
-	if (apml_read_byte(APML_BUS, SB_TSI_ADDR, SBTSI_UPDATE_RATE, &read_data)) {
+	if (apml_read_byte(apml_bus, SB_TSI_ADDR, SBTSI_UPDATE_RATE, &read_data)) {
 		LOG_ERR("Failed to read alert config.");
 		return;
 	}
 	if (read_data != TSI_TEMP_ALERT_UPDATE_RATE) {
-		if (apml_write_byte(APML_BUS, SB_TSI_ADDR, SBTSI_UPDATE_RATE,
+		if (apml_write_byte(apml_bus, SB_TSI_ADDR, SBTSI_UPDATE_RATE,
 				    TSI_TEMP_ALERT_UPDATE_RATE)) {
 			LOG_ERR("Failed to set alert config.");
 			return;
@@ -152,12 +170,14 @@ static void read_cpuid_error_callback(apml_msg *msg)
 
 void read_cpuid()
 {
+	uint8_t apml_bus = apml_get_bus();
+
 	memset(cpuid, 0, sizeof(cpuid));
 
 	// read eax&ebx
 	apml_msg apml_data = { 0 };
 	apml_data.msg_type = APML_MSG_TYPE_CPUID;
-	apml_data.bus = APML_BUS;
+	apml_data.bus = apml_bus;
 	apml_data.target_addr = SB_RMI_ADDR;
 	apml_data.cb_fn = read_cpuid_callback;
 	apml_data.error_cb_fn = read_cpuid_error_callback;
@@ -169,7 +189,7 @@ void read_cpuid()
 	// read ecx&edx
 	memset(&apml_data, 0x00, sizeof(apml_msg));
 	apml_data.msg_type = APML_MSG_TYPE_CPUID;
-	apml_data.bus = APML_BUS;
+	apml_data.bus = apml_bus;
 	apml_data.target_addr = SB_RMI_ADDR;
 	apml_data.cb_fn = read_cpuid_callback;
 	apml_data.error_cb_fn = read_cpuid_error_callback;

--- a/meta-facebook/yv4-sd/src/platform/plat_apml.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_apml.h
@@ -20,7 +20,6 @@
 #include "apml.h"
 #include "plat_i2c.h"
 
-#define APML_BUS I2C_BUS14
 #define TSI_HIGH_TEMP_THRESHOLD 0x5F
 #define TSI_TEMP_ALERT_UPDATE_RATE 0x0A
 #define PLAT_SBRMI_REVISION 0x20


### PR DESCRIPTION
# Description
- Change all definitions of APML bus from 14 to 10 after the EVT stage.

# Motivation
- Currently, some definitions of APML bus are missing change.

# Test plan
- Build code: Pass
- Get CPU sensor: Pass

# Log
1. Get CPU sensor on EVT SB. root@bmc:~# mfg-tool sensor-display
...
    "MB_CPU_PWR_W_85_60": {
        "max": 10485.75,
        "min": 0.0,
        "status": "ok",
        "unit": "Watts",
        "value": 42.730000000000004
    },
...
    "MB_CPU_TEMP_C_4_60": {
        "critical": {
            "high": 91.0
        },
        "max": 200.0,
        "min": 0.0,
        "status": "ok",
        "unit": "DegreesC",
        "value": 66.75
    },

2. Get CPU sensor on DVT SB. root@bmc:~# mfg-tool sensor-display
...
    "MB_CPU_PWR_W_85_30": {
        "max": 10485.75,
        "min": 0.0,
        "status": "warning",
        "unit": "Watts",
        "value": 116.61,
        "warning": {
            "high": 0.0,
            "low": 0.0
        }
    },
...
    "MB_CPU_TEMP_C_4_30": {
        "max": 200.0,
        "min": 0.0,
        "status": "warning",
        "unit": "DegreesC",
        "value": 46.5,
        "warning": {
            "high": 0.0,
            "low": 0.0
        }
    },