### PR TITLE
yv4:sd:Correct E1.S sensor list for T1C system

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
@@ -67,6 +67,7 @@ void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
 					     PDR_numeric_sensor *numeric_sensor_table);
 uint8_t plat_pldm_sensor_get_vr_dev(uint8_t *vr_dev);
 void plat_pldm_sensor_change_vr_dev();
+void plat_pldm_sensor_change_ssd_dev();
 void plat_pldm_sensor_change_cpu_bus();
 void plat_pldm_sensor_change_retimer_dev();
 


### PR DESCRIPTION
# Description:
SD BIC according to ADC voltage to know the system config, and using the correct sensor list.

# Motivation:
Change the setting of E1.S sensor for T1M or T1C system.

# Test Plan:
Build code - Pass
Tested on yv4-T1C system - Pass
Check if display nvme error log in SD BIC