### PR TITLE
op2:op: Send event log when Exp CLOCK data write failed

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_class.c
+++ b/meta-facebook/op2-op/src/platform/plat_class.c
@@ -26,6 +26,8 @@
 #include "rg3mxxb12.h"
 #include "p3h284x.h"
 #include "m88rt51632.h"
+#include "plat_util.h"
+#include "libipmi.h"
 
 LOG_MODULE_REGISTER(plat_class);
 
@@ -205,7 +207,12 @@ void set_clock_buffer_bypass_mode()
 
 		if (i2c_master_write(&msg, retry) != 0) {
 			LOG_ERR("Failed to set Exp A clock buffer to bypass mode!");
+			// send event log to BMC
+			send_system_status_event(IPMI_OEM_EVENT_TYPE_NOTIFY,IPMI_EVENT_OFFSET_SYS_EXPA_CLOCK_BUFFER,0);
+
 			return;
 		}
 	}
+
+	return;
 }

--- a/meta-facebook/op2-op/src/platform/plat_util.h
+++ b/meta-facebook/op2-op/src/platform/plat_util.h
@@ -24,6 +24,7 @@
 #define IPMI_EVENT_OFFSET_SYS_E1S_P12V_FAULT 0x83
 #define IPMI_EVENT_OFFSET_SYS_E1S_P3V3_FAULT 0x84
 #define IPMI_EVENT_OFFSET_SYS_INA233_ALERT 0x86
+#define IPMI_EVENT_OFFSET_SYS_EXPA_CLOCK_BUFFER 0x88
 
 void send_system_status_event(uint8_t event_type, uint8_t error_type, uint8_t device_index);
 


### PR DESCRIPTION
# Description:
 When write ExpA CLOCK buffer register to bypass mode fail, send event log to BMC.

# Motivation:
 let BMC can receive this event.

# Test Plan:
 1. Build and test pass on OLP2.0 system pass.
 2. check event log in BMC when write ExpA CLOCK buffer register to bypass mode fail.

# Log:
 When ExpA CLOCK buffer register to bypass mode fail check BMC logs below
 root@bmc-oob:~# cat /var/log/messages | grep CLOCK
 2024 Jun  6 03:34:43 bmc-oob. user.crit greatlakes-v2024.23.e1: ipmid: SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2024-06-06 03:34:43, Sensor: SYSTEM_STATUS (0x10), Event Data: (880000) 1OU BIC set the CLOCK buffer register data failed Triggered
 2024 Jun  6 03:35:53 bmc-oob. user.crit greatlakes-v2024.23.e1: ipmid: SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2024-06-06 03:35:53, Sensor: SYSTEM_STATUS (0x10), Event Data: (880200) 3OU BIC set the CLOCK buffer register data failed Triggered