### PR TITLE
fby4: wf: Reset CXL EID when CXL reset

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.c
@@ -167,15 +167,15 @@ static void set_dev_endpoint(void)
 
 				uint8_t rc = mctp_ctrl_send_msg(find_mctp_by_bus(p->bus), &msg);
 				if (!rc) {
-					switch(p->bus) {
-						case I2C_BUS_CXL1: {
-							set_eid[CXL_ID_1] = true;
-							break;
-						}
-						case I2C_BUS_CXL2: {
-							set_eid[CXL_ID_2] = true;
-							break;
-						}
+					switch (p->bus) {
+					case I2C_BUS_CXL1: {
+						set_eid[CXL_ID_1] = true;
+						break;
+					}
+					case I2C_BUS_CXL2: {
+						set_eid[CXL_ID_2] = true;
+						break;
+					}
 					}
 				} else {
 					LOG_ERR("Fail to set endpoint %d", p->endpoint);
@@ -282,6 +282,7 @@ void send_cmd_to_dev_handler(struct k_work *work)
 
 void send_cmd_to_dev(struct k_timer *timer)
 {
+	LOG_INF("Send set EID command to CXL");
 	k_work_submit(&send_cmd_work);
 }
 

--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
@@ -48,6 +48,9 @@ static bool is_cxl_power_on[MAX_CXL_ID] = { false, false };
 static bool is_cxl_ready[MAX_CXL_ID] = { false, false };
 static bool is_cxl_vr_accessible[MAX_CXL_ID] = { false, false };
 
+static k_tid_t cxl1_tid = NULL;
+static k_tid_t cxl2_tid = NULL;
+
 cxl_power_control_gpio cxl_power_ctrl_pin[MAX_CXL_ID] = {
 	[0] = {
 	.enclk_100m_osc = EN_CLK_100M_ASIC1_OSC,
@@ -169,20 +172,33 @@ void execute_power_on_sequence()
 		set_DC_status(PG_CARD_OK);
 		k_work_schedule(&set_dc_on_5s_work, K_SECONDS(DC_ON_DELAY5_SEC));
 
-		k_tid_t cxl1_tid = k_thread_create(&cxl1_thread_data, cxl1_stack_area,
-                                        K_THREAD_STACK_SIZEOF(cxl1_stack_area),
-                                        cxl1_ready_handler, NULL, NULL, NULL,
-                                        CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+		create_check_cxl_ready_thread();
+	}
+}
 
-		k_tid_t cxl2_tid = k_thread_create(&cxl2_thread_data, cxl2_stack_area,
-                                        K_THREAD_STACK_SIZEOF(cxl2_stack_area),
-                                        cxl2_ready_handler, NULL, NULL, NULL,
-                                        CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
-
+void create_check_cxl_ready_thread()
+{
+	if ((cxl1_tid != NULL) && ((strcmp(k_thread_state_str(cxl1_tid), "dead") != 0) &&
+				   (strcmp(k_thread_state_str(cxl1_tid), "unknown") != 0))) {
+		;
+	} else {
+		cxl1_tid = k_thread_create(&cxl1_thread_data, cxl1_stack_area,
+					   K_THREAD_STACK_SIZEOF(cxl1_stack_area),
+					   cxl1_ready_handler, NULL, NULL, NULL,
+					   CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
 		k_thread_name_set(cxl1_tid, "cxl1_ready_thread");
-		k_thread_name_set(cxl2_tid, "cxl2_ready_thread");
-
 		k_thread_start(cxl1_tid);
+	}
+
+	if ((cxl2_tid != NULL) && ((strcmp(k_thread_state_str(cxl2_tid), "dead") != 0) &&
+				   (strcmp(k_thread_state_str(cxl2_tid), "unknown") != 0))) {
+		;
+	} else {
+		cxl2_tid = k_thread_create(&cxl2_thread_data, cxl2_stack_area,
+					   K_THREAD_STACK_SIZEOF(cxl2_stack_area),
+					   cxl2_ready_handler, NULL, NULL, NULL,
+					   CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+		k_thread_name_set(cxl2_tid, "cxl2_ready_thread");
 		k_thread_start(cxl2_tid);
 	}
 }
@@ -344,7 +360,6 @@ bool is_power_controlled(int cxl_id, int power_pin, uint8_t check_power_status, 
 	} else {
 		return true;
 	}
-
 }
 
 void execute_power_off_sequence()
@@ -551,7 +566,6 @@ int check_powers_disabled(int cxl_id, int pwr_stage)
 
 void switch_mux_to_bic(uint8_t value_to_write)
 {
-
 	uint8_t value = 0x0;
 
 	k_mutex_lock(&switch_ioe_mux_mutex, K_SECONDS(SWITCH_IOE_MUX_TIMEOUT_SECONDS));

--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
@@ -113,5 +113,6 @@ bool cxl2_ready_access(uint8_t sensor_num);
 void set_cxl_vr_access(uint8_t cxl_id, bool value);
 bool cxl1_vr_access(uint8_t sensor_num);
 bool cxl2_vr_access(uint8_t sensor_num);
+void create_check_cxl_ready_thread();
 
 #endif


### PR DESCRIPTION
# Description
- Set CXL EID again, when it reboot.

# Motivation
- In case of warm reset or power cycle, the cxl card reload the f/w and re-init all blocks including mctp (from v2.0.12 release onwards) so bic need to assign EID.

# Test plan
- Build code: Pass
- Reset host and get CXL version: Pass

# Log
1. Reset host and get CXL version. root@bmc:~# ./power-util_v6.sh reset 4; sleep 480; ./fw-util_v7.8.sh --version wf_cxl 4 Executing power-util: reset 4
Executing host power reset...
pldmtool: Tx: 80 02 39 00 00 01 00 04
pldmtool: Rx: 00 02 39 00
Host4 is power reset
success
./fw-util_v7.8.sh: line 426: warning: command substitution: ignored null byte in input CXL1 Slot 4 version:
Get Firmware Info for EID: 44
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.12-c26492c7
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:
./fw-util_v7.8.sh: line 446: warning: command substitution: ignored null byte in input CXL2 Slot 4 version:
Get Firmware Info for EID: 45
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.12-c26492c7
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision: