### PR TITLE
 fby3.5: ji: Version commit for oby35-ji-2024.25.02

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_version.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_version.h
@@ -28,7 +28,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x03
+#define FIRMWARE_REVISION_2 0x05
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -37,8 +37,8 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x24
-#define BIC_FW_WEEK 0x24
-#define BIC_FW_VER 0x01
+#define BIC_FW_WEEK 0x25
+#define BIC_FW_VER 0x02
 #define BIC_FW_platform_0 0x6A // char: j
 #define BIC_FW_platform_1 0x69 // char: i
 #define BIC_FW_platform_2 0x00 // char: '\0'


### PR DESCRIPTION
Summary:
- Version commit for Yv3.5 JavaIsland BIC oby35-ji-2024.25.02.

Test Plan:
- Build code: PASS
- Get BIC version: PASS

Log:
- BMC console:
```
root@bmc-oob:~# fw-util slot1 --version bic
SB Bridge-IC Version: oby35-ji-v2024.25.02
root@bmc-oob:~# bic-util slot1 0x18 0x01
00 80 3A 05 02 BF 15 A0 00 00 00 00 00 00 00
```