### PR TITLE
op2: op: Fix retimer recovery function

### DIFF
--- a/meta-facebook/op2-op/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/op2-op/src/ipmi/plat_ipmi.c
@@ -281,7 +281,7 @@ void OEM_1S_FW_UPDATE(ipmi_msg *msg)
 			return;
 		}
 
-		i2c_msg.bus = I2C_BUS8;
+		i2c_msg.bus = I2C_BUS9;
 		i2c_msg.target_addr = EXPA_RETIMER_EEPROM_ADDR;
 
 		pre_retimer_eeprom_recover();

--- a/meta-facebook/op2-op/src/platform/plat_hook.c
+++ b/meta-facebook/op2-op/src/platform/plat_hook.c
@@ -365,20 +365,20 @@ bool pre_retimer_read(sensor_cfg *cfg, void *args)
 
 void pre_retimer_eeprom_recover()
 {
-	if (gpio_get(OPA_SMB_PCIE_EXP1_ALERT_N) == GPIO_HIGH) {
-		gpio_set(OPA_SMB_PCIE_EXP1_ALERT_N, GPIO_LOW);
+	if (gpio_get(SELECT_SMB_MUX_N) == GPIO_LOW) {
+		gpio_set(SELECT_SMB_MUX_N, GPIO_HIGH);
 	}
-	if (gpio_get(OPA_LED_E1S_2_ATTN_R) == GPIO_LOW) {
-		gpio_set(OPA_LED_E1S_2_ATTN_R, GPIO_HIGH);
+	if (gpio_get(SMB_LS_MUX_EN) == GPIO_LOW) {
+		gpio_set(SMB_LS_MUX_EN, GPIO_HIGH);
 	}
 }
 
 void post_retimer_eeprom_recover()
 {
-	if (gpio_get(OPA_SMB_PCIE_EXP1_ALERT_N) == GPIO_LOW) {
-		gpio_set(OPA_SMB_PCIE_EXP1_ALERT_N, GPIO_HIGH);
+	if (gpio_get(SELECT_SMB_MUX_N) == GPIO_HIGH) {
+		gpio_set(SELECT_SMB_MUX_N, GPIO_LOW);
 	}
-	if (gpio_get(OPA_LED_E1S_2_ATTN_R) == GPIO_HIGH) {
-		gpio_set(OPA_LED_E1S_2_ATTN_R, GPIO_LOW);
+	if (gpio_get(SMB_LS_MUX_EN) == GPIO_HIGH) {
+		gpio_set(SMB_LS_MUX_EN, GPIO_LOW);
 	}
 }


### PR DESCRIPTION
# Description
- Correct the i2c bus of retimer EEPROM and control the correct GPIO.

# Motivation
- Before we write the EEPROM we need to set the GPIO (SELECT_SMB_MUX_N) to switch the i2c MUX in front of the EEPROM.
That BIC can access the retimer EEPROM.
After we implemented the function of retimer recovery, we test on the DVT rework board. That definition of i2c bus and GPIO is different from the PVT board because it’s reworked for the test. However, we forgot to correct the i2c bus and GPIO settings when we submitted the BIC code.

# Test plan
- Build code: Pass
- Recovery retimer: Pass

# Log
root@bmc-oob:~# fw-util slot1 --version 1ou_retimer 1OU Retimer Version: Astera Labs v0_0_0

root@bmc-oob:~# fw-util slot1 --update 1ou_retimer_rcvy pt516_x2x2x2x2x2x2x2x2_normal_uspp_p5_HOT_PLUG-X2-TX_DCC_RANGE-ICC0SA_ACS-1093_Exp1_v2_8_14.bin Checking if the server is ready...
slot_id: 1, comp: 3a, intf: 0, img: pt516_x2x2x2x2x2x2x2x2_normal_uspp_p5_HOT_PLUG-X2-TX_DCC_RANGE-ICC0SA_ACS-1093_Exp1_v2_8_14.bin, force: 0 updated retimer: 100 %
Elapsed time:  45   sec.

Power-cycling the server...
Upgrade of slot1 : 1ou_retimer_rcvy succeeded

root@bmc-oob:~# fw-util slot1 --version 1ou_retimer 1OU Retimer Version: Astera Labs v2_8_3584