### PR TITLE
fby4: sd: postpone BIC ready setting

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -98,6 +98,7 @@ void pal_post_init()
 	pldm_load_state_effecter_table(PLAT_PLDM_MAX_STATE_EFFECTER_IDX);
 	pldm_assign_gpio_effecter_id(PLAT_EFFECTER_ID_GPIO_HIGH_BYTE);
 	start_get_dimm_info_thread();
+	set_sys_ready_pin(BIC_READY_R);
 }
 
 void pal_set_sys_status()
@@ -106,7 +107,6 @@ void pal_set_sys_status()
 	set_DC_on_delayed_status();
 	set_post_status(FM_BIOS_POST_CMPLT_BIC_N);
 	sync_bmc_ready_pin();
-	set_sys_ready_pin(BIC_READY_R);
 	reset_usb_hub();
 	apml_init();
 


### PR DESCRIPTION
# Description:
As title.

# Motivation:
We should set BIC ready after MCTP/PLDM init.

# Test plan:
1. check BIC ready pin is set correctly. root@bmc:~# gpioget $(basename "/sys/bus/i2c/devices/0-0024/"*gpiochip*) 1 1