### PR TITLE
op2: op: Expansion board A clock architecture

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_class.c
+++ b/meta-facebook/op2-op/src/platform/plat_class.c
@@ -187,3 +187,25 @@ void init_i3c_hub_type(void)
 		return;
 	}
 }
+
+void set_clock_buffer_bypass_mode()
+{
+	//for Expansion board A
+	if (get_card_type() == CARD_TYPE_OPA) { //check Expansion board type
+		uint8_t retry = 3;
+		I2C_MSG msg = { 0 };
+
+		msg.bus = I2C_BUS4; //bus 3
+		msg.target_addr = CLOCK_BUFFER_ADDR; //clock buffer address
+		msg.tx_len = 3;
+		msg.rx_len = 0;
+		msg.data[0] = CLOCK_BUFFER_REG_LOC; //clock buffer register location
+		msg.data[1] = CLOCK_BUFFER_BYPASS_DATA_1; //clock buffer bypass data value 1
+		msg.data[2] = CLOCK_BUFFER_BYPASS_DATA_2; //clock buffer bypass data value 2
+
+		if (i2c_master_write(&msg, retry) != 0) {
+			LOG_ERR("Failed to set Exp A clock buffer to bypass mode!");
+			return;
+		}
+	}
+}

--- a/meta-facebook/op2-op/src/platform/plat_class.h
+++ b/meta-facebook/op2-op/src/platform/plat_class.h
@@ -22,6 +22,10 @@
 
 #define RETIMER_UNKNOWN_VERSION -1
 #define RETIMER_VERSION_MAX_LENGTH 5
+#define CLOCK_BUFFER_ADDR 0x6B
+#define CLOCK_BUFFER_REG_LOC 0x01
+#define CLOCK_BUFFER_BYPASS_DATA_1 0x08
+#define CLOCK_BUFFER_BYPASS_DATA_2 0x2E
 
 enum CARD_POSITION {
 	CARD_POSITION_1OU,
@@ -76,5 +80,6 @@ void init_board_revision();
 void init_i3c_hub_type();
 uint32_t get_pcie_retimer_version();
 void cache_pcie_retimer_version();
+void set_clock_buffer_bypass_mode();
 
 #endif

--- a/meta-facebook/op2-op/src/platform/plat_init.c
+++ b/meta-facebook/op2-op/src/platform/plat_init.c
@@ -105,6 +105,7 @@ DEVICE_DEFINE(PRE_DEF_PROJ_GPIO, "PRE_DEF_PROJ_GPIO_NAME", &gpio_init, NULL, NUL
 
 void pal_set_sys_status()
 {
+	set_clock_buffer_bypass_mode();
 	init_sequence_status();
 	set_DC_status(FM_EXP_MAIN_PWR_EN);
 	control_power_sequence();


### PR DESCRIPTION
# Description
- Set Expansion board A clock buffer to bypass mode before AC on.

# Motivation
- AC cycle will reset the setting of clock buffer.

# Test plan
- Build code: Pass
- Check clock buffer data: Pass

# Log
1.Origin expansion board A clock buffer register:
root@bmc-oob:~# bic-util slot1 0xE0 0x2 0x15 0xA0 0x00 0x05 0x18 0x52 0x7 0xD6 2 0x01 15 A0 00 05 07 52 00 08 06

2.After set bypass mode expansion board A clock buffer register: root@bmc-oob:~# bic-util slot1 0xE0 0x2 0x15 0xA0 0x00 0x05 0x18 0x52 0x7 0xD6 2 0x01 15 A0 00 05 07 52 00 08 2E