### PR TITLE
yv4: sd: Enable APML alert mask

### DIFF
--- a/common/service/apml/apml.c
+++ b/common/service/apml/apml.c
@@ -621,6 +621,27 @@ void disable_mailbox_completion_alert()
 	}
 }
 
+void enable_alert_signal()
+{
+	uint8_t reg;
+
+	if (command_code_len == SBRMI_CMD_CODE_LEN_TWO_BYTE) {
+		if (apml_read_byte(apml_bus, SB_RMI_ADDR, SBRMI_CONTROL, &reg)) {
+			LOG_ERR("Failed to read SBRMI control.");
+			return;
+		} else {
+			LOG_INF("SBRMI_CONTROL read");
+		}
+		reg &= ~(1 << 0); // write 0 to bit0 AlertMask
+		if (apml_write_byte(apml_bus, SB_RMI_ADDR, SBRMI_CONTROL, reg)) {
+			LOG_ERR("Failed to write SBRMI control.");
+			return;
+		} else {
+			LOG_INF("SBRMI_CONTROL written");
+		}
+	}
+}
+
 __weak uint8_t pal_get_apml_bus()
 {
 	return APML_BUS_UNKNOWN;

--- a/common/service/apml/apml.h
+++ b/common/service/apml/apml.h
@@ -163,5 +163,6 @@ uint8_t apml_get_bus();
 int set_sbrmi_command_code_len(uint8_t value);
 int get_sbrmi_command_code_len();
 void disable_mailbox_completion_alert();
+void enable_alert_signal();
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -114,6 +114,7 @@ void pal_set_sys_status()
 		set_tsi_threshold();
 		read_cpuid();
 		disable_mailbox_completion_alert();
+		enable_alert_signal();
 	}
 }
 

--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -113,9 +113,10 @@ void ISR_POST_COMPLETE()
 	if (get_post_status()) {
 		set_tsi_threshold();
 		read_cpuid();
+		disable_mailbox_completion_alert();
+		enable_alert_signal();
 		//todo : add sel to bmc for assert
 		hw_event_register[12]++;
-		disable_mailbox_completion_alert();
 	} else {
 		if (get_DC_status()) { // Host is reset
 			k_work_submit(&switch_i3c_dimm_work);


### PR DESCRIPTION
# Description:
The APML alert mask should be enabled, and CPU will pull down the APML alert when error occurred.

# Motivation:
Hardware team observed that the CPU didn't pull down the APML alert when error occurred. AMD team suggested that the alert mask bit should be enabled.

# Test Plan:
Build code - Pass
Tested on YV4 system - Pass