### PR TITLE
common: modify the hal_wdt to support npcm400f

### DIFF
--- a/common/hal/hal_wdt.h
+++ b/common/hal/hal_wdt.h
@@ -17,7 +17,13 @@
 #ifndef HAL_WDT_H
 #define HAL_WDT_H
 
+#if defined(CONFIG_WDT_ASPEED)
 #define WDT_DEVICE_NAME "wdt2"
+#elif (CONFIG_WDT_NPCM4XX)
+#define WDT_DEVICE_NAME "TWD_0"
+#else /* defined(CONFIG_WDT_ASPEED) */
+#endif /* defined(CONFIG_WDT_ASPEED) */
+
 #define WDT_TIMEOUT (15 * 1000) // 15s
 #define WDT_FEED_DELAY_MS (10 * 1000) // 10s
 


### PR DESCRIPTION
Summary:
- modify the hal_wdt to support npcm400f

Description:
- The label name for the watchdog device on the npcm400f is "TWD_0", which differs from the label name "wdt2" used on the ast1030. 

Test Plan:
- Build code: PASS
- npcm400f wdt test: PASS