### PR TITLE
YV4: SD: Fix OEM command to prevent incorrect resopnse

### DIFF
--- a/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
@@ -120,6 +120,11 @@ void OEM_GET_CHASSIS_POSITION(ipmi_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
 
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
 	msg->completion_code = CC_SUCCESS;
 	msg->data_len = 1;
 
@@ -128,6 +133,7 @@ void OEM_GET_CHASSIS_POSITION(ipmi_msg *msg)
 	uint8_t blade_config = BLADE_CONFIG_UNKNOWN;
 	if (get_blade_config(&blade_config) == false) {
 		LOG_ERR("Failed to get the blade configuration");
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
 		return;
 	}
 


### PR DESCRIPTION
# Description:
- Fix OEM command (Get chassis position) to prevent incorrect response.
- Add the input data limit to prevent incorrect command.

# Motivation:
- Fix OEM command to prevent incorrect resopnse.

# Test Plan:
- Build code: Pass
- Get chassis position: Pass

# Log:
uart:~$ platform ipmi raw 0x30 0x7E
BIC self command netfn:0x30 cmd:0x7e response with cc 0x0
00000000: 84                                               |.                |

uart:~$ platform ipmi raw 0x30 0x7E 0x15
BIC self command netfn:0x30 cmd:0x7e response with cc 0xc7