### PR TITLE
aalc: add quick sensor thread

### DIFF
--- a/meta-facebook/aalc-rpu/src/platform/plat_fsc.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_fsc.c
@@ -1,0 +1,16 @@
+#include "plat_fsc.h"
+#include <logging/log.h>
+
+static uint8_t fsc_enable_flag;
+
+uint8_t get_fsc_enable_flag(void)
+{
+	return fsc_enable_flag;
+}
+
+void set_fsc_enable_flag(uint8_t flag)
+{
+	fsc_enable_flag = flag;
+}
+
+LOG_MODULE_REGISTER(plat_fsc);

--- a/meta-facebook/aalc-rpu/src/platform/plat_fsc.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_fsc.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-bool modbus_i2c_master_write_read(const uint16_t *modbus_data, uint8_t data_len);
-void modbus_i2c_master_write_read_response(uint16_t *modbus_data);
-void regs_reverse(uint16_t reg_len, uint16_t *data);
-void plat_enable_sensor_poll();
-void plat_disable_sensor_poll();
-void set_rpu_ready();
-float pow_of_10(int8_t exp);
+
+#ifndef PLAT_FSC_H
+#define PLAT_FSC_H
+#include "stdio.h"
+#include "stdint.h"
+
+uint8_t get_fsc_enable_flag(void);
+void set_fsc_enable_flag(uint8_t flag);
+
+#endif

--- a/meta-facebook/aalc-rpu/src/platform/plat_hook.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_hook.c
@@ -974,13 +974,15 @@ bool post_adm1272_read(sensor_cfg *cfg, void *args, int *reading)
 	return true;
 }
 
+extern bool pre_quick_sensor_read(sensor_cfg *cfg, void *args);
 bool post_ads112c_read(sensor_cfg *cfg, void *args, int *reading)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 
 	if (reading == NULL) {
 		// if pre_sensor_read_hook is not null, unlock PCA9546A mutex
-		if (cfg->pre_sensor_read_hook != NULL) {
+		if (cfg->pre_sensor_read_hook != NULL &&
+		    cfg->pre_sensor_read_hook != pre_quick_sensor_read) {
 			if (!post_PCA9546A_read(cfg, args, reading)) {
 				LOG_ERR("adm1272 in post read unlock PCA9546A mutex fail");
 				return false;
@@ -1025,7 +1027,8 @@ bool post_ads112c_read(sensor_cfg *cfg, void *args, int *reading)
 	sval->fraction = (val - sval->integer) * 1000;
 
 	//according to pre_sensor_read_fn(pre_PCA9546A_read), determinies if apply post_PCA9546A_read
-	if (cfg->pre_sensor_read_hook != NULL) {
+	if (cfg->pre_sensor_read_hook != NULL &&
+	    cfg->pre_sensor_read_hook != pre_quick_sensor_read) {
 		post_PCA9546A_read(cfg, args, reading);
 	}
 
@@ -1096,38 +1099,23 @@ static uint8_t get_fb_index(uint8_t sen_num)
 	}
 
 	/* mapping the fan board index by i2c mux info */
-	uint8_t index =
-		(cfg->pre_sensor_read_args == bus_1_PCA9546A_configs) ?
-			0 :
-			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 1)) ?
-			1 :
-			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 2)) ?
-			2 :
-			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 3)) ?
-			3 :
-			(cfg->pre_sensor_read_args == bus_2_PCA9546A_configs) ?
-			4 :
-			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 1)) ?
-			5 :
-			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 2)) ?
-			6 :
-			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 3)) ?
-			7 :
-			(cfg->pre_sensor_read_args == bus_6_PCA9546A_configs) ?
-			8 :
-			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 1)) ?
-			9 :
-			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 2)) ?
-			10 :
-			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 3)) ?
-			11 :
-			(cfg->pre_sensor_read_args == bus_7_PCA9546A_configs) ?
-			12 :
-			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 1)) ?
-			13 :
-			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 2)) ?
-			14 :
-			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 3)) ? 15 : 0xff;
+	uint8_t index = (cfg->pre_sensor_read_args == bus_1_PCA9546A_configs)	    ? 0 :
+			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 1)) ? 1 :
+			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 2)) ? 2 :
+			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 3)) ? 3 :
+			(cfg->pre_sensor_read_args == bus_2_PCA9546A_configs)	    ? 4 :
+			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 1)) ? 5 :
+			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 2)) ? 6 :
+			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 3)) ? 7 :
+			(cfg->pre_sensor_read_args == bus_6_PCA9546A_configs)	    ? 8 :
+			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 1)) ? 9 :
+			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 2)) ? 10 :
+			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 3)) ? 11 :
+			(cfg->pre_sensor_read_args == bus_7_PCA9546A_configs)	    ? 12 :
+			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 1)) ? 13 :
+			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 2)) ? 14 :
+			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 3)) ? 15 :
+										      0xff;
 
 	return index;
 }

