### PR TITLE
yv4: sd: BMC cold reset event log to BMC

### DIFF
--- a/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
@@ -100,6 +100,15 @@ void APP_COLD_RESET(ipmi_msg *msg)
 		return;
 	}
 
+	// BMC COLD RESET event assert
+	LOG_ERR("BMC COLD RESET event assert");
+	struct pldm_addsel_data event_msg = { 0 };
+	event_msg.event_type = BMC_COMES_OUT_COLD_RESET;
+	event_msg.assert_type = EVENT_ASSERTED;
+	if (PLDM_SUCCESS != send_event_log_to_bmc(event_msg)) {
+		LOG_ERR("Failed to assert BMC COLD RESET event log.");
+	};
+
 	switch (pal_submit_bmc_cold_reset()) {
 	case -EBUSY:
 		msg->completion_code = CC_NODE_BUSY;


### PR DESCRIPTION
# Summary:
- Add BMC cold reset event log before BMC cold reset

# Description:
- Support register an event when BMC comes out of cold reset

# Test Plan:
- Build code: pass
- Tigger BMC cold reset through BIC ipmi command, then check event log after BMC comes up

# Test Log:
1. Trigger BMC cold reset through BIC uart uart:~$ platform ipmi raw 0x6 0x2
BIC self command netfn:0x6 cmd:0x2 response with cc 0x0 uart:~$ [00:01:04.410,000] <err> plat_ipmi: BMC COLD RESET event assert

2. Check BMC event log after boot up root@bmc:~# mfg-tool log-display
"2": {
        "additional_data": [],
        "event_id": "",
        "message": "Event: Host1 BMC comes out of cold reset, ASSERTED",
        "resolution": "",
        "resolved": false,
        "severity": "xyz.openbmc_project.Logging.Entry.Level.Error",
        "timestamp": "2024-07-19T12:11:30.515000000Z",
        "updated_timestamp": "2024-07-19T12:11:30.515000000Z"
    },