### PR TITLE
fby4: sd: Change GPIO initialize sequence

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -47,6 +47,7 @@ SCU_CFG scu_cfg[] = {
 
 void pal_pre_init()
 {
+	gpio_init(NULL);
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
 	aspeed_print_sysrst_info();
 
@@ -118,7 +119,3 @@ void pal_set_sys_status()
 	}
 }
 
-#define DEF_PROJ_GPIO_PRIORITY 78
-
-DEVICE_DEFINE(PRE_DEF_PROJ_GPIO, "PRE_DEF_PROJ_GPIO_NAME", &gpio_init, NULL, NULL, NULL,
-	      POST_KERNEL, DEF_PROJ_GPIO_PRIORITY, NULL);


### PR DESCRIPTION
# Description
- Change GPIO initialize sequence after I2C is initialized.

# Motivation
- We read the CPLD register through I2C to get board revision. If the board revision is POC or EVT, load the EVT GPIO table. However, the sequence of GPIO initialization is too early, i2c doesn't initialization finished and can't get the correct board revision. That causes loading the wrong table on DVT system.

# Test plan
- Build code: Pass
- Get GPIO list: Pass

# Log
1. Get GPIO list on DVT board. uart:~$ platform gpio list_all
[0  ] FM_CPU_BIC_SLP_S5_N                : OD  | input (I) | 1(1)
[1  ] FM_CPU_BIC_SLP_S3_N                : OD  | input (I) | 1(1)
[2  ] RST_RSMRST_BMC_N                   : OD  | input (I) | 1(1)
[3  ] PWRGD_CPU_LVC3                     : OD  | input (I) | 1(1)
[4  ] CPU_SMERR_BIC_N                    : OD  | input (I) | 1(1)
[5  ] BMC_READY                          : PP  | output(O) | 1(1)
[6  ] RST_CPU_RESET_BIC_N                : OD  | input (I) | 1(1)
[7  ] RST_USB_HUB_R_N                    : PP  | output(O) | 1(1)
[8  ] AUTH_PRSNT_BIC_N                   : OD  | input (I) | 1(1)
[9  ] BIC_CPU_NMI_N                      : OD  | output(I) | 1(1)
[10 ] FM_SMI_ACTIVE_N                    : OD  | output(O) | 0(0)
[11 ] IRQ_BIC_CPU_SMI_N                  : OD  | output(O) | 0(0)
[12 ] FM_CPU_BIC_THERMTRIP_N             : OD  | input (I) | 1(1)
[13 ] APML_CPU_ALERT_BIC_N               : OD  | input (I) | 1(1)
[14 ] PRSNT_CPU_R_N                      : OD  | input (I) | 0(0)
[15 ] SYS_PWRBTN_BIC_N                   : OD  | input (I) | 1(1)
[16 ] PVDDCR_CPU0_PMALERT_N              : OD  | input (I) | 1(1)
[17 ] FM_HSC_TIMER_ALT_N                 : OD  | input (I) | 1(1)
[18 ] SMB_RTM1_INA233_ALRT_N             : OD  | input (I) | 0(0)
[19 ] PVDDCR_CPU1_PMALERT_N              : OD  | input (I) | 1(1)
[20 ] PWRBTN_N                           : OD  | input (I) | 1(1)
[21 ] RST_BMC_R_N                        : OD  | output(I) | 1(1)
[22 ] HDT_BIC_DBREQ_R_N                  : OD  | output(I) | 1(1)
[23 ] BIC_READY_R                        : PP  | output(O) | 1(1)
[24 ] FM_SOL_UART_CH_SEL_R               : PP  | output(O) | 0(0)
[25 ] SMB_RTM2_INA233_ALRT_N             : OD  | input (I) | 0(0)
[26 ] FAST_PROCHOT_N                     : OD  | input (I) | 1(1)
[27 ] BIC_JTAG_SEL_R                     : PP  | output(O) | 0(0)
[28 ] FM_CPU_BIC_PROCHOT_LVT3_N          : OD  | input (I) | 1(1)
[29 ] SMB_E1S_0_RST_R_N                  : PP  | output(O) | 1(1)
[30 ] SMB_E1S_1_RST_R_N                  : PP  | output(O) | 1(1)
[31 ] SMB_E1S_0_INA233_ALRT_N            : OD  | input (I) | 1(1)
[32 ] FM_BIOS_MRC_DEBUG_MSG_DIS          : OD  | output(I) | 1(1)
[33 ] SMB_SENSOR_LVC3_ALERT_N            : OD  | input (I) | 1(1)
[34 ] FM_BIOS_POST_CMPLT_BIC_N           : OD  | input (I) | 0(0)
[35 ] IRQ_UV_DETECT_N                    : OD  | input (I) | 1(1)
[36 ] PVDDCR_CPU0_OCP_N                  : OD  | input (I) | 1(1)
[37 ] PVDDCR_CPU1_OCP_N                  : OD  | input (I) | 1(1)
[38 ] P3V_BAT_SCALED_R_EN                : PP  | output(O) | 0(0)
[39 ] HDT_BIC_TRST_R_N                   : OD  | output(I) | 1(1)
[40 ] CARD_TYPE_EXP                      : OD  | input (I) | 0(0)
[41 ] CPU_ERROR_BIC_LVC3_R_N             : OD  | input (I) | 1(1)
[42 ] PVDD11_S3_PMALERT_N                : OD  | input (I) | 1(1)
[43 ] BIC_READY_FRONT_EXP                : OD  | input (I) | 0(0)
[44 ] CPU_TYPE0                          : OD  | input (I) | 1(1)
[45 ] FM_BMC_DEBUG_ENABLE_R_N            : OD  | output(I) | 1(1)
[46 ] FM_DBP_PRESENT_N                   : OD  | input (I) | 1(1)
[47 ] FM_FAST_PROCHOT_R_EN_N             : PP  | output(O) | 1(1)
[48 ] IO_EXP_ALERT                       : OD  | input (I) | 1(1)
[49 ] FM_CPLD_BMC_BIC_READY              : OD  | input (I) | 1(1)
[50 ] BIC_JTAG_MUX_SEL                   : PP  | output(O) | 1(1)
[51 ] RST_PLTRST_BIC_N                   : OD  | input (I) | 1(1)
[52 ] CPU_BIC_RTC_GET_N                  : OD  | input (I) | 1(1)
[53 ] AUTH_COMPLETE                      : OD  | input (I) | 0(0)
[54 ] P3V3_STBY_SIDECAR_FAULT_N          : OD  | input (I) | 1(1)
[55 ] BIC_READY_TOP_EXP                  : OD  | input (I) | 0(0)
[56 ] PRSNT_CEM_CONN                     : OD  | input (I) | 1(1)
[57 ] TOP_CXL_SMBUS_ALERT_N              : OD  | input (I) | 0(0)
[58 ] FRONT_CXL_SMBUS_ALERT_N            : OD  | input (I) | 1(1)
[59 ] P1V2_STBY_SIDECAR_FAULT_N          : OD  | input (I) | 1(1)
[76 ] RTM2_INT_N                         : OD  | input (I) | 1(1)
[77 ] RTM_IOEXP_INT_N                    : OD  | input (I) | 1(1)
[90 ] PWRGD_HSC_SLOT_BIC                 : OD  | input (I) | 1(1)
[91 ] SIDECAR_PRESENT_BIC_N              : OD  | input (I) | 0(0)
[92 ] SMB_E1S_1_INA233_ALRT_N            : OD  | input (I) | 1(1)
[93 ] VR_TYPE_0                          : PP  | input (I) | 1(1)
[94 ] VR_TYPE_1                          : PP  | input (I) | 1(1)
[95 ] RTM_TYPE_0                         : PP  | input (I) | 1(1)
[97 ] RTM_TYPE_1                         : PP  | input (I) | 0(0)
[99 ] BIC_ESPI_SELECT                    : PP  | input (I) | 0(0)

