### PR TITLE
yv4: sd: Send all IPMI commands to BIC from KCS

### DIFF
--- a/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
@@ -40,29 +40,8 @@ LOG_MODULE_REGISTER(plat_ipmi);
 
 bool pal_request_msg_to_BIC_from_HOST(uint8_t netfn, uint8_t cmd)
 {
-	if (netfn == NETFN_APP_REQ) {
-		if ((cmd == CMD_APP_SET_ACPI_POWER) || (cmd == CMD_APP_GET_DEVICE_GUID) ||
-		    (cmd == CMD_APP_GET_BMC_GLOBAL_ENABLES) ||
-		    (cmd == CMD_APP_CLEAR_MESSAGE_FLAGS) || (cmd == CMD_APP_GET_CAHNNEL_INFO) ||
-		    (cmd == CMD_APP_GET_DEVICE_ID) || (cmd == CMD_APP_GET_SELFTEST_RESULTS) ||
-		    (cmd == CMD_APP_COLD_RESET)) {
-			return true;
-		}
-	} else if (netfn == NETFN_DCMI_REQ) {
-		if (cmd == CMD_DCMI_GET_PICMG_PROPERTIES) {
-			return true;
-		}
-	} else if (netfn == NETFN_OEM_REQ) {
-		if (cmd == CMD_OEM_GET_CHASSIS_POSITION) {
-			return true;
-		}
-	}
-
-	else {
-		return false;
-	}
-
-	return false;
+	// In YV4, all IPMI commands are all sent to BIC
+	return true;
 }
 
 void APP_GET_BMC_GLOBAL_ENABLES(ipmi_msg *msg)


### PR DESCRIPTION
# Description:
Remove the table that identifies whether the IPMI command is sent to BIC or BMC.

# Motivation:
In YV4, all IPMI commands from KCS should be sent to BIC.

# Test Plan:
Host sends IPMI commands to BIC without timeout: Pass

# Test log:
    Before:
        [root@20231109-643fbk1rc21 ~]# date ; ipmitool raw 0x0 0x9; date;
        Tue Aug 22 08:53:39 AM CST 2023
        No data available
        Unable to send RAW command (channel=0x0 netfn=0x0 lun=0x0 cmd=0x9)
        Tue Aug 22 08:53:54 AM CST 2023
        /* Cost 15 sec */

    After:
        [root@20240220-643fbk2 ~]# date ; ipmitool raw 0x0 0x9; date;
        Fri May 10 01:09:38 PM CST 2024
        Unable to send RAW command (channel=0x0 netfn=0x0 lun=0x0 cmd=0x9 rsp=0xc1): Invalid command
        Fri May 10 01:09:39 PM CST 2024
        /* Cost 1 sec */