### PR TITLE
Artemis: ACB: Check the module present before check power fault

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_dev.c
+++ b/meta-facebook/at-cb/src/platform/plat_dev.c
@@ -396,31 +396,37 @@ void sw_heartbeat_read()
 
 		// Check ACCL power fault
 		for (index = 0; index < ASIC_CARD_COUNT; ++index) {
-			if (accl_cable_power_fault[index] != true) {
-				ret = is_accl_cable_power_good_fault(index);
-				if (ret != false) {
-					plat_accl_cable_power_good_fail_event(
-						index, PLDM_STATE_SET_OEM_DEVICE_POWER_GOOD_FAULT);
-					accl_cable_power_fault[index] = true;
-					continue;
-				}
-
-				result = get_cpld_register(asic_card_info[index].power_fault_reg,
-							   &val);
-				if (ret != 0) {
-					LOG_ERR("Failed to get power fault register, card id: 0x%x, reg: 0x%x",
-						index, asic_card_info[index].power_fault_reg);
-					continue;
-				}
-
-				for (pwr_fault_index = 0;
-				     pwr_fault_index < ARRAY_SIZE(power_fault_info);
-				     ++pwr_fault_index) {
-					if (val & power_fault_info[pwr_fault_index].check_bit) {
-						plat_accl_power_good_fail_event(
-							index, power_fault_info[pwr_fault_index]
-								       .power_fault_state);
+			if (asic_card_info[index].card_status == ASIC_CARD_PRESENT) {
+				if (accl_cable_power_fault[index] != true) {
+					ret = is_accl_cable_power_good_fault(index);
+					if (ret != false) {
+						plat_accl_cable_power_good_fail_event(
+							index,
+							PLDM_STATE_SET_OEM_DEVICE_POWER_GOOD_FAULT);
 						accl_cable_power_fault[index] = true;
+						continue;
+					}
+
+					result = get_cpld_register(
+						asic_card_info[index].power_fault_reg, &val);
+					if (ret != 0) {
+						LOG_ERR("Failed to get power fault register, card id: 0x%x, reg: 0x%x",
+							index,
+							asic_card_info[index].power_fault_reg);
+						continue;
+					}
+
+					for (pwr_fault_index = 0;
+					     pwr_fault_index < ARRAY_SIZE(power_fault_info);
+					     ++pwr_fault_index) {
+						if (val &
+						    power_fault_info[pwr_fault_index].check_bit) {
+							plat_accl_power_good_fail_event(
+								index,
+								power_fault_info[pwr_fault_index]
+									.power_fault_state);
+							accl_cable_power_fault[index] = true;
+						}
 					}
 				}
 			}

--- a/meta-facebook/at-cb/src/platform/plat_isr.c
+++ b/meta-facebook/at-cb/src/platform/plat_isr.c
@@ -430,6 +430,10 @@ void check_accl_card_pwr_good_work_handler()
 	};
 
 	for (card_id = 0; card_id < ARRAY_SIZE(asic_card_info); ++card_id) {
+		if (asic_card_info[card_id].card_status == ASIC_CARD_NOT_PRESENT) {
+			continue;
+		}
+
 		if (is_accl_cable_power_good_timeout(card_id)) {
 			plat_accl_cable_power_good_fail_event(
 				card_id, PLDM_STATE_SET_OEM_DEVICE_NO_POWER_GOOD);


### PR DESCRIPTION
# Description:
 - Currently, ASIC Power Fault will be triggered by module not present.

# Motivation:
 - As title.

# Test Plan:
 - ASIC Power Fault will not be logged while ASIC is not present  - pass