### PR TITLE
common: Fix mctp multi-pkg send fail issue

### DIFF
--- a/common/service/mctp/mctp.c
+++ b/common/service/mctp/mctp.c
@@ -336,7 +336,7 @@ static void mctp_tx_task(void *arg, void *dummy0, void *dummy1)
 		}
 
 		/* Setup MCTP header and send to destination endpoint */
-		static uint8_t msg_tag;
+		uint8_t msg_tag = mctp_inst->msg_tag;
 		uint16_t max_msg_size = mctp_inst->max_msg_size;
 		uint8_t i;
 		uint8_t split_pkt_num =
@@ -396,7 +396,7 @@ static void mctp_tx_task(void *arg, void *dummy0, void *dummy1)
 
 		/* Only request mctp message needs to increase msg_tag */
 		if (mctp_msg.ext_params.tag_owner)
-			msg_tag++;
+			mctp_inst->msg_tag++;
 	}
 }
 

--- a/common/service/mctp/mctp.h
+++ b/common/service/mctp/mctp.h
@@ -197,6 +197,8 @@ typedef struct _mctp {
 	uint8_t ncsi_inst_id;
 	uint32_t ncsi_inst_table[8]; // 256 bits field for instance id
 
+	/* for MCTP msg tag */
+	uint8_t msg_tag;
 } mctp;
 
 typedef struct _mctp_smbus_port {


### PR DESCRIPTION
Summary:
- Root cause: Because all of the MCTP channels using the same transfer function, and the "msg_tag" of header using static variable which may be modified by each transaction from every channel. And BMC won't accept multi-package message with different msg_tag. Actually it is illegal, so the message would be ignored.
- Change msg_tag variable from static to global. Each channel got there own msg_tag.

Test Plan:
- BuildCode: PASS
- Check whether command lost by stressing command "ipmitool raw 0x6 0x1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0" in HOST: PASS

