### PR TITLE
GT: Version commit for obgt-cc-2024.20.01

### DIFF
--- a/meta-facebook/gt-cc/src/platform/plat_version.h
+++ b/meta-facebook/gt-cc/src/platform/plat_version.h
@@ -39,8 +39,8 @@
 #define AUXILIARY_FW_REVISION 0x00000000
 
 #define BIC_FW_YEAR_MSB 0x20
-#define BIC_FW_YEAR_LSB 0x23
-#define BIC_FW_WEEK 0x48
+#define BIC_FW_YEAR_LSB 0x24
+#define BIC_FW_WEEK 0x20
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x47 // char: G
 #define BIC_FW_platform_1 0x54 // char: T


### PR DESCRIPTION
Summary:
- Version commit for Grand Teton switch board BIC obgt-cc-2024.20.01.

Test Plan:
- Build code: Pass
- Get BIC version: Pass

Log:
```
root@bmc-oob:~# fw-util swb --version bic
SWB BIC Version: 2024.20.01
```