### PR TITLE
fby35: ji: Adjust fio temp sensor reading

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_hook.c
@@ -37,6 +37,7 @@
 #define ADJUST_MP5990_POWER(x) (x * 1) // temporary set
 #define ADJUST_RS31380R_CURRENT(x) (x * 1) // temporary set
 #define ADJUST_RS31380R_POWER(x) (x * 1) // temporary set
+#define ADJUST_TMP75_TEMP(x) (x + 1.6)
 
 LOG_MODULE_REGISTER(plat_hook);
 
@@ -260,6 +261,23 @@ bool pre_tmp75_read(sensor_cfg *cfg, void *args)
 	}
 
 	return false;
+}
+
+bool post_tmp75_read(sensor_cfg *cfg, void *args, int *reading)
+{
+	ARG_UNUSED(args);
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	if (!reading) {
+		return check_reading_pointer_null_is_allowed(cfg);
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	float val = sval->integer + (sval->fraction * 0.001);
+	val = ADJUST_TMP75_TEMP(val);
+	sval->integer = (int16_t)val;
+	sval->fraction = (val - sval->integer) * 1000;
+
+	return true;
 }
 
 bool pre_pt4080l_read(sensor_cfg *cfg, void *args)

--- a/meta-facebook/yv35-ji/src/platform/plat_hook.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_hook.h
@@ -50,6 +50,7 @@ bool post_rs31380r_cur_read(sensor_cfg *cfg, void *args, int *reading);
 bool post_rs31380r_pwr_read(sensor_cfg *cfg, void *args, int *reading);
 bool pre_tmp451_read(sensor_cfg *cfg, void *args);
 bool pre_tmp75_read(sensor_cfg *cfg, void *args);
+bool post_tmp75_read(sensor_cfg *cfg, void *args, int *reading);
 bool pre_pt4080l_read(sensor_cfg *cfg, void *args);
 bool pre_ds160pt801_read(sensor_cfg *cfg, void *args);
 

--- a/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
@@ -126,7 +126,7 @@ sensor_cfg plat_sensor_config[] = {
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_TEMP_TMP75_FIO, sensor_dev_tmp75, I2C_BUS2, TMP75_ADDR, TMP75_TEMP_OFFSET,
 	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, pre_tmp75_read, &mux_conf_addr_0xe2[0], NULL, NULL, NULL },
+	  SENSOR_INIT_STATUS, pre_tmp75_read, &mux_conf_addr_0xe2[0], post_tmp75_read, NULL, NULL },
 
 #ifdef ENABLE_NVIDIA
 	/* SatMC */


### PR DESCRIPTION
Summary:
- Adjust FIO tmp75 sensor reading by adding 1.6 offset.

TestPlan:
- BuildCode: PASS
- Get sensor reading: PASS
