### PR TITLE
fby35: ji: Support ds160pt801 sensor read

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_class.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_class.c
@@ -196,10 +196,9 @@ void init_platform_config()
 	}
 
 	/* work around */
-	if (get_post_status() == true) {
-		if (modify_sensor_cfg() == false)
-			LOG_ERR("Failed to modify sensor cfg!");
-	}
+	set_post_status(VIRTUAL_BIOS_POST_COMPLETE_L);
+	if (get_post_status() == true)
+		modify_sensor_cfg();
 
 	LOG_INF("Board revision: %d", board_revision);
 	LOG_INF("Retimer module: %d, OTH module: %d, HSC module: %d", retimer_module, oth_module,

--- a/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
@@ -288,6 +288,8 @@ void pal_extend_sensor_config()
 		LOG_INF("HSC vendor: MP5990");
 		sensor_count = ARRAY_SIZE(mp5990_sensor_config_table);
 		for (int index = 0; index < sensor_count; index++) {
+			if (get_board_revision() >= SYS_BOARD_EVT2)
+				mp5990_sensor_config_table[index].target_addr = MP5990_ADDR_1;
 			add_sensor_config(mp5990_sensor_config_table[index]);
 		}
 		/* MP5990 can read HSC temperature */

--- a/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
@@ -213,10 +213,8 @@ static sensor_cfg *change_retimer_sensor_cfg(uint8_t module)
 		}
 	}
 
-	if (i == sensor_config_count) {
-		LOG_ERR("Can't find Retimer %d in sensor config", module);
+	if (i == sensor_config_count)
 		return NULL;
-	}
 
 	return &sensor_config[i];
 }
@@ -267,7 +265,7 @@ bool modify_sensor_cfg()
 	sensor_cfg *retimer_cfg = NULL;
 	retimer_cfg = change_retimer_sensor_cfg(retimer_module);
 	if (!retimer_cfg) {
-		LOG_ERR("Retimer sensor config not found!!");
+		LOG_WRN("Retimer sensor config not found!!");
 		return false;
 	}
 

--- a/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
@@ -192,8 +192,8 @@ sensor_cfg pt4080l_sensor_config_table[] = {
 sensor_cfg ds160pt801_sensor_config_table[] = {
 	{ SENSOR_NUM_TEMP_RETIMER, sensor_dev_ds160pt801, I2C_BUS2, TI_RETIMER_ADDR,
 	  DS160PT801_READ_TEMP, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
-	  DISABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ds160pt801_read,
-	  &mux_conf_addr_0xe2[1], NULL, NULL, NULL },
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ds160pt801_read, &mux_conf_addr_0xe2[1],
+	  NULL, NULL, NULL },
 };
 
 static sensor_cfg *change_retimer_sensor_cfg(uint8_t module)

--- a/meta-facebook/yv35-ji/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_sensor_table.h
@@ -29,6 +29,7 @@
 #define FPGA_ADDR (0xC0 >> 1)
 #define TEMP_HSC_ADDR (0x98 >> 1)
 #define MP5990_ADDR (0xA0 >> 1)
+#define MP5990_ADDR_1 (0xC0 >> 1) // for board >= EVT2
 #define INA230_ADDR (0x8A >> 1)
 #define INA3221_ADDR (0x80 >> 1)
 #define TMP451_ADDR (0x98 >> 1)


### PR DESCRIPTION
Summary:
- Fix DS160PT801 sensor read bug.
- Enable TI retimer temperature sensor polling.

TestPlan:
- BuildCode: PASS
- Check sensor reading in BMC: PASS

Log:
- BMC console:
  ```
  root@bmc-oob:~# sensor-util slot1
  slot1:
  MB_INLET_TEMP_C              (0x1) :  29.562 C     | (ok)
  MB_OUTLET_TEMP_C             (0x2) :  41.062 C     | (ok)
  MB_FIO_FRONT_TEMP_C          (0x3) :  26.000 C     | (ok)
  MB_SOC_CPU_TEMP_C            (0x4) :  44.030 C     | (ok)
  MB_E1S_SSD_TEMP_C            (0x6) :  37.000 C     | (ok)
  MB_HSC_TEMP_C                (0x7) :  40.000 C     | (ok)
  MB_RETIMER_TEMP_C            (0xB) :  50.340 C     | (ok)
  MB_LPDDR5_UP_TEMP_C          (0xC) :  35.625 C     | (ok)
  MB_LPDDR5_DOWN_TEMP_C        (0xD) :  39.125 C     | (ok)
  MB_HSC_INPUT_VOLT_V          (0x10) :  11.968 Volts | (ok)
  MB_ADC_P12V_STBY_VOLT_V      (0x11) :  12.177 Volts | (ok)
  MB_ADC_VDD_1V8_VOLT_V        (0x12) :   1.828 Volts | (ok)
  MB_ADC_P3V3_STBY_VOLT_V      (0x13) :   3.344 Volts | (ok)
  MB_ADC_SOCVDD_VOLT_V         (0x14) :   0.859 Volts | (ok)
  MB_ADC_P3V_BAT_VOLT_V        (0x15) :   3.157 Volts | (ok)
  MB_ADC_CPUVDD_VOLT_V         (0x16) :   1.105 Volts | (ok)
  MB_ADC_1V2_VOLT_V            (0x18) :   1.228 Volts | (ok)
  MB_ADC_P1V2_STBY_VOLT_V      (0x1A) :   1.186 Volts | (ok)
  MB_ADC_FBVDDQ_VOLT_V         (0x1B) :   0.517 Volts | (ok)
  MB_ADC_FBVDDP2_VOLT_V        (0x1C) :   1.057 Volts | (ok)
  MB_ADC_FBVDD1_VOLT_V         (0x1D) :   1.796 Volts | (ok)
  MB_ADC_P5V_STBY_VOLT_V       (0x1E) :   4.955 Volts | (ok)
  MB_ADC_CPU_DVDD_VOLT_V       (0x1F) :   0.903 Volts | (ok)
  MB_E1S_SSD_VOLT_V            (0x20) :  12.031 Volts | (ok)
  MB_CPUVDD_VOLT_V             (0x22) :   1.080 Volts | (ok)
  MB_SOCVDD_VOLT_V             (0x23) :   0.850 Volts | (ok)
  MB_HSC_OUTPUT_CURR_A         (0x25) :   7.000 Amps  | (ok)
  MB_E1S_SSD_CURR_A            (0x26) :   0.265 Amps  | (ok)
  MB_CPU_PWR_W                 (0x30) :  68.967 Watts | (ok)
  MB_HSC_INPUT_PWR_W           (0x31) :  84.000 Watts | (ok)
  MB_E1S_SSD_PWR_W             (0x32) :   3.200 Watts | (ok)
  MB_CPUVDD_PWR_W              (0x34) :  20.261 Watts | (ok)
  MB_SOCVDD_PWR_W              (0x35) :   7.833 Watts | (ok)
  MB_CPU_THROTTLE_STA          (0x40) :   1.000       | (ok)
  MB_PWR_BREAK_STA             (0x41) :   1.000       | (ok)
  MB_SPARE_CH_STA              (0x42) :   2.000       | (ok)
  ```