### PR TITLE
fby4: sd/wf: Change fw update limit size

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_def.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_def.h
@@ -69,4 +69,6 @@
 #define BMC_USB_PORT "CDC_ACM_0"
 #define MCTP_I3C_PEC_ENABLE 1
 
+#define BIC_UPDATE_MAX_OFFSET 0xC0000
+
 #endif

--- a/meta-facebook/yv4-wf/src/platform/plat_def.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_def.h
@@ -26,4 +26,7 @@
 #define ENABLE_PLDM_SENSOR
 #define ENABLE_CCI
 #define ENABLE_VISTARA
+
+#define BIC_UPDATE_MAX_OFFSET 0xC0000
+
 #endif


### PR DESCRIPTION
# Description:
- Change the update size limit of BIC to 768KB, equals the hardware size limit.

# Motivation:
- Since yosemite4, the size of BIC firmware package are mostly above 320KB, causes failure while updating in-band from host, therefore redefine this limit to 768KB, that is 0xC0000 bytes, equals the BIC hardware size limit.

# Log:
========================{SHELL COMMAND INFO}========================================
* NAME:          Platform command
* DESCRIPTION:   Commands that could be used to debug or validate.
* DATE/VERSION:  none
* CHIP/OS:       ast1030_evb - Zephyr
* Note:          none
------------------------------------------------------------------
* PLATFORM:      Yosemite V4-Sentinel Dome
* BOARD ID:      1
* STAGE:         3
* SYSTEM:        255
* FW VERSION:    49.1
* FW DATE:       2024.31.1
* FW IMAGE:      Y4BSD.bin
========================{SHELL COMMAND INFO}========================================

Try to update BIC from host 3 (192.168.0.135) ...
===============================================================================
* Name         : FW UPDATE TOOL
* Description  : Firmware update tool from host, including [BIC].
* Ver/Date     : v1.1.1/2022.08.24
* Note         : none
===============================================================================
<warn>   Force update without validate sign-key.
<system> Start [BIC] update task with image [/tmp/iuwu/update.bin]

<system> STEP1. Read image
<system> PASS!

<system> STEP2. Create free-ipmi session
<system> PASS!

<system> STEP3. Verify image
<system> skip!

<system> STEP4. Upload image
<error>  send_recv_command: ipmi-raw received bad cc 0xff

<system> FW update retry 1/2 ...
         update status 0%
         update status 5%
         update status 10%
         update status 15%
         update status 20%
         update status 25%
         update status 30%
         update status 35%
         update status 40%
         update status 45%
         update status 50%
         update status 55%
         update status 60%
         update status 65%
         update status 70%
         update status 75%
         update status 80%
         update status 85%
         update status 90%
         update status 95%
         update status 100%
<system> PASS!

<system> Update complete!
Host update 3 done.

========================{SHELL COMMAND INFO}========================================
* NAME:          Platform command
* DESCRIPTION:   Commands that could be used to debug or validate.
* DATE/VERSION:  none
* CHIP/OS:       ast1030_evb - Zephyr
* Note:          none
------------------------------------------------------------------
* PLATFORM:      Yosemite V4-Sentinel Dome
* BOARD ID:      1
* STAGE:         3
* SYSTEM:        255
* FW VERSION:    49.1
* FW DATE:       2024.31.1
* FW IMAGE:      Y4BSD.bin
========================{SHELL COMMAND INFO}========================================