### PR TITLE
op2: op: Correct P1V2 and P1V8 access time

### DIFF
--- a/meta-facebook/op2-op/src/platform/plat_sensor_table.c
+++ b/meta-facebook/op2-op/src/platform/plat_sensor_table.c
@@ -121,7 +121,7 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 	  e1s_access, 2, 1, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &adc_expa_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_P1V8_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, dc_access, 1, 1,
+	{ SENSOR_NUM_1OU_P1V8_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT6, NONE, NONE, stby_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_expa_asd_init_args[0] },
 
@@ -129,7 +129,7 @@ sensor_cfg plat_expansion_A_sensor_config[] = {
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_expa_asd_init_args[0] },
 
-	{ SENSOR_NUM_1OU_P1V2_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT8, NONE, NONE, dc_access, 1, 1,
+	{ SENSOR_NUM_1OU_P1V2_ADC_VOLT, sensor_dev_ast_adc, ADC_PORT8, NONE, NONE, stby_access, 1, 1,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  NULL, NULL, NULL, NULL, &adc_expa_asd_init_args[1] },
 


### PR DESCRIPTION
# Description
- Correct the EXP A P1V2 and P1V8 sensor access time.

# Motivation
- EXP A P1V2 and P1V8 is standby sensor.

# Test Plan
1. Get the sensor when normal power is disable. root@bmc-oob:~# sensor-util slot1 | grep "3OU\|4OU"
3OU_BIC_TEMP_C               (0xA0) :  26.000 C     | (ok)
3OU_ADC_P3V3_STBY_VOLT_V     (0xAC) :   3.354 Volts | (ok)
3OU_ADC_P1V8_VOLT_V          (0xAD) :   1.823 Volts | (ok)
3OU_ADC_P1V2_VOLT_V          (0xAF) :   1.201 Volts | (ok)
4OU_BIC_TEMP_C               (0xD0) :  25.000 C     | (ok)
4OU_ADC_P3V3_STBY_VOLT_V     (0xDC) :   3.310 Volts | (ok)
4OU_ADC_P1V8_VOLT_V          (0xDD) :   1.799 Volts | (ok)
4OU_ADC_P1V2_VOLT_V          (0xDF) :   1.169 Volts | (ok)