### PR TITLE
aalc: Add fan board and pump board led status

### DIFF
--- a/common/dev/include/nct7363.h
+++ b/common/dev/include/nct7363.h
@@ -138,3 +138,5 @@ bool nct7363_set_duty(sensor_cfg *cfg, uint8_t duty, uint8_t port);
 #endif
 uint8_t nct7363_init(sensor_cfg *cfg);
 bool nct7363_setting_wdt(sensor_cfg *cfg, uint8_t wdt);
+uint8_t nct7363_read_back_data(sensor_cfg *cfg, uint8_t reading_offset);
+bool nct7363_write(sensor_cfg *cfg, uint8_t offset, uint8_t val);

--- a/meta-facebook/aalc-rpu/src/platform/plat_hook.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_hook.c
@@ -243,13 +243,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -262,13 +263,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -281,13 +283,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -300,13 +303,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -319,13 +323,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -338,13 +343,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -357,13 +363,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -376,13 +383,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -395,13 +403,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -414,13 +423,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -433,13 +443,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -452,13 +463,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -471,13 +483,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -490,13 +503,14 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_1_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
 		.gpio_00 = 1, //gpio out default value (active low)
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_PWM,
 		.pin_type[NCT7363_15_PORT] = NCT7363_PIN_TPYE_FANIN,
 		.pin_type[NCT7363_17_PORT] = NCT7363_PIN_TPYE_PWM,
 		// pwm setting
 		.fan_frequency[NCT7363_11_PORT] = 2, 
 		.fan_frequency[NCT7363_17_PORT] = 25000, 
-		.duty[NCT7363_11_PORT] = 100, 
+		.duty[NCT7363_11_PORT] = 0, 
 		.duty[NCT7363_17_PORT] = 60,
 		// fanin setting
 		.threshold[NCT7363_15_PORT] = 50, // TO DO wait to check
@@ -512,7 +526,9 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_6_PORT] = NCT7363_PIN_TPYE_FANIN, // fan fanin
 		.pin_type[NCT7363_7_PORT] = NCT7363_PIN_TPYE_FANIN, // fan fanin
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_11 = 0,
 		// pwm setting
 		.fan_frequency[NCT7363_1_PORT] = 500, // TO DO wait to check
 		.fan_frequency[NCT7363_2_PORT] = 500, // TO DO wait to check
@@ -536,7 +552,9 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_6_PORT] = NCT7363_PIN_TPYE_FANIN, // fan fanin
 		.pin_type[NCT7363_7_PORT] = NCT7363_PIN_TPYE_FANIN, // fan fanin
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_11 = 0,
 		// pwm setting
 		.fan_frequency[NCT7363_1_PORT] = 500, // TO DO wait to check
 		.fan_frequency[NCT7363_2_PORT] = 500, // TO DO wait to check
@@ -560,7 +578,9 @@ nct7363_init_arg nct7363_init_args[] = {
 		.pin_type[NCT7363_6_PORT] = NCT7363_PIN_TPYE_FANIN, // fan fanin
 		.pin_type[NCT7363_7_PORT] = NCT7363_PIN_TPYE_FANIN, // fan fanin
 		.pin_type[NCT7363_10_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_10 = 1,
 		.pin_type[NCT7363_11_PORT] = NCT7363_PIN_TPYE_GPIO_DEFAULT_OUTPUT,
+		.gpio_11 = 0,
 		// pwm setting
 		.fan_frequency[NCT7363_1_PORT] = 500, // TO DO wait to check
 		.fan_frequency[NCT7363_2_PORT] = 500, // TO DO wait to check
@@ -1096,38 +1116,23 @@ static uint8_t get_fb_index(uint8_t sen_num)
 	}
 
 	/* mapping the fan board index by i2c mux info */
-	uint8_t index =
-		(cfg->pre_sensor_read_args == bus_1_PCA9546A_configs) ?
-			0 :
-			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 1)) ?
-			1 :
-			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 2)) ?
-			2 :
-			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 3)) ?
-			3 :
-			(cfg->pre_sensor_read_args == bus_2_PCA9546A_configs) ?
-			4 :
-			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 1)) ?
-			5 :
-			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 2)) ?
-			6 :
-			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 3)) ?
-			7 :
-			(cfg->pre_sensor_read_args == bus_6_PCA9546A_configs) ?
-			8 :
-			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 1)) ?
-			9 :
-			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 2)) ?
-			10 :
-			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 3)) ?
-			11 :
-			(cfg->pre_sensor_read_args == bus_7_PCA9546A_configs) ?
-			12 :
-			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 1)) ?
-			13 :
-			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 2)) ?
-			14 :
-			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 3)) ? 15 : 0xff;
+	uint8_t index = (cfg->pre_sensor_read_args == bus_1_PCA9546A_configs)	    ? 0 :
+			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 1)) ? 1 :
+			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 2)) ? 2 :
+			(cfg->pre_sensor_read_args == (bus_1_PCA9546A_configs + 3)) ? 3 :
+			(cfg->pre_sensor_read_args == bus_2_PCA9546A_configs)	    ? 4 :
+			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 1)) ? 5 :
+			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 2)) ? 6 :
+			(cfg->pre_sensor_read_args == (bus_2_PCA9546A_configs + 3)) ? 7 :
+			(cfg->pre_sensor_read_args == bus_6_PCA9546A_configs)	    ? 8 :
+			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 1)) ? 9 :
+			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 2)) ? 10 :
+			(cfg->pre_sensor_read_args == (bus_6_PCA9546A_configs + 3)) ? 11 :
+			(cfg->pre_sensor_read_args == bus_7_PCA9546A_configs)	    ? 12 :
+			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 1)) ? 13 :
+			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 2)) ? 14 :
+			(cfg->pre_sensor_read_args == (bus_7_PCA9546A_configs + 3)) ? 15 :
+										      0xff;
 
 	return index;
 }