2. Get GPIO list on EVT board. uart:~$ platform gpio list_all
[0  ] FM_CPU_BIC_SLP_S5_N                : OD  | input (I) | 0(0)
[1  ] FM_CPU_BIC_SLP_S3_N                : OD  | input (I) | 0(0)
[2  ] RST_RSMRST_BMC_N                   : OD  | input (I) | 1(1)
[3  ] PWRGD_CPU_LVC3                     : OD  | input (I) | 0(0)
[4  ] CPU_SMERR_BIC_N                    : OD  | input (I) | 1(1)
[5  ] BMC_READY                          : PP  | output(O) | 1(1)
[6  ] RST_CPU_RESET_BIC_N                : OD  | input (I) | 0(0)
[7  ] RST_USB_HUB_R_N                    : PP  | output(O) | 1(1)
[8  ] AUTH_PRSNT_BIC_N                   : OD  | input (I) | 1(1)
[9  ] BIC_CPU_NMI_N                      : OD  | output(I) | 1(1)
[10 ] FM_SMI_ACTIVE_N                    : OD  | output(O) | 0(0)
[11 ] IRQ_BIC_CPU_SMI_N                  : OD  | output(O) | 0(0)
[12 ] FM_CPU_BIC_THERMTRIP_N             : OD  | input (I) | 1(1)
[13 ] APML_CPU_ALERT_BIC_N               : OD  | input (I) | 1(1)
[14 ] PRSNT_CPU_R_N                      : OD  | input (I) | 0(0)
[15 ] SYS_PWRBTN_BIC_N                   : OD  | input (I) | 1(1)
[16 ] PVDDCR_CPU0_PMALERT_N              : OD  | input (I) | 1(1)
[17 ] FM_HSC_TIMER_ALT_N                 : OD  | input (I) | 1(1)
[18 ] EXAMAX_RESERVED_1                  : OD  | input (I) | 0(0)
[19 ] PVDDCR_CPU1_PMALERT_N              : OD  | input (I) | 1(1)
[20 ] PWRBTN_N                           : OD  | input (I) | 1(1)
[21 ] RST_BMC_R_N                        : OD  | output(I) | 1(1)
[22 ] HDT_BIC_DBREQ_R_N                  : OD  | output(I) | 1(1)
[23 ] BIC_READY_R                        : PP  | output(O) | 1(1)
[24 ] FM_SOL_UART_CH_SEL_R               : PP  | output(O) | 0(0)
[25 ] EXAMAX_RESERVED_2                  : OD  | input (I) | 0(0)
[26 ] FAST_PROCHOT_N                     : OD  | input (I) | 1(1)
[27 ] BIC_JTAG_SEL_R                     : PP  | output(O) | 0(0)
[28 ] FM_CPU_BIC_PROCHOT_LVT3_N          : OD  | input (I) | 1(1)
[29 ] SMB_E1S_0_RST_R_N                  : PP  | output(O) | 1(1)
[30 ] SMB_E1S_1_RST_R_N                  : PP  | output(O) | 1(1)
[31 ] SMB_E1S_0_INA233_ALRT_N            : OD  | input (I) | 1(1)
[32 ] FM_BIOS_MRC_DEBUG_MSG_DIS          : OD  | output(I) | 1(1)
[33 ] SMB_SENSOR_LVC3_ALERT_N            : OD  | input (I) | 1(1)
[34 ] FM_BIOS_POST_CMPLT_BIC_N           : OD  | input (I) | 1(1)
[35 ] IRQ_UV_DETECT_N                    : OD  | input (I) | 1(1)
[36 ] PVDDCR_CPU0_OCP_N                  : OD  | input (I) | 1(1)
[37 ] PVDDCR_CPU1_OCP_N                  : OD  | input (I) | 1(1)
[38 ] P3V_BAT_SCALED_R_EN                : PP  | output(O) | 0(0)
[39 ] HDT_BIC_TRST_R_N                   : OD  | output(I) | 1(1)
[40 ] CARD_TYPE_EXP                      : OD  | input (I) | 0(0)
[41 ] CPU_ERROR_BIC_LVC3_R_N             : OD  | input (I) | 1(1)
[42 ] PVDD11_S3_PMALERT_N                : OD  | input (I) | 1(1)
[43 ] EXAMAX_RESERVED_4                  : OD  | input (I) | 0(0)
[44 ] CPU_TYPE0                          : OD  | input (I) | 0(0)
[45 ] FM_BMC_DEBUG_ENABLE_R_N            : OD  | output(I) | 1(1)
[46 ] FM_DBP_PRESENT_N                   : OD  | input (I) | 1(1)
[47 ] FM_FAST_PROCHOT_R_EN_N             : PP  | output(O) | 1(1)
[48 ] IO_EXP_ALERT                       : OD  | input (I) | 1(1)
[49 ] FM_CPLD_BMC_BIC_READY              : OD  | input (I) | 1(1)
[50 ] BIC_JTAG_MUX_SEL                   : PP  | output(O) | 1(1)
[51 ] RST_PLTRST_BIC_N                   : OD  | input (I) | 0(0)
[52 ] CPU_TYPE1                          : OD  | input (I) | 0(0)
[53 ] RTM_IOEXP_INT_N                    : OD  | input (I) | 0(0)
[54 ] P3V3_STBY_SIDECAR_FAULT_N          : OD  | input (I) | 1(1)
[55 ] EXAMAX_RESERVED_3                  : OD  | input (I) | 0(0)
[56 ] PRSNT_CEM_CONN                     : OD  | input (I) | 1(1)
[57 ] TOP_CXL_SMBUS_ALERT_N              : OD  | input (I) | 0(0)
[58 ] FRONT_CXL_SMBUS_ALERT_N            : OD  | input (I) | 1(1)
[59 ] P1V2_STBY_SIDECAR_FAULT_N          : OD  | input (I) | 1(1)
[72 ] AUTH_COMPLETE                      : OD  | input (I) | 0(0)
[73 ] BIC_READY_TOP_EXP                  : OD  | input (I) | 1(1)
[74 ] RTM2_IOEXP_INT_N                   : OD  | input (I) | 0(0)
[76 ] BIC_READY_FRONT_EXP                : OD  | input (I) | 1(1)
[77 ] CPU_BIC_RTC_GET_N                  : OD  | input (I) | 1(1)
[78 ] SMB_RTM1_INA233_ALRT_N             : OD  | input (I) | 1(1)
[79 ] SMB_RTM2_INA233_ALRT_N             : OD  | input (I) | 1(1)
[90 ] PWRGD_HSC_SLOT_BIC                 : OD  | input (I) | 1(1)
[91 ] SIDECAR_PRESENT_BIC_N              : OD  | input (I) | 0(0)
[92 ] SMB_E1S_1_INA233_ALRT_N            : OD  | input (I) | 1(1)
[93 ] VR_TYPE_0                          : PP  | input (I) | 0(0)
[94 ] VR_TYPE_1                          : PP  | input (I) | 0(0)
[95 ] RTM_TYPE_0                         : PP  | input (I) | 0(0)
[97 ] RTM_TYPE_1                         : PP  | input (I) | 0(0)
[98 ] MEDUSA_HSC_R_PG                    : OD  | input (I) | 0(0)