### PR TITLE
yv4: sd: Send APML ALERT event to BMC

### DIFF
--- a/common/service/pldm/pldm_oem.h
+++ b/common/service/pldm/pldm_oem.h
@@ -35,6 +35,7 @@ extern "C" {
 enum cmd_type {
 	POST_CODE = 0x00,
 	BIOS_VERSION = 0x01,
+	APML_ALERT = 0x04,
 };
 
 struct _cmd_echo_req {

--- a/meta-facebook/yv4-sd/src/platform/plat_apml.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_apml.c
@@ -208,3 +208,8 @@ void read_cpuid()
 	}
 	apml_read(&apml_data);
 }
+
+const uint8_t* get_cpuid()
+{
+    return cpuid;
+}

--- a/meta-facebook/yv4-sd/src/platform/plat_apml.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_apml.h
@@ -23,6 +23,7 @@
 #define TSI_HIGH_TEMP_THRESHOLD 0x5F
 #define TSI_TEMP_ALERT_UPDATE_RATE 0x0A
 #define PLAT_SBRMI_REVISION 0x20
+#define CPUID_SIZE 16
 
 typedef struct _addc_trigger_info {
 	uint8_t event_version;
@@ -36,5 +37,6 @@ bool get_tsi_status();
 void reset_tsi_status();
 void set_tsi_threshold();
 void read_cpuid();
+const uint8_t* get_cpuid();
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -113,9 +113,9 @@ void pal_set_sys_status()
 	if (get_post_status()) {
 		apml_recovery();
 		set_tsi_threshold();
-		read_cpuid();
 		disable_mailbox_completion_alert();
 		enable_alert_signal();
+		read_cpuid();
 	}
 }
 


### PR DESCRIPTION
# Description:
Send APML ALERT event to BMC.

# Motivation:
This will make BMC be able to do auto crash dump.

# Test Plan:
Build code - Pass
Tested on yv4 - Pass