### PR TITLE
yv4: sd: Support retimer recovery

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_i2c.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_i2c.h
@@ -27,6 +27,8 @@
 #define I2C_BUS4 3
 #define I2C_BUS5 4
 #define I2C_BUS6 5
+#define I2C_BUS7 6
+#define I2C_BUS8 7
 #define I2C_BUS10 9
 #define I2C_BUS14 13
 


### PR DESCRIPTION
# Description:
Support to recover retimer.
1. Switch the MUX to SD BIC to let BIC can directly write the eeprom to do recovery.
2. Parse the image can write to the correct address.

# Motivation:
To support retimer recovery.

# Test Plan:
1. Build and test pass on YV4 system. pass

2. Recover Astera Labs retimer. pass