### PR TITLE
op2: op: Modify ina233 and sq52205 average times

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_hook.c
+++ b/meta-facebook/op2-op/src/platform/plat_hook.c
@@ -75,36 +75,84 @@ ina233_init_arg ina233_init_args[] = {
 		.r_shunt = 0.002,
 		.is_need_mfr_device_config_init = false,
 		.is_need_set_alert_threshold = false,
+		.mfr_config_init = true,
+		.mfr_config = {
+			.operating_mode = 0b111,
+			.shunt_volt_time = 0b100,
+			.bus_volt_time = 0b100,
+			.aver_mode = 0b011, //set 64 average times
+			.rsvd = 0b0000,
+		},
 	},
 	[1] = { .is_init = false,
 		.current_lsb = 0.001,
 		.r_shunt = 0.002,
 		.is_need_mfr_device_config_init = false,
 		.is_need_set_alert_threshold = false,
+		.mfr_config_init = true,
+		.mfr_config = {
+			.operating_mode = 0b111,
+			.shunt_volt_time = 0b100,
+			.bus_volt_time = 0b100,
+			.aver_mode = 0b011, //set 64 average times
+			.rsvd = 0b0000,
+		},
 	},
 	[2] = { .is_init = false,
 		.current_lsb = 0.001,
 		.r_shunt = 0.002,
 		.is_need_mfr_device_config_init = false,
 		.is_need_set_alert_threshold = false,
+		.mfr_config_init = true,
+		.mfr_config = {
+			.operating_mode = 0b111,
+			.shunt_volt_time = 0b100,
+			.bus_volt_time = 0b100,
+			.aver_mode = 0b011, //set 64 average times
+			.rsvd = 0b0000,
+		},
 	},
 	[3] = { .is_init = false,
 		.current_lsb = 0.001,
 		.r_shunt = 0.002,
 		.is_need_mfr_device_config_init = false,
 		.is_need_set_alert_threshold = false,
+		.mfr_config_init = true,
+		.mfr_config = {
+			.operating_mode = 0b111,
+			.shunt_volt_time = 0b100,
+			.bus_volt_time = 0b100,
+			.aver_mode = 0b011, //set 64 average times
+			.rsvd = 0b0000,
+		},
 	},
 	[4] = { .is_init = false,
 		.current_lsb = 0.001,
 		.r_shunt = 0.002,
 		.is_need_mfr_device_config_init = false,
 		.is_need_set_alert_threshold = false,
+		.mfr_config_init = true,
+		.mfr_config = {
+			.operating_mode = 0b111,
+			.shunt_volt_time = 0b100,
+			.bus_volt_time = 0b100,
+			.aver_mode = 0b011, //set 64 average times
+			.rsvd = 0b0000,
+		},
 	},
 	[5] = { .is_init = false,
 		.current_lsb = 0.001,
 		.r_shunt = 0.002,
 		.is_need_mfr_device_config_init = false,
 		.is_need_set_alert_threshold = false,
+		.mfr_config_init = true,
+		.mfr_config = {
+			.operating_mode = 0b111,
+			.shunt_volt_time = 0b100,
+			.bus_volt_time = 0b100,
+			.aver_mode = 0b011, //set 64 average times
+			.rsvd = 0b0000,
+		},
 	},
 };
 
@@ -114,7 +162,7 @@ sq52205_init_arg sq52205_init_args[] = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
 		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
+		.aver_mode = 0b011, //set 64 average times
 		.rsvd = 0b000,
 		.reset_bit = 0b0,
 	},
@@ -126,7 +174,7 @@ sq52205_init_arg sq52205_init_args[] = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
 		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
+		.aver_mode = 0b011, //set 64 average times
 		.rsvd = 0b000,
 		.reset_bit = 0b0,
 	},
@@ -138,7 +186,7 @@ sq52205_init_arg sq52205_init_args[] = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
 		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
+		.aver_mode = 0b011, //set 64 average times
 		.rsvd = 0b000,
 		.reset_bit = 0b0,
 	},
@@ -150,7 +198,7 @@ sq52205_init_arg sq52205_init_args[] = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
 		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
+		.aver_mode = 0b011, //set 64 average times
 		.rsvd = 0b000,
 		.reset_bit = 0b0,
 	},
@@ -162,7 +210,7 @@ sq52205_init_arg sq52205_init_args[] = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
 		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
+		.aver_mode = 0b011, //set 64 average times
 		.rsvd = 0b000,
 		.reset_bit = 0b0,
 	},
@@ -174,7 +222,7 @@ sq52205_init_arg sq52205_init_args[] = {
 		.operating_mode =0b111,
 		.shunt_volt_time = 0b100,
 		.bus_volt_time = 0b100,
-		.aver_mode = 0b111, //set 1024 average times
+		.aver_mode = 0b011, //set 64 average times
 		.rsvd = 0b000,
 		.reset_bit = 0b0,
 	},


### PR DESCRIPTION
# Description
- Modify ina233 average times from 1 to 64.
- Modify sq52205 average times from 1024 to 64.

# Motivation
- Currently, the average times setting of sq52205 is 1024, which might trigger the threshold event. According to EE and vendor suggestions modify the setting.
- Align the settings of two devices.

# Test plan
- Build code: Pass
- Test on INA233: Pass
- Test on SQ52205: Pass

# Log
1. Power cycle with ina233 and read setting. root@bmc-oob:~# log-util --print all
2024 May 06 11:05:57 log-util: User cleared all logs
1    slot1    2024-05-06 11:06:09    gpiod            FRU: 1, System powered OFF
1    slot1    2024-05-06 11:06:14    power-util       SERVER_POWER_CYCLE successful for FRU: 1
1    slot1    2024-05-06 11:06:15    gpiod            FRU: 1, System powered ON

uart:~$ i2c read I2C_2 0x4c 0xD0 2
00000000: 27 41                                            |'A               |

2. Power cycle with sq52205 and read setting. root@bmc-oob:~# log-util slot1 --print
2098 Jan 01 07:32:04 log-util: User cleared FRU: 1 logs
1    slot1    2098-01-01 07:32:14    gpiod            FRU: 1, System powered OFF
1    slot1    2098-01-01 07:32:19    power-util       SERVER_POWER_CYCLE successful for FRU: 1
1    slot1    2098-01-01 07:32:20    gpiod            FRU: 1, System powered ON

uart:~$ i2c read I2C_2 0x4c 0x00 2
00000000: 47 27                                            |G'               |