### PR TITLE
common: nct7363 driver add setting fan poles 

### DIFF
--- a/common/dev/include/nct7363.h
+++ b/common/dev/include/nct7363.h
@@ -84,7 +84,7 @@ typedef struct _nct7363_init_arg {
 	uint8_t value;
 	// According to the pin position on the right side of the component, from top to bottom, there are 16 pins in total.
 	uint8_t pin_type[16];
-	uint8_t fan_poles;
+	uint8_t fan_poles[16];
 	float fan_frequency[16];
 	uint8_t duty;
 	uint16_t threshold[16];


### PR DESCRIPTION
common: nct7363 driver add function of setting fan poles to each different port
Summary:
- edit fan poles setting in nct7363.c
- add fan poles setting define in nct7363.h

Description:
- for AALC project sensor

Test Plan:
- Waiting for test