### PR TITLE
fby4: sd: Change ADC range of system config

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_class.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_class.c
@@ -88,7 +88,7 @@ bool get_blade_config(uint8_t *blade_config)
 		return false;
 	}
 
-	if (voltage <= 1.02f && voltage >= 0.98f) {
+	if (voltage <= 1.05f && voltage >= 0.95f) {
 		*blade_config = BLADE_CONFIG_T1C;
 	} else {
 		*blade_config = BLADE_CONFIG_T1M;


### PR DESCRIPTION
# Description
- Change the ADC range (+-5%) to avoid misjudgment the system config.

# Motivation
- Due to the resistor's tolerance, the ADC value may be over the range.

# Test Plan
- Build code: Pass