### PR TITLE
yv4: sd: support FRB3 event log to BMC

### DIFF
--- a/common/service/pldm/pldm_oem.h
+++ b/common/service/pldm/pldm_oem.h
@@ -25,6 +25,10 @@ extern "C" {
 #include <stdint.h>
 
 #define IANA_LEN 0x03
+/* define for pldm oem event */
+#define OEM_EVENT_LEN 0x02
+#define EVENT_ASSERTED 0x01
+#define EVENT_DEASSERTED 0x00
 
 /* commands of pldm type 0x3F : PLDM_TYPE_OEM */
 #define PLDM_OEM_CMD_ECHO 0x00
@@ -40,6 +44,7 @@ enum cmd_type {
 	POWER_CONTROL = 0x02,
 	HTTP_BOOT = 0X03,
 	APML_ALERT = 0x04,
+	EVENT_LOG = 0x05,
 };
 
 enum POWER_CONTROL_OPTION {
@@ -51,6 +56,36 @@ enum POWER_CONTROL_OPTION {
 	NIC2_POWER_CYCLE = 0x05,
 	NIC3_POWER_CYCLE = 0x06,
 	MAX_POWER_OPTION,
+};
+
+enum oem_event_type {
+	CPU_THERMAL_TRIP = 0x00,
+	HSC_OCP,
+	P12V_STBY_UV,
+	PMALERT_ASSERT,
+	FAST_PROCHOT_ASSERT,
+	FRB3_TIMER_EXPIRE,
+	POWER_ON_SEQUENCE_FAIL,
+	DIMM_PMIC_ERROR,
+	ADDC_DUMP,
+	BMC_COMES_OUT_COLD_RESET,
+	BIOS_FRB2_WDT_EXPIRE,
+	BIC_POWER_FAIL,
+	CPU_POWER_FAIL,
+	BMC_VBOOT_FAIL,
+	BMC_REBOOT_REQUESTED,
+	CHASSIS_POWER_ON_BY_NIC_INSERT,
+	BLADE_POWER_CYCLE_BY_BLADE_BTN,
+	CHASSIS_POWER_CYCLE_BY_SLED_BTN,
+	HSC_FAULT,
+	SYS_THROTTLE,
+	VR_FAULT,
+	SYS_MANAMENT_ERROR,
+	POST_COMPLETED,
+	FAN_ERROR,
+	HDT_PRSNT_ASSERT,
+	PLTRST_ASSERT,
+	APML_ALERT_ASSERT,
 };
 
 struct _cmd_echo_req {
@@ -109,6 +144,7 @@ struct pldm_oem_read_file_io_resp {
 
 uint8_t check_iana(const uint8_t *iana);
 uint8_t set_iana(uint8_t *buf, uint8_t buf_len);
+uint8_t send_event_log_to_bmc(uint8_t event_type, uint8_t assertion);
 
 uint8_t pldm_oem_handler_query(uint8_t code, void **ret_fn);
 


### PR DESCRIPTION
# Summary:
- Add send_event_log_to_bmc to send event log to BMC via pldm file_io
- Add PROC_FAIL_handler to check FRB3 after DC ON

- Support event log features

# Test Plan:
1. Build and test pass on Yv4 system.
2. Add FRB3 event when FRB3 check passed to validate that function of send_event_log_to_bmc is worked.

# Test Log:
1. notification in BIC [00:00:53.518,000] <inf> plat_isr: FRB3 checked pass

2. Check SEL through BMC mfg-tool and journal logs to check FRB3 passed event (test purpose)
- journal log Jun 25 05:25:14 bmc pldmd[1076]: Event: Host1 FRB3 Timer Expired, DEASSERTED
- SEL "80624": { "additional_data": [], "event_id": "", "message": "Event: Host1 FRB3 Timer Expired, DEASSERTED", "resolution": "", "resolved": false, "severity": "xyz.openbmc_project.Logging.Entry.Level.Error", "timestamp": "2024-06-25T12:25:14.110000000Z", "updated_timestamp": "2024-06-25T12:25:14.110000000Z" },