### PR TITLE
fby4: sd: Fix dimm mux when OS reboot

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_dimm.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_dimm.c
@@ -76,7 +76,7 @@ void get_dimm_info_handler()
 		}
 
 		if (is_dimm_checked_presnt == false) {
-			if (init_dimm_prsnt_status() < 0){
+			if (init_dimm_prsnt_status() < 0) {
 				k_msleep(GET_DIMM_INFO_TIME_MS);
 				continue;
 			}
@@ -101,6 +101,12 @@ void get_dimm_info_handler()
 			if (ret != 0) {
 				clear_unaccessible_dimm_data(dimm_id);
 				continue;
+			}
+
+			// When OS reboot, we need to switch it back to CPU
+			if (!get_post_status()) {
+				switch_i3c_dimm_mux(I3C_MUX_CPU_TO_DIMM);
+				break;
 			}
 
 			memset(&i3c_msg, 0, sizeof(I3C_MSG));


### PR DESCRIPTION
Description:
1. When OS reboot, it has a low chance that BIC finally switch DIMM mux to BIC side.
2. BIC should stop polling DIMM and switch DIMM mux to CPU side when OS reboot.

Motivation:
1. Fix issue YV4T1M-404

Test Plan:
OS reboot stress > 1000 times
The DIMM mux switch to CPU side when reboot.