### PR TITLE
fby4: Fix I3C PID is wrong after doing BIC reset

### DIFF
--- a/common/hal/hal_i3c.c
+++ b/common/hal/hal_i3c.c
@@ -46,7 +46,7 @@ static struct i3c_dev_desc *find_matching_desc(const struct device *dev, uint8_t
 
 	for (i = 0; i < I3C_MAX_NUM; i++) {
 		desc = &i3c_desc_table[i];
-		if ((desc->master_dev == dev) && (desc->info.dynamic_addr == desc_addr)) {
+		if ((desc->bus == dev) && (desc->info.dynamic_addr == desc_addr)) {
 			if (pos == NULL) {
 				return desc;
 			}
@@ -326,7 +326,19 @@ int i3c_set_pid(I3C_MSG *msg, uint16_t slot_pid)
 {
 	CHECK_NULL_ARG_WITH_RETURN(msg, -EINVAL);
 
-	int ret = i3c_set_pid_extra_info(dev_i3c[msg->bus], slot_pid);
+	const struct device *target = dev_i3c[msg->bus];
+
+	if (!target) {
+		LOG_ERR("i3c_set_pid fail. i3c device not found");
+		return false;
+	}
+
+	if (!device_is_ready(target)) {
+		LOG_ERR("i3c_set_pid fail. i3c device not ready");
+		return false;
+	}
+
+	int ret = i3c_set_pid_extra_info(target, slot_pid);
 	if (ret != 0) {
 		LOG_ERR("Failed to set pid to bus 0x%d, ret: %d", msg->bus, ret);
 		return false;
@@ -404,7 +416,7 @@ static int get_bus_id(struct i3c_dev_desc *desc)
 	char *substr = NULL;
 	int bus_id;
 
-	strncpy(i3c_dev_name, desc->master_dev->name, I3C_DEV_STR_LEN);
+	strncpy(i3c_dev_name, desc->bus->name, I3C_DEV_STR_LEN);
 
 	substr = strtok_r(i3c_dev_name, delim, &saveptr);
 	substr = strtok_r(NULL, delim, &saveptr);

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0065-i3c-aspeed-Fix-the-step-of-the-stop-condition.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0065-i3c-aspeed-Fix-the-step-of-the-stop-condition.patch
@@ -1,0 +1,36 @@
+From 776d61a33331050cb9af8d97a7a83f74bd539a27 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Thu, 31 Aug 2023 16:59:28 +0800
+Subject: [PATCH 01/11] i3c: aspeed: Fix the step of the stop condition.
+
+The stop condition for the i3c protocol requires both the SCL and SDA
+lines to be low before the transition from low to high on the SDA line
+with the SCL line remains high.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: Id21c5504ac73211b97216da4955416c012c78d37
+---
+ drivers/i3c/i3c_aspeed.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index c4131176a2..714f72bb40 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -648,10 +648,12 @@ void i3c_aspeed_gen_stop_to_internal(int inst_id)
+ 	uint32_t value;
+ 
+ 	value = sys_read32(i3c_gr + I3CG_REG1(inst_id));
+-	value |= SCL_IN_SW_MODE_VAL;
++	value &= ~SCL_IN_SW_MODE_VAL;
+ 	sys_write32(value, i3c_gr + I3CG_REG1(inst_id));
+ 	value &= ~SDA_IN_SW_MODE_VAL;
+ 	sys_write32(value, i3c_gr + I3CG_REG1(inst_id));
++	value |= SCL_IN_SW_MODE_VAL;
++	sys_write32(value, i3c_gr + I3CG_REG1(inst_id));
+ 	value |= SDA_IN_SW_MODE_VAL;
+ 	sys_write32(value, i3c_gr + I3CG_REG1(inst_id));
+ }
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0066-i3c-aspeed-Check-the-fail-of-i3c-slave-enable.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0066-i3c-aspeed-Check-the-fail-of-i3c-slave-enable.patch
@@ -1,0 +1,115 @@
+From 8ab4f9b2038ede772c56b7d7d4704a687d3855d4 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Thu, 31 Aug 2023 18:39:02 +0800
+Subject: [PATCH 02/11] i3c: aspeed: Check the fail of i3c slave enable.
+
+Toggling the 8 SCL_IN signals to the i3c slave can ensure the success of
+the enable procedure, rather than using a while loop that might lead to
+the CPU becoming stuck indefinitely.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I61fa249615f9999e26c637529d8d084b5ed38434
+---
+ drivers/i3c/i3c_aspeed.c | 41 ++++++++++++++++++++++------------------
+ 1 file changed, 23 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 714f72bb40..63770cb850 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -612,19 +612,19 @@ void i3c_aspeed_gen_tbits_low(struct i3c_aspeed_obj *obj)
+ 		LOG_ERR("Failed to recovery the i3c fsm from %x to idle: %d",
+ 			i3c_register->present_state.fields.cm_tfr_sts, ret);
+ }
+-void i3c_aspeed_toggle_scl_in(int inst_id)
++
++void i3c_aspeed_toggle_scl_in(int inst_id, uint32_t times)
+ {
+ 	uint32_t i3c_gr = DT_REG_ADDR(DT_NODELABEL(i3c_gr));
+ 	uint32_t value;
+ 
+ 	value = sys_read32(i3c_gr + I3CG_REG1(inst_id));
+-	value |= SCL_IN_SW_MODE_VAL;
+-	sys_write32(value, i3c_gr + I3CG_REG1(inst_id));
+-
+-	value &= ~SCL_IN_SW_MODE_VAL;
+-	sys_write32(value, i3c_gr + I3CG_REG1(inst_id));
+-	value |= SCL_IN_SW_MODE_VAL;
+-	sys_write32(value, i3c_gr + I3CG_REG1(inst_id));
++	for (; times; times--) {
++		value &= ~SCL_IN_SW_MODE_VAL;
++		sys_write32(value, i3c_gr + I3CG_REG1(inst_id));
++		value |= SCL_IN_SW_MODE_VAL;
++		sys_write32(value, i3c_gr + I3CG_REG1(inst_id));
++	}
+ }
+ 
+ void i3c_aspeed_gen_start_to_internal(int inst_id)
+@@ -1238,7 +1238,7 @@ static void i3c_aspeed_init_queues(struct i3c_aspeed_obj *obj)
+ 	i3c_register->data_buff_ctrl.value = data_buff_ctrl.value;
+ }
+ 
+-static void i3c_aspeed_enable(struct i3c_aspeed_obj *obj)
++static int i3c_aspeed_enable(struct i3c_aspeed_obj *obj)
+ {
+ 	struct i3c_aspeed_config *config = obj->config;
+ 	struct i3c_register_s *i3c_register = config->base;
+@@ -1257,11 +1257,17 @@ static void i3c_aspeed_enable(struct i3c_aspeed_obj *obj)
+ 		k_busy_wait(DIV_ROUND_UP(config->core_period *
+ 						 i3c_register->bus_free_timing.fields.i3c_ibi_free,
+ 					 NSEC_PER_USEC));
+-		while (!i3c_register->device_ctrl.fields.enable)
+-			i3c_aspeed_toggle_scl_in(config->inst_id);
+-		i3c_aspeed_gen_stop_to_internal(config->inst_id);
++		i3c_aspeed_toggle_scl_in(config->inst_id, 8);
++		if (!i3c_register->device_ctrl.fields.enable) {
++			LOG_WRN("Failed to enable controller");
++			i3c_aspeed_isolate_scl_sda(config->inst_id, false);
++			return -EACCES;
++		}
++		if (!config->assigned_addr)
++			i3c_aspeed_gen_stop_to_internal(config->inst_id);
+ 		i3c_aspeed_isolate_scl_sda(config->inst_id, false);
+ 	}
++	return 0;
+ }
+ 
+ static void i3c_aspeed_wr_tx_fifo(struct i3c_aspeed_obj *obj, uint8_t *bytes, int nbytes)
+@@ -1558,12 +1564,10 @@ static void i3c_aspeed_slave_reset_queue(const struct device *dev)
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
+ 	struct i3c_register_s *i3c_register = config->base;
+ 	union i3c_reset_ctrl_s reset_ctrl;
+-	int i;
+ 
+ 	i3c_aspeed_isolate_scl_sda(config->inst_id, true);
+ 	i3c_register->device_ctrl.fields.enable = 0;
+-	for (i = 0; i < 8; i++)
+-		i3c_aspeed_toggle_scl_in(config->inst_id);
++	i3c_aspeed_toggle_scl_in(config->inst_id, 8);
+ 	if (i3c_register->device_ctrl.fields.enable) {
+ 		LOG_ERR("failed to disable controller: reset i3c controller\n");
+ 		i3c_aspeed_isolate_scl_sda(config->inst_id, false);
+@@ -1581,8 +1585,7 @@ static void i3c_aspeed_slave_reset_queue(const struct device *dev)
+ 	k_busy_wait(DIV_ROUND_UP(config->core_period *
+ 					 i3c_register->bus_free_timing.fields.i3c_ibi_free,
+ 				 NSEC_PER_USEC));
+-	for (i = 0; i < 8; i++)
+-		i3c_aspeed_toggle_scl_in(config->inst_id);
++	i3c_aspeed_toggle_scl_in(config->inst_id, 8);
+ 	if (!i3c_register->device_ctrl.fields.enable) {
+ 		LOG_ERR("failed to enable controller: reset i3c controller\n");
+ 		i3c_aspeed_isolate_scl_sda(config->inst_id, false);
+@@ -1982,7 +1985,9 @@ static int i3c_aspeed_init(const struct device *dev)
+ 	/* Reject SIR by default */
+ 	i3c_register->sir_reject = GENMASK(31, 0);
+ 
+-	i3c_aspeed_enable(obj);
++	ret = i3c_aspeed_enable(obj);
++	if (ret)
++		return ret;
+ 
+ 	return 0;
+ }
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0067-i3c-aspeed-Generate-the-stop-condition-when-slave-di.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0067-i3c-aspeed-Generate-the-stop-condition-when-slave-di.patch
@@ -1,0 +1,124 @@
+From 2b06ee07fed13a6c0fdd1a44a0b96b3f8578cbd3 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Thu, 31 Aug 2023 19:28:10 +0800
+Subject: [PATCH 03/11] i3c: aspeed: Generate the stop condition when slave
+ disable.
+
+The i3c slave requires a stop condition to clear the internal hardware
+flag. This prevents subsequent enable operations from failing due to this
+flag. This patch also organize the disable procedure as one api to enhance
+maintainability.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I0b3ab5a229dded97b884951c6837b2296de684a2
+---
+ drivers/i3c/i3c_aspeed.c | 60 ++++++++++++++++++++++++----------------
+ 1 file changed, 36 insertions(+), 24 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 63770cb850..3c7d9964c8 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1270,6 +1270,28 @@ static int i3c_aspeed_enable(struct i3c_aspeed_obj *obj)
+ 	return 0;
+ }
+ 
++static int i3c_aspeed_disable(struct i3c_aspeed_obj *obj)
++{
++	struct i3c_aspeed_config *config = obj->config;
++	struct i3c_register_s *i3c_register = config->base;
++
++	if (config->secondary)
++		i3c_aspeed_isolate_scl_sda(config->inst_id, true);
++	i3c_register->device_ctrl.fields.enable = 0;
++	if (config->secondary) {
++		i3c_aspeed_toggle_scl_in(config->inst_id, 8);
++		/* Clear the internal busy status */
++		i3c_aspeed_gen_stop_to_internal(config->inst_id);
++		if (i3c_register->device_ctrl.fields.enable) {
++			LOG_WRN("Failed to disable controller");
++			i3c_aspeed_isolate_scl_sda(config->inst_id, false);
++			return -EACCES;
++		}
++		i3c_aspeed_isolate_scl_sda(config->inst_id, false);
++	}
++	return 0;
++}
++
+ static void i3c_aspeed_wr_tx_fifo(struct i3c_aspeed_obj *obj, uint8_t *bytes, int nbytes)
+ {
+ 	struct i3c_register_s *i3c_register = obj->config->base;
+@@ -1559,21 +1581,17 @@ int i3c_aspeed_slave_register(const struct device *dev, struct i3c_slave_setup *
+ 	return 0;
+ }
+ 
+-static void i3c_aspeed_slave_reset_queue(const struct device *dev)
++static int i3c_aspeed_slave_reset_queue(const struct device *dev)
+ {
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
++	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
+ 	struct i3c_register_s *i3c_register = config->base;
+ 	union i3c_reset_ctrl_s reset_ctrl;
++	int ret;
+ 
+-	i3c_aspeed_isolate_scl_sda(config->inst_id, true);
+-	i3c_register->device_ctrl.fields.enable = 0;
+-	i3c_aspeed_toggle_scl_in(config->inst_id, 8);
+-	if (i3c_register->device_ctrl.fields.enable) {
+-		LOG_ERR("failed to disable controller: reset i3c controller\n");
+-		i3c_aspeed_isolate_scl_sda(config->inst_id, false);
+-		i3c_aspeed_init(dev);
+-		return;
+-	}
++	ret = i3c_aspeed_disable(obj);
++	if (ret)
++		return ret;
+ 	reset_ctrl.value = 0;
+ 	reset_ctrl.fields.tx_queue_reset = 1;
+ 	reset_ctrl.fields.rx_queue_reset = 1;
+@@ -1581,18 +1599,11 @@ static void i3c_aspeed_slave_reset_queue(const struct device *dev)
+ 	reset_ctrl.fields.cmd_queue_reset = 1;
+ 	reset_ctrl.fields.resp_queue_reset = 1;
+ 	i3c_register->reset_ctrl.value = reset_ctrl.value;
+-	i3c_register->device_ctrl.fields.enable = 1;
+-	k_busy_wait(DIV_ROUND_UP(config->core_period *
+-					 i3c_register->bus_free_timing.fields.i3c_ibi_free,
+-				 NSEC_PER_USEC));
+-	i3c_aspeed_toggle_scl_in(config->inst_id, 8);
+-	if (!i3c_register->device_ctrl.fields.enable) {
+-		LOG_ERR("failed to enable controller: reset i3c controller\n");
+-		i3c_aspeed_isolate_scl_sda(config->inst_id, false);
+-		i3c_aspeed_init(dev);
+-		return;
+-	}
+-	i3c_aspeed_isolate_scl_sda(config->inst_id, false);
++
++	ret = i3c_aspeed_enable(obj);
++	if (ret)
++		return ret;
++	return 0;
+ }
+ 
+ static uint32_t i3c_aspeed_slave_wait_data_consume(const struct device *dev)
+@@ -1687,8 +1698,7 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 				    K_SECONDS(3).ticks);
+ 	if (flag_ret & osFlagsError) {
+ 		LOG_WRN("Wait master read timeout: reset queue\n");
+-		i3c_aspeed_slave_reset_queue(dev);
+-		ret = -EIO;
++		ret = i3c_aspeed_slave_reset_queue(dev);
+ 	}
+ ibi_err:
+ 	return ret;
+@@ -1905,6 +1915,8 @@ static int i3c_aspeed_init(const struct device *dev)
+ 	clock_control_on(config->clock_dev, config->clock_id);
+ 	reset_control_deassert(reset_dev, config->reset_id);
+ 
++	ret = i3c_aspeed_disable(obj);
++
+ 	reset_ctrl.value = 0;
+ 	reset_ctrl.fields.core_reset = 1;
+ 	reset_ctrl.fields.tx_queue_reset = 1;
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0068-i3c-aspeed-Reorganize-the-APIs-for-entering-and-exit.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0068-i3c-aspeed-Reorganize-the-APIs-for-entering-and-exit.patch
@@ -1,0 +1,360 @@
+From a3073db691e3c8c90394c3e2f8931e1570790c6e Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Fri, 6 Oct 2023 16:19:53 +0800
+Subject: [PATCH 04/11] i3c: aspeed: Reorganize the APIs for entering and
+ exiting the HALT state
+
+In certain situations, such as receiving an error response or
+experiencing a timeout during transfer transmission, it becomes
+necessary to reset the hardware queues. This reset operation must be
+executed when the controller is in the HALT state.
+
+To achieve this, this commit adds the `enter_halt` API to handle these
+two cases:
+- Receiving an error response: the I3C controller will automatically
+enter the HALT state. The API will monitore `present_state` register for
+this.
+
+- Timeout during transfer transmission: Use the `abort` bit to force the
+controller to enter the HALT state.
+
+When the reset is done, use `exit_halt` API to exit from the HALT state
+and back to the normal operation state.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: Icb63e5cfd5732c2e2b16a1752455673f577cac46
+---
+ drivers/i3c/i3c_aspeed.c | 241 ++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 214 insertions(+), 27 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 3c7d9964c8..6db8432728 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -275,7 +275,8 @@ union i3c_present_state_s {
+ 		volatile uint32_t current_master : 1;		/* bit[2] */
+ 		volatile uint32_t reserved0 : 5;		/* bit[7:3] */
+ #define CM_TFR_STS_SLAVE_HALT	0x6
+-#define CM_TFR_STS_MASTER_SERV_IBI	0xe
++#define CM_TFR_STS_MASTER_SERV_IBI 0xe
++#define CM_TFR_STS_MASTER_HALT	0xf
+ 		volatile uint32_t cm_tfr_sts : 6;		/* bit[13:8] */
+ 		volatile uint32_t reserved1 : 2;		/* bit[15:14] */
+ 		volatile uint32_t cm_tfr_st_sts : 6;		/* bit[21:16] */
+@@ -524,6 +525,13 @@ struct i3c_aspeed_dev_priv {
+ 	} ibi;
+ };
+ 
++enum i3c_aspeed_reset_type {
++	I3C_ASPEED_RESET_ALL,
++	I3C_ASPEED_RESET_QUEUES,
++	I3C_ASPEED_RESET_XFER_QUEUES,
++	I3C_ASPEED_RESET_IBI_QUEUE,
++};
++
+ struct i3c_aspeed_obj {
+ 	const struct device *dev;
+ 	struct i3c_aspeed_config *config;
+@@ -742,6 +750,106 @@ static void i3c_aspeed_rd_rx_fifo(struct i3c_aspeed_obj *obj, uint8_t *bytes, in
+ 	}
+ }
+ 
++static int i3c_aspeed_reset_ctrl(struct i3c_aspeed_obj *obj, enum i3c_aspeed_reset_type type)
++{
++	struct i3c_aspeed_config *config = obj->config;
++	struct i3c_register_s *i3c_register = config->base;
++	union i3c_reset_ctrl_s reset_ctrl;
++	int ret;
++
++	reset_ctrl.value = 0;
++
++	switch (type) {
++	case I3C_ASPEED_RESET_IBI_QUEUE:
++		reset_ctrl.fields.ibi_queue_reset = 1;
++		break;
++	case I3C_ASPEED_RESET_ALL:
++		reset_ctrl.fields.core_reset = 1;
++		__fallthrough;
++	case I3C_ASPEED_RESET_QUEUES:
++		reset_ctrl.fields.ibi_queue_reset = 1;
++		__fallthrough;
++	case I3C_ASPEED_RESET_XFER_QUEUES:
++		reset_ctrl.fields.resp_queue_reset = 1;
++		reset_ctrl.fields.cmd_queue_reset = 1;
++		reset_ctrl.fields.tx_queue_reset = 1;
++		reset_ctrl.fields.rx_queue_reset = 1;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	i3c_register->reset_ctrl.value = reset_ctrl.value;
++	ret = reg_read_poll_timeout(i3c_register, reset_ctrl, reset_ctrl, !reset_ctrl.value, 0, 10);
++	if (ret) {
++		LOG_ERR("Reset failed. Reset ctrl: %08x %08x", reset_ctrl.value,
++			i3c_register->reset_ctrl.value);
++	}
++
++	return ret;
++}
++
++static void i3c_aspeed_exit_halt(struct i3c_aspeed_obj *obj)
++{
++	struct i3c_aspeed_config *config = obj->config;
++	struct i3c_register_s *i3c_register = config->base;
++	union i3c_device_ctrl_s ctrl;
++	union i3c_present_state_s state;
++	uint32_t halt_state = CM_TFR_STS_MASTER_HALT;
++	int ret;
++
++	if (obj->config->secondary) {
++		halt_state = CM_TFR_STS_SLAVE_HALT;
++	}
++
++	state.value = i3c_register->present_state.value;
++	if (state.fields.cm_tfr_sts != halt_state) {
++		LOG_DBG("I3C not in halt state, no need for resume");
++		return;
++	}
++
++	ctrl.value = i3c_register->device_ctrl.value;
++	ctrl.fields.resume = 1;
++	i3c_register->device_ctrl.value = ctrl.value;
++
++	ret = reg_read_poll_timeout(i3c_register, present_state, state,
++				    state.fields.cm_tfr_sts != halt_state, 0, 10);
++
++	if (ret) {
++		LOG_ERR("Exit halt state failed: %d %08x %08x", ret, state.value,
++			i3c_register->queue_status_level.value);
++	}
++}
++
++static void i3c_aspeed_enter_halt(struct i3c_aspeed_obj *obj, bool by_sw)
++{
++	struct i3c_aspeed_config *config = obj->config;
++	struct i3c_register_s *i3c_register = config->base;
++	union i3c_device_ctrl_s ctrl;
++	union i3c_present_state_s state;
++	uint32_t halt_state = CM_TFR_STS_MASTER_HALT;
++	int ret;
++
++	if (obj->config->secondary) {
++		halt_state = CM_TFR_STS_SLAVE_HALT;
++	}
++
++	LOG_DBG("present state = %08x\n", i3c_register->present_state.value);
++
++	if (by_sw) {
++		ctrl.value = i3c_register->device_ctrl.value;
++		ctrl.fields.abort = 1;
++		i3c_register->device_ctrl.value = ctrl.value;
++	}
++
++	ret = reg_read_poll_timeout(i3c_register, present_state, state,
++				    state.fields.cm_tfr_sts == halt_state, 0, 1000);
++	if (ret) {
++		LOG_ERR("Enter halt state failed: %d %08x %08x", ret, state.value,
++			i3c_register->queue_status_level.value);
++	}
++}
++
+ static void i3c_aspeed_end_xfer(struct i3c_aspeed_obj *obj)
+ {
+ 	struct i3c_register_s *i3c_register = obj->config->base;
+@@ -774,15 +882,9 @@ static void i3c_aspeed_end_xfer(struct i3c_aspeed_obj *obj)
+ 	}
+ 
+ 	if (ret) {
+-		union i3c_reset_ctrl_s reset_ctrl;
+-
+-		reset_ctrl.value = 0;
+-		reset_ctrl.fields.rx_queue_reset = 1;
+-		reset_ctrl.fields.tx_queue_reset = 1;
+-		reset_ctrl.fields.resp_queue_reset = 1;
+-		reset_ctrl.fields.cmd_queue_reset = 1;
+-		i3c_register->reset_ctrl.value = reset_ctrl.value;
+-		i3c_register->device_ctrl.fields.resume = 1;
++		i3c_aspeed_enter_halt(obj, false);
++		i3c_aspeed_reset_ctrl(obj, I3C_ASPEED_RESET_XFER_QUEUES);
++		i3c_aspeed_exit_halt(obj);
+ 	}
+ 
+ 	xfer->ret = ret;
+@@ -980,7 +1082,8 @@ static void i3c_aspeed_slave_event(const struct device *dev, union i3c_intr_s st
+ 	if (status.fields.ccc_update) {
+ 		if (cm_tfr_sts == CM_TFR_STS_SLAVE_HALT) {
+ 			LOG_DBG("slave halt resume\n");
+-			i3c_register->device_ctrl.fields.resume = 1;
++			i3c_aspeed_enter_halt(obj, false);
++			i3c_aspeed_exit_halt(obj);
+ 		}
+ 
+ 		if (i3c_register->slave_event_ctrl.fields.mrl_update) {
+@@ -1006,6 +1109,7 @@ static void i3c_aspeed_isr(const struct device *dev)
+ 	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
+ 	struct i3c_register_s *i3c_register = config->base;
+ 	union i3c_intr_s status;
++	uint32_t cm_tfr_sts;
+ 
+ 	status.value = i3c_register->intr_status.value;
+ 	if (config->secondary) {
+@@ -1027,8 +1131,10 @@ static void i3c_aspeed_isr(const struct device *dev)
+ 		}
+ 	}
+ 
+-	if (status.fields.xfr_error) {
+-		i3c_register->device_ctrl.fields.resume = 1;
++	cm_tfr_sts = i3c_register->present_state.fields.cm_tfr_sts;
++	if (cm_tfr_sts == CM_TFR_STS_MASTER_HALT || cm_tfr_sts == CM_TFR_STS_SLAVE_HALT) {
++		LOG_ERR("Un-handled HALT");
++		i3c_aspeed_exit_halt(obj);
+ 	}
+ 
+ 	i3c_register->intr_status.value = status.value;
+@@ -1404,7 +1510,12 @@ int i3c_aspeed_master_priv_xfer(struct i3c_dev_desc *i3cdev, struct i3c_priv_xfe
+ 	i3c_aspeed_start_xfer(obj, &xfer);
+ 
+ 	/* wait done, xfer.ret will be changed in ISR */
+-	k_sem_take(&xfer.sem, I3C_ASPEED_XFER_TIMEOUT);
++	ret = k_sem_take(&xfer.sem, I3C_ASPEED_XFER_TIMEOUT);
++	if (ret) {
++		i3c_aspeed_enter_halt(obj, true);
++		i3c_aspeed_reset_ctrl(obj, I3C_ASPEED_RESET_XFER_QUEUES);
++		i3c_aspeed_exit_halt(obj);
++	}
+ 
+ 	/* report actual read length */
+ 	for (i = 0; i < nxfers; i++) {
+@@ -1880,7 +1991,12 @@ int i3c_aspeed_master_send_ccc(const struct device *dev, struct i3c_ccc_cmd *ccc
+ 	i3c_aspeed_start_xfer(obj, &xfer);
+ 
+ 	/* wait done, xfer.ret will be changed in ISR */
+-	k_sem_take(&xfer.sem, I3C_ASPEED_CCC_TIMEOUT);
++	ret = k_sem_take(&xfer.sem, I3C_ASPEED_CCC_TIMEOUT);
++	if (ret) {
++		i3c_aspeed_enter_halt(obj, true);
++		i3c_aspeed_reset_ctrl(obj, I3C_ASPEED_RESET_XFER_QUEUES);
++		i3c_aspeed_exit_halt(obj);
++	}
+ 
+ 	ret = xfer.ret;
+ 
+@@ -1899,13 +2015,94 @@ static void sir_allowed_worker(struct k_work *work)
+ 	obj->sir_allowed_by_sw = 1;
+ }
+ 
++static uint16_t parse_extra_gpio(const struct extra_gpio *extra_gpios, int size)
++{
++	const struct device *gpio_dev;
++	int i, ret;
++	uint16_t result = 0;
++
++	for (i = 0; i < size; i++) {
++		gpio_dev = device_get_binding(extra_gpios[i].port);
++		ret = gpio_pin_configure(gpio_dev, extra_gpios[i].pin, extra_gpios[i].flags | GPIO_INPUT);
++		if (ret < 0) {
++			LOG_ERR("pin %s:%d:%d configure failed %d\n", extra_gpios[i].port,
++				extra_gpios[i].pin, extra_gpios[i].flags | GPIO_INPUT, ret);
++			result = 0;
++			break;
++		}
++		ret = gpio_pin_get(gpio_dev, extra_gpios[i].pin);
++		if (ret < 0) {
++			LOG_ERR("pin %s:%d get value failed %d\n", extra_gpios[i].port,
++				extra_gpios[i].pin, ret);
++			result = 0;
++			break;
++		}
++		result |= ret << i;
++	}
++	LOG_DBG("extra val = %x\n", result);
++	return result;
++}
++
++int i3c_aspeed_master_send_entdaa(struct i3c_dev_desc *i3cdev)
++{
++	struct i3c_aspeed_obj *obj = DEV_DATA(i3cdev->bus);
++	struct i3c_aspeed_dev_priv *priv = DESC_PRIV(i3cdev);
++	struct i3c_aspeed_xfer xfer;
++	struct i3c_aspeed_cmd cmd;
++	union i3c_device_cmd_queue_port_s cmd_hi, cmd_lo;
++	int ret;
++
++	cmd_hi.value = 0;
++	cmd_hi.xfer_arg.cmd_attr = COMMAND_PORT_XFER_ARG;
++
++	cmd_lo.value = 0;
++	cmd_lo.addr_assign_cmd.cmd = I3C_CCC_ENTDAA;
++	cmd_lo.addr_assign_cmd.cmd_attr = COMMAND_PORT_ADDR_ASSIGN;
++	cmd_lo.addr_assign_cmd.toc = 1;
++	cmd_lo.addr_assign_cmd.roc = 1;
++
++	cmd_lo.addr_assign_cmd.dev_cnt = 1;
++	cmd_lo.addr_assign_cmd.dev_idx = priv->pos;
++
++	cmd.cmd_hi = cmd_hi.value;
++	cmd.cmd_lo = cmd_lo.value;
++	cmd.rx_length = 0;
++	cmd.tx_length = 0;
++
++	k_sem_init(&xfer.sem, 0, 1);
++	xfer.ret = -ETIMEDOUT;
++	xfer.ncmds = 1;
++	xfer.cmds = &cmd;
++	i3c_aspeed_start_xfer(obj, &xfer);
++
++	/* wait done, xfer.ret will be changed in ISR */
++	ret = k_sem_take(&xfer.sem, I3C_ASPEED_CCC_TIMEOUT);
++	if (ret) {
++		i3c_aspeed_enter_halt(obj, true);
++		i3c_aspeed_reset_ctrl(obj, I3C_ASPEED_RESET_XFER_QUEUES);
++		i3c_aspeed_exit_halt(obj);
++		return -ETIMEDOUT;
++	}
++
++	if (cmd.rx_length) {
++		LOG_INF("ENTDAA: No more new device. DA 0x%02x at DAT[%d] is not assigned",
++			i3cdev->info.dynamic_addr, priv->pos);
++		return -1;
++	}
++
++	i3c_master_send_getpid(i3cdev->bus, i3cdev->info.dynamic_addr, &i3cdev->info.pid);
++	LOG_INF("ENTDAA: DA 0x%02x at DAT[%d] is assigned, PID 0x%llx",
++			i3cdev->info.dynamic_addr, priv->pos, i3cdev->info.pid);
++
++	return 0;
++}
++
+ static int i3c_aspeed_init(const struct device *dev)
+ {
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
+ 	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
+ 	struct i3c_register_s *i3c_register = config->base;
+ 	const struct device *reset_dev = device_get_binding(ASPEED_RST_CTRL_NAME);
+-	union i3c_reset_ctrl_s reset_ctrl;
+ 	union i3c_intr_s intr_reg;
+ 	int ret;
+ 
+@@ -1916,17 +2113,7 @@ static int i3c_aspeed_init(const struct device *dev)
+ 	reset_control_deassert(reset_dev, config->reset_id);
+ 
+ 	ret = i3c_aspeed_disable(obj);
+-
+-	reset_ctrl.value = 0;
+-	reset_ctrl.fields.core_reset = 1;
+-	reset_ctrl.fields.tx_queue_reset = 1;
+-	reset_ctrl.fields.rx_queue_reset = 1;
+-	reset_ctrl.fields.ibi_queue_reset = 1;
+-	reset_ctrl.fields.cmd_queue_reset = 1;
+-	reset_ctrl.fields.resp_queue_reset = 1;
+-	i3c_register->reset_ctrl.value = reset_ctrl.value;
+-
+-	ret = reg_read_poll_timeout(i3c_register, reset_ctrl, reset_ctrl, !reset_ctrl.value, 0, 10);
++	ret = i3c_aspeed_reset_ctrl(obj, I3C_ASPEED_RESET_ALL);
+ 	if (ret) {
+ 		return ret;
+ 	}
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0069-i3c-aspeed-Avoid-the-bus-hang-issue-when-ibi-queue-o.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0069-i3c-aspeed-Avoid-the-bus-hang-issue-when-ibi-queue-o.patch
@@ -1,0 +1,69 @@
+From 0588453fb32b967fd8ecb1862b42115820a5d278 Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Fri, 6 Oct 2023 16:27:55 +0800
+Subject: [PATCH 05/11] i3c: aspeed: Avoid the bus hang issue when ibi queue
+ overflow.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This patch is modified from Aspeed Linux-v5.15 commit #d316a127.
+The original commit message is
+```
+When our i3c controller nack the IBI which isn’t existed in our DAT the
+ibi buffer counter (IBI Buffer Status Count) may lose the control.
+
+Consequently, the counter surpasses the tolerance level for the ibi buffer
+capability(16). When the controller attempts to read the IBI buffer with a
+counter value greater than 16, the CPU will experience a hang due to the
+absence of a response from the bus.
+
+This patch will clear the IBI FIFO when the IBI counter exceeds 16, and
+the IBI response status receives a NACK, indicating that the controller
+received the IBI from an address not included in the hardware DAT.
+```
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: I67c5701dd44a576731de8ae7d6e48fa560d28b6b
+---
+ drivers/i3c/i3c_aspeed.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 6db8432728..75df46d4e5 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -980,12 +980,17 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 		return;
+ 	}
+ 
++	if (nstatus > 16) {
++		LOG_ERR("The nibi %d surpasses the tolerance level for the IBI buffer", nstatus);
++		goto clear;
++	}
++
+ 	for (i = 0; i < nstatus; i++) {
+ 		obj->ibi_status_parser(i3c_register->ibi_queue_status.value, &ibi_status);
+ 		data_consumed = false;
+ 		if (ibi_status.ibi_status) {
+ 			LOG_WRN("IBI NACK\n");
+-			goto out;
++			goto clear;
+ 		}
+ 
+ 		if (ibi_status.error) {
+@@ -1065,6 +1070,11 @@ out:
+ 				i3c_aspeed_gen_tbits_low(obj);
+ 		}
+ 	}
++	return;
++clear:
++	i3c_aspeed_enter_halt(obj, true);
++	i3c_aspeed_reset_ctrl(obj, I3C_ASPEED_RESET_IBI_QUEUE);
++	i3c_aspeed_exit_halt(obj);
+ }
+ 
+ static void i3c_aspeed_slave_event(const struct device *dev, union i3c_intr_s status)
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0070-i3c-Remove-n-from-the-log-messages.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0070-i3c-Remove-n-from-the-log-messages.patch
@@ -1,0 +1,285 @@
+From be52a89c30c77cfdc31ff0919269a74f88246304 Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Tue, 12 Dec 2023 14:42:52 +0800
+Subject: [PATCH 06/11] i3c: Remove '\n' from the log messages
+
+Remove '\n' from all the log messages to avoid unnecessary newline.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: Ib768a165606b395a2bb4dfb10be8672743c38d2f
+---
+ drivers/i3c/i3c_aspeed.c | 69 ++++++++++++++++++++--------------------
+ 1 file changed, 35 insertions(+), 34 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 75df46d4e5..aa0a1fc9cb 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -744,7 +744,7 @@ static void i3c_aspeed_rd_rx_fifo(struct i3c_aspeed_obj *obj, uint8_t *bytes, in
+ 	if (obj->config->priv_xfer_pec) {
+ 		ret = pec_valid(obj->dev, bytes, nbytes);
+ 		if (ret) {
+-			LOG_ERR("PEC error\n");
++			LOG_ERR("PEC error");
+ 			memset(bytes, 0, nbytes);
+ 		}
+ 	}
+@@ -834,7 +834,7 @@ static void i3c_aspeed_enter_halt(struct i3c_aspeed_obj *obj, bool by_sw)
+ 		halt_state = CM_TFR_STS_SLAVE_HALT;
+ 	}
+ 
+-	LOG_DBG("present state = %08x\n", i3c_register->present_state.value);
++	LOG_DBG("present state = %08x", i3c_register->present_state.value);
+ 
+ 	if (by_sw) {
+ 		ctrl.value = i3c_register->device_ctrl.value;
+@@ -905,13 +905,13 @@ static void i3c_aspeed_slave_resp_handler(struct i3c_aspeed_obj *obj, union i3c_
+ 
+ 		resp.value = i3c_register->resp_queue_port.value;
+ 		if (resp.fields.err_status) {
+-			LOG_ERR("Respons Error: 0x%x\n", resp.fields.err_status);
++			LOG_ERR("Respons Error: 0x%x", resp.fields.err_status);
+ 		}
+ 
+ 		if (resp.fields.data_length && !resp.fields.err_status &&
+ 		    resp.fields.tid == SLAVE_TID_MASTER_WRITE_DATA) {
+ 			if (!cb) {
+-				__ASSERT(0, "flush rx fifo is TBD\n");
++				__ASSERT(0, "flush rx fifo is TBD");
+ 				continue;
+ 			}
+ 			if (cb->write_requested) {
+@@ -989,39 +989,40 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 		obj->ibi_status_parser(i3c_register->ibi_queue_status.value, &ibi_status);
+ 		data_consumed = false;
+ 		if (ibi_status.ibi_status) {
+-			LOG_WRN("IBI NACK\n");
++			LOG_WRN("IBI NACK");
+ 			goto clear;
+ 		}
+ 
+ 		if (ibi_status.error) {
+-			LOG_ERR("IBI error\n");
++			LOG_ERR("IBI error");
+ 			goto out;
+ 		}
+ 
+ 		if ((ibi_status.id >> 1) != 0x2 && !(ibi_status.id & 0x1)) {
+-			LOG_INF("Receive Controller Role Request event (Not supported for now)\n");
++			LOG_INF("Receive Controller Role Request event (Not supported for now)");
+ 			goto out;
+ 		}
+ 
+ 		if ((ibi_status.id >> 1) == 0x2 && !(ibi_status.id & 0x1)) {
+-			LOG_INF("Receive Hot-join event (Not supported for now)\n");
++			LOG_INF("Receive Hot-join event (Not supported for now)");
+ 			goto out;
+ 		}
+ 
+ 		pos = i3c_aspeed_get_pos(obj, ibi_status.id >> 1);
+ 		if (pos < 0) {
+-			LOG_ERR("unregistered IBI source: 0x%x\n", ibi_status.id >> 1);
++			LOG_ERR("unregistered IBI source: 0x%x", ibi_status.id >> 1);
+ 			goto out;
+ 		}
+ 
+ 		if (pos > ARRAY_SIZE(obj->dev_descs)) {
+-			LOG_ERR("pos(%d) exceeds the max device(%ld)\n", pos, ARRAY_SIZE(obj->dev_descs));
++			LOG_ERR("pos(%d) exceeds the max device(%ld)", pos,
++				ARRAY_SIZE(obj->dev_descs));
+ 			goto out;
+ 		}
+ 
+ 		i3cdev = obj->dev_descs[pos];
+ 		if (!i3cdev) {
+-			LOG_ERR("device descriptor not found\n");
++			LOG_ERR("device descriptor not found");
+ 			goto out;
+ 		}
+ 
+@@ -1036,7 +1037,7 @@ static void i3c_aspeed_master_rx_ibi(struct i3c_aspeed_obj *obj)
+ 		nbytes = ibi_status.length;
+ 		nwords = nbytes >> 2;
+ 		if ((payload->size + ibi_status.length) > payload->max_payload_size) {
+-			LOG_ERR("IBI length exceeds the max size (%d bytes)\n",
++			LOG_ERR("IBI length exceeds the max size (%d bytes)",
+ 				payload->max_payload_size);
+ 			goto out;
+ 		}
+@@ -1085,27 +1086,27 @@ static void i3c_aspeed_slave_event(const struct device *dev, union i3c_intr_s st
+ 	uint32_t cm_tfr_sts = i3c_register->present_state.fields.cm_tfr_sts;
+ 
+ 	if (status.fields.dyn_addr_assign) {
+-		LOG_DBG("dynamic address assigned\n");
++		LOG_DBG("dynamic address assigned");
+ 		k_work_submit(&obj->work);
+ 	}
+ 
+ 	if (status.fields.ccc_update) {
+ 		if (cm_tfr_sts == CM_TFR_STS_SLAVE_HALT) {
+-			LOG_DBG("slave halt resume\n");
++			LOG_DBG("slave halt resume");
+ 			i3c_aspeed_enter_halt(obj, false);
+ 			i3c_aspeed_exit_halt(obj);
+ 		}
+ 
+ 		if (i3c_register->slave_event_ctrl.fields.mrl_update) {
+-			LOG_DBG("master sets MRL %d\n", i3c_register->slave_max_len.fields.mrl);
++			LOG_DBG("master sets MRL %d", i3c_register->slave_max_len.fields.mrl);
+ 		}
+ 
+ 		if (i3c_register->slave_event_ctrl.fields.mwl_update) {
+-			LOG_DBG("master sets MWL %d\n", i3c_register->slave_max_len.fields.mwl);
++			LOG_DBG("master sets MWL %d", i3c_register->slave_max_len.fields.mwl);
+ 		}
+ 
+ 		if (i3c_register->slave_event_ctrl.fields.sir_allowed) {
+-			LOG_DBG("master allows slave sending sir\n");
++			LOG_DBG("master allows slave sending sir");
+ 		}
+ 
+ 		/* W1C the slave events */
+@@ -1124,7 +1125,7 @@ static void i3c_aspeed_isr(const struct device *dev)
+ 	status.value = i3c_register->intr_status.value;
+ 	if (config->secondary) {
+ 		if (status.fields.read_q_recv)
+-			LOG_WRN("Master read when CMDQ is empty\n");
++			LOG_WRN("Master read when CMDQ is empty");
+ 
+ 		if (status.fields.resp_q_ready) {
+ 			i3c_aspeed_slave_resp_handler(obj, status);
+@@ -1186,8 +1187,8 @@ static void i3c_aspeed_init_clock(struct i3c_aspeed_obj *obj)
+ 	clock_control_get_rate(config->clock_dev, config->clock_id, &core_rate);
+ 	config->core_period = DIV_ROUND_UP(1000000000, core_rate);
+ 
+-	LOG_INF("core_rate %d hz (%d ns)\n", core_rate, config->core_period);
+-	LOG_INF("i2c-scl = %d, i3c-scl = %d\n", config->i2c_scl_hz, config->i3c_scl_hz);
++	LOG_INF("core_rate %d hz (%d ns)", core_rate, config->core_period);
++	LOG_INF("i2c-scl = %d, i3c-scl = %d", config->i2c_scl_hz, config->i3c_scl_hz);
+ 
+ 	if (config->i2c_scl_hz) {
+ 		calc_i2c_clk(config->i2c_scl_hz, &hi_ns, &lo_ns);
+@@ -1416,7 +1417,7 @@ static void i3c_aspeed_wr_tx_fifo(struct i3c_aspeed_obj *obj, uint8_t *bytes, in
+ 	int i;
+ 
+ 	for (i = 0; i < nwords; i++) {
+-		LOG_DBG("tx data: %x\n", *src);
++		LOG_DBG("tx data: %x", *src);
+ 		i3c_register->rx_tx_data_port = *src++;
+ 	}
+ 
+@@ -1424,7 +1425,7 @@ static void i3c_aspeed_wr_tx_fifo(struct i3c_aspeed_obj *obj, uint8_t *bytes, in
+ 		uint32_t tmp = 0;
+ 
+ 		memcpy(&tmp, bytes + (nbytes & ~0x3), nbytes & 3);
+-		LOG_DBG("tx data: %x\n", tmp);
++		LOG_DBG("tx data: %x", tmp);
+ 		i3c_register->rx_tx_data_port = tmp;
+ 	}
+ }
+@@ -1453,7 +1454,7 @@ static void i3c_aspeed_start_xfer(struct i3c_aspeed_obj *obj, struct i3c_aspeed_
+ 		cmd = &xfer->cmds[i];
+ 		i3c_register->cmd_queue_port.value = cmd->cmd_hi;
+ 		i3c_register->cmd_queue_port.value = cmd->cmd_lo;
+-		LOG_DBG("cmd_hi: %08x cmd_lo: %08x\n", cmd->cmd_hi, cmd->cmd_lo);
++		LOG_DBG("cmd_hi: %08x cmd_lo: %08x", cmd->cmd_hi, cmd->cmd_lo);
+ 	}
+ 
+ 	k_spin_unlock(&obj->lock, key);
+@@ -1480,7 +1481,7 @@ int i3c_aspeed_master_priv_xfer(struct i3c_dev_desc *i3cdev, struct i3c_priv_xfe
+ 	}
+ 
+ 	cmds = (struct i3c_aspeed_cmd *)k_calloc(sizeof(struct i3c_aspeed_cmd), nxfers);
+-	__ASSERT(cmds, "failed to allocat cmd\n");
++	__ASSERT(cmds, "failed to allocat cmd");
+ 
+ 	xfer.ncmds = nxfers;
+ 	xfer.cmds = cmds;
+@@ -1595,7 +1596,7 @@ int i3c_aspeed_master_attach_device(const struct device *dev, struct i3c_dev_des
+ 
+ 	pos = i3c_aspeed_get_pos(obj, slave->info.dynamic_addr);
+ 	if (pos >= 0) {
+-		LOG_WRN("addr %x has been registered at %d\n", slave->info.dynamic_addr, pos);
++		LOG_WRN("addr %x has been registered at %d", slave->info.dynamic_addr, pos);
+ 		return pos;
+ 	}
+ 	obj->dev_addr_tbl[i] = slave->info.dynamic_addr;
+@@ -1603,7 +1604,7 @@ int i3c_aspeed_master_attach_device(const struct device *dev, struct i3c_dev_des
+ 
+ 	/* allocate private data of the device */
+ 	priv = (struct i3c_aspeed_dev_priv *)k_calloc(sizeof(struct i3c_aspeed_dev_priv), 1);
+-	__ASSERT(priv, "failed to allocat device private data\n");
++	__ASSERT(priv, "failed to allocat device private data");
+ 
+ 	priv->pos = i;
+ 	slave->priv_data = priv;
+@@ -1757,12 +1758,12 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 
+ 	if (ibi_notify) {
+ 		if (i3c_register->slave_event_ctrl.fields.sir_allowed == 0) {
+-			LOG_ERR("SIR is not enabled by the main master\n");
++			LOG_ERR("SIR is not enabled by the main master");
+ 			return -EACCES;
+ 		}
+ 
+ 		if (obj->sir_allowed_by_sw == 0) {
+-			LOG_ERR("SIR is not allowed by software\n");
++			LOG_ERR("SIR is not allowed by software");
+ 			return -EACCES;
+ 		}
+ 
+@@ -1808,7 +1809,7 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 		flag_ret = osEventFlagsWait(obj->ibi_event, events.value, osFlagsWaitAll,
+ 					    K_SECONDS(1).ticks);
+ 		if (flag_ret & osFlagsError) {
+-			LOG_WRN("SIR timeout: reset i3c controller\n");
++			LOG_WRN("SIR timeout: reset i3c controller");
+ 			i3c_aspeed_init(dev);
+ 			ret = -EIO;
+ 			goto ibi_err;
+@@ -1818,7 +1819,7 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 	flag_ret = osEventFlagsWait(obj->data_event, data_events.value, osFlagsWaitAny,
+ 				    K_SECONDS(3).ticks);
+ 	if (flag_ret & osFlagsError) {
+-		LOG_WRN("Wait master read timeout: reset queue\n");
++		LOG_WRN("Wait master read timeout: reset queue");
+ 		ret = i3c_aspeed_slave_reset_queue(dev);
+ 	}
+ ibi_err:
+@@ -1840,7 +1841,7 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+ 	__ASSERT_NO_MSG(payload->size);
+ 
+ 	if (i3c_register->slave_event_ctrl.fields.sir_allowed == 0) {
+-		LOG_ERR("SIR is not enabled by the main master\n");
++		LOG_ERR("SIR is not enabled by the main master");
+ 		return -EACCES;
+ 	}
+ 
+@@ -2035,21 +2036,21 @@ static uint16_t parse_extra_gpio(const struct extra_gpio *extra_gpios, int size)
+ 		gpio_dev = device_get_binding(extra_gpios[i].port);
+ 		ret = gpio_pin_configure(gpio_dev, extra_gpios[i].pin, extra_gpios[i].flags | GPIO_INPUT);
+ 		if (ret < 0) {
+-			LOG_ERR("pin %s:%d:%d configure failed %d\n", extra_gpios[i].port,
++			LOG_ERR("pin %s:%d:%d configure failed %d", extra_gpios[i].port,
+ 				extra_gpios[i].pin, extra_gpios[i].flags | GPIO_INPUT, ret);
+ 			result = 0;
+ 			break;
+ 		}
+ 		ret = gpio_pin_get(gpio_dev, extra_gpios[i].pin);
+ 		if (ret < 0) {
+-			LOG_ERR("pin %s:%d get value failed %d\n", extra_gpios[i].port,
++			LOG_ERR("pin %s:%d get value failed %d", extra_gpios[i].port,
+ 				extra_gpios[i].pin, ret);
+ 			result = 0;
+ 			break;
+ 		}
+ 		result |= ret << i;
+ 	}
+-	LOG_DBG("extra val = %x\n", result);
++	LOG_DBG("extra val = %x", result);
+ 	return result;
+ }
+ 
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0071-i3c-aspeed-Correct-the-timing-for-stop-condition.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0071-i3c-aspeed-Correct-the-timing-for-stop-condition.patch
@@ -1,0 +1,42 @@
+From aeabe251baec5b3aedaef59903e624b18837195a Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Fri, 7 Jun 2024 16:52:46 +0800
+Subject: [PATCH 07/11] i3c: aspeed: Correct the timing for stop condition
+
+The stop condition, meant to clear the internal hardware busy flag, should
+be generated before setting the enable bit of the i3c controller. This is
+necessary for both enable and disable operations.
+Additionally, the waiting time for controller enable should use the
+maximum value between bus available/idle times.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: Icc701f9f9655b78e82feda0177ff861387f00646
+---
+ drivers/i3c/i3c_aspeed.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index aa0a1fc9cb..9f46386770 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1392,13 +1392,14 @@ static int i3c_aspeed_disable(struct i3c_aspeed_obj *obj)
+ 	struct i3c_aspeed_config *config = obj->config;
+ 	struct i3c_register_s *i3c_register = config->base;
+ 
+-	if (config->secondary)
++	if (config->secondary) {
+ 		i3c_aspeed_isolate_scl_sda(config->inst_id, true);
++		/* Clear the internal busy status */
++		i3c_aspeed_gen_stop_to_internal(config->inst_id);
++	}
+ 	i3c_register->device_ctrl.fields.enable = 0;
+ 	if (config->secondary) {
+ 		i3c_aspeed_toggle_scl_in(config->inst_id, 8);
+-		/* Clear the internal busy status */
+-		i3c_aspeed_gen_stop_to_internal(config->inst_id);
+ 		if (i3c_register->device_ctrl.fields.enable) {
+ 			LOG_WRN("Failed to disable controller");
+ 			i3c_aspeed_isolate_scl_sda(config->inst_id, false);
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0072-i3c-aspeed-Check-the-enable-bit-before-disable-it.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0072-i3c-aspeed-Check-the-enable-bit-before-disable-it.patch
@@ -1,0 +1,32 @@
+From b2c32016ce549986117a03f0493b2d35e54206e2 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Wed, 12 Jun 2024 16:41:47 +0800
+Subject: [PATCH 08/11] i3c: aspeed: Check the enable bit before disable it
+
+Add a check for the setting of the enable bit to prevent the driver from
+generating the dummy waveform when the controller remains in disabled
+status.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I4430bf2a9f0236c5841a2e88e991b75e376e2a37
+---
+ drivers/i3c/i3c_aspeed.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 9f46386770..b5699ae5ce 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1392,6 +1392,9 @@ static int i3c_aspeed_disable(struct i3c_aspeed_obj *obj)
+ 	struct i3c_aspeed_config *config = obj->config;
+ 	struct i3c_register_s *i3c_register = config->base;
+ 
++	if (!i3c_register->device_ctrl.fields.enable)
++		return 0;
++
+ 	if (config->secondary) {
+ 		i3c_aspeed_isolate_scl_sda(config->inst_id, true);
+ 		/* Clear the internal busy status */
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0073-i3c-aspeed-Correct-the-timing-for-stop-condition.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0073-i3c-aspeed-Correct-the-timing-for-stop-condition.patch
@@ -1,0 +1,29 @@
+From 8efe4ab58362873f2042f2e0ce59b052e2d3d618 Mon Sep 17 00:00:00 2001
+From: Billy Tsai <billy_tsai@aspeedtech.com>
+Date: Wed, 12 Jun 2024 17:07:11 +0800
+Subject: [PATCH 09/11] i3c: aspeed: Correct the timing for stop condition
+
+Before setting the enable bit, a stop condition is needed to clear the
+busy flag in the hardware internally.
+
+Signed-off-by: Billy Tsai <billy_tsai@aspeedtech.com>
+Change-Id: I76191bdac56c395286fec89a58296bb61b600150
+---
+ drivers/i3c/i3c_aspeed.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index b5699ae5ce..541acd55f9 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1368,6 +1368,7 @@ static int i3c_aspeed_enable(struct i3c_aspeed_obj *obj)
+ 	if (config->secondary) {
+ 		reg.fields.slave_auto_mode_adapt = 0;
+ 		i3c_aspeed_isolate_scl_sda(config->inst_id, true);
++		i3c_aspeed_gen_stop_to_internal(config->inst_id);
+ 	}
+ 	i3c_register->device_ctrl.value = reg.value;
+ 	if (config->secondary) {
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0074-i3c-Export-set_pid_extra_info-API.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0074-i3c-Export-set_pid_extra_info-API.patch
@@ -1,0 +1,212 @@
+From 45aef0cbd9c296c3226e0c9564e35c410c205b1b Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Wed, 12 Jun 2024 17:33:22 +0800
+Subject: [PATCH 10/11] i3c: Export set_pid_extra_info API
+
+Refactor set_pid_extra_info and export it to allow applications to
+configure the PID[11:0]. Add "wait-pid-extra-info" to the DTS node
+to inform the driver to initialize the hardware but not enable target
+mode at boot time. The application will later configure the PID using
+the set_pid_extra_info API, which will also enable the hardware.
+
+Besides, remove the gpio-extra-info related code as the PID extra
+information comes from the application layer now.
+
+Change-Id: I8ed81a932f0563bdba23f37609f3ecae58e3b203
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+---
+ drivers/i3c/i3c_aspeed.c         | 60 +++++++-------------------------
+ dts/bindings/i3c/aspeed,i3c.yaml | 14 +++++---
+ include/drivers/i3c/i3c.h        |  6 ++--
+ 3 files changed, 24 insertions(+), 56 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 541acd55f9..cc80ea90e9 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -485,7 +485,7 @@ struct i3c_aspeed_config {
+ 	uint32_t core_period;
+ 	uint32_t i3c_scl_hz;
+ 	uint32_t i2c_scl_hz;
+-	uint16_t pid_extra_info;
++	int wait_pid_extra_info;
+ 	int secondary;
+ 	int assigned_addr;
+ 	int dcr;
+@@ -1305,7 +1305,6 @@ static void i3c_aspeed_init_pid(struct i3c_aspeed_obj *obj)
+ 	i3c_register->slave_pid_hi.value = slave_pid_hi.value;
+ 
+ 	slave_pid_lo.value = 0;
+-	slave_pid_lo.fields.extra_info = config->pid_extra_info;
+ 	slave_pid_lo.fields.part_id = rev_id;
+ 	slave_pid_lo.fields.inst_id = config->inst_id;
+ 	i3c_register->slave_pid_lo.value = slave_pid_lo.value;
+@@ -1881,25 +1880,10 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+ 	return 0;
+ }
+ 
+-int i3c_aspeed_slave_set_static_addr(const struct device *dev, uint8_t static_addr)
+-{
+-	struct i3c_aspeed_config *config = DEV_CFG(dev);
+-	struct i3c_register_s *i3c_register = config->base;
+-	union i3c_device_addr_s device_addr;
+-
+-	config->assigned_addr = static_addr;
+-
+-	device_addr.value = i3c_register->device_addr.value;
+-	device_addr.fields.static_addr = static_addr;
+-	device_addr.fields.static_addr_valid = static_addr ? 1 : 0;
+-	i3c_register->device_addr.value = device_addr.value;
+-
+-	return 0;
+-}
+-
+ int i3c_aspeed_set_pid_extra_info(const struct device *dev, uint16_t extra_info)
+ {
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
++	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
+ 	struct i3c_register_s *i3c_register = config->base;
+ 	union i3c_slave_pid_lo_s slave_pid_lo;
+ 
+@@ -1910,7 +1894,7 @@ int i3c_aspeed_set_pid_extra_info(const struct device *dev, uint16_t extra_info)
+ 	slave_pid_lo.fields.extra_info = extra_info;
+ 	i3c_register->slave_pid_lo.value = slave_pid_lo.value;
+ 
+-	return 0;
++	return i3c_aspeed_enable(obj);
+ }
+ 
+ int i3c_aspeed_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynamic_addr)
+@@ -2031,34 +2015,6 @@ static void sir_allowed_worker(struct k_work *work)
+ 	obj->sir_allowed_by_sw = 1;
+ }
+ 
+-static uint16_t parse_extra_gpio(const struct extra_gpio *extra_gpios, int size)
+-{
+-	const struct device *gpio_dev;
+-	int i, ret;
+-	uint16_t result = 0;
+-
+-	for (i = 0; i < size; i++) {
+-		gpio_dev = device_get_binding(extra_gpios[i].port);
+-		ret = gpio_pin_configure(gpio_dev, extra_gpios[i].pin, extra_gpios[i].flags | GPIO_INPUT);
+-		if (ret < 0) {
+-			LOG_ERR("pin %s:%d:%d configure failed %d", extra_gpios[i].port,
+-				extra_gpios[i].pin, extra_gpios[i].flags | GPIO_INPUT, ret);
+-			result = 0;
+-			break;
+-		}
+-		ret = gpio_pin_get(gpio_dev, extra_gpios[i].pin);
+-		if (ret < 0) {
+-			LOG_ERR("pin %s:%d get value failed %d", extra_gpios[i].port,
+-				extra_gpios[i].pin, ret);
+-			result = 0;
+-			break;
+-		}
+-		result |= ret << i;
+-	}
+-	LOG_DBG("extra val = %x", result);
+-	return result;
+-}
+-
+ int i3c_aspeed_master_send_entdaa(struct i3c_dev_desc *i3cdev)
+ {
+ 	struct i3c_aspeed_obj *obj = DEV_DATA(i3cdev->bus);
+@@ -2200,6 +2156,14 @@ static int i3c_aspeed_init(const struct device *dev)
+ 	/* Reject SIR by default */
+ 	i3c_register->sir_reject = GENMASK(31, 0);
+ 
++	if (config->secondary && config->wait_pid_extra_info) {
++		/*
++		 * i3c target mode initialized but not enabled yet, waiting for the PID extra-info
++		 * provided by the application.
++		 */
++		return 0;
++	}
++
+ 	ret = i3c_aspeed_enable(obj);
+ 	if (ret)
+ 		return ret;
+@@ -2223,7 +2187,7 @@ static int i3c_aspeed_init(const struct device *dev)
+ 		.ibi_append_pec = DT_INST_PROP_OR(n, ibi_append_pec, 0),                           \
+ 		.priv_xfer_pec = DT_INST_PROP_OR(n, priv_xfer_pec, 0),                             \
+ 		.sda_tx_hold_ns = DT_INST_PROP_OR(n, sda_tx_hold_ns, 0),                           \
+-		.pid_extra_info = DT_INST_PROP_OR(n, pid_extra_info, 0),                           \
++		.wait_pid_extra_info = DT_INST_PROP_OR(n, wait_pid_extra_info, 0),                 \
+ 		.i3c_pp_scl_hi_period_ns = DT_INST_PROP_OR(n, i3c_pp_scl_hi_period_ns, 0),         \
+ 		.i3c_pp_scl_lo_period_ns = DT_INST_PROP_OR(n, i3c_pp_scl_lo_period_ns, 0),         \
+ 		.i3c_od_scl_hi_period_ns = DT_INST_PROP_OR(n, i3c_od_scl_hi_period_ns, 0),         \
+diff --git a/dts/bindings/i3c/aspeed,i3c.yaml b/dts/bindings/i3c/aspeed,i3c.yaml
+index 83cc0cddf3..dcb15c4ac0 100644
+--- a/dts/bindings/i3c/aspeed,i3c.yaml
++++ b/dts/bindings/i3c/aspeed,i3c.yaml
+@@ -16,13 +16,14 @@ properties:
+   assigned-address:
+     required: false
+     type: int
+-    description: Dynamic address when playing the role as the main master. Static address when playing the role as the slave.
++    description: |
++      Dynamic address when playing the role as the main master. Static address when playing the role as the slave.
+ 
+   dcr:
+     required: false
+     type: int
+     description: Device Characteristic Register (DCR).
+-                 See https://www.mipi.org/mipi_i3c_device_characteristics_register for detail.
++      See https://www.mipi.org/mipi_i3c_device_characteristics_register for detail.
+ 
+   instance-id:
+     required: true
+@@ -42,10 +43,13 @@ properties:
+       The PEC will auto append to the tail of the data when doing private transfer and verify
+       the PEC when receiving the data from master.
+ 
+-  pid-extra-info:
++  wait-pid-extra-info:
+     required: false
+-    type: int
+-    description: Extra information of the PID Bits[11:0]. Use to identify the different BIC.
++    type: boolean
++    description: |
++      In target mode, the driver will hold the I3c controller until the pid-extra-info is set by
++      the user application through the API i3c_set_pid_extra_info. This ensures that the PID is set
++      before ENTDAA.
+ 
+   i3c-pp-scl-hi-period-ns:
+     required: false
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index 0dc8e8df1a..74a55c7400 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -204,7 +204,6 @@ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *
+ 
+ /**
+  * @brief slave device prepares the data for master private read transfer
+- *
+  * @param dev the I3C controller in slave mode
+  * @param data pointer to the data structure to be read
+  * @param ibi_notify pointer to the IBI notification structure (optional)
+@@ -222,9 +221,10 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 
+ /**
+  * @brief set the pid extra info of the i3c controller
++ *
+  * @param dev the I3C controller
+  * @param extra_info the extra info of the pid bits[11:0]
+- * @return int 0 = success
++ * @return
+  */
+ int i3c_aspeed_set_pid_extra_info(const struct device *dev, uint16_t extra_info);
+ 
+@@ -251,7 +251,7 @@ int i3c_master_send_getbcr(const struct device *master, uint8_t addr, uint8_t *b
+ #define i3c_slave_put_read_data		i3c_aspeed_slave_put_read_data
+ #define i3c_slave_get_dynamic_addr	i3c_aspeed_slave_get_dynamic_addr
+ #define i3c_slave_get_event_enabling	i3c_aspeed_slave_get_event_enabling
+-#define i3c_set_pid_extra_info		i3c_aspeed_set_pid_extra_info
++#define i3c_set_pid_extra_info          i3c_aspeed_set_pid_extra_info
+ 
+ int i3c_jesd403_read(struct i3c_dev_desc *slave, uint8_t *addr, int addr_size, uint8_t *data,
+ 		     int data_size);
+-- 
+2.25.1
+

--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0075-i3c-Use-bus-to-represent-the-bus-controller-in-i3c_d.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0075-i3c-Use-bus-to-represent-the-bus-controller-in-i3c_d.patch
@@ -1,0 +1,142 @@
+From 9ddcd28b71b80fd2c4a0d98ddc6978cef238eaff Mon Sep 17 00:00:00 2001
+From: Dylan Hung <dylan_hung@aspeedtech.com>
+Date: Mon, 27 Mar 2023 17:07:31 +0800
+Subject: [PATCH 11/11] i3c: Use "bus" to represent the bus controller in
+ i3c_dev_desc
+
+Replace "master_dev" by "bus" to represent the bus that the target
+device attached.
+
+Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>
+Change-Id: I2c85c40c02f9abf3b94d0b5e95ea05915155355d
+---
+ drivers/i3c/i3c_aspeed.c  | 10 +++++-----
+ drivers/i3c/i3c_common.c  |  8 ++++----
+ drivers/i3c/i3c_shell.c   |  2 +-
+ include/drivers/i3c/i3c.h |  4 ++--
+ 4 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index cc80ea90e9..f3e31bda74 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -1467,7 +1467,7 @@ static void i3c_aspeed_start_xfer(struct i3c_aspeed_obj *obj, struct i3c_aspeed_
+ int i3c_aspeed_master_priv_xfer(struct i3c_dev_desc *i3cdev, struct i3c_priv_xfer *xfers,
+ 				int nxfers)
+ {
+-	struct i3c_aspeed_obj *obj = DEV_DATA(i3cdev->master_dev);
++	struct i3c_aspeed_obj *obj = DEV_DATA(i3cdev->bus);
+ 	struct i3c_aspeed_dev_priv *priv = DESC_PRIV(i3cdev);
+ 	struct i3c_aspeed_xfer xfer;
+ 	struct i3c_aspeed_cmd *cmds, *cmd;
+@@ -1579,7 +1579,7 @@ int i3c_aspeed_master_attach_device(const struct device *dev, struct i3c_dev_des
+ 	uint32_t dat_addr;
+ 	int i, pos;
+ 
+-	slave->master_dev = dev;
++	slave->bus = dev;
+ 
+ 	for (i = 0; i < obj->hw_dat.fields.depth; i++) {
+ 		if (obj->hw_dat_free_pos & BIT(i)) {
+@@ -1642,7 +1642,7 @@ int i3c_aspeed_master_request_ibi(struct i3c_dev_desc *i3cdev, struct i3c_ibi_ca
+ 
+ int i3c_aspeed_master_enable_ibi(struct i3c_dev_desc *i3cdev)
+ {
+-	struct i3c_aspeed_obj *obj = DEV_DATA(i3cdev->master_dev);
++	struct i3c_aspeed_obj *obj = DEV_DATA(i3cdev->bus);
+ 	struct i3c_register_s *i3c_register = obj->config->base;
+ 	struct i3c_aspeed_dev_priv *priv = DESC_PRIV(i3cdev);
+ 	union i3c_dev_addr_tbl_s dat;
+@@ -1680,7 +1680,7 @@ int i3c_aspeed_master_enable_ibi(struct i3c_dev_desc *i3cdev)
+ 		 * Therefore, the last argument of i3c_master_send_setmrl is set to
+ 		 * "CONFIG_I3C_ASPEED_MAX_IBI_PAYLOAD - 1"
+ 		 */
+-		ret = i3c_master_send_setmrl(i3cdev->master_dev, i3cdev->info.dynamic_addr, 256,
++		ret = i3c_master_send_setmrl(i3cdev->bus, i3cdev->info.dynamic_addr, 256,
+ 					     CONFIG_I3C_ASPEED_MAX_IBI_PAYLOAD - 1);
+ 		__ASSERT(!ret, "failed to send SETMRL\n");
+ 	}
+@@ -1693,7 +1693,7 @@ int i3c_aspeed_master_enable_ibi(struct i3c_dev_desc *i3cdev)
+ 	intr_reg.fields.ibi_thld = 1;
+ 	i3c_register->intr_signal_en.value = intr_reg.value;
+ 
+-	return i3c_master_send_enec(i3cdev->master_dev, i3cdev->info.dynamic_addr, I3C_CCC_EVT_SIR);
++	return i3c_master_send_enec(i3cdev->bus, i3cdev->info.dynamic_addr, I3C_CCC_EVT_SIR);
+ }
+ 
+ int i3c_aspeed_slave_register(const struct device *dev, struct i3c_slave_setup *slave_data)
+diff --git a/drivers/i3c/i3c_common.c b/drivers/i3c/i3c_common.c
+index 400a572f1e..ddd9a386c7 100644
+--- a/drivers/i3c/i3c_common.c
++++ b/drivers/i3c/i3c_common.c
+@@ -169,7 +169,7 @@ int i3c_jesd403_read(struct i3c_dev_desc *slave, uint8_t *addr, int addr_size, u
+ {
+ 	struct i3c_priv_xfer xfer[2];
+ 
+-	__ASSERT(slave->master_dev, "Unregistered device\n");
++	__ASSERT(slave->bus, "Unregistered device\n");
+ 	__ASSERT(!slave->info.i2c_mode, "Not I3C device\n\n");
+ 
+ 	xfer[0].rnw = 0;
+@@ -199,7 +199,7 @@ int i3c_jesd403_write(struct i3c_dev_desc *slave, uint8_t *addr, int addr_size,
+ 	uint8_t *out;
+ 	int ret;
+ 
+-	__ASSERT(slave->master_dev, "Unregistered device\n");
++	__ASSERT(slave->bus, "Unregistered device\n");
+ 	__ASSERT(!slave->info.i2c_mode, "Not I3C device\n\n");
+ 
+ 	out = k_calloc(sizeof(uint8_t), addr_size + data_size);
+@@ -230,7 +230,7 @@ int i3c_i2c_read(struct i3c_dev_desc *slave, uint8_t addr, uint8_t *buf, int len
+ 	uint8_t mode_reg = addr;
+ 	int ret;
+ 
+-	__ASSERT(slave->master_dev, "Unregistered device\n");
++	__ASSERT(slave->bus, "Unregistered device\n");
+ 	__ASSERT(slave->info.i2c_mode, "Not I2C device\n\n");
+ 
+ 	xfer.rnw = 0;
+@@ -261,7 +261,7 @@ int i3c_i2c_write(struct i3c_dev_desc *slave, uint8_t addr, uint8_t *buf, int le
+ 	uint8_t *out;
+ 	int ret;
+ 
+-	__ASSERT(slave->master_dev, "Unregistered device\n");
++	__ASSERT(slave->bus, "Unregistered device\n");
+ 	__ASSERT(slave->info.i2c_mode, "Not I2C device\n\n");
+ 
+ 	out = k_calloc(sizeof(uint8_t), length + 1);
+diff --git a/drivers/i3c/i3c_shell.c b/drivers/i3c/i3c_shell.c
+index b38d7a0f2c..a976bfe963 100644
+--- a/drivers/i3c/i3c_shell.c
++++ b/drivers/i3c/i3c_shell.c
+@@ -35,7 +35,7 @@ static struct i3c_dev_desc *find_matching_desc(const struct device *dev, uint8_t
+ 	int i;
+ 
+ 	for (i = 0; i < I3C_SHELL_MAX_DESC_NUM; i++) {
+-		if (i3c_shell_desc_tbl[i].master_dev == dev &&
++		if (i3c_shell_desc_tbl[i].bus == dev &&
+ 		    i3c_shell_desc_tbl[i].info.dynamic_addr == desc_addr) {
+ 			desc = &i3c_shell_desc_tbl[i];
+ 			break;
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index 74a55c7400..ae6aa7dc70 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -89,12 +89,12 @@ struct i3c_device_info {
+ 
+ /**
+  * @brief descriptor of the i3c device attached to the bus
+- * @param master_dev the master device which hosts the bus
++ * @param bus the bus controller which hosts the bus
+  * @param priv_data pointer to the low level driver private data
+  * @param info the device information
+  */
+ struct i3c_dev_desc {
+-	const struct device *master_dev;
++	const struct device *bus;
+ 	struct i3c_device_info info;
+ 	void *priv_data;
+ };
+-- 
+2.25.1
+

--- a/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
@@ -87,6 +87,7 @@
 	pinctrl-0 = <&pinctrl_i3c0_default>;
 	i3c-scl-hz = <12500000>;
 	secondary;
+	wait-pid-extra-info;
 	ibi-append-pec;
 	dcr = <0xCC>;
 	i3c0_smq: i3c-slave-mqueue@9 {


### PR DESCRIPTION
# Summary:
We have observed that the BIC PID becomes incorrect following consecutive resets. This issue prevents communication with the correct BIC.

The problem occurs because the driver initialization precedes the PID configuration in the application layer. Consequently, when the BMC requests the PID, it retrieves an incorrect value if the application layer has not yet set the correct PID.

The patchs are for add “wait-pid-extra-info” to i3c DTS nodes. This addition will allow the I3C driver to initialize the hardware without enabling the I3C target mode at boot time (during the driver probe). When application subsequently calls i3c_set_pid_extra_info, the API will set the PID and enable the hardware accordingly.

# Motivation:
Prevent PID is wrong after BIC reset

# Test Plan:
BIC reset stress - pass