### PR TITLE
yv4: sd: Send BIOS SEL to BMC

### DIFF
--- a/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
@@ -41,6 +41,17 @@ LOG_MODULE_REGISTER(plat_ipmi);
 
 bool pal_request_msg_to_BIC_from_HOST(uint8_t netfn, uint8_t cmd)
 {
+	if (netfn == NETFN_STORAGE_REQ) {
+		if (cmd == CMD_STORAGE_ADD_SEL) {
+			return false;
+		}
+	}
+
+	if (netfn == NETFN_APP_REQ) {
+		if (cmd == CMD_APP_SET_SYS_INFO_PARAMS) {
+			return false;
+		}
+	}
 	// In YV4, all IPMI commands are all sent to BIC
 	return true;
 }


### PR DESCRIPTION
# Description:
The commit 7c2240a534cbf11bfab15de9a42c1b674fb80700 blocked all IPMI commands in BIC. Added add SEL command to list in order to send SEL to BMC.

# Motivation:
The BIOS SEL should be able to send to BMC.

# Test Plan:
Build code - Pass
Tested on YV4 system - Pass