### PR TITLE
fby35: ji: Add sel for cpu shut down

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_hook.c
@@ -37,7 +37,6 @@
 #define ADJUST_MP5990_POWER(x) (x * 1) // temporary set
 #define ADJUST_RS31380R_CURRENT(x) (x * 1) // temporary set
 #define ADJUST_RS31380R_POWER(x) (x * 1) // temporary set
-#define ADJUST_TMP75_TEMP(x) (x + 1.6)
 
 LOG_MODULE_REGISTER(plat_hook);
 
@@ -261,23 +260,6 @@ bool pre_tmp75_read(sensor_cfg *cfg, void *args)
 	}
 
 	return false;
-}
-
-bool post_tmp75_read(sensor_cfg *cfg, void *args, int *reading)
-{
-	ARG_UNUSED(args);
-	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
-	if (!reading) {
-		return check_reading_pointer_null_is_allowed(cfg);
-	}
-
-	sensor_val *sval = (sensor_val *)reading;
-	float val = sval->integer + (sval->fraction * 0.001);
-	val = ADJUST_TMP75_TEMP(val);
-	sval->integer = (int16_t)val;
-	sval->fraction = (val - sval->integer) * 1000;
-
-	return true;
 }
 
 bool pre_pt4080l_read(sensor_cfg *cfg, void *args)

--- a/meta-facebook/yv35-ji/src/platform/plat_hook.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_hook.h
@@ -50,7 +50,6 @@ bool post_rs31380r_cur_read(sensor_cfg *cfg, void *args, int *reading);
 bool post_rs31380r_pwr_read(sensor_cfg *cfg, void *args, int *reading);
 bool pre_tmp451_read(sensor_cfg *cfg, void *args);
 bool pre_tmp75_read(sensor_cfg *cfg, void *args);
-bool post_tmp75_read(sensor_cfg *cfg, void *args, int *reading);
 bool pre_pt4080l_read(sensor_cfg *cfg, void *args);
 bool pre_ds160pt801_read(sensor_cfg *cfg, void *args);
 

--- a/meta-facebook/yv35-ji/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_isr.c
@@ -21,6 +21,7 @@
 #include "plat_mctp.h"
 #include "plat_class.h"
 #include "plat_power_status.h"
+#include "plat_i2c.h"
 #include "power_status.h"
 #include "ipmi.h"
 #include "pldm.h"
@@ -205,6 +206,49 @@ static void PROC_FAIL_handler(struct k_work *work)
 	}
 }
 
+#define CPLD_CPU_POWER_SEQ_STATE 0x11
+#define CPU_SHDN_STATE 0x07
+
+#define IPMI_SYS_EVENT_OFFSET_CPU_THERM_TRIP_OR_VR_HOT 0x16
+
+static void read_cpu_power_seq_status(struct k_work *work)
+{
+	if (CPU_power_good() == true)
+		return;
+
+	I2C_MSG i2c_msg = { 0 };
+	uint8_t retry = 3;
+	i2c_msg.bus = I2C_BUS1;
+	i2c_msg.target_addr = (CPLD_I2C_ADDR >> 1);
+	i2c_msg.tx_len = 1;
+	i2c_msg.rx_len = 1;
+	i2c_msg.data[0] = CPLD_CPU_POWER_SEQ_STATE;
+
+	if (i2c_master_read(&i2c_msg, retry)) {
+		LOG_ERR("Failed to read CPU power seq state from CPLD.");
+		return;
+	}
+
+	LOG_WRN("CPU power seq state: 0x%x", i2c_msg.data[0]);
+
+	/* if cpu abnormal off, add SEL, it might trigger from CPU or VR. */
+	if (i2c_msg.data[0] == CPU_SHDN_STATE) {
+		LOG_WRN("CPU abnormal off, add CPU thermal trip or VR hot sel.");
+		common_addsel_msg_t sel_msg;
+		sel_msg.InF_target = PLDM;
+		sel_msg.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
+		sel_msg.sensor_number = SENSOR_NUM_SYSTEM_STATUS;
+		sel_msg.event_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
+		sel_msg.event_data1 = IPMI_SYS_EVENT_OFFSET_CPU_THERM_TRIP_OR_VR_HOT;
+		sel_msg.event_data2 = 0xFF;
+		sel_msg.event_data3 = 0xFF;
+		if (!mctp_add_sel_to_ipmi(&sel_msg)) {
+			LOG_ERR("Failed to add CPU thermal trip or VR hot sel.");
+		}
+	}
+}
+
+K_WORK_DELAYABLE_DEFINE(read_cpu_power_seq_status_work, read_cpu_power_seq_status);
 K_WORK_DELAYABLE_DEFINE(set_DC_on_5s_work, set_DC_on_delayed_status);
 K_WORK_DELAYABLE_DEFINE(PROC_FAIL_work, PROC_FAIL_handler);
 #define DC_ON_5_SECOND 5
@@ -236,6 +280,7 @@ void ISR_PWRGD_CPU()
 			LOG_ERR("Failed to cancel set dc on delay work.");
 		}
 		set_DC_on_delayed_status();
+		k_work_schedule(&read_cpu_power_seq_status_work, K_MSEC(500));
 	}
 }
 

--- a/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
@@ -126,7 +126,7 @@ sensor_cfg plat_sensor_config[] = {
 	  NULL, NULL, NULL },
 	{ SENSOR_NUM_TEMP_TMP75_FIO, sensor_dev_tmp75, I2C_BUS2, TMP75_ADDR, TMP75_TEMP_OFFSET,
 	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
-	  SENSOR_INIT_STATUS, pre_tmp75_read, &mux_conf_addr_0xe2[0], post_tmp75_read, NULL, NULL },
+	  SENSOR_INIT_STATUS, pre_tmp75_read, &mux_conf_addr_0xe2[0], NULL, NULL, NULL },
 
 #ifdef ENABLE_NVIDIA
 	/* SatMC */


### PR DESCRIPTION
Summary:
- Support new sel for CPU shut down by CPU its self or VR hot.

TestPlan:
- Build Code: PASS
- Check SEL from BMC after thermal trip test: PASS

Log:
- BMC console:
```
2    slot2    2018-03-15 05:38:43    ipmid            SEL Entry: FRU: 2, Record: Standard (0x02), Time: 2018-03-15 05:38:43, Sensor: SYSTEM_STATUS (0x10), Event Data: (16FFFF) Undefined system event Assertion
```