### PR TITLE
common: Fix add sel from host via ssif bug

### DIFF
--- a/common/service/host/ssif.c
+++ b/common/service/host/ssif.c
@@ -357,8 +357,6 @@ static bool ssif_data_handle(ssif_dev *ssif_inst, ssif_action_t action, uint8_t 
 					ssif_inst->current_ipmi_msg.buffer.data[0] = 0x00;
 					ssif_inst->current_ipmi_msg.buffer.data[1] = 0x00;
 				}
-				ssif_inst->current_ipmi_msg.buffer.netfn =
-					(ssif_inst->current_ipmi_msg.buffer.netfn + 1) << 2;
 
 				if (ssif_set_data(ssif_inst->index, &ssif_inst->current_ipmi_msg) ==
 				    false) {


### PR DESCRIPTION
Summary:
- Fix add sel from host via ssif bug

TestPlan:
- BuildCode: PASS
- Send add sel command from HOST: PASS

Log:
- HOST console:
```
[root@localhost ~]# ipmitool raw 0xa 0x44 0x0 0x0 0x2 0x0 0x0 0x0 0x0
 32 00
```
