### PR TITLE
Common add nct214 、ast_tach、 xdp710 drivers

### DIFF
--- a/common/dev/ast_tach.c
+++ b/common/dev/ast_tach.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <drivers/pwm.h>
+#include <drivers/sensor.h>
+#include "sensor.h"
+#include <logging/log.h>
+
+#include "ast_tach.h"
+
+LOG_MODULE_REGISTER(dev_ast_tach);
+
+#undef DT_DRV_COMPAT
+#if DT_HAS_COMPAT_STATUS_OKAY(aspeed_tach)
+#define DT_DRV_COMPAT aspeed_tach
+#endif
+
+static const struct device *dev_tach[TACH_MAX_NUM];
+
+static void init_tach_dev(void)
+{
+	for (uint8_t i = TACH_PORT0; i < TACH_MAX_NUM; i++) {
+		char device_name[6];
+		snprintf(device_name, sizeof(device_name), "FAN%d", i);
+		dev_tach[i] = device_get_binding(device_name);
+	}
+}
+
+static uint8_t get_fan_rpm(uint8_t port, int32_t *val)
+{
+	CHECK_NULL_ARG_WITH_RETURN(val, SENSOR_UNSPECIFIED_ERROR);
+	struct sensor_value sensor_value;
+	int ret = 0;
+
+	if (port >= TACH_MAX_NUM) {
+		LOG_ERR("port %d out of range", port);
+		return SENSOR_PARAMETER_NOT_VALID;
+	}
+
+	if (dev_tach[port] == NULL) {
+		LOG_ERR("tach dev %d NULL", port);
+		return SENSOR_UNAVAILABLE;
+	}
+
+	ret = sensor_sample_fetch(dev_tach[port]);
+	if (ret < 0) {
+		LOG_ERR("Failed to read FAN%d due to sensor_sample_fetch failed, ret: %d", port,
+			ret);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	ret = sensor_channel_get(dev_tach[port], SENSOR_CHAN_RPM, &sensor_value);
+	if (ret < 0) {
+		LOG_ERR("Failed to read FAN%d due to sensor_channel_get failed, ret: %d", port,
+			ret);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	*val = sensor_value.val1;
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t ast_tach_read(sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_DBG("Invalid sensor number");
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	int32_t ret_val = 0;
+	uint8_t ret = SENSOR_UNSPECIFIED_ERROR;
+
+	switch (cfg->offset) {
+	case AST_TACH_RPM:
+		ret = get_fan_rpm(cfg->port, &ret_val);
+		if (ret != SENSOR_READ_SUCCESS)
+			LOG_ERR("get fan %d rpm fail", cfg->port);
+		break;
+	default:
+		LOG_ERR("fan %d method undefined", cfg->port);
+		break;
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	sval->integer = (int16_t)ret_val;
+	sval->fraction = 0;
+
+	return ret;
+}
+
+uint8_t ast_tach_init(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(cfg->init_args, SENSOR_INIT_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_DBG("Invalid sensor number");
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	ast_tach_init_arg *init_args = (ast_tach_init_arg *)cfg->init_args;
+	if (init_args->is_init)
+		goto skip_init;
+
+	init_tach_dev();
+
+	init_args->is_init = true;
+
+skip_init:
+	cfg->read = ast_tach_read;
+
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/dev/include/ads112c.h
+++ b/common/dev/include/ads112c.h
@@ -48,3 +48,11 @@ enum ADS112C_REG1_CONFIG {
 #define CFG_REG_OFFSET1 0x04
 #define CFG_REG_OFFSET2 0x08
 #define CFG_REG_OFFSET3 0x0C
+
+typedef struct _ads112c_init_arg {
+	uint8_t reg0_input;
+	uint8_t reg0_gain;
+	uint8_t reg0_pga;
+	uint8_t reg1_conversion;
+	uint8_t reg1_vol_refer;
+} ads112c_init_arg;

--- a/common/dev/include/ast_tach.h
+++ b/common/dev/include/ast_tach.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TACH_H
+#define TACH_H
+
+enum {
+	AST_TACH_RPM = 0,
+};
+
+enum {
+	TACH_PORT0 = 0,
+	TACH_PORT1,
+	TACH_PORT2,
+	TACH_PORT3,
+	TACH_PORT4,
+	TACH_PORT5,
+	TACH_PORT6,
+	TACH_PORT7,
+	TACH_PORT8,
+	TACH_PORT9,
+	TACH_PORT10,
+	TACH_PORT11,
+	TACH_PORT12,
+	TACH_PORT13,
+	TACH_PORT14,
+	TACH_PORT15,
+	TACH_MAX_NUM,
+};
+
+typedef struct _ast_tach_init_arg {
+	bool is_init;
+} ast_tach_init_arg;
+
+#endif //TACH_H

--- a/common/dev/include/hdc1080.h
+++ b/common/dev/include/hdc1080.h
@@ -21,4 +21,8 @@
 #define HDC1080_HUM_OFFSET 0x01
 #define HDC1080_CONFIGURE_OFFSET 0x02
 
+typedef struct _hdc1080_init_arg {
+	bool is_init;
+} hdc1080_init_arg;
+
 #endif //HDC1080_H

--- a/common/dev/include/nct214.h
+++ b/common/dev/include/nct214.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NCT214_H
+#define NCT214_H
+
+#define LOCAL_TEMP_REG 0x00
+#define EXTERNAL_TEMP_UPPER_BYTE_REG 0x01
+#define EXTERNAL_TEMP_LOWER_BYTE_REG 0x10
+#define CONFIG_READ_REG 0x03
+#define CONFIG_WRITE_REG 0x09
+
+typedef struct _nct214_init_arg {
+	bool is_init;
+	uint8_t temperature_range;
+} nct214_init_arg;
+
+enum NCT214_CHANNELS {
+	NCT214_LOCAL_TEMPERATRUE,
+	NCT214_REMOTE_TEMPERATRUE,
+};
+
+enum NCT_214_TEMPERATURE_RANGE {
+	NCT_214_TEMPERATURE_RANGE_0_TO_127,
+	NCT_214_TEMPERATURE_RANGE_EXTENDED, // −64°C to +191°C
+};
+#endif

--- a/common/dev/include/xdp710.h
+++ b/common/dev/include/xdp710.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef XDP710_H
+#define XDP710_H
+
+#include <stdint.h>
+
+enum XDP710_VTLM_RNG {
+	VTLM_RNG_88,
+	VTLM_RNG_44,
+	VTLM_RNG_22,
+	VTLM_RNG_RESERVED,
+};
+
+enum XDP710_VSNS_CS {
+	VSNS_CS_12_5,
+	VSNS_CS_25,
+	VSNS_CS_50,
+	VSNS_CS_100,
+	VSNS_CS_MAX,
+};
+
+typedef struct {
+	bool mbr_init;
+	uint16_t m;
+	uint16_t b;
+	uint16_t r; /* multiples of 10, r = -2 -> val = 100 */
+	float r_sense; /* mohm */
+} xdp710_priv;
+
+typedef struct _xdp710_init_arg {
+	float r_sense;
+} xdp710_init_arg;
+
+#endif // XDP710_H

--- a/common/dev/nct214.c
+++ b/common/dev/nct214.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "libutil.h"
+#include <logging/log.h>
+#include "nct214.h"
+
+#define TEMPERATURE_RANGE_EXTENDED_VALUE 64
+#define TEMPERATURE_REMOTE_FRACTION 0.25
+#define TEMPERATURE_REMOTE_FRACTION_FOR_SENSOR_READ_FRACTION (TEMPERATURE_REMOTE_FRACTION * 1000)
+#define TEMPERATURE_RANGE_SELECT_MASK BIT(2)
+
+LOG_MODULE_REGISTER(nct214);
+
+uint8_t nct214_read(sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("sensor num: 0x%x is invalid", cfg->num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	uint8_t retry = 5;
+	I2C_MSG msg = { 0 };
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	uint8_t offset = cfg->offset;
+	sensor_val *sval = (sensor_val *)reading;
+	msg.rx_len = 1;
+	msg.tx_len = 1;
+	msg.data[0] = CONFIG_READ_REG;
+	if (i2c_master_read(&msg, retry)) {
+		LOG_ERR("NCT214 read CONFIG_READ_REG reg error");
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	// read bit2 to check temperature range
+	uint8_t temperature_range_select = (msg.data[0] & TEMPERATURE_RANGE_SELECT_MASK) >> 2;
+
+	switch (offset) {
+	case NCT214_LOCAL_TEMPERATRUE:
+
+		msg.rx_len = 1;
+		msg.tx_len = 1;
+		msg.data[0] = LOCAL_TEMP_REG;
+		if (i2c_master_read(&msg, retry)) {
+			LOG_ERR("NCT214_LOCAL_TEMPERATRUE read reg error");
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+
+		uint8_t val_local_temp = msg.data[0];
+		if (temperature_range_select == NCT_214_TEMPERATURE_RANGE_EXTENDED) {
+			sval->integer =
+				(int16_t)(val_local_temp - TEMPERATURE_RANGE_EXTENDED_VALUE);
+		} else {
+			sval->integer = (int16_t)val_local_temp;
+		}
+
+		sval->fraction = 0;
+		return SENSOR_READ_SUCCESS;
+
+	case NCT214_REMOTE_TEMPERATRUE:
+		msg.rx_len = 1;
+		msg.tx_len = 1;
+		msg.data[0] = EXTERNAL_TEMP_LOWER_BYTE_REG;
+		if (i2c_master_read(&msg, retry)) {
+			LOG_ERR("NCT214_REMOTE_TEMPERATRUE read lower byte reg error");
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+
+		uint8_t val_external_temp_lower_byte = msg.data[0];
+		val_external_temp_lower_byte = val_external_temp_lower_byte >> 6; // get two MSBs
+		msg.data[0] = EXTERNAL_TEMP_UPPER_BYTE_REG;
+		if (i2c_master_read(&msg, retry)) {
+			LOG_ERR("NCT214_REMOTE_TEMPERATRUE read upper byte reg error");
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+
+		uint8_t val_external_temp_upper_byte = msg.data[0];
+		sval->fraction = val_external_temp_lower_byte *
+				 TEMPERATURE_REMOTE_FRACTION_FOR_SENSOR_READ_FRACTION;
+		if (temperature_range_select == NCT_214_TEMPERATURE_RANGE_EXTENDED) {
+			sval->integer = (int16_t)(val_external_temp_upper_byte -
+						  TEMPERATURE_RANGE_EXTENDED_VALUE);
+			if (sval->integer < 0)
+				sval->fraction *= (-1);
+
+		} else {
+			sval->integer = (int16_t)val_external_temp_upper_byte;
+		}
+
+		return SENSOR_READ_SUCCESS;
+	default:
+		LOG_ERR("Unknown register offset(%d)", offset);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+}
+
+uint8_t nct214_init(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	nct214_init_arg *nct214_init_arg_data = (nct214_init_arg *)cfg->init_args;
+	if (nct214_init_arg_data->is_init)
+		goto skip_init;
+
+	uint8_t retry = 5;
+	I2C_MSG msg = { 0 };
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.rx_len = 1;
+	msg.tx_len = 1;
+	msg.data[0] = CONFIG_READ_REG;
+	if (i2c_master_read(&msg, retry)) {
+		LOG_ERR("NCT214 read CONFIG_READ_REG reg error");
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	uint8_t config_val = msg.data[0];
+
+	if (nct214_init_arg_data->temperature_range == NCT_214_TEMPERATURE_RANGE_EXTENDED) {
+		msg.tx_len = 2;
+		msg.data[0] = CONFIG_WRITE_REG;
+		WRITE_BIT(config_val, 2, 1);
+		msg.data[1] = config_val;
+
+		if (i2c_master_write(&msg, retry)) {
+			LOG_ERR("NCT214 write CONFIG_WRITE reg error");
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+	}
+
+	nct214_init_arg_data->is_init = true;
+
+skip_init:
+	cfg->read = nct214_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/dev/xdp710.c
+++ b/common/dev/xdp710.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <logging/log.h>
+#include "pmbus.h"
+#include "sensor.h"
+#include "xdp710.h"
+
+LOG_MODULE_REGISTER(dev_xdp710);
+
+#define VSNS_CFG_REG 0xD4
+#define ISNS_CFG_REG 0xD5
+
+#define VSNS_CFG_RESET_VAL 0x28
+#define ISNS_CFG_RESET_VAL 0xB418
+
+static const uint16_t vin_vtlm_to_m[VTLM_RNG_RESERVED] = { 4653, 9307, 18614 };
+static const uint16_t iout_vsns_to_m[VSNS_CS_MAX] = { 23165, 11582, 5791, 28956 };
+static const uint16_t pin_vtlm_vsns_to_m[VTLM_RNG_RESERVED][VSNS_CS_MAX] = {
+	{ 4211, 21054, 10527, 5263 },
+	{ 8422, 4211, 21054, 10527 },
+	{ 16843, 8422, 4211, 21054 }
+};
+static const uint16_t pin_vtlm_vsns_to_r[VTLM_RNG_RESERVED][VSNS_CS_MAX] = {
+	{ 100, 1000, 1000, 1000 },
+	{ 100, 100, 1000, 1000 },
+	{ 100, 100, 100, 1000 }
+};
+
+static uint8_t xdp710_read_vsns_cfg(uint8_t bus, uint8_t addr)
+{
+	uint8_t val = VSNS_CFG_RESET_VAL;
+
+	uint8_t retry = 5;
+	I2C_MSG msg = { 0 };
+
+	msg.bus = bus;
+	msg.target_addr = addr;
+	msg.tx_len = 1;
+	msg.rx_len = 1;
+	msg.data[0] = VSNS_CFG_REG;
+
+	if (i2c_master_read(&msg, retry)) {
+		LOG_ERR("read vsns cfg fail!");
+		return val;
+	}
+
+	val = msg.data[0];
+	return val;
+}
+
+static uint16_t xdp710_read_isns_cfg(uint8_t bus, uint8_t addr)
+{
+	uint16_t val = ISNS_CFG_RESET_VAL;
+
+	uint8_t retry = 5;
+	I2C_MSG msg = { 0 };
+
+	msg.bus = bus;
+	msg.target_addr = addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = ISNS_CFG_REG;
+
+	if (i2c_master_read(&msg, retry)) {
+		LOG_ERR("read isns cfg fail!");
+		return val;
+	}
+
+	val = ((msg.data[1] << 8) | msg.data[0]);
+	return val;
+}
+
+/* set mbr
+	1/m * Y * (10^-r) - b
+	if r = -2, return (10^-(-2)) -> 100
+*/
+static bool xdp710_set_mbr(uint8_t offset, uint8_t vtlm, uint8_t vsns, uint16_t *m, uint16_t *b,
+			   uint16_t *r)
+{
+	CHECK_NULL_ARG_WITH_RETURN(m, false);
+	CHECK_NULL_ARG_WITH_RETURN(b, false);
+	CHECK_NULL_ARG_WITH_RETURN(r, false);
+
+	if (vtlm >= VTLM_RNG_RESERVED || vsns >= VSNS_CS_MAX) {
+		LOG_ERR("vtlm_rng: %x, vsns_cs: %x out of range", vtlm, vsns);
+		return false;
+	}
+
+	switch (offset) {
+	case PMBUS_READ_TEMPERATURE_1:
+		*m = 52;
+		*b = 14321;
+		*r = 10;
+		break;
+	case PMBUS_READ_VIN:
+		*m = vin_vtlm_to_m[vtlm];
+		*b = 0;
+		*r = 100;
+		break;
+	case PMBUS_READ_IOUT:
+		*m = iout_vsns_to_m[vsns];
+		*b = 0;
+		*r = (vsns == VSNS_CS_100) ? 1000 : 100;
+		break;
+	case PMBUS_READ_PIN:
+		*m = pin_vtlm_vsns_to_m[vtlm][vsns];
+		*b = 0;
+		*r = pin_vtlm_vsns_to_r[vtlm][vsns];
+		break;
+	default:
+		LOG_WRN("Invalid offset 0x%x", offset);
+		return false;
+	}
+
+	return true;
+}
+
+uint8_t xdp710_read(sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(cfg->init_args, SENSOR_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("Sensor number out of range.");
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	xdp710_priv *priv_data = (xdp710_priv *)cfg->priv_data;
+	if (priv_data->mbr_init == false) {
+		LOG_ERR("0x%02x mbr isn't initialized", cfg->num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	float r_sense = priv_data->r_sense; // mohm
+	float val;
+	uint8_t retry = 5;
+	I2C_MSG msg;
+	uint8_t offset = cfg->offset;
+
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 1;
+	msg.data[0] = offset;
+	msg.rx_len = 2;
+
+	if (i2c_master_read(&msg, retry))
+		return SENSOR_FAIL_TO_ACCESS;
+
+	switch (offset) {
+	case PMBUS_READ_TEMPERATURE_1:
+		val = (float)(((msg.data[1] << 8) | msg.data[0]) * priv_data->r - priv_data->b) /
+		      priv_data->m;
+		break;
+	case PMBUS_READ_VIN:
+		val = (float)((msg.data[1] << 8) | msg.data[0]) * priv_data->r / priv_data->m;
+		break;
+	case PMBUS_READ_IOUT:
+	case PMBUS_READ_PIN:
+		val = (float)(((msg.data[1] << 8) | msg.data[0]) * priv_data->r) /
+		      (priv_data->m * r_sense);
+		break;
+	default:
+		LOG_WRN("Invalid offset 0x%x", offset);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	sval->integer = (int)val & 0xFFFF;
+	sval->fraction = (val - sval->integer) * 1000;
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t xdp710_init(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(cfg->init_args, SENSOR_INIT_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("Sensor number out of range.");
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	xdp710_init_arg *init_args = (xdp710_init_arg *)cfg->init_args;
+	if (!init_args->r_sense) {
+		LOG_ERR("0x%02x r_sense not provided", cfg->num);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	/* re-init, free priv_data */
+	if (cfg->priv_data)
+		SAFE_FREE(cfg->priv_data);
+
+	xdp710_priv *priv_data = (xdp710_priv *)malloc(sizeof(priv_data));
+	if (priv_data == NULL) {
+		LOG_ERR("malloc xdp710 priv_data fail!");
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+	priv_data->mbr_init = false;
+
+	uint8_t vtlm = (xdp710_read_vsns_cfg(cfg->port, cfg->target_addr) & BIT_MASK(2));
+	uint8_t vsns = (xdp710_read_isns_cfg(cfg->port, cfg->target_addr) & GENMASK(7, 6));
+
+	uint16_t m = 0, b = 0, r = 0;
+	if (xdp710_set_mbr(cfg->offset, vtlm, vsns, &m, &b, &r)) {
+		LOG_INF("set 0x%02x to m: %d, b: %d,r: %d", cfg->num, m, b, r);
+		priv_data->mbr_init = true;
+	}
+
+	/* set priv data */
+	priv_data->m = m;
+	priv_data->b = b;
+	priv_data->r = r;
+	priv_data->r_sense = init_args->r_sense;
+
+	cfg->priv_data = priv_data;
+
+	cfg->read = xdp710_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -133,6 +133,7 @@ const char *const sensor_type_name[] = {
   	sensor_name_to_num(ina238)
 	sensor_name_to_num(nct214)
 	sensor_name_to_num(ast_tach)
+	sensor_name_to_num(xdp710)
 };
 // clang-format on
 
@@ -201,6 +202,7 @@ SENSOR_DRIVE_INIT_DECLARE(hdc1080);
 SENSOR_DRIVE_INIT_DECLARE(ina238);
 SENSOR_DRIVE_INIT_DECLARE(nct214);
 SENSOR_DRIVE_INIT_DECLARE(ast_tach);
+SENSOR_DRIVE_INIT_DECLARE(xdp710);
 
 // The sequence needs to same with SENSOR_DEV ID
 sensor_drive_api sensor_drive_tbl[] = {
@@ -260,6 +262,7 @@ sensor_drive_api sensor_drive_tbl[] = {
 	SENSOR_DRIVE_TYPE_INIT_MAP(nct7363),	SENSOR_DRIVE_TYPE_INIT_MAP(ads112c),
 	SENSOR_DRIVE_TYPE_INIT_MAP(hdc1080),	SENSOR_DRIVE_TYPE_INIT_MAP(ina238),
 	SENSOR_DRIVE_TYPE_INIT_MAP(nct214),	SENSOR_DRIVE_TYPE_INIT_MAP(ast_tach),
+	SENSOR_DRIVE_TYPE_INIT_MAP(xdp710),
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -131,6 +131,7 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(ads112c)
 	sensor_name_to_num(hdc1080)
   	sensor_name_to_num(ina238)
+	sensor_name_to_num(nct214)
 };
 // clang-format on
 
@@ -197,6 +198,7 @@ SENSOR_DRIVE_INIT_DECLARE(nct7363);
 SENSOR_DRIVE_INIT_DECLARE(ads112c);
 SENSOR_DRIVE_INIT_DECLARE(hdc1080);
 SENSOR_DRIVE_INIT_DECLARE(ina238);
+SENSOR_DRIVE_INIT_DECLARE(nct214);
 
 // The sequence needs to same with SENSOR_DEV ID
 sensor_drive_api sensor_drive_tbl[] = {
@@ -255,6 +257,7 @@ sensor_drive_api sensor_drive_tbl[] = {
 #endif
 	SENSOR_DRIVE_TYPE_INIT_MAP(nct7363),	SENSOR_DRIVE_TYPE_INIT_MAP(ads112c),
 	SENSOR_DRIVE_TYPE_INIT_MAP(hdc1080),	SENSOR_DRIVE_TYPE_INIT_MAP(ina238),
+	SENSOR_DRIVE_TYPE_INIT_MAP(nct214),
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -132,6 +132,7 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(hdc1080)
   	sensor_name_to_num(ina238)
 	sensor_name_to_num(nct214)
+	sensor_name_to_num(ast_tach)
 };
 // clang-format on
 
@@ -199,6 +200,7 @@ SENSOR_DRIVE_INIT_DECLARE(ads112c);
 SENSOR_DRIVE_INIT_DECLARE(hdc1080);
 SENSOR_DRIVE_INIT_DECLARE(ina238);
 SENSOR_DRIVE_INIT_DECLARE(nct214);
+SENSOR_DRIVE_INIT_DECLARE(ast_tach);
 
 // The sequence needs to same with SENSOR_DEV ID
 sensor_drive_api sensor_drive_tbl[] = {
@@ -257,7 +259,7 @@ sensor_drive_api sensor_drive_tbl[] = {
 #endif
 	SENSOR_DRIVE_TYPE_INIT_MAP(nct7363),	SENSOR_DRIVE_TYPE_INIT_MAP(ads112c),
 	SENSOR_DRIVE_TYPE_INIT_MAP(hdc1080),	SENSOR_DRIVE_TYPE_INIT_MAP(ina238),
-	SENSOR_DRIVE_TYPE_INIT_MAP(nct214),
+	SENSOR_DRIVE_TYPE_INIT_MAP(nct214),	SENSOR_DRIVE_TYPE_INIT_MAP(ast_tach),
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -171,6 +171,7 @@ enum SENSOR_DEV {
 	sensor_dev_ina238 = 0x35,
 	sensor_dev_nct214 = 0x36,
 	sensor_dev_ast_tach = 0x37,
+	sensor_dev_xdp710 = 0x38,
 	sensor_dev_max
 };
 

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -724,17 +724,6 @@ typedef struct _nv_satmc_init_arg {
 	pldm_sensor_pdr_parm parm; //only used for numeric sensor
 } nv_satmc_init_arg;
 
-typedef struct _ads112c_init_arg {
-	uint8_t reg0_input;
-	uint8_t reg0_gain;
-	uint8_t reg0_pga;
-	uint8_t reg1_conversion;
-	uint8_t reg1_vol_refer;
-} ads112c_init_arg;
-typedef struct _hdc1080_init_arg {
-	bool is_init;
-} hdc1080_init_arg;
-
 extern bool enable_sensor_poll_thread;
 extern sensor_cfg *sensor_config;
 // Mapping sensor number to sensor config index

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -169,6 +169,7 @@ enum SENSOR_DEV {
 	sensor_dev_ads112c = 0x33,
 	sensor_dev_hdc1080 = 0x34,
 	sensor_dev_ina238 = 0x35,
+	sensor_dev_nct214 = 0x36,
 	sensor_dev_max
 };
 

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -170,6 +170,7 @@ enum SENSOR_DEV {
 	sensor_dev_hdc1080 = 0x34,
 	sensor_dev_ina238 = 0x35,
 	sensor_dev_nct214 = 0x36,
+	sensor_dev_ast_tach = 0x37,
 	sensor_dev_max
 };
 


### PR DESCRIPTION
Summary:
 Add drivers
- add nct214.c, nct214.h
- add ast_tach.c, ast_tach.h
- add xdp710.c, xdp710.h

 Move  init_args structure of hdc1080 and ads112c from sensor.h to own header file
- move typedef struct _hdc1080_init_arg from sensor.h to hdc1080.h 
- move typedef struct _ads112c_init_arg from sensor.h to ads112c.h

Description:
- for AALC project sensor

Test Plan:
- Waiting for test