### PR TITLE
yv4: wf: Ensure WF BIC can access to VR, despite CXL not ready

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
@@ -591,6 +591,8 @@ void cxl1_ready_handler()
 	}
 	LOG_ERR("Failed to read %s due to sensor_sample_fetch failed, ret: %d",
 		CXL1_HEART_BEAT_LABEL, heartbeat_status);
+	switch_mux_to_bic(IOE_SWITCH_CXL1_VR_TO_BIC);
+	set_cxl_vr_access(CXL_ID_1, true);
 	return;
 }
 
@@ -622,6 +624,8 @@ void cxl2_ready_handler()
 	}
 	LOG_ERR("Failed to read %s due to sensor_sample_fetch failed, ret: %d",
 		CXL2_HEART_BEAT_LABEL, heartbeat_status);
+	switch_mux_to_bic(IOE_SWITCH_CXL2_VR_TO_BIC);
+	set_cxl_vr_access(CXL_ID_2, true);
 	return;
 }
 


### PR DESCRIPTION
# Description:
- Regardless of whether CXL is ready within the expected time at WF BIC switch the MUX connected to VR back to the WF BIC.

# Motivation:
- CXL may not be ready within the expected time frame at WF BIC causing the MUX to remain directed to CXL and preventing WF BIC from reading the VR version.

# Test Plan:
Build code - Pass
Tested on yv4 system - Pass