--- a/meta-facebook/aalc-rpu/src/platform/plat_init.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_init.c
@@ -75,6 +75,7 @@ void pal_post_init()
 	init_pwm_dev();
 	init_custom_modbus_server();
 	init_modbus_command_table();
+	quick_sensor_poll_init();
 	threshold_poll_init();
 	ctl_all_pwm_dev(60);
 	set_rpu_ready();

--- a/meta-facebook/aalc-rpu/src/platform/plat_modbus.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_modbus.c
@@ -39,7 +39,8 @@
 #include "plat_hwmon.h"
 #include "plat_log.h"
 #include "plat_i2c.h"
-#include <plat_threshold.h>
+#include "plat_threshold.h"
+#include "plat_fsc.h"
 
 LOG_MODULE_REGISTER(plat_modbus);
 
@@ -56,6 +57,7 @@ LOG_MODULE_REGISTER(plat_modbus);
 typedef struct {
 	char *iface_name;
 	bool is_custom_fc64;
+	uint8_t addr;
 } modbus_server;
 modbus_server modbus_server_config[] = {
 	// iface_name, is_custom_fc64
@@ -364,6 +366,9 @@ uint8_t modbus_set_pwm(modbus_command_mapping *cmd)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cmd, MODBUS_EXC_ILLEGAL_DATA_VAL);
 
+	if (get_fsc_enable_flag())
+		return MODBUS_EXC_SERVER_DEVICE_FAILURE;
+
 	uint8_t is_group = cmd->arg0;
 	uint8_t idx = cmd->arg1;
 	uint8_t duty = (uint8_t)cmd->data[0];
@@ -382,6 +387,61 @@ uint8_t modbus_get_sensor_status(modbus_command_mapping *cmd)
 
 	uint8_t status_num = cmd->arg0;
 	cmd->data[0] = read_sensor_status(status_num);
+
+	return MODBUS_EXC_NONE;
+}
+
+uint8_t modbus_get_fsc_enable_flag(modbus_command_mapping *cmd)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cmd, MODBUS_EXC_ILLEGAL_DATA_VAL);
+
+	cmd->data[0] = get_fsc_enable_flag();
+
+	return MODBUS_EXC_NONE;
+}
+
+uint8_t modbus_set_fsc_enable_flag(modbus_command_mapping *cmd)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cmd, MODBUS_EXC_ILLEGAL_DATA_VAL);
+
+	set_fsc_enable_flag((uint8_t)cmd->data[0]);
+
+	return MODBUS_EXC_NONE;
+}
+
+uint8_t modbus_sensor_poll_get(modbus_command_mapping *cmd)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cmd, MODBUS_EXC_ILLEGAL_DATA_VAL);
+
+	cmd->data[0] = get_sensor_poll_enable_flag() ? 1 : 0;
+	return MODBUS_EXC_NONE;
+}
+
+uint8_t modbus_sensor_poll_set(modbus_command_mapping *cmd)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cmd, MODBUS_EXC_ILLEGAL_DATA_VAL);
+
+	cmd->data[0] ? plat_enable_sensor_poll() : plat_disable_sensor_poll();
+	return MODBUS_EXC_NONE;
+}
+
+uint8_t modbus_get_rpu_addr(modbus_command_mapping *cmd)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cmd, MODBUS_EXC_ILLEGAL_DATA_VAL);
+
+	cmd->data[0] = modbus_server_config[0].addr;
+
+	return MODBUS_EXC_NONE;
+}
+
+uint8_t modbus_set_rpu_addr(modbus_command_mapping *cmd)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cmd, MODBUS_EXC_ILLEGAL_DATA_VAL);
+
+	uint8_t addr = (uint8_t)cmd->data[0];
+
+	if (change_modbus_slave_addr(0, addr))
+		return MODBUS_EXC_SERVER_DEVICE_FAILURE;
 
 	return MODBUS_EXC_NONE;
 }
