### PR TITLE
common: add hsc enable function in adm1272 driver

### DIFF
--- a/common/dev/adm1272.c
+++ b/common/dev/adm1272.c
@@ -28,6 +28,30 @@ LOG_MODULE_REGISTER(dev_adm1272);
 #define ADM1272_EIN_ROLLOVER_CNT_MAX 0x100
 #define ADM1272_EIN_SAMPLE_CNT_MAX 0x1000000
 #define ADM1272_EIN_ENERGY_CNT_MAX 0x8000
+#define OPERATION_REGISTER 0x01;
+#define HSC_ENABLE_BIT BIT(7)
+
+bool enable_adm1272_hsc(uint8_t bus, uint8_t addr, uint8_t enable_flag)
+{
+	uint8_t retry = 5;
+	int ret = -1;
+	I2C_MSG msg = { 0 };
+	msg.bus = bus;
+	msg.target_addr = addr;
+	msg.tx_len = 2;
+	msg.data[0] = OPERATION_REGISTER;
+	msg.data[1] = HSC_DISABLE;
+	if (enable_flag == HSC_ENABLE)
+		msg.data[1] = HSC_ENABLE_BIT;
+
+	ret = i2c_master_write(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("Set enable hsc fail");
+		return false;
+	}
+
+	return true;
+}
 
 static int adm1272_convert_real_value(uint8_t vrange, uint8_t irange, float rsense, uint8_t offset,
 				      float *val)

--- a/common/dev/include/adm1272.h
+++ b/common/dev/include/adm1272.h
@@ -27,4 +27,11 @@ enum ADM1272_VRANGE {
 	VRANGE_0V_TO_100V = 0x1,
 };
 
+enum ADM1272_HSC {
+	HSC_DISABLE = 0x0,
+	HSC_ENABLE = 0x1,
+};
+
+bool enable_adm1272_hsc(uint8_t bus,uint8_t addr, uint8_t enable_flag);
+
 #endif


### PR DESCRIPTION
Summary:
- add bool enable_adm1272_hsc() in nct214.c
- add bool enable_adm1272_hsc() in nct214.h

Description:
- for AALC project enable hsc function

Test Plan:
- Waiting for test