### PR TITLE
aalc: Add nct7363 pwm init duty setting

### DIFF
--- a/common/dev/include/nct7363.h
+++ b/common/dev/include/nct7363.h
@@ -110,7 +110,7 @@ typedef struct _nct7363_init_arg {
 		uint16_t gpio_out_default_val;
 	};
 	float fan_frequency[16];
-	uint8_t duty;
+	uint8_t duty[16];
 	uint16_t threshold[16];
 	uint8_t wdt_cfg;
 } nct7363_init_arg;

--- a/common/dev/nct7363.c
+++ b/common/dev/nct7363.c
@@ -485,7 +485,8 @@ uint8_t nct7363_init(sensor_cfg *cfg)
 
 		/*  set init fan duty */
 		if (nct7363_init_arg_data->pin_type[i] == NCT7363_PIN_TPYE_PWM) {
-			bool set_duty = nct7363_set_duty(cfg, 40, i); // 40% duty for init
+			bool set_duty = nct7363_set_duty(cfg, nct7363_init_arg_data->duty[i],
+							 i); // set duty for init
 			if (!set_duty) {
 				LOG_ERR("set init duty error");
 				return SENSOR_INIT_UNSPECIFIED_ERROR;

--- a/meta-facebook/aalc-rpu/src/platform/plat_hook.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_hook.c
@@ -247,8 +247,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -264,8 +266,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -281,8 +285,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -298,8 +304,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -315,8 +323,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -332,8 +342,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -349,8 +361,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -366,8 +380,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -383,8 +399,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -400,8 +418,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -417,8 +437,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -434,8 +456,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -451,8 +475,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -468,8 +494,10 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
-		.fan_frequency[NCT7363_11_PORT] = 2, // TO DO wait to check
-		.fan_frequency[NCT7363_17_PORT] = 25000, // TO DO wait to check
+		.fan_frequency[NCT7363_11_PORT] = 2, 
+		.fan_frequency[NCT7363_17_PORT] = 25000, 
+		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
 		.fan_poles[NCT7363_15_PORT] = 4, // TO DO wait to check
@@ -488,6 +516,8 @@ nct7363_init_arg nct7363_init_args[] = {
 		// pwm setting
 		.fan_frequency[NCT7363_1_PORT] = 500, // TO DO wait to check
 		.fan_frequency[NCT7363_2_PORT] = 500, // TO DO wait to check
+		.duty[NCT7363_1_PORT] = 60,
+		.duty[NCT7363_2_PORT] = 60,
 		// fanin setting
 		.fan_poles[NCT7363_5_PORT] = 12, // TO DO wait to check
 		.fan_poles[NCT7363_6_PORT] = 4, // TO DO wait to check
@@ -510,6 +540,8 @@ nct7363_init_arg nct7363_init_args[] = {
 		// pwm setting
 		.fan_frequency[NCT7363_1_PORT] = 500, // TO DO wait to check
 		.fan_frequency[NCT7363_2_PORT] = 500, // TO DO wait to check
+		.duty[NCT7363_1_PORT] = 60,
+		.duty[NCT7363_2_PORT] = 60,
 		// fanin setting
 		.fan_poles[NCT7363_5_PORT] = 12, // TO DO wait to check
 		.fan_poles[NCT7363_6_PORT] = 4, // TO DO wait to check
@@ -532,6 +564,8 @@ nct7363_init_arg nct7363_init_args[] = {
 		// pwm setting
 		.fan_frequency[NCT7363_1_PORT] = 500, // TO DO wait to check
 		.fan_frequency[NCT7363_2_PORT] = 500, // TO DO wait to check
+		.duty[NCT7363_1_PORT] = 60,
+		.duty[NCT7363_2_PORT] = 60,
 		// fanin setting
 		.fan_poles[NCT7363_5_PORT] = 12, // TO DO wait to check
 		.fan_poles[NCT7363_6_PORT] = 4, // TO DO wait to check
@@ -562,6 +596,9 @@ nct7363_init_arg nct7363_init_args[] = {
 		.fan_frequency[NCT7363_1_PORT] = 500, // TO DO wait to check
 		.fan_frequency[NCT7363_2_PORT] = 500, // TO DO wait to check
 		.fan_frequency[NCT7363_3_PORT] = 500, // TO DO wait to check
+		.duty[NCT7363_1_PORT] = 60,
+		.duty[NCT7363_2_PORT] = 60,
+		.duty[NCT7363_3_PORT] = 60,
 		// fanin setting
 		.fan_poles[NCT7363_4_PORT] = 12, // TO DO wait to check
 		.threshold[NCT7363_4_PORT] = 50, // TO DO wait to check


### PR DESCRIPTION
Summary:

-modified:   common/dev/include/nct7363.h
-modified:   common/dev/nct7363.c
-modified:   meta-facebook/aalc-rpu/src/platform/plat_hook.c

Description:

-Add nct7363 pwm init duty setting in define
-Setting default duty to fan board nct7363

Test Plan:

-Build code: PASS