### PR TITLE
op2:gl: Record BIOS firmware version in EEPROM

### DIFF
--- a/meta-facebook/yv35-gl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-gl/src/ipmi/plat_ipmi.c
@@ -30,6 +30,10 @@
 #include "plat_ipmi.h"
 #include "plat_ipmb.h"
 #include "plat_class.h"
+#include <logging/log.h>
+#include "fru.h"
+#include "eeprom.h"
+#include "plat_fru.h"
 
 LOG_MODULE_REGISTER(plat_ipmi);
 
@@ -48,6 +52,76 @@ bool pal_set_dimm_presence_status(uint8_t *buf)
 	set_dimm_presence_status(dimm_index, status);
 
 	return true;
+}
+
+int pal_record_bios_fw_version(uint8_t *buf, uint8_t size)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, -1);
+
+	int ret = -1;
+	EEPROM_ENTRY set_bios_ver = { 0 };
+	EEPROM_ENTRY get_bios_ver = { 0 };
+
+	const uint8_t block_index = buf[3];
+	if (block_index >= BIOS_FW_VERSION_BLOCK_NUM) {
+		LOG_ERR("bios version block index is out of range");
+		return -1;
+	}
+
+	ret = get_bios_version(&get_bios_ver, block_index);
+	if (ret == -1) {
+		LOG_ERR("Get version fail");
+		return -1;
+	}
+
+	set_bios_ver.data_len = size - 3; // skip netfn, cmd and command code
+	memcpy(&set_bios_ver.data[0], &buf[3], set_bios_ver.data_len);
+
+	// Check the written BIOS version is the same with the stored
+	ret = memcmp(&get_bios_ver.data[0], &set_bios_ver.data[0],
+		     BIOS_FW_VERSION_BLOCK_MAX_SIZE * sizeof(uint8_t));
+	if (ret == 0) {
+		LOG_DBG("The Written bios version is the same with the stored bios version in EEPROM");
+	} else {
+		LOG_DBG("Set bios version");
+
+		ret = set_bios_version(&set_bios_ver, block_index);
+		if (ret == -1) {
+			LOG_ERR("Set version fail");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+void OEM_1S_GET_BIOS_VERSION(ipmi_msg *msg)
+{
+	CHECK_NULL_ARG(msg);
+
+	if (msg->data_len != 0) {
+		msg->completion_code = CC_INVALID_LENGTH;
+		return;
+	}
+
+	msg->data_len = 0;
+
+	for (uint8_t block_index = 0; block_index < BIOS_FW_VERSION_BLOCK_NUM; block_index++) {
+		EEPROM_ENTRY get_bios_ver = { 0 };
+		int ret = get_bios_version(&get_bios_ver, block_index);
+		if (ret == -1) {
+			LOG_ERR("Get version fail");
+			msg->completion_code = CC_UNSPECIFIED_ERROR;
+			return;
+		}
+
+		memcpy(msg->data + msg->data_len, get_bios_ver.data, get_bios_ver.data_len);
+		msg->data_len += get_bios_ver.data_len;
+	}
+
+	msg->completion_code = CC_SUCCESS;
+
+	return;
 }
 
 void OEM_1S_GET_CARD_TYPE(ipmi_msg *msg)

--- a/meta-facebook/yv35-gl/src/platform/plat_fru.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_fru.c
@@ -20,6 +20,8 @@
 #include "fru.h"
 #include "plat_fru.h"
 #include <logging/log.h>
+#include "libutil.h"
+#include "eeprom.h"
 
 LOG_MODULE_REGISTER(plat_fru);
 
@@ -44,6 +46,17 @@ const EEPROM_CFG plat_fru_config[] = {
 	},
 };
 
+// BIOS version is stored in MB EEPROM, but the location of EEPROM is different from fru information
+const EEPROM_CFG plat_bios_version_area_config = {
+	NV_ATMEL_24C128,
+	MB_FRU_ID,
+	MB_FRU_PORT,
+	MB_FRU_ADDR,
+	FRU_DEV_ACCESS_BYTE,
+	BIOS_FW_VERSION_START,
+	BIOS_FW_VERSION_MAX_SIZE,
+};
+
 void pal_load_fru_config(void)
 {
 	if (ARRAY_SIZE(plat_fru_config) > FRU_CFG_NUM) {
@@ -54,4 +67,48 @@ void pal_load_fru_config(void)
 	memcpy(&fru_config, &plat_fru_config, sizeof(plat_fru_config));
 out:
 	return;
+}
+
+int set_bios_version(EEPROM_ENTRY *entry, uint8_t block_index)
+{
+	CHECK_NULL_ARG_WITH_RETURN(entry, -1);
+
+	if (block_index >= BIOS_FW_VERSION_BLOCK_NUM)
+		return -1;
+
+	bool ret = false;
+	entry->config = plat_bios_version_area_config;
+	if (block_index == 1)
+		entry->config.start_offset += BIOS_FW_VERSION_SECOND_BLOCK_OFFSET;
+	entry->data_len = BIOS_FW_VERSION_BLOCK_MAX_SIZE;
+
+	ret = eeprom_write(entry);
+	if (ret == false) {
+		LOG_ERR("eeprom_write fail");
+		return -1;
+	}
+
+	return 0;
+}
+
+int get_bios_version(EEPROM_ENTRY *entry, uint8_t block_index)
+{
+	CHECK_NULL_ARG_WITH_RETURN(entry, -1);
+
+	if (block_index >= BIOS_FW_VERSION_BLOCK_NUM)
+		return -1;
+
+	bool ret = false;
+	entry->config = plat_bios_version_area_config;
+	if (block_index == 1)
+		entry->config.start_offset += BIOS_FW_VERSION_SECOND_BLOCK_OFFSET;
+	entry->data_len = BIOS_FW_VERSION_BLOCK_MAX_SIZE;
+
+	ret = eeprom_read(entry);
+	if (ret == false) {
+		LOG_ERR("eeprom_read fail");
+		return -1;
+	}
+
+	return 0;
 }

--- a/meta-facebook/yv35-gl/src/platform/plat_fru.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_fru.h
@@ -17,15 +17,27 @@
 #ifndef PLAT_FRU_H
 #define PLAT_FRU_H
 
+#include "eeprom.h"
+
 #define MB_FRU_PORT 0x01
 #define MB_FRU_ADDR (0xA8 >> 1)
 #define FRU_CFG_NUM MAX_FRU_ID
 #define SYS_DAM_OFFSET 0
+
+#define BIOS_FW_VERSION_START 0x0A00
+#define BIOS_FW_VERSION_MAX_SIZE 34
+#define BIOS_FW_VERSION_BLOCK_NUM 2
+#define BIOS_FW_VERSION_SECOND_BLOCK_OFFSET 17
+#define BIOS_FW_VERSION_BLOCK_MAX_SIZE 17
 
 enum {
 	MB_FRU_ID,
 	SYS_DAM_ID,
 	MAX_FRU_ID,
 };
+
+bool get_bios_version_area_config(EEPROM_CFG *config);
+int set_bios_version(EEPROM_ENTRY *entry, uint8_t block_index);
+int get_bios_version(EEPROM_ENTRY *entry, uint8_t block_index);
 
 #endif


### PR DESCRIPTION
# Description:
 1.Record BIOS firmware version in EEPROM.
 2.Add ipmi oem command (netfn = 0x38, cmd = 0xA2) to support BMC get BIOS firmware version.
 3.When BMC can't get BIOS version from fru1_sysfw_ver, use ipmi oem command get from BIC.

# Motivation:
 Record BIOS firmware version in EEPROM.

# Test Plan:
1.Build and test pass on OLP2.0 system pass.
2.Stress with BMC check bios version after reboot -f.