### PR TITLE
yv4: sd: fix the issue that BMC couldn't get EID of WF BIC

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_mctp.c
@@ -101,7 +101,7 @@ mctp *find_mctp_by_addr(uint8_t addr)
 			if (addr == p->conf.smbus_conf.addr) {
 				return p->mctp_inst;
 			}
-		} else if (p->medium_type == MCTP_MEDIUM_TYPE_CONTROLLER_I3C) {
+		} else if (p->medium_type == MCTP_MEDIUM_TYPE_CONTROLLER_I3C || p->medium_type == MCTP_MEDIUM_TYPE_TARGET_I3C) {
 			if (addr == p->conf.i3c_conf.addr) {
 				return p->mctp_inst;
 			}
@@ -363,9 +363,9 @@ void plat_set_eid_by_slot()
 void set_routing_table_eid()
 {
 	// skip bmc
-	for (uint8_t i = 2; i < ARRAY_SIZE(plat_mctp_route_tbl); i++) {
+	for (uint8_t i = 2, j = 1; i < ARRAY_SIZE(plat_mctp_route_tbl); i++, j++) {
 		mctp_route_entry *p = plat_mctp_route_tbl + i;
-		p->endpoint = plat_eid + i;
+		p->endpoint = plat_eid + j;
 	}
 }
 


### PR DESCRIPTION
# Description:
Fix the issue that BMC couldn't get EID of WF BIC and CXL.

# Motivation:
Revise the function so SD BIC could set EID to WF correctly.

# Test plan:
1. Check BMC could get the EID of WF BIC and CXLs.

# Test logs:
1. Check BMC could get the EID of WF BIC and CXLs

root@bmc:~# busctl tree xyz.openbmc_project.MCTP
└─ /xyz
  └─ /xyz/openbmc_project
    └─ /xyz/openbmc_project/mctp
      └─ /xyz/openbmc_project/mctp/1
        ...
        ├─ /xyz/openbmc_project/mctp/1/50
        ├─ /xyz/openbmc_project/mctp/1/52
        ├─ /xyz/openbmc_project/mctp/1/54
        ├─ /xyz/openbmc_project/mctp/1/55
        ...

root@bmc:~# pldmtool base GetTID -m 50
{
    "Response": 50
}
root@bmc:~# pldmtool base GetTID -m 52
{
    "Response": 52
}