### PR TITLE
yv4: sd: add check mctp smbus read len

### DIFF
--- a/common/service/mctp/mctp_smbus.c
+++ b/common/service/mctp/mctp_smbus.c
@@ -139,6 +139,10 @@ static uint16_t mctp_smbus_read(void *mctp_p, uint8_t *buf, uint32_t len,
 		LOG_ERR("i2c_target_read fail, ret %d", ret);
 		return 0;
 	}
+	if (rlen < sizeof(smbus_hdr)) {
+		LOG_ERR("recv invalid len %d", rlen);
+		return 0;
+	}
 
 	/**
    * Since the i2c driver provided by ASPEED may read redundant duplicates data,


### PR DESCRIPTION
Description:
- When BMC only write 1 data through i2c to BIC, BIC will hang
- BIC hang caused by memcpy incorrect length to buf (memory overflow)

Motivation:
- BIC shouldn't hang even if receive invalid length data

Test Plan:
- Build code: Pass
- BMC write only 1 data to BIC through i2c bus
- Test with BMC reboot

Test Log:
type command to test slot3 in BMC console:
i2ctransfer -y -f 2 w1@0x20 0x01

Or reboot BMC, it will write only 1 data to BIC through i2c bus [00:02:37.952,000] <wrn> hal_i2c_target: Data not ready [00:02:37.953,000] <err> mctp: recv invalid len 1
[00:02:37.953,000] <wrn> hal_i2c_target: Data not ready [00:02:37.954,000] <wrn> hal_i2c_target: Data not ready [00:02:37.954,000] <wrn> hal_i2c_target: Data not ready [00:02:37.954,000] <wrn> hal_i2c_target: Data not ready [00:02:37.954,000] <err> mctp: recv invalid len 1
[00:02:37.954,000] <wrn> hal_i2c_target: Data not ready [00:02:37.954,000] <wrn> hal_i2c_target: Data not ready [00:02:37.955,000] <wrn> hal_i2c_target: Data not ready [00:02:37.955,000] <wrn> hal_i2c_target: Data not ready [00:02:37.955,000] <wrn> hal_i2c_target: Data not ready [00:02:37.956,000] <err> mctp: recv invalid len 1
[00:02:37.957,000] <err> mctp: recv invalid len 1
[00:02:37.958,000] <err> mctp: recv invalid len 1