### PR TITLE
fby35: ji: Fix RT8848C address

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_i2c.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_i2c.h
@@ -54,6 +54,7 @@ enum _i2c_bus_num {
 
 #define CPUVDD_I2C_BUS I2C_BUS3
 #define CPUVDD_I2C_ADDR 0x4A //8bit
+#define RT8848C_I2C_ADDR 0x94 //8bit
 
 #define SOCVDD_I2C_BUS I2C_BUS3
 #define SOCVDD_I2C_ADDR 0x4C //8bit

--- a/meta-facebook/yv35-ji/src/platform/plat_ssif.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_ssif.c
@@ -53,7 +53,7 @@ static void set_rt8848c_config()
 	I2C_MSG i2c_msg = { 0 };
 	uint8_t retry = 3;
 	i2c_msg.bus = CPUVDD_I2C_BUS;
-	i2c_msg.target_addr = (CPUVDD_I2C_ADDR >> 1);
+	i2c_msg.target_addr = (RT8848C_I2C_ADDR >> 1);
 
 	/* unlock register 0x01~0x5F */
 	i2c_msg.tx_len = 2;
@@ -109,7 +109,7 @@ static void set_rt8848c_config()
 K_TIMER_DEFINE(send_cmd_timer, send_cmd_to_dev, NULL);
 void handle_post_end_handler(struct k_work *work)
 {
-	k_timer_start(&send_cmd_timer, K_MSEC(3000), K_NO_WAIT);
+	k_timer_start(&send_cmd_timer, K_NO_WAIT, K_NO_WAIT);
 
 	/* Pull low virtual bios complete pin */
 	gpio_set(VIRTUAL_BIOS_POST_COMPLETE_L, GPIO_LOW);


### PR DESCRIPTION
Summary:
- Fix RT8848C 8-bit address from 0x4A to 0x94.
- Modify delay time of set endpoint command after post complete.

TestPlan:
- BuildCode: PASS
- Check RT8848C config set successfully after post complete.