--- a/meta-facebook/aalc-rpu/src/platform/plat_init.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_init.c
@@ -35,6 +35,9 @@ LOG_MODULE_REGISTER(plat_init);
 
 #define DEF_PROJ_GPIO_PRIORITY 78
 
+static void pump_board_init(struct k_work *work);
+K_WORK_DELAYABLE_DEFINE(up_15sec_handler, pump_board_init);
+
 SCU_CFG scu_cfg[] = {
 	//register    value
 	{ 0x7e789108, 0x00000500 }, // uart1,2 RS485 DE/nRE
@@ -48,6 +51,56 @@ SCU_CFG scu_cfg[] = {
 	{ 0x7e6e2630, 0x00000002 },
 };
 
+uint8_t pump_board_init_tbl[] = {
+	// pump board 1
+	SENSOR_NUM_PB_1_FAN_1_TACH_RPM, SENSOR_NUM_PB_1_FAN_1_TACH_RPM,
+	SENSOR_NUM_PB_1_FAN_2_TACH_RPM, SENSOR_NUM_PB_1_HDC1080DMBR_TEMP_C,
+	SENSOR_NUM_PB_1_HUM_PCT_RH, SENSOR_NUM_PB_1_HSC_P48V_TEMP_C,
+	SENSOR_NUM_PB_1_HSC_P48V_VIN_VOLT_V, SENSOR_NUM_PB_1_HSC_P48V_IOUT_CURR_A,
+	SENSOR_NUM_PB_1_HSC_P48V_PIN_PWR_W,
+	// pump board 2
+	SENSOR_NUM_PB_2_PUMP_TACH_RPM, SENSOR_NUM_PB_2_FAN_1_TACH_RPM,
+	SENSOR_NUM_PB_2_FAN_2_TACH_RPM, SENSOR_NUM_PB_2_HDC1080DMBR_TEMP_C,
+	SENSOR_NUM_PB_2_HUM_PCT_RH, SENSOR_NUM_PB_2_HSC_P48V_TEMP_C,
+	SENSOR_NUM_PB_2_HSC_P48V_VIN_VOLT_V, SENSOR_NUM_PB_2_HSC_P48V_IOUT_CURR_A,
+	SENSOR_NUM_PB_2_HSC_P48V_PIN_PWR_W,
+	// pump board 3
+	SENSOR_NUM_PB_3_PUMP_TACH_RPM, SENSOR_NUM_PB_3_FAN_1_TACH_RPM,
+	SENSOR_NUM_PB_3_FAN_2_TACH_RPM, SENSOR_NUM_PB_3_HDC1080DMBR_TEMP_C,
+	SENSOR_NUM_PB_3_HUM_PCT_RH, SENSOR_NUM_PB_3_HSC_P48V_TEMP_C,
+	SENSOR_NUM_PB_3_HSC_P48V_VIN_VOLT_V, SENSOR_NUM_PB_3_HSC_P48V_IOUT_CURR_A,
+	SENSOR_NUM_PB_3_HSC_P48V_PIN_PWR_W
+};
+
+void pump_board_init(struct k_work *work)
+{
+	if (work == NULL) {
+		LOG_ERR("pump_board_init get NULL work handler!");
+		return;
+	}
+
+	// init pump board 1, 2 and 3
+	LOG_WRN("pump board start init");
+	for (uint8_t i = 0; i < ARRAY_SIZE(pump_board_init_tbl); i++) {
+		sensor_cfg *cfg = get_common_sensor_cfg_info(pump_board_init_tbl[i]);
+		if (cfg->pre_sensor_read_hook) {
+			if (cfg->pre_sensor_read_hook(cfg, cfg->pre_sensor_read_args) != true) {
+				LOG_ERR("init pump board pre-read fail, sensor num: 0x%x",
+					cfg->num);
+			}
+		}
+
+		bool ret = init_drive_type_delayed(cfg);
+
+		if (ret != true)
+			LOG_ERR("init drive type fail, sensor num: 0x%x", cfg->num);
+
+		if (cfg->post_sensor_read_hook) {
+			cfg->post_sensor_read_hook(cfg, cfg->post_sensor_read_args, NULL);
+		}
+	}
+}
+
 void pal_pre_init()
 {
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
@@ -55,18 +108,32 @@ void pal_pre_init()
 	gpio_set(FM_BIC_READY_R_N, 0); //MM4 for bus3 power up
 	k_msleep(10);
 	// pull bpb nct7363 sensor box power high first;
-	sensor_cfg plat_sensor_config[] = {
-		{ SENSOR_NUM_BPB_RACK_LEVEL_1, sensor_dev_nct7363, I2C_BUS5, BPB_NCT7363_ADDR,
-		  NCT7363_GPIO_READ_OFFSET, stby_access, NCT7363_5_PORT, 0, SAMPLE_COUNT_DEFAULT,
-		  POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL,
-		  NULL, &nct7363_init_args[17] }
-	};
-	uint8_t ret = nct7363_init(&plat_sensor_config[0]);
+	sensor_cfg plat_sensor_config = { SENSOR_NUM_BPB_RACK_LEVEL_1,
+					  sensor_dev_nct7363,
+					  I2C_BUS5,
+					  BPB_NCT7363_ADDR,
+					  NCT7363_GPIO_READ_OFFSET,
+					  stby_access,
+					  NCT7363_5_PORT,
+					  0,
+					  SAMPLE_COUNT_DEFAULT,
+					  POLL_TIME_DEFAULT,
+					  ENABLE_SENSOR_POLLING,
+					  0,
+					  SENSOR_INIT_STATUS,
+					  NULL,
+					  NULL,
+					  NULL,
+					  NULL,
+					  &nct7363_init_args[17] };
+
+	uint8_t ret = nct7363_init(&plat_sensor_config);
 
 	if (ret)
 		LOG_ERR("init result fail:0x%x", ret);
 
 	k_msleep(1000);
+	k_work_schedule(&up_15sec_handler, K_SECONDS(15));
 }
 
 void pal_post_init()
@@ -78,6 +145,7 @@ void pal_post_init()
 	threshold_poll_init();
 	ctl_all_pwm_dev(60);
 	set_rpu_ready();
+	fan_pump_pwrgd();
 }
 
 void pal_device_init()

--- a/meta-facebook/aalc-rpu/src/platform/plat_threshold.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_threshold.h
@@ -67,4 +67,5 @@ enum AALC_SENSOR_STATUS_E {
 void set_threshold_poll_enable_flag(bool flag);
 bool get_threshold_poll_enable_flag();
 void threshold_poll_init();
+void fan_pump_pwrgd();
 uint16_t read_sensor_status(uint8_t sensor_status_num);


### PR DESCRIPTION
Summary:

- modified:   common/dev/include/nct7363.h
- modified:   common/dev/nct7363.c
- modified:   meta-facebook/aalc-rpu/src/platform/plat_init.c
- modified:   meta-facebook/aalc-rpu/src/platform/plat_threshold.c
- modified:   meta-facebook/aalc-rpu/src/platform/plat_threshold.h

Description:

- Add thread to check fan board and pump board gok pin status -Add threshold to set different led status

Test Plan:

- Build code: PASS