### PR TITLE
fby4: sd: Fix sensor post reading function APML bus

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_class.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_class.c
@@ -119,7 +119,7 @@ bool get_board_rev(uint8_t *board_rev)
 	case BOARD_REV_DVT:
 	case BOARD_REV_PVT:
 	case BOARD_REV_MP:
-		LOG_INF("Board revision 0x%x", *board_rev);
+		LOG_DBG("Board revision 0x%x", *board_rev);
 		return true;
 	default:
 		LOG_ERR("Invalid board revision 0x%x", *board_rev);

--- a/meta-facebook/yv4-sd/src/platform/plat_hook.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_hook.c
@@ -141,7 +141,8 @@ bool post_amd_tsi_read(sensor_cfg *cfg, void *args, int *const reading)
 	}
 
 	uint8_t tsi_status = 0;
-	if (apml_read_byte(I2C_BUS14, SB_TSI_ADDR, SBTSI_STATUS, &tsi_status)) {
+	uint8_t apml_bus = pal_get_apml_bus();
+	if (apml_read_byte(apml_bus, SB_TSI_ADDR, SBTSI_STATUS, &tsi_status)) {
 		LOG_ERR("Failed to read TSI status");
 		return true;
 	}


### PR DESCRIPTION
# Description
- Correct the I2C bus on DVT board in post reading function.

# Motivation
- SD BIC console shows "plat_hook: Failed to read TSI status" error messages.

# Log
- Before Fix uart:~$ [00:24:17.720,000] <err> hal_i2c: I2C 13 master read retry reach max with ret -16 [00:24:17.720,000] <err> plat_hook: Failed to read TSI status

- After Fix uart:~$
uart:~$