### PR TITLE
yv4: sd: Enable PEC in MCTP I3C

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_def.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_def.h
@@ -25,5 +25,6 @@
 
 #define HOST_KCS_PORT kcs3
 #define BMC_USB_PORT "CDC_ACM_0"
+#define MCTP_I3C_PEC_ENABLE 1
 
 #endif


### PR DESCRIPTION
# Description:
Enable PEC byte in MCTP I3C because it is mandatory.

# Motivation:
We would like to use MCTP over I3C for the communication between BMC and BIC on Yv4 system and the MCTP-I3C driver in BMC would send the PEC byte.

Therefore, enable PEC byte in MCTP I3C so that BMC could communicate with SD BIC using MCTP I3C successfully.

# Test plan:
1. Check that BMC could get PLDM sensors from SD BIC.

# Test logs:
1. Check that BMC could get PLDM sensors from SD BIC.

root@bmc:~# busctl tree xyz.openbmc_project.PLDM
└─ /xyz
  └─ /xyz/openbmc_project
	├─ /xyz/openbmc_project/inventory
	│ └─ /xyz/openbmc_project/inventory/Item
	│   └─ /xyz/openbmc_project/inventory/Item/Board
	│     ├─ /xyz/openbmc_project/inventory/Item/Board/PLDM_Device_50
	│     ├─ /xyz/openbmc_project/inventory/Item/Board/PLDM_Device_52
	│     └─ /xyz/openbmc_project/inventory/Item/Board/PLDM_Device_60
	├─ /xyz/openbmc_project/pldm
	└─ /xyz/openbmc_project/sensors
	  ├─ /xyz/openbmc_project/sensors/current
	  ├─ /xyz/openbmc_project/sensors/current
	  │ ├─ /xyz/openbmc_project/sensors/current/MB_INA233_E1S_Boot_CURR_A_71_50
	  │ ├─ /xyz/openbmc_project/sensors/current/MB_INA233_E1S_Data_CURR_A_72_50
	  │ ├─ /xyz/openbmc_project/sensors/current/MB_INA233_x16_RTM_CURR_A_70_50
	  │ ├─ /xyz/openbmc_project/sensors/current/MB_INA233_x8_RTM_CURR_A_69_50
		...
	  │ ├─ /xyz/openbmc_project/sensors/current/WF_INA233_P12V_E1S_0_L_CURR_A_65_52
	  │ ├─ /xyz/openbmc_project/sensors/current/WF_INA233_P12V_STBY_CURR_A_64_52
	  │ ├─ /xyz/openbmc_project/sensors/current/WF_VR_P0V85_ASIC1_CURR_A_68_52
	  │ ├─ /xyz/openbmc_project/sensors/current/WF_VR_P0V85_ASIC2_CURR_A_72_52
		...