### PR TITLE
fby35: ji: Improve ssif message handle

### DIFF
--- a/common/service/host/ssif.c
+++ b/common/service/host/ssif.c
@@ -43,7 +43,10 @@ LOG_MODULE_REGISTER(ssif);
 #define SSIF_TARGET_MSGQ_SIZE 0x0A
 
 #define SSIF_STATUS_CHECK_PER_MS 100
+
+#ifndef SSIF_TIMEOUT_MS
 #define SSIF_TIMEOUT_MS 5000 // i2c bus drop off maximum time
+#endif
 
 ssif_dev *ssif;
 static uint8_t ssif_channel_cnt = 0;
@@ -408,6 +411,12 @@ static bool ssif_data_handle(ssif_dev *ssif_inst, ssif_action_t action, uint8_t 
 					ipmi_req.buffer.data_len = 2;
 					ipmi_req.buffer.data[0] = 0x00;
 					ipmi_req.buffer.data[1] = 0x00;
+				} else if (((ssif_inst->current_ipmi_msg.buffer.netfn ==
+					     NETFN_OEM_REQ) &&
+					    (ssif_inst->current_ipmi_msg.buffer.cmd ==
+					     CMD_OEM_POST_END))) {
+					pal_bios_post_complete();
+					ipmi_req.buffer.data_len = 0;
 				}
 
 				ipmi_req.buffer.netfn =
@@ -441,11 +450,6 @@ static bool ssif_data_handle(ssif_dev *ssif_inst, ssif_action_t action, uint8_t 
 				if (ret == -1) {
 					LOG_ERR("Record bios fw version fail");
 				}
-			}
-
-			if ((ssif_inst->current_ipmi_msg.buffer.netfn == NETFN_OEM_REQ) &&
-			    (ssif_inst->current_ipmi_msg.buffer.cmd == CMD_OEM_POST_END)) {
-				pal_bios_post_complete();
 			}
 
 			do {

--- a/meta-facebook/yv35-ji/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-ji/src/ipmi/plat_ipmi.c
@@ -50,6 +50,22 @@ bool pal_request_msg_to_BIC_from_HOST(uint8_t netfn, uint8_t cmd)
 	return false;
 }
 
+bool pal_immediate_respond_from_HOST(uint8_t netfn, uint8_t cmd)
+{
+	if (netfn == NETFN_STORAGE_REQ) {
+		if (cmd == CMD_STORAGE_ADD_SEL)
+			return true;
+	} else if (netfn == NETFN_SENSOR_REQ) {
+		if (cmd == CMD_SENSOR_PLATFORM_EVENT)
+			return true;
+	} else if (netfn == NETFN_OEM_REQ) {
+		if (cmd == CMD_OEM_POST_END)
+			return true;
+	}
+
+	return false;
+}
+
 int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
 {
 	CHECK_NULL_ARG_WITH_RETURN(buf, -1);

--- a/meta-facebook/yv35-ji/src/platform/plat_def.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_def.h
@@ -31,4 +31,6 @@
 #define MAX_FWUPDATE_RSP_BUF_SIZE 200 // for pldm fw update max transfer size
 #define BIC_UPDATE_MAX_OFFSET 0x60000
 
+#define SSIF_TIMEOUT_MS 1000
+
 #endif

--- a/meta-facebook/yv35-ji/src/platform/plat_ssif.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_ssif.c
@@ -107,8 +107,7 @@ static void set_rt8848c_config()
 }
 
 K_TIMER_DEFINE(send_cmd_timer, send_cmd_to_dev, NULL);
-
-void pal_bios_post_complete()
+void handle_post_end_handler(struct k_work *work)
 {
 	k_timer_start(&send_cmd_timer, K_MSEC(3000), K_NO_WAIT);
 
@@ -129,4 +128,10 @@ void pal_bios_post_complete()
 	if (modify_sensor_cfg() == false) {
 		LOG_ERR("Failed to modify sensor cfg!");
 	}
+}
+
+K_WORK_DEFINE(handle_post_end_work, handle_post_end_handler);
+void pal_bios_post_complete()
+{
+	k_work_submit(&handle_post_end_work);
 }


### PR DESCRIPTION
Summary:
- Modify ssif timeout from 5sec to 1sec.
- Add post-end command to immediately response list.

TestPlan:
- BuildCode: PASS
- Check post complete status after CPU on: PASS
