### PR TITLE
YV4: sd: Modify the implementation of http boot

### DIFF
--- a/common/service/pldm/pldm_oem.h
+++ b/common/service/pldm/pldm_oem.h
@@ -96,6 +96,8 @@ enum vr_event_source {
 	PVDD11_S3,
 };
 
+enum READ_FILE_OPTION { READ_FILE_ATTR, READ_FILE_DATA };
+
 struct _cmd_echo_req {
 	uint8_t iana[IANA_LEN];
 	uint8_t first_data;
@@ -135,19 +137,29 @@ struct pldm_oem_write_file_io_resp {
 
 struct pldm_oem_read_file_io_req {
 	uint8_t cmd_code;
-	uint8_t data_length;
-	uint8_t transfer_flag;
-	uint8_t highOffset;
-	uint8_t lowOffset;
+	uint8_t read_option;
+	uint8_t read_info_length;
+	uint8_t read_info[];
 } __attribute__((packed));
 
 struct pldm_oem_read_file_io_resp {
 	uint8_t completion_code;
+	uint8_t read_option;
+	uint8_t read_info_length;
+	uint8_t read_info[];
+} __attribute__((packed));
+
+struct pldm_oem_read_file_attr_info {
+	uint8_t size_lsb;
+	uint8_t size_msb;
+	uint32_t crc32;
+} __attribute__((packed));
+
+struct pldm_oem_read_file_data_info {
 	uint8_t data_length;
 	uint8_t transfer_flag;
 	uint8_t highOffset;
 	uint8_t lowOffset;
-	uint8_t messages[];
 } __attribute__((packed));
 
 struct pldm_addsel_data {

--- a/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
@@ -292,42 +292,35 @@ void OEM_GET_HTTP_BOOT_DATA(ipmi_msg *msg)
 	CHECK_NULL_ARG(msg);
 
 	if (msg->data_len != 3) {
+		LOG_ERR("Failed to get OEM http boot data because of invalid length: 0x%x",
+			msg->data_len);
 		msg->completion_code = CC_INVALID_LENGTH;
 		return;
 	}
 
-	uint8_t *httpBootData = (uint8_t *)malloc(sizeof(uint8_t) * HTTP_BOOT_DATA_MAXIMUM);
-	if (httpBootData == NULL) {
+	uint8_t ret = 0;
+	uint8_t length = msg->data[2];
+	uint16_t offset = (uint16_t)(msg->data[1] << 8) | msg->data[0];
+
+	uint8_t *httpbootdata = (uint8_t *)malloc(sizeof(uint8_t) * length);
+	if (httpbootdata == NULL) {
 		LOG_ERR("Failed to allocate http boot data buffer");
 		msg->completion_code = CC_UNSPECIFIED_ERROR;
 		return;
 	}
 
-	uint8_t ret = 0;
-	uint16_t httpBootDataLen = 0;
-	ret = plat_pldm_get_http_boot_data(httpBootData, &httpBootDataLen);
+	ret = plat_pldm_get_http_boot_data(offset, &length, msg->data[2], httpbootdata);
 	if (ret != PLDM_SUCCESS) {
 		LOG_ERR("Failed to get http boot data, ret: 0x%x", ret);
+		SAFE_FREE(httpbootdata);
 		msg->completion_code = CC_UNSPECIFIED_ERROR;
-		free(httpBootData);
-		return;
-	}
-
-	uint16_t offset = (uint16_t)(msg->data[1] << 8) | msg->data[0];
-	uint16_t length = (uint16_t)msg->data[2];
-
-	if (offset + length > httpBootDataLen) {
-		LOG_ERR("Failed to get OEM HTTP BOOT DATA because of invalid offset or length");
-		msg->completion_code = CC_INVALID_PARAM;
-		free(httpBootData);
 		return;
 	}
 
 	msg->data_len = 1 + length; // 1 byte length + length bytes Data
 	msg->data[0] = (uint8_t)length;
-	memcpy(&msg->data[1], &httpBootData[offset], length);
-
-	free(httpBootData);
+	memcpy(&msg->data[1], httpbootdata, length);
+	SAFE_FREE(httpbootdata);
 	msg->completion_code = CC_SUCCESS;
 	return;
 }
@@ -337,59 +330,46 @@ void OEM_GET_HTTP_BOOT_ATTR(ipmi_msg *msg)
 	CHECK_NULL_ARG(msg);
 
 	if (msg->data_len != 1) {
-		LOG_ERR("Failed to get OEM HTTP BOOT DATA because of invalid length");
+		LOG_ERR("Failed to get OEM http boot attribute because of invalid length: 0x%x",
+			msg->data_len);
 		msg->completion_code = CC_INVALID_LENGTH;
 		return;
 	}
 
 	uint8_t attr = msg->data[0];
 	if (attr >= GET_HTTP_BOOT_MAX) {
-		LOG_ERR("Failed to get OEM HTTP BOOT DATA because of invalid command");
+		LOG_ERR("Failed to get OEM http boot attribute because of invalid command: 0x%x",
+			attr);
 		msg->completion_code = CC_INVALID_CMD;
-		return;
-	}
-
-	uint8_t *httpBootData = (uint8_t *)malloc(sizeof(uint8_t) * HTTP_BOOT_DATA_MAXIMUM);
-	if (httpBootData == NULL) {
-		LOG_ERR("Failed to allocate http boot data buffer");
-		msg->completion_code = CC_UNSPECIFIED_ERROR;
 		return;
 	}
 
 	uint8_t ret = 0;
-	uint16_t httpBootDataLen = 0;
-	ret = plat_pldm_get_http_boot_data(httpBootData, &httpBootDataLen);
+	struct pldm_oem_read_file_attr_info info = { 0 };
+
+	ret = plat_pldm_get_http_boot_attr(sizeof(struct pldm_oem_read_file_attr_info),
+					   (uint8_t *)&info);
 	if (ret != PLDM_SUCCESS) {
-		LOG_ERR("Failed to get http boot data, ret: 0x%x", ret);
+		LOG_ERR("Failed to get http boot attributes, ret: 0x%x", ret);
 		msg->completion_code = CC_UNSPECIFIED_ERROR;
-		free(httpBootData);
 		return;
 	}
-
-	uint32_t crc32_value = 0;
 
 	switch (attr) {
 	case GET_HTTP_BOOT_SIZE:
 		msg->data_len = 2;
-		msg->data[0] = httpBootDataLen & 0xFF;
-		msg->data[1] = (httpBootDataLen >> 8) & 0xFF;
+		msg->data[0] = info.size_lsb;
+		msg->data[1] = info.size_msb;
 		break;
 	case GET_HTTP_BOOT_CRC32:
-		crc32_value = crc32_ieee(httpBootData, httpBootDataLen);
-
 		msg->data_len = 4;
-		msg->data[0] = crc32_value & 0xFF;
-		msg->data[1] = (crc32_value >> 8) & 0xFF;
-		msg->data[2] = (crc32_value >> 16) & 0xFF;
-		msg->data[3] = (crc32_value >> 24) & 0xFF;
+		memcpy(&msg->data[0], &info.crc32, sizeof(uint32_t));
 		break;
 	default:
 		msg->completion_code = CC_INVALID_CMD;
-		free(httpBootData);
 		return;
 	}
 
-	free(httpBootData);
 	msg->completion_code = CC_SUCCESS;
 	return;
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm.c
@@ -4,6 +4,7 @@
 #include <logging/log_ctrl.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "libutil.h"
 #include "plat_mctp.h"
 #include "plat_pldm.h"
 #include "hal_i2c.h"
@@ -17,10 +18,11 @@ uint8_t plat_pldm_get_tid()
 	return plat_get_eid();
 }
 
-uint8_t plat_pldm_get_http_boot_data(uint8_t *httpBootData, uint16_t *httpBootDataLen)
+uint8_t plat_pldm_get_http_boot_attr(uint8_t length, uint8_t *httpBootattr)
 {
-	pldm_msg pmsg = { 0 };
+	CHECK_NULL_ARG_WITH_RETURN(httpBootattr, PLDM_ERROR);
 
+	pldm_msg pmsg = { 0 };
 	uint8_t bmc_bus = I2C_BUS_BMC;
 	uint8_t bmc_interface = pal_get_bmc_interface();
 	pmsg.ext_params.ep = MCTP_EID_BMC;
@@ -44,48 +46,177 @@ uint8_t plat_pldm_get_http_boot_data(uint8_t *httpBootData, uint16_t *httpBootDa
 	pmsg.hdr.pldm_type = PLDM_TYPE_OEM;
 	pmsg.hdr.cmd = PLDM_OEM_READ_FILE_IO;
 
-	struct pldm_oem_read_file_io_req ptr = { 0 };
-	ptr.cmd_code = HTTP_BOOT;
-	ptr.data_length = BMC_PLDM_DATA_MAXIMUM - sizeof(struct pldm_oem_read_file_io_req);
-	ptr.transfer_flag = PLDM_START;
-	ptr.highOffset = 0;
-	ptr.lowOffset = 0;
-
-	pmsg.buf = (uint8_t *)&ptr;
-	pmsg.len = sizeof(struct pldm_oem_read_file_io_req);
-
-	uint16_t resp_len = BMC_PLDM_DATA_MAXIMUM;
-
-	struct pldm_oem_read_file_io_resp *rbuf =
-		(struct pldm_oem_read_file_io_resp *)malloc(sizeof(uint8_t) * resp_len);
-	if (rbuf == NULL) {
-		LOG_ERR("Failed to allocate response buffer");
+	struct pldm_oem_read_file_io_req *ptr = (struct pldm_oem_read_file_io_req *)malloc(
+		sizeof(struct pldm_oem_read_file_io_req) +
+		sizeof(uint8_t) /* Minimum requried length */);
+	if (ptr == NULL) {
+		LOG_ERR("Fail to allocate ptr for reading file IO request: get http attr");
 		return PLDM_ERROR;
 	}
 
-	uint16_t offset = 0;
+	ptr->cmd_code = HTTP_BOOT;
+	ptr->read_option = READ_FILE_ATTR;
+	ptr->read_info_length = 1;
+	ptr->read_info[0] = 0x00;
+
+	pmsg.buf = (uint8_t *)ptr;
+	pmsg.len = sizeof(struct pldm_oem_read_file_io_req) + sizeof(uint8_t);
+	uint16_t resp_len = BMC_PLDM_DATA_MAXIMUM;
+	struct pldm_oem_read_file_io_resp *rbuf =
+		(struct pldm_oem_read_file_io_resp *)malloc(sizeof(uint8_t) * resp_len);
+	if (rbuf == NULL) {
+		LOG_ERR("Fail to allocate rbuf for getting http boot attribute");
+		SAFE_FREE(ptr);
+		return PLDM_ERROR;
+	}
+
+	resp_len = mctp_pldm_read(find_mctp_by_bus(bmc_bus), &pmsg, (uint8_t *)rbuf, resp_len);
+	if (resp_len == 0) {
+		LOG_ERR("Fail to send command to get http boot attribute");
+		SAFE_FREE(ptr);
+		SAFE_FREE(rbuf);
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	SAFE_FREE(ptr);
+	if (rbuf->completion_code != PLDM_SUCCESS) {
+		LOG_ERR("Read http attribute fail, cc: 0x%x", rbuf->completion_code);
+		SAFE_FREE(rbuf);
+		return PLDM_ERROR;
+	}
+
+	if (rbuf->read_info_length > length) {
+		LOG_ERR("Read info length exceeded buffer length, read length: 0x%x, buffer length: 0x%x",
+			rbuf->read_info_length, length);
+		SAFE_FREE(rbuf);
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	memcpy(httpBootattr, rbuf->read_info, rbuf->read_info_length);
+	SAFE_FREE(rbuf);
+	return PLDM_SUCCESS;
+}
+
+uint8_t plat_pldm_get_http_boot_data(uint16_t offset, uint8_t *read_length, uint8_t buffer_length,
+				     uint8_t *httpBootData)
+{
+	CHECK_NULL_ARG_WITH_RETURN(httpBootData, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(read_length, PLDM_ERROR);
+
+	if (*read_length > buffer_length) {
+		LOG_ERR("Invalid read length: 0x%x, buffer length: 0x%x", *read_length,
+			buffer_length);
+		return PLDM_ERROR;
+	}
+
+	pldm_msg pmsg = { 0 };
+	uint8_t bmc_bus = I2C_BUS_BMC;
+	uint8_t bmc_interface = pal_get_bmc_interface();
+	uint8_t hdr_req_len = sizeof(pldm_hdr) + sizeof(struct pldm_oem_read_file_io_req);
+	pmsg.ext_params.ep = MCTP_EID_BMC;
+
+	switch (bmc_interface) {
+	case BMC_INTERFACE_I3C:
+		bmc_bus = I3C_BUS_BMC;
+		pmsg.ext_params.type = MCTP_MEDIUM_TYPE_TARGET_I3C;
+		pmsg.ext_params.i3c_ext_params.addr = I3C_STATIC_ADDR_BMC;
+		break;
+	case BMC_INTERFACE_I2C:
+		bmc_bus = I2C_BUS_BMC;
+		pmsg.ext_params.type = MCTP_MEDIUM_TYPE_SMBUS;
+		pmsg.ext_params.smbus_ext_params.addr = I2C_ADDR_BMC;
+		break;
+	default:
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	pmsg.hdr.rq = PLDM_REQUEST;
+	pmsg.hdr.pldm_type = PLDM_TYPE_OEM;
+	pmsg.hdr.cmd = PLDM_OEM_READ_FILE_IO;
+
+	struct pldm_oem_read_file_io_req *ptr = (struct pldm_oem_read_file_io_req *)malloc(
+		sizeof(struct pldm_oem_read_file_io_req) +
+		sizeof(struct pldm_oem_read_file_data_info));
+	if (ptr == NULL) {
+		LOG_ERR("Fail to allocate ptr for reading file IO request: get http data");
+		return PLDM_ERROR;
+	}
+
+	ptr->cmd_code = HTTP_BOOT;
+	ptr->read_option = READ_FILE_DATA;
+	ptr->read_info_length = sizeof(struct pldm_oem_read_file_data_info);
+
+	struct pldm_oem_read_file_data_info data_info = { 0 };
+	data_info.data_length = (*read_length > (BMC_PLDM_DATA_MAXIMUM - hdr_req_len) ?
+					 (BMC_PLDM_DATA_MAXIMUM - hdr_req_len) :
+					 *read_length);
+	data_info.transfer_flag = PLDM_START;
+	data_info.highOffset = (offset >> 8) & 0xFF;
+	data_info.lowOffset = offset & 0xFF;
+	memcpy(ptr->read_info, &data_info, sizeof(struct pldm_oem_read_file_data_info));
+
+	pmsg.buf = (uint8_t *)ptr;
+	pmsg.len = sizeof(struct pldm_oem_read_file_io_req) +
+		   sizeof(struct pldm_oem_read_file_data_info);
+	uint16_t resp_len = BMC_PLDM_DATA_MAXIMUM;
+	struct pldm_oem_read_file_io_resp *rbuf =
+		(struct pldm_oem_read_file_io_resp *)malloc(sizeof(uint8_t) * resp_len);
+	if (rbuf == NULL) {
+		LOG_ERR("Fail to allocate rbuf for getting http boot data");
+		SAFE_FREE(ptr);
+		return PLDM_ERROR;
+	}
+
+	uint8_t total_length = 0;
 	while (true) {
-		if (!mctp_pldm_read(find_mctp_by_bus(bmc_bus), &pmsg, (uint8_t *)rbuf, resp_len)) {
-			LOG_ERR("Fail to send OEM HTTP BOOT DATA");
-			free(rbuf);
+		resp_len =
+			mctp_pldm_read(find_mctp_by_bus(bmc_bus), &pmsg, (uint8_t *)rbuf, resp_len);
+		if (resp_len == 0) {
+			LOG_ERR("Fail to send command to get http boot data");
+			SAFE_FREE(ptr);
+			SAFE_FREE(rbuf);
 			return PLDM_ERROR_INVALID_DATA;
 		}
 
-		memcpy(httpBootData + offset, rbuf->messages, rbuf->data_length);
+		if (rbuf->completion_code != PLDM_SUCCESS) {
+			LOG_ERR("Read http data fail, cc: 0x%x", rbuf->completion_code);
+			SAFE_FREE(ptr);
+			SAFE_FREE(rbuf);
+			return PLDM_ERROR;
+		}
 
-		ptr.transfer_flag = rbuf->transfer_flag;
-		ptr.highOffset = rbuf->highOffset;
-		ptr.lowOffset = rbuf->lowOffset;
-		pmsg.buf = (uint8_t *)&ptr;
+		memcpy(&data_info, rbuf->read_info, sizeof(struct pldm_oem_read_file_data_info));
+		if ((total_length + data_info.data_length) > buffer_length) {
+			LOG_ERR("Total data length exceeded buffer length, total length: 0x%x, buffer length: 0x%x",
+				total_length + data_info.data_length, buffer_length);
+			SAFE_FREE(ptr);
+			SAFE_FREE(rbuf);
+			return PLDM_ERROR_INVALID_DATA;
+		}
 
-		if (rbuf->transfer_flag == PLDM_END || rbuf->transfer_flag == PLDM_START_AND_END) {
-			*httpBootDataLen = offset + rbuf->data_length;
+		memcpy(httpBootData + total_length,
+		       &rbuf->read_info[sizeof(struct pldm_oem_read_file_data_info)],
+		       data_info.data_length);
+		total_length += data_info.data_length;
+
+		if (total_length >= *read_length || data_info.transfer_flag == PLDM_END ||
+		    data_info.transfer_flag == PLDM_START_AND_END) {
+			// Correct read_length
+			*read_length = total_length;
 			break;
 		}
 
-		offset = ((uint16_t)ptr.highOffset << 8) | ptr.lowOffset;
+		data_info.data_length =
+			((*read_length - total_length) > (BMC_PLDM_DATA_MAXIMUM - hdr_req_len) ?
+				 (BMC_PLDM_DATA_MAXIMUM - hdr_req_len) :
+				 (*read_length - total_length));
+		memcpy(ptr->read_info, &data_info, sizeof(struct pldm_oem_read_file_data_info));
+		pmsg.buf = (uint8_t *)ptr;
+		pmsg.len = sizeof(struct pldm_oem_read_file_io_req) +
+			   sizeof(struct pldm_oem_read_file_data_info);
 	}
 
-	free(rbuf);
+	SAFE_FREE(ptr);
+	SAFE_FREE(rbuf);
 	return PLDM_SUCCESS;
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm.h
@@ -18,8 +18,8 @@
 #define PLAT_PLDM_H
 
 #define BMC_PLDM_DATA_MAXIMUM 150
-#define HTTP_BOOT_DATA_MAXIMUM 2200 //The current estimated maximum value of the BIOS
 
-uint8_t plat_pldm_get_http_boot_data(uint8_t *httpBootData, uint16_t *httpBootDataLen);
-
+uint8_t plat_pldm_get_http_boot_attr(uint8_t length, uint8_t *httpBootattr);
+uint8_t plat_pldm_get_http_boot_data(uint16_t offset, uint8_t *read_length, uint8_t buffer_length,
+				     uint8_t *httpBootData);
 #endif


### PR DESCRIPTION
# Description:
- After discussing to the BIOS team, we found that there is no size limit for certification, and BIC can't allocate too large buffer to store certification, so getting data/size/checksum behaviors is changed to BMC. BIC only bypass the message to BMC.

# Motivation:
- After discussing to the BIOS team, we found that there is no size limit for certification, and BIC can't allocate too large buffer to store certification, so getting data/size/checksum behaviors is changed to BMC.

# Test Plan:
- Get certification data/size/checksum: Pass
- Test http boot in http server: Pass

# Test Log:
- Get certification data/size/checksum [BMC console]
root@bmc:~# cat /tmp/HTTP.crt > /mnt/data/host/bios-rootcert root@bmc:~# du -b /mnt/data/host/bios-rootcert
2159    /mnt/data/host/bios-rootcert
root@bmc:~# cat /mnt/data/host/bios-rootcert
-----BEGIN CERTIFICATE-----
MIIGDjCCA/agAwIBAgIUNxYac0HAjG+ed4WF89EHfunwuakwDQYJKoZIhvcNAQEL
BQAwgY0xCzAJBgNVBAYTAlRXMQ8wDQYDVQQIDAZUYWl3YW4xDzANBgNVBAcMBlRh
aXBlaTEPMA0GA1UECgwGV2l3eW5uMQ0wCwYDVQQLDARCSU9TMSUwIwYJKoZIhvcN
AQkBFhZjbG92ZXJfY2hlbkB3aXd5bm4uY29tMRUwEwYDVQQDDAxCaW9zREhDUC5j
b20wIBcNMjMwNDI4MDUxNTAxWhgPNzc2NTAyMDgwNTE1MDFaMIGNMQswCQYDVQQG
EwJUVzEPMA0GA1UECAwGVGFpd2FuMQ8wDQYDVQQHDAZUYWlwZWkxDzANBgNVBAoM
Bldpd3lubjENMAsGA1UECwwEQklPUzElMCMGCSqGSIb3DQEJARYWY2xvdmVyX2No
ZW5Ad2l3eW5uLmNvbTEVMBMGA1UEAwwMQmlvc0RIQ1AuY29tMIICIjANBgkqhkiG
9w0BAQEFAAOCAg8AMIICCgKCAgEAx5bUA3ITKOAeuIrNcApi/FPpfmBnZHpOotBJ
aGJgxTz+TK50jBTPWqchcnJ5blo7eK4Fe7NVJsgpBupHJFfBuBvIEll6/fYRHkfU
ie+8Sxfdg6rPv5k4EgwZvdia7zE2JNpwpGoqNwZwbi9eDkwD/g1d6TG8N793sVnT
LJ4yz9FWH7IH/f8et8Qiixw5t/nZP7y1a9w7M0Xw76Vx5g69xrU+1sujcxOFrhN0
Zj5OuztXnsDyMdKaCGauq7yrBWGIjYLGH916XTGwwakAeZkF02QKn+2Kh1yUO0kj
UgMVY0QDmyimln6uAHFgcY/eORqN9qlzDiAn6lzAu1MMBQuXFFSXuAEnobtji2ow
q6LPlkjEUux497nwmCItc+ZlrMVwKOG8ONjqS+4ofGgK+sQI9Ce+BvgjlXXbpOac
qvgm/Km9puWVCDj+QYiZeZD4rLy3LYAHYoew7E4qQb+SiIXoBfwBIiJh9hWw7GUE
TLIR/vrVgDvWjx4Z7jo6e6QZSs8WLQ/L9e8M5Z+PsD4KB9oSm1WntyDk5TAeRcFQ
4Bo9sKg0mzRKzYacriH4hi96F2RUlbsJVo0FrSydeiLJji484BgIKWQjV2PgrGch
M+Ntxy8r9B5mA0iUaF2HuZt/phpza5V3dDlsIuphBsXQT71YY7ooS39vRGf86Vm1
178okoMCAwEAAaNiMGAwPwYDVR0RBDgwNoIOKi5CaW9zREhDUC5jb22CDEJpb3NE
SENQLmNvbYcECgoKAYcQABAAEAAQAAAAAAAAAAAAATAdBgNVHQ4EFgQUspUL3xaj
mvKGdQUnO5hnrj3T8DQwDQYJKoZIhvcNAQELBQADggIBAKOJR9xJRbXoXIHK3o/0
r+f9MisbB01JREtvCiySAUpNSNQUpKMtQ/Yp+8grRh275FEKegUYqg2qyeI8XPtm
KzbD08r42ihAhKh14D11HB3SoW5hym0m9seouDV0jFG7t1+TESn2ZPMv+KY5Tty8
uuSC+EtrWvD2CDfDGRdIkCwSgRx/wpQnrhVck2zq05opf3DNaK7mTbLt8oarcLjP
egeQBL4jEwZEbT33o3qpNIx47e83ZhveqojC+ua3Az+x1Ptr7AjBjS4GLSve6MpJ
1WOWbId0LvVsDP2RfANZ9VZrs+3ngj34oORwoJ9FEivURXrGyv8HWcGu7zpAU/ii
l4aMPegDNRJ9NVDZDcxkm0BC4cIDpRX0cwckn/EH2vvE7FY72YKaJ3vm8VW2L6xH
nG6ZRNZf3/m2KiHArbZ1hC9Llz4A3aUMTzNfJQQE72r/IiOMH5SAvVel/rwnOxN4
8kPdRCDySZCGF9r2riZBf9XAuMfVRA7PbncLjcLpMdjnSfojDwUSLMiNSTIW0J8e
E7cchzGP8hiPOluXyVvtNTo4Zl+9qhH6sn4IVij8RMHDD+Et2Pm9Ya2BzavaVvZg
VyTtgplax5a6MMhDGqOKQQ5dj7fYBQzS8tLKArBor9urSUBsBDyJl8PN2RTLo6cL
8cLp8ILs8wJWeoHuxo4gzTHA
-----END CERTIFICATE-----
root@bmc:~# crc32 /mnt/data/host/bios-rootcert
8c07e33a /mnt/data/host/bios-rootcert

[BIC console]
uart:~$ platform ipmi raw 0x30 0x58 0x00
BIC self command netfn:0x30 cmd:0x58 response with cc 0x0
00000000: 6f 08                                            |o.               |

uart:~$ platform ipmi raw 0x30 0x58 0x01
BIC self command netfn:0x30 cmd:0x58 response with cc 0x0
00000000: 3a e3 07 8c                                      |:...             |

uart:~$ platform ipmi raw 0x30 0x57 0x00 0x00 0x30 BIC self command netfn:0x30 cmd:0x57 response with cc 0x0 00000000: 30 2d 2d 2d 2d 2d 42 45  47 49 4e 20 43 45 52 54 |0-----BE GIN CERT| 00000010: 49 46 49 43 41 54 45 2d  2d 2d 2d 2d 0a 4d 49 49 |IFICATE- ----.MII| 00000020: 47 44 6a 43 43 41 2f 61  67 41 77 49 42 41 67 49 |GDjCCA/a gAwIBAgI|
00000030: 55                                               |U                |