### PR TITLE
yv4: wf: Check CXLs ready status before setting EIDs

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.c
@@ -135,6 +135,13 @@ static void set_dev_endpoint(void)
 			if (!p->set_endpoint)
 				continue;
 
+			// Check CXLs ready status before setting EID
+			if (p->bus == I2C_BUS_CXL1 && !get_cxl_ready_status(CXL_ID_1))
+				continue;
+
+			if (p->bus == I2C_BUS_CXL2 && !get_cxl_ready_status(CXL_ID_2))
+				continue;
+
 			for (uint8_t j = 0; j < ARRAY_SIZE(plat_mctp_port); j++) {
 				if (p->bus != plat_mctp_port[j].conf.smbus_conf.bus)
 					continue;


### PR DESCRIPTION
# Description:
Check CXLs ready status before setting EIDs.

# Motivation:
If we send command to CXL before it is ready, the CXL FW will work abnormally.

# Test Plan:
Build code - Pass
Tested on yv4 system - Pass