### PR TITLE
common: Fix memory leak and memory overflow

### DIFF
--- a/common/dev/pcc.c
+++ b/common/dev/pcc.c
@@ -253,6 +253,7 @@ bool pldm_send_post_code_to_bmc(uint16_t send_index)
 	uint8_t rbuf[resp_len];
 
 	if (!mctp_pldm_read(find_mctp_by_bus(bmc_bus), &msg, rbuf, resp_len)) {
+		SAFE_FREE(ptr);
 		LOG_ERR("mctp_pldm_read fail");
 		return false;
 	}
@@ -291,6 +292,7 @@ bool ipmi_send_post_code_to_bmc(uint16_t send_index)
 	msg->data[7] = (pcc_read_buffer[send_index] >> 24) & 0xFF;
 	ipmb_error status = ipmb_read(msg, IPMB_inf_index_map[msg->InF_target]);
 	if (status != IPMB_ERROR_SUCCESS) {
+		SAFE_FREE(msg);
 		LOG_ERR("Failed to send 4-byte post code to BMC, status %d.", status);
 		return false;
 	}

--- a/common/service/host/kcs.c
+++ b/common/service/host/kcs.c
@@ -199,12 +199,14 @@ static int send_bios_version_to_bmc(char *bios_version, uint8_t bios_version_len
 	uint8_t rbuf[resp_len];
 
 	if (!mctp_pldm_read(find_mctp_by_bus(bmc_bus), &msg, rbuf, resp_len)) {
+		SAFE_FREE(ptr);
 		LOG_ERR("mctp_pldm_read fail");
 		return 2;
 	}
 
 	struct pldm_oem_write_file_io_resp *resp = (struct pldm_oem_write_file_io_resp *)rbuf;
 	if (resp->completion_code != PLDM_SUCCESS) {
+		SAFE_FREE(ptr);
 		LOG_ERR("Check reponse completion code fail %x", resp->completion_code);
 		return resp->completion_code;
 	}

--- a/common/service/pldm/pldm_monitor.c
+++ b/common/service/pldm/pldm_monitor.c
@@ -346,7 +346,13 @@ uint8_t pldm_platform_event_message_req(void *mctp_inst, mctp_ext_params ext_par
 	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, PLDM_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(event_data, PLDM_ERROR_INVALID_DATA);
 
-	uint8_t req_len = sizeof(struct pldm_platform_event_message_req) + event_data_length - 1;
+	if (event_data_length > PLDM_MONITOR_EVENT_DATA_SIZE_MAX) {
+		LOG_ERR("Exceed max event data size, (%d)", event_data_length);
+		return PLDM_ERROR_INVALID_LENGTH;
+	}
+
+	uint8_t req_len = sizeof(struct pldm_platform_event_message_req) + event_data_length -
+			  PLDM_MONITOR_EVENT_DATA_SIZE_MAX;
 	uint8_t resp_len = sizeof(struct pldm_platform_event_message_resp);
 	uint8_t rbuf[resp_len];
 

--- a/common/service/pldm/pldm_monitor.h
+++ b/common/service/pldm/pldm_monitor.h
@@ -44,8 +44,8 @@ typedef enum pldm_platform_monitor_commands {
 /* Define size of response */
 #define PLDM_GET_STATE_EFFECTER_RESP_NO_STATE_FIELD_BYTES 2
 
-/* The maximum event data size of event type currently support */
-#define PLDM_MONITOR_EVENT_DATA_SIZE_MAX 7
+/* The maximum event data size of event type currently support, ipmi event 16 bytes */
+#define PLDM_MONITOR_EVENT_DATA_SIZE_MAX 16
 /* The default maximum event message number in the queue */
 #define PLDM_MONITOR_EVENT_QUEUE_MSG_NUM_MAX_DEFAULT 10
 #define PLDM_MONITOR_SENSOR_SUPPORT_MAX 0xFF
@@ -277,7 +277,7 @@ struct pldm_platform_event_message_req {
 	uint8_t format_version;
 	uint8_t tid;
 	uint8_t event_class;
-	uint8_t event_data[1];
+	uint8_t event_data[PLDM_MONITOR_EVENT_DATA_SIZE_MAX];
 } __attribute__((packed));
 
 struct pldm_platform_event_message_resp {


### PR DESCRIPTION
Description:
- When BIC can't send pldm/mctp message, it will return without free malloc for pcc and kcs.
- When sending pldm event, it will cause memory overflow by doing memcpy.
- BIC will crash in YV4 about 1-2 mins, if we stop mctp/pldm service by BMC, and OS stay in PXE-loop.

Motivation:
- We see BIC crash in YV4 for some special condition.

Test Plan:
- Build code: Pass
- Stop mctp/pldm service by BMC, and OS stay in PXE-loop. BIC run more than 1 hour without crash.