### PR TITLE
apml: Revise mailbox sequence for TURIN CPU

### DIFF
--- a/common/service/apml/apml.h
+++ b/common/service/apml/apml.h
@@ -65,6 +65,7 @@ enum SBRMI_MAILBOX_ERR_CODE {
 
 enum SBRMI_REGISTER {
 	SBRMI_REVISION = 0x00,
+	SBRMI_CONTROL = 0x01,
 	SBRMI_STATUS = 0x02,
 	SBRMI_OUTBANDMSG_INST0 = 0x30,
 	SBRMI_OUTBANDMSG_INST1 = 0x31,
@@ -161,5 +162,6 @@ uint8_t pal_get_apml_bus();
 uint8_t apml_get_bus();
 int set_sbrmi_command_code_len(uint8_t value);
 int get_sbrmi_command_code_len();
+void disable_mailbox_completion_alert();
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -113,6 +113,7 @@ void pal_set_sys_status()
 		apml_recovery();
 		set_tsi_threshold();
 		read_cpuid();
+		disable_mailbox_completion_alert();
 	}
 }
 

--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -115,6 +115,7 @@ void ISR_POST_COMPLETE()
 		read_cpuid();
 		//todo : add sel to bmc for assert
 		hw_event_register[12]++;
+		disable_mailbox_completion_alert();
 	} else {
 		if (get_DC_status()) { // Host is reset
 			k_work_submit(&switch_i3c_dimm_work);


### PR DESCRIPTION
# Description:
It was polling SwAlertSts as mailbox completion. However, ADDC also utilizing SwAlertSts. If we clear the SwAlertSts when mailbox completion, it might also deassert APML_ALERT.

# Motivation:
As suggest by AMD, we should revise sequence, so the APML_ALERT won't be clear accidentally.

# Test Plan:
Build code - Pass
Test on yv4 system - Pass