### PR TITLE
fby4: sd: Add timeout in pldm update mode

### DIFF
--- a/common/lib/util_spi.c
+++ b/common/lib/util_spi.c
@@ -282,6 +282,7 @@ uint8_t fw_update(uint32_t offset, uint16_t msg_len, uint8_t *msg_buf, uint8_t f
 	if (offset == 0) {
 		// Set default fw update retry count at first package
 		fw_update_retry = default_retry_count;
+		is_init = 0;
 	}
 
 	if (!is_init) {


### PR DESCRIPTION
# Description:
According to PLDM SPEC DSP0267_1.3.0 7.12 Timing Specification, The FD shall exit from update mode if no command is recieved from the Update Agent when it's expeced, during the firmware update process. (timeout MIN 60 seconds, MAX 120 seconds)

# Motivation:
To fix BIC is stalled in update mode.

# Test Plan:
1. Build and test pass on YV4 system. pass.

2. Check BIC update and pretent the BIC is stalled in update mode. root@bmc:~# ./fw-util slot7 --update sd_bic pldm_sd_v2024.25.e1.bin Updating sd_bic in slot7 with image pldm_sd_v2024.25.e1.bin Restart MCTP and PLDM service
└─ /xyz
  └─ /xyz/openbmc_project
    └─ /xyz/openbmc_project/mctp
      └─ /xyz/openbmc_project/mctp/1
        ├─ /xyz/openbmc_project/mctp/1/20
        ├─ /xyz/openbmc_project/mctp/1/22
        ├─ /xyz/openbmc_project/mctp/1/24
        ├─ /xyz/openbmc_project/mctp/1/30
        ├─ /xyz/openbmc_project/mctp/1/32
        ├─ /xyz/openbmc_project/mctp/1/34
        ├─ /xyz/openbmc_project/mctp/1/35
        ├─ /xyz/openbmc_project/mctp/1/40
        ├─ /xyz/openbmc_project/mctp/1/42
        ├─ /xyz/openbmc_project/mctp/1/44
        ├─ /xyz/openbmc_project/mctp/1/45
        ├─ /xyz/openbmc_project/mctp/1/50
        ├─ /xyz/openbmc_project/mctp/1/52
        ├─ /xyz/openbmc_project/mctp/1/60
        ├─ /xyz/openbmc_project/mctp/1/62
        ├─ /xyz/openbmc_project/mctp/1/70
        ├─ /xyz/openbmc_project/mctp/1/72
        ├─ /xyz/openbmc_project/mctp/1/75
        ├─ /xyz/openbmc_project/mctp/1/8
        ├─ /xyz/openbmc_project/mctp/1/80
        ├─ /xyz/openbmc_project/mctp/1/82
        ├─ /xyz/openbmc_project/mctp/1/90
        └─ /xyz/openbmc_project/mctp/1/91
Start to Update PLDM component
Generating software ID...
software_id = 3207297738
^Citing for updating... 5 sec
root@bmc:~# systemctl stop pldmd
(reverse-i-search)`pldm': systemctl stop ^Cdmd
root@bmc:~# pldmtool fw_update GetStatus -m 70
{
    "CurrentState": "DOWNLOAD",
    "PreviousState": "READY XFER",
    "AuxState": "Operation Failed",
    "AuxStateStatus": "Generic Error has occured",
    "ProgressPercent": 101,
    "ReasonCode": "Initialization of firmware device has occurred",
    "UpdateOptionFlagsEnabled": 0
}
root@bmc:~# pldmtool fw_update GetStatus -m 70
{
    "CurrentState": "IDLE",
    "PreviousState": "DOWNLOAD",
    "AuxState": "Not applicable in current state",
    "AuxStateStatus": "AuxState is In Progress or Success",
    "ProgressPercent": 101,
    "ReasonCode": "Initialization of firmware device has occurred",
    "UpdateOptionFlagsEnabled": 0
}
root@bmc:~# ./fw-util slot7 --update sd_bic pldm_sd_v2024.25.e1.bin Updating sd_bic in slot7 with image pldm_sd_v2024.25.e1.bin Restart MCTP and PLDM service
└─ /xyz
  └─ /xyz/openbmc_project
    └─ /xyz/openbmc_project/mctp
      └─ /xyz/openbmc_project/mctp/1
        ├─ /xyz/openbmc_project/mctp/1/20
        ├─ /xyz/openbmc_project/mctp/1/22
        ├─ /xyz/openbmc_project/mctp/1/24
        ├─ /xyz/openbmc_project/mctp/1/30
        ├─ /xyz/openbmc_project/mctp/1/32
        ├─ /xyz/openbmc_project/mctp/1/34
        ├─ /xyz/openbmc_project/mctp/1/35
        ├─ /xyz/openbmc_project/mctp/1/40
        ├─ /xyz/openbmc_project/mctp/1/42
        ├─ /xyz/openbmc_project/mctp/1/44
        ├─ /xyz/openbmc_project/mctp/1/45
        ├─ /xyz/openbmc_project/mctp/1/50
        ├─ /xyz/openbmc_project/mctp/1/52
        ├─ /xyz/openbmc_project/mctp/1/60
        ├─ /xyz/openbmc_project/mctp/1/62
        ├─ /xyz/openbmc_project/mctp/1/70
        ├─ /xyz/openbmc_project/mctp/1/72
        ├─ /xyz/openbmc_project/mctp/1/75
        ├─ /xyz/openbmc_project/mctp/1/8
        ├─ /xyz/openbmc_project/mctp/1/80
        ├─ /xyz/openbmc_project/mctp/1/82
        ├─ /xyz/openbmc_project/mctp/1/90
        └─ /xyz/openbmc_project/mctp/1/91
Start to Update PLDM component
Generating software ID...
software_id = 3207297738
Waiting for updating... 75 sec
Update done.
Delete software id. software id = 3207297738
Done