### PR TITLE
common: mctp-i3c: include address byte for PEC byte

### DIFF
--- a/common/hal/hal_i3c.c
+++ b/common/hal/hal_i3c.c
@@ -607,3 +607,21 @@ int i3c_target_set_address(I3C_MSG *msg)
 
 	return 0;
 }
+
+int i3c_target_get_dynamic_address(I3C_MSG *msg, uint8_t *dynamic_addr)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
+	CHECK_NULL_ARG_WITH_RETURN(dynamic_addr, -EINVAL);
+
+	if (!dev_i3c[msg->bus]) {
+		return -ENODEV;
+	}
+
+	int ret = i3c_slave_get_dynamic_addr(dev_i3c[msg->bus], dynamic_addr);
+	if (ret != 0) {
+		LOG_ERR("Failed to get address for I3C bus: %x, ret: %d", msg->bus, ret);
+		return -1;
+	}
+
+	return 0;
+}

--- a/common/hal/hal_i3c.h
+++ b/common/hal/hal_i3c.h
@@ -134,5 +134,6 @@ int i3c_controller_ibi_init(I3C_MSG *msg);
 int i3c_controller_ibi_read(I3C_MSG *msg);
 int i3c_controller_write(I3C_MSG *msg);
 int i3c_target_set_address(I3C_MSG *msg);
+int i3c_target_get_dynamic_address(I3C_MSG *msg, uint8_t *dynamic_addr);
 
 #endif


### PR DESCRIPTION
# Description:
Include the address byte for calculating the PEC byte for MCTP-I3C according to the MCTP-I3C driver in torvalds/linux repository.

BIC as a I3C controller, the PEC byte should include the address of target device.
BIC as a I3C target, the PEC byte should include its own address.

# Motivation:
We would like to use MCTP over I3C for the communication between BMC and BIC, but the MCTP-I3C driver in BMC would send the PEC byte including the address of target device.
Therefore, include the address byte for PEC byte so that BMC could communicate with BIC using MCTP-I3C successfully.

# Test plan:
1. Tested on Yv4 system and check BMC could communicate with SD BIC using MCTP over I3C.

# Test logs:
1. Check BMC could communicate with SD BIC using MCTP over I3C.

root@bmc:~# pldmtool base GetTID -m 50
{
    "Response": 50
}