### PR TITLE
aalc: Version commit for aalc-2024.26.01

### DIFF
--- a/meta-facebook/aalc-rpu/src/platform/plat_modbus.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_modbus.c
@@ -141,11 +141,13 @@ uint8_t modbus_get_fw_reversion(modbus_command_mapping *cmd)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cmd, MODBUS_EXC_ILLEGAL_DATA_VAL);
 
-	uint16_t byte_val[4] = { BIC_FW_YEAR_MSB_ASCII, BIC_FW_YEAR_LSB_ASCII, BIC_FW_WEEK_ASCII,
-				 BIC_FW_VER_ASCII };
-	memcpy(cmd->data, &byte_val[0], sizeof(uint16_t) * cmd->cmd_size);
+	uint8_t ver[4] = { BIC_FW_YEAR_MSB, BIC_FW_YEAR_LSB, BIC_FW_WEEK, BIC_FW_VER };
 
-	regs_reverse(cmd->data_len, cmd->data);
+	for (uint8_t i = 0; i < cmd->cmd_size; i++) {
+		char tmp[3] = { 0 };
+		sprintf(tmp, "%02x", ver[i]);
+		cmd->data[i] = tmp[1] << 8 | tmp[0];
+	}
 
 	return MODBUS_EXC_NONE;
 }
@@ -923,7 +925,6 @@ static int coil_wr(uint16_t addr, bool state)
 
 static int holding_reg_multi_wr(char *iface_name, uint16_t addr, uint16_t *reg, uint16_t num_regs)
 {
-
 	modbus_command_mapping *ptr = ptr_to_modbus_table(addr);
 	if (!ptr) {
 		LOG_ERR("modbus write command 0x%x not find!\n", addr);

--- a/meta-facebook/aalc-rpu/src/platform/plat_version.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_version.h
@@ -42,14 +42,10 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x24
-#define BIC_FW_WEEK 0x20
+#define BIC_FW_WEEK 0x26
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x61 // char: a
 #define BIC_FW_platform_1 0x61 // char: a
 #define BIC_FW_platform_2 0x00 // char: '\0'
 
-#define BIC_FW_YEAR_MSB_ASCII 0x3230 // char: 20
-#define BIC_FW_YEAR_LSB_ASCII 0x3234 // char: 24
-#define BIC_FW_WEEK_ASCII 0x3230 // char: 20
-#define BIC_FW_VER_ASCII 0x3031 //char: 01
 #endif


### PR DESCRIPTION
Summary:

-modified:   meta-facebook/aalc-rpu/src/platform/plat_modbus.c
-modified:   meta-facebook/aalc-rpu/src/platform/plat_version.h
	
Description:

-Version commit for aalc-2024.26.01
-Add modbus function of getting version

Test Plan:

-Build code: PASS
-Modbus get versin: Pass