### PR TITLE
fby4: sd: Support keep sending setaasa to EXP BIC

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_i3c.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_i3c.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <logging/log.h>
+#include "hal_i3c.h"
+#include "plat_mctp.h"
+#include "plat_i3c.h"
+
+LOG_MODULE_REGISTER(plat_i3c);
+
+k_tid_t tid;
+K_THREAD_STACK_DEFINE(send_setaasa_stack, SEND_SETAASA_STACK_SIZE);
+struct k_thread send_setaasa_thread;
+
+void start_setaasa()
+{
+	LOG_INF("Start a thread to send setaasa");
+	tid = k_thread_create(&send_setaasa_thread, send_setaasa_stack,
+			      K_THREAD_STACK_SIZEOF(send_setaasa_stack), send_setaasa, NULL, NULL,
+			      NULL, CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+	k_thread_name_set(&send_setaasa_thread, "send_setaasa_thread");
+}
+
+void send_setaasa()
+{
+	I3C_MSG i3c_msg = { 0 };
+	i3c_msg.bus = I3C_BUS_HUB;
+
+	while (1) {
+		// I3C_CCC_SETAASA: Set all addresses to static address
+		i3c_brocast_ccc(&i3c_msg, I3C_CCC_SETAASA, I3C_BROADCAST_ADDR);
+		k_msleep(SEND_SETAASA_TIME_MS);
+	}
+}

--- a/meta-facebook/yv4-sd/src/platform/plat_i3c.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_i3c.h
@@ -21,8 +21,14 @@
 
 #define I3C_BUS3 2
 
+#define SEND_SETAASA_STACK_SIZE 1024
+#define SEND_SETAASA_TIME_MS 5000
+
 #define LDO_VOLT                                                                                   \
 	V_LDO_SETTING(rg3mxxb12_ldo_1_2_volt, rg3mxxb12_ldo_1_2_volt, rg3mxxb12_ldo_1_2_volt,      \
 		      rg3mxxb12_ldo_1_2_volt)
+
+void start_setaasa();
+void send_setaasa();
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -85,6 +85,9 @@ void pal_pre_init()
 
 	i3c_attach(&i3c_msg);
 
+	// Create a thread to keep sending AASA
+	start_setaasa();
+
 	// Initialize I3C HUB
 	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
 		printk("failed to initialize 1ou rg3mxxb12\n");
@@ -121,4 +124,3 @@ void pal_set_sys_status()
 		read_cpuid();
 	}
 }
-


### PR DESCRIPTION
# Description
- Create a thread to broadcast CCC SETAASA (set all addresses to static address 0x29).

# Motivation
- SD BIC doesn't support getting the hot-join signal, it needs to poll monitor i3c salve device.

# Test plan
- Build code: Pass
- Stress SD BIC reboot: Pass 3929 run

# Log
1. Get SD/WF BIC version after SD BIC reset. pldmtool raw -d 0x80 0x3f 0x1 0x15 0xa0 0x0 0x18 0x03 -m 30 pldmtool: Tx: 80 3f 01 15 a0 00 18 03
pldmtool: Rx: 00 3f 01 00 15 a0 00 1c 03 00

busctl tree xyz.openbmc_project.MCTP
└─ /xyz
  └─ /xyz/openbmc_project
    └─ /xyz/openbmc_project/mctp
      └─ /xyz/openbmc_project/mctp/1
        ├─ /xyz/openbmc_project/mctp/1/30
        ├─ /xyz/openbmc_project/mctp/1/32
        ├─ /xyz/openbmc_project/mctp/1/34
        ├─ /xyz/openbmc_project/mctp/1/35
        ├─ /xyz/openbmc_project/mctp/1/8
        └─ /xyz/openbmc_project/mctp/1/91

./fw-util_v7.9.sh --version sd_bic 3
Sentinel Dome BIC Slot 3 version: "2024.31.01"
./fw-util_v7.9.sh --version wf_bic 3
Waluia Falls BIC Slot 3 version: "2024.31.01"