### PR TITLE
fby35: ji: Fix threshold table

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sdr_table.c
@@ -741,7 +741,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x13, // [7:0] M bits
+		0x06, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -754,10 +754,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x12, // UCT
+		0x39, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x10, // LCT
+		0x34, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold


### PR DESCRIPTION
Summary:
- Fix threshold value of sensor 0x13.

TestPlan:
- BuildCode: PASS
- Check threshold value: PASS

Log:
- BMC log:
  ```
  root@bmc-oob:~# sensor-util slot1 -t 0x13
  slot1:
  MB_ADC_P3V3_STBY_VOLT_V      (0x13) :   3.344 Volts | (ok) | UCR: 3.420 | UNC: NA | UNR: NA | LCR: 3.120 | LNC: NA | LNR: NA
  ```