### PR TITLE
yv4: sd: Fix APML RMI access for Rev 2.1

### DIFF
--- a/common/service/apml/apml.h
+++ b/common/service/apml/apml.h
@@ -103,6 +103,13 @@ typedef struct _cpuid_WrData_ {
 	uint8_t ecx_value;
 } cpuid_WrData;
 
+/* RMI Rev 2.1 use 2 bytes thread */
+typedef struct _cpuid_WrData_TwoPOne_ {
+	uint8_t thread[2];
+	uint8_t cpuid_func[4];
+	uint8_t ecx_value;
+} cpuid_WrData_TwoPOne;
+
 typedef struct _cpuid_RdData_ {
 	uint8_t status;
 	uint8_t data_out[8];
@@ -112,6 +119,12 @@ typedef struct _mca_WrData_ {
 	uint8_t thread;
 	uint8_t register_addr[4];
 } mca_WrData;
+
+/* RMI Rev 2.1 use 2 bytes thread */
+typedef struct _mca_WrData_TwoPOne {
+	uint8_t thread[2];
+	uint8_t register_addr[4];
+} mca_WrData_TwoPOne;
 
 typedef struct _mca_RdData_ {
 	uint8_t status;
@@ -147,5 +160,6 @@ int pal_check_sbrmi_command_code_length();
 uint8_t pal_get_apml_bus();
 uint8_t apml_get_bus();
 int set_sbrmi_command_code_len(uint8_t value);
+int get_sbrmi_command_code_len();
 
 #endif

--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -1910,6 +1910,7 @@ __weak void OEM_1S_SEND_APML_REQUEST(ipmi_msg *msg)
 	static uint8_t index = 0;
 	uint8_t apml_bus = apml_get_bus();
 	apml_msg apml_data = { 0 };
+	uint8_t wr_len = 0;
 
 	switch (msg->data[0]) {
 	case APML_MSG_TYPE_MAILBOX: /* Mailbox */
@@ -1920,18 +1921,24 @@ __weak void OEM_1S_SEND_APML_REQUEST(ipmi_msg *msg)
 		memcpy(apml_data.WrData, &msg->data[1], sizeof(mailbox_WrData));
 		break;
 	case APML_MSG_TYPE_CPUID: /* CPUID */
-		if (msg->data_len != 1 + sizeof(cpuid_WrData)) {
+		wr_len = (get_sbrmi_command_code_len() == SBRMI_CMD_CODE_LEN_TWO_BYTE) ?
+				 sizeof(cpuid_WrData_TwoPOne) :
+				 sizeof(cpuid_WrData);
+		if (msg->data_len != 1 + wr_len) {
 			msg->completion_code = CC_INVALID_LENGTH;
 			return;
 		}
-		memcpy(apml_data.WrData, &msg->data[1], sizeof(cpuid_WrData));
+		memcpy(apml_data.WrData, &msg->data[1], wr_len);
 		break;
 	case APML_MSG_TYPE_MCA: /* MCA */
-		if (msg->data_len != 1 + sizeof(mca_WrData)) {
+		wr_len = (get_sbrmi_command_code_len() == SBRMI_CMD_CODE_LEN_TWO_BYTE) ?
+				 sizeof(mca_WrData_TwoPOne) :
+				 sizeof(mca_WrData);
+		if (msg->data_len != 1 + wr_len) {
 			msg->completion_code = CC_INVALID_LENGTH;
 			return;
 		}
-		memcpy(apml_data.WrData, &msg->data[1], sizeof(mca_WrData));
+		memcpy(apml_data.WrData, &msg->data[1], wr_len);
 		break;
 	default:
 		msg->completion_code = CC_UNSPECIFIED_ERROR;

--- a/meta-facebook/yv4-sd/src/platform/plat_apml.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_apml.c
@@ -182,8 +182,13 @@ void read_cpuid()
 	apml_data.cb_fn = read_cpuid_callback;
 	apml_data.error_cb_fn = read_cpuid_error_callback;
 	apml_data.ui32_arg = 0x00;
-	cpuid_WrData *wrdata = (cpuid_WrData *)&apml_data.WrData;
-	wrdata->ecx_value = 0x00;
+	if (get_sbrmi_command_code_len() == SBRMI_CMD_CODE_LEN_TWO_BYTE) {
+		cpuid_WrData_TwoPOne *wrdata = (cpuid_WrData_TwoPOne *)&apml_data.WrData;
+		wrdata->ecx_value = 0x00;
+	} else {
+		cpuid_WrData *wrdata = (cpuid_WrData *)&apml_data.WrData;
+		wrdata->ecx_value = 0x00;
+	}
 	apml_read(&apml_data);
 
 	// read ecx&edx
@@ -194,7 +199,12 @@ void read_cpuid()
 	apml_data.cb_fn = read_cpuid_callback;
 	apml_data.error_cb_fn = read_cpuid_error_callback;
 	apml_data.ui32_arg = 0x01;
-	wrdata = (cpuid_WrData *)&apml_data.WrData;
-	wrdata->ecx_value = 0x01;
+	if (get_sbrmi_command_code_len() == SBRMI_CMD_CODE_LEN_TWO_BYTE) {
+		cpuid_WrData_TwoPOne *wrdata = (cpuid_WrData_TwoPOne *)&apml_data.WrData;
+		wrdata->ecx_value = 0x01;
+	} else {
+		cpuid_WrData *wrdata = (cpuid_WrData *)&apml_data.WrData;
+		wrdata->ecx_value = 0x01;
+	}
 	apml_read(&apml_data);
 }


### PR DESCRIPTION
Description:
- APML RMI Rev 2.1 changes thread bytes from 1 to 2
- BIC should support Rev < 2.0 and Rev 2.1

Motivation:
- We need to access CPU by APML correctly

Test Plan:
- Build code: Pass
- Stress pass with CPU Turin (Rev 2.1) and Bergamo (Rev 2.0)

Test log:
(Turin CPUID)
root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0x2E 0x15 0xA0 0x00 0x01 0 0 0 0 0 0 0 pldmtool: Tx: 80 3f 01 15 a0 00 e0 2e 15 a0 00 01 00 00 00 00 00 00 00 pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 2e 00 15 a0 00 00 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0x2F 0x15 0xA0 0x00 0 pldmtool: Tx: 80 3f 01 15 a0 00 e0 2f 15 a0 00 00
pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 2f 00 15 a0 00 00 10 00 00 00 41 75 74 68

(Turin MCA)
root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0x2E 0x15 0xA0 0x00 0x02 0 0 0x05 0x20 0x00 0xC0 pldmtool: Tx: 80 3f 01 15 a0 00 e0 2e 15 a0 00 02 00 00 05 20 00 c0 pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 2e 00 15 a0 00 01 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0x2F 0x15 0xA0 0x00 1 pldmtool: Tx: 80 3f 01 15 a0 00 e0 2f 15 a0 00 01
pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 2f 00 15 a0 00 00 00 a2 00 20 b0 00 00 00

(Bergamo CPUID)
root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0x2E 0x15 0xA0 0x00 0x01 0 0 0 0 0 0 pldmtool: Tx: 80 3f 01 15 a0 00 e0 2e 15 a0 00 01 00 00 00 00 00 00 pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 2e 00 15 a0 00 03 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0x2F 0x15 0xA0 0x00 3 pldmtool: Tx: 80 3f 01 15 a0 00 e0 2f 15 a0 00 03
pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 2f 00 15 a0 00 00 10 00 00 00 41 75 74 68

(Bergamo MCA)
root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0x2E 0x15 0xA0 0x00 0x02 0 0x05 0x20 0x00 0xC0 pldmtool: Tx: 80 3f 01 15 a0 00 e0 2e 15 a0 00 02 00 05 20 00 c0 pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 2e 00 15 a0 00 05 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0x2F 0x15 0xA0 0x00 5 pldmtool: Tx: 80 3f 01 15 a0 00 e0 2f 15 a0 00 05
pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 2f 00 15 a0 00 00 00 ae 00 20 b0 00 10 00
