### PR TITLE
Artemis: mc: Version commit for 2024.21.01

### DIFF
--- a/meta-facebook/at-mc/src/platform/plat_version.h
+++ b/meta-facebook/at-mc/src/platform/plat_version.h
@@ -33,7 +33,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x28
+#define FIRMWARE_REVISION_2 0x29
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -42,7 +42,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x24
-#define BIC_FW_WEEK 0x15
+#define BIC_FW_WEEK 0x21
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x6d // char: m
 #define BIC_FW_platform_1 0x63 // char: c


### PR DESCRIPTION
Summary:

# Description:
- Version commit for MooseCreek BIC 2024.21.01.

# Motivation:
- Committing the version to align with the BMC version.

# Test Plan:
- Build code: Pass
- Get firmware version: Pass

Log:
```
root@bmc-oob:~# fw-util mc --version bic
MC BIC Version: mc2024.21.01
```