@@ -411,7 +471,7 @@ modbus_command_mapping modbus_command_table[] = {
 	  SENSOR_NUM_BPB_HSC_P48V_VIN_VOLT_V, 1, -1, 1 },
 	{ MODBUS_MB_RPU_AIR_INLET_TEMP_ADDR, NULL, modbus_get_senser_reading,
 	  SENSOR_NUM_MB_RPU_AIR_INLET_TEMP_C, 1, -1, 1 },
-	{ MODBUS_RPU_PUMP_PWM_TACH_PCT_ADDR, NULL, modbus_get_senser_reading, 0, 1, 0, 1 },
+	{ MODBUS_RPU_PUMP_PWM_TACH_PCT_ADDR, NULL, modbus_get_pwm, 1, PWM_GROUP_E_PUMP, 0, 1 },
 	{ MODBUS_PB_1_PUMP_TACH_RPM_ADDR, NULL, modbus_get_senser_reading,
 	  SENSOR_NUM_PB_1_PUMP_TACH_RPM, 1, 0, 1 },
 	{ MODBUS_PB_2_PUMP_TACH_RPM_ADDR, NULL, modbus_get_senser_reading,
@@ -526,7 +586,7 @@ modbus_command_mapping modbus_command_table[] = {
 	  1, 0, 1 },
 	{ MODBUS_PB_3_HUM_PCT_RH_ADDR, NULL, modbus_get_senser_reading, SENSOR_NUM_PB_3_HUM_PCT_RH,
 	  1, 0, 1 },
-	{ MODBUS_HEX_FAN_PWM_TACH_PCT_ADDR, NULL, modbus_get_senser_reading, 0, 1, 0, 1 },
+	{ MODBUS_HEX_FAN_PWM_TACH_PCT_ADDR, NULL, modbus_get_pwm, 1, PWM_GROUP_E_HEX_FAN, 0, 1 },
 	{ MODBUS_HEX_PWR_W_ADDR, NULL, modbus_get_senser_reading, SENSOR_NUM_HEX_PWR_W, 1, -1, 1 },
 	{ MODBUS_HEX_INPUT_VOLT_V_ADDR, NULL, modbus_get_senser_reading,
 	  SENSOR_NUM_FB_1_HSC_P48V_VIN_VOLT_V, 1, 0, 1 },
@@ -787,8 +847,10 @@ modbus_command_mapping modbus_command_table[] = {
 	{ MODBUS_HEX_FAN_ALARM_1_ADDR, NULL, modbus_get_sensor_status, HEX_FAN_ALARM_1, 0, 0, 1 },
 	{ MODBUS_HEX_FAN_ALARM_2_ADDR, NULL, modbus_get_sensor_status, HEX_FAN_ALARM_2, 0, 0, 1 },
 	{ MODBUS_AALC_TOTAL_PWR_EXT_W_ADDR, NULL, modbus_to_do, 0, 0, 0, 1 },
-	{ MODBUS_MODBUS_ADDR_PATH_WITH_WEDGE400_ADDR, NULL, modbus_to_do, 0, 0, 0, 1 },
-	{ MODBUS_MANUAL_CONTROL_RPU_FAN_ON_OFF_ADDR, NULL, modbus_to_do, 0, 0, 0, 1 },
+	{ MODBUS_MODBUS_ADDR_PATH_WITH_WEDGE400_ADDR, modbus_set_rpu_addr, modbus_get_rpu_addr, 0,
+	  0, 0, 1 },
+	{ MODBUS_MANUAL_CONTROL_RPU_FAN_ON_OFF_ADDR, modbus_set_fsc_enable_flag,
+	  modbus_get_fsc_enable_flag, 0, 0, 0, 1 },
 	// Control
 	{ MODBUS_AUTO_TUNE_COOLANT_FLOW_RATE_TARGET_SET_ADDR, modbus_to_do, NULL, 0, 0, 0, 1 },
 	{ MODBUS_AUTO_TUNE_COOLANT_OUTLET_TEMPERATURE_TARGET_SET_ADDR, modbus_to_do, NULL, 0, 0, 0,
@@ -909,8 +971,8 @@ modbus_command_mapping modbus_command_table[] = {
 	{ MODBUS_FB_14_FRU_ADDR, modbus_write_fruid_data, modbus_read_fruid_data, FB_14_FRU_ID, 0,
 	  0, 256 },
 	// sensor poll
-	{ MODBUS_SET_SENSOR_POLL_EN_ADDR, modbus_sensor_poll_en, NULL, 0, 0, 0, 1 },
-	{ MODBUS_GET_SENSOR_POLL_EN_ADDR, NULL, modbus_sensor_poll_en, 1, 0, 0, 1 },
+	{ MODBUS_GET_SET_SENSOR_POLL_ADDR, modbus_sensor_poll_set, modbus_sensor_poll_get, 0, 0, 0,
+	  1 },
 	// eeprom related
 	{ MODBUS_GET_SET_HMI_VER_ADDR, modbus_write_hmi_version, modbus_read_hmi_version, 0, 0, 0,
 	  8 },
@@ -1064,7 +1126,7 @@ static struct modbus_user_callbacks mbs_cbs = {
 	.holding_reg_multi_wr = holding_reg_multi_wr,
 };
 
-const static struct modbus_iface_param server_param = {
+static struct modbus_iface_param server_param = {
 	.mode = MODBUS_MODE_RTU,
 	.server = {
 		.user_cb = &mbs_cbs,
@@ -1118,6 +1180,7 @@ int init_custom_modbus_server(void)
 				modbus_server_config[i].iface_name);
 			return -ENODEV;
 		}
+
 		int err = modbus_init_server(server_iface, server_param);
 
 		if (err < 0) {
@@ -1130,7 +1193,40 @@ int init_custom_modbus_server(void)
 			if (ret)
 				return ret;
 		}
+
+		modbus_server_config[i].addr = server_param.server.unit_id;
 	}
+
+	return ret;
+}
+
+int change_modbus_slave_addr(uint8_t idx, uint8_t addr)
+{
+	server_param.server.unit_id = addr;
+
+	int server_iface = modbus_iface_get_by_name(modbus_server_config[idx].iface_name);
+	modbus_disable(server_iface);
+
+	if (server_iface < 0) {
+		LOG_ERR("Failed to get iface index for %s", modbus_server_config[idx].iface_name);
+		return -ENODEV;
+	}
+
+	int err = modbus_init_server(server_iface, server_param);
+	int ret = 0;
+
+	if (err < 0) {
+		LOG_ERR("modbus_init_server fail %d\n", idx);
+		return err;
+	}
+
+	if (modbus_server_config[idx].is_custom_fc64) {
+		ret = modbus_register_user_fc(server_iface, &modbus_cfg_custom_fc64);
+		if (ret)
+			return ret;
+	}
+
+	modbus_server_config[idx].addr = addr;
 
 	return ret;
 }

--- a/meta-facebook/aalc-rpu/src/platform/plat_modbus.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_modbus.h
@@ -36,13 +36,13 @@
 #define MODBUS_MASTER_I2C_SCAN_BUS_SET_ADDR 0xF020 // 1 byte
 #define MODBUS_MASTER_I2C_SCAN_ADDR 0xF021 // 31 bytes
 
-#define MODBUS_SET_SENSOR_POLL_EN_ADDR 0xF080
-#define MODBUS_GET_SENSOR_POLL_EN_ADDR 0xF081
+#define MODBUS_GET_SET_SENSOR_POLL_ADDR 0xF080
 
 #define MODBUS_GET_SET_HMI_VER_ADDR 0x19F2
 
 int init_custom_modbus_server(void);
 void init_modbus_command_table(void);
+int change_modbus_slave_addr(uint8_t idx, uint8_t addr);
 
 typedef struct _modbus_command_mapping {
 	uint16_t addr;
@@ -253,11 +253,6 @@ typedef struct _modbus_command_mapping {
 #define MODBUS_FB_12_HUM_PCT_RH_ADDR 0xA157
 #define MODBUS_FB_13_HUM_PCT_RH_ADDR 0xA158
 #define MODBUS_FB_14_HUM_PCT_RH_ADDR 0xA159
-#define MODBUS_V_12_AUX_ADDR 0xA15A
-#define MODBUS_V_5_AUX_ADDR 0xA15B
-#define MODBUS_V_3_3_AUX_ADDR 0xA15C
-#define MODBUS_V_1_2_AUX_ADDR 0xA15D
-#define MODBUS_V_5_USB_ADDR 0xA15E
 
 #define MODBUS_LEAKAGE_STATUS_ADDR 0x9202
 #define MODBUS_SB_TTV_COOLANT_LEAKAGE_ADDR 0xA200
@@ -295,6 +290,11 @@ typedef struct _modbus_command_mapping {
 #define MODBUS_PUMP_FAN_STATUS_ADDR 0xA080
 #define MODBUS_HEX_AIR_THERMOMETER_STATUS_ADDR 0xA202
 #define MODBUS_AALC_TOTAL_PWR_EXT_W_ADDR 0xA02D
+#define MODBUS_V_12_AUX_ADDR 0xA02E
+#define MODBUS_V_5_AUX_ADDR 0xA02F
+#define MODBUS_V_3_3_AUX_ADDR 0xA030
+#define MODBUS_V_1_2_AUX_ADDR 0xA031
+#define MODBUS_V_5_USB_ADDR 0xA032
 #define MODBUS_MODBUS_ADDR_PATH_WITH_WEDGE400_ADDR 0xA401
 #define MODBUS_MANUAL_CONTROL_RPU_FAN_ON_OFF_ADDR 0xA480
 #define MODBUS_ERROR_LOG_COUNT_ADDR 0x1A28

--- a/meta-facebook/aalc-rpu/src/platform/plat_pwm.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_pwm.c
@@ -20,6 +20,7 @@
 #include "nct7363.h"
 #include "plat_sensor_table.h"
 #include "plat_hook.h"
+#include "plat_fsc.h"
 #include "plat_pwm.h"
 
 LOG_MODULE_REGISTER(plat_pwm);

--- a/meta-facebook/aalc-rpu/src/platform/plat_sensor_table.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_sensor_table.h
@@ -242,5 +242,6 @@ uint8_t plat_get_config_size();
 void load_sensor_config(void);
 uint8_t get_sensor_reading_to_real_val(uint8_t sensor_num, float *val);
 uint16_t get_sensor_reading_to_modbus_val(uint8_t sensor_num, int8_t exp, int8_t scale);
+void quick_sensor_poll_init();
 
 #endif

--- a/meta-facebook/aalc-rpu/src/platform/plat_shell.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_shell.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <shell/shell.h>
+#include "plat_pwm.h"
+#include "plat_threshold.h"
+#include "sensor.h"
+#include "plat_sensor_table.h"
+#include "plat_util.h"
+
+LOG_MODULE_REGISTER(plat_shell);
+
+// sensor polling flag
+void cmd_sensor_polling(const struct shell *shell, size_t argc, char **argv)
+{
+	uint8_t onoff = strtoul(argv[1], NULL, 10);
+	if (onoff == 0) {
+		plat_disable_sensor_poll();
+	} else if (onoff == 1) {
+		plat_enable_sensor_poll();
+	} else {
+		shell_warn(shell, "poll flag: %d", get_sensor_poll_enable_flag() ? 1 : 0);
+	}
+}
+
+// pwm
+void cmd_get_pump_duty(const struct shell *shell, size_t argc, char **argv)
+{
+	uint8_t duty = 0xff;
+	duty = get_pwm_group_cache(PWM_GROUP_E_PUMP);
+	shell_warn(shell, "get pump duty: %d", duty);
+}
+void cmd_get_hex_fan_duty(const struct shell *shell, size_t argc, char **argv)
+{
+	uint8_t duty = 0xff;
+	duty = get_pwm_group_cache(PWM_GROUP_E_HEX_FAN);
+	shell_warn(shell, "get hex fan duty: %d", duty);
+}
+void cmd_get_rpu_fan_duty(const struct shell *shell, size_t argc, char **argv)
+{
+	uint8_t duty = 0xff;
+	duty = get_pwm_group_cache(PWM_GROUP_E_RPU_FAN);
+	shell_warn(shell, "get rpu fan duty: %d", duty);
+}
+void cmd_get_fan_duty(const struct shell *shell, size_t argc, char **argv)
+{
+	uint8_t idx = strtoul(argv[1], NULL, 10);
+	uint8_t duty = 0xff;
+
+	duty = get_pwm_cache(idx);
+	shell_warn(shell, "get fan %d duty: %d", idx, duty);
+}
+
+void cmd_set_pump_duty(const struct shell *shell, size_t argc, char **argv)
+{
+	uint8_t duty = strtoul(argv[1], NULL, 10);
+
+	shell_warn(shell, "set pump duty: %d", duty);
+	set_pwm_group(PWM_GROUP_E_PUMP, duty);
+}
+void cmd_set_hex_fan_duty(const struct shell *shell, size_t argc, char **argv)
+{
+	uint8_t duty = strtoul(argv[1], NULL, 10);
+
+	shell_warn(shell, "set hex fan duty: %d", duty);
+	set_pwm_group(PWM_GROUP_E_HEX_FAN, duty);
+}
+void cmd_set_rpu_fan_duty(const struct shell *shell, size_t argc, char **argv)
+{
+	uint8_t duty = strtoul(argv[1], NULL, 10);
+
+	shell_warn(shell, "set rpu fan duty: %d", duty);
+	set_pwm_group(PWM_GROUP_E_RPU_FAN, duty);
+}
+void cmd_set_fan_duty(const struct shell *shell, size_t argc, char **argv)
+{
+	uint8_t idx = strtoul(argv[1], NULL, 10);
+	uint8_t duty = strtoul(argv[2], NULL, 10);
+
+	shell_warn(shell, "set fan %d duty: %d", idx, duty);
+	plat_pwm_ctrl(idx, duty);
+}
+
+// test command
+void cmd_test(const struct shell *shell, size_t argc, char **argv)
+{
+	// test code
+}
+
+/* Sub-command Level 3 of command test */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_get_pwm_cmd,
+			       SHELL_CMD(pump, NULL, "get pump duty", cmd_get_pump_duty),
+			       SHELL_CMD(hex_fan, NULL, "get hex fan duty", cmd_get_hex_fan_duty),
+			       SHELL_CMD(rpu_fan, NULL, "get rpu fan duty", cmd_get_rpu_fan_duty),
+			       SHELL_CMD(single, NULL, "get fan device duty", cmd_get_fan_duty),
+			       SHELL_SUBCMD_SET_END);
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_set_pwm_cmd,
+			       SHELL_CMD(pump, NULL, "set pump duty", cmd_set_pump_duty),
+			       SHELL_CMD(hex_fan, NULL, "set hex fan duty", cmd_set_hex_fan_duty),
+			       SHELL_CMD(rpu_fan, NULL, "set rpu fan duty", cmd_set_rpu_fan_duty),
+			       SHELL_CMD(single, NULL, "set fan device duty", cmd_set_fan_duty),
+			       SHELL_SUBCMD_SET_END);
+
+/* Sub-command Level 2 of command test */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_pwm_cmd, SHELL_CMD(get, &sub_get_pwm_cmd, "get duty", NULL),
+			       SHELL_CMD(set, &sub_set_pwm_cmd, "set duty", NULL),
+			       SHELL_SUBCMD_SET_END);
+
+/* Sub-command Level 1 of command test */
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_test_cmds, SHELL_CMD(pwm, &sub_pwm_cmd, "set/get pwm command", NULL),
+	SHELL_CMD(poll, NULL, "enable/disable sensor polling", cmd_sensor_polling),
+	SHELL_CMD(test, NULL, "test command", cmd_test), SHELL_SUBCMD_SET_END);
+
+/* Root of command test */
+SHELL_CMD_REGISTER(test, &sub_test_cmds, "Test commands for AALC", NULL);

--- a/meta-facebook/aalc-rpu/src/platform/plat_threshold.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_threshold.c
@@ -439,6 +439,8 @@ void threshold_poll_handler(void *arug0, void *arug1, void *arug2)
 
 	int threshold_poll_interval_ms = 1000; // interval 1s
 
+	k_msleep(15000); // wait 15s for sensor ready
+
 	while (1) {
 		if (!get_sensor_init_done_flag()) {
 			k_msleep(threshold_poll_interval_ms);

--- a/meta-facebook/aalc-rpu/src/platform/plat_util.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_util.c
@@ -26,6 +26,7 @@
 #include "libutil.h"
 #include "sensor.h"
 #include "plat_gpio.h"
+#include "plat_pwm.h"
 
 #define I2C_MASTER_READ_BACK_MAX_SIZE 16 // 16 registers
 
@@ -90,28 +91,16 @@ void regs_reverse(uint16_t reg_len, uint16_t *data)
 		data[i] = sys_be16_to_cpu(data[i]);
 }
 
-uint8_t modbus_sensor_poll_en(modbus_command_mapping *cmd)
+void plat_enable_sensor_poll(void)
 {
-	CHECK_NULL_ARG_WITH_RETURN(cmd, MODBUS_EXC_ILLEGAL_DATA_VAL);
+	enable_sensor_poll();
+	nct7363_wdt_all_enable();
+}
 
-	uint8_t op = cmd->arg0;
-
-#define SET_SENSOR_POLL 0
-#define GET_SENSOR_POLL 1
-
-	switch (op) {
-	case SET_SENSOR_POLL:
-		// if data[0] != 0, enable
-		cmd->data[0] ? enable_sensor_poll() : disable_sensor_poll();
-		break;
-	case GET_SENSOR_POLL:
-		cmd->data[0] = get_sensor_poll_enable_flag() ? 1 : 0;
-		break;
-	default:
-		LOG_ERR("Unknow sensor poll arg0 %d", op);
-	}
-
-	return MODBUS_EXC_NONE;
+void plat_disable_sensor_poll(void)
+{
+	nct7363_wdt_all_disable();
+	disable_sensor_poll();
 }
 
 void set_rpu_ready()


### PR DESCRIPTION
Summary:
- add quick sensor for bpb leak sensor
- add manual control fan command
- modify sensor poll enable command
- add set/get rpu slave addr
- modify rpu ADC sensor number
- add plat_fsc/plat_shell

Test Plan:
- Build code: PASS