### PR TITLE
fby4: sd: Change T1C/T1M judgment conditions

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_class.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_class.c
@@ -88,10 +88,13 @@ bool get_blade_config(uint8_t *blade_config)
 		return false;
 	}
 
-	if (voltage <= 1.05f && voltage >= 0.95f) {
+	if (voltage >= 0.0f && voltage <= 1.05f) {
 		*blade_config = BLADE_CONFIG_T1C;
-	} else {
+	} else if (voltage >= 1.2f && voltage <= 1.7f) {
 		*blade_config = BLADE_CONFIG_T1M;
+	} else {
+		*blade_config = BLADE_CONFIG_UNKNOWN;
+		return false;
 	}
 	return true;
 }


### PR DESCRIPTION
# Description
- Change T1C/T1M judgment condition of voltage: T1C: 0 <= value <= 1.05V, show 0x9X
T1M: 1.2 <= value <= 1.7V, show 0x8X

# Motivation
- System definition has changed.

# Test plan
- Build code: Pass
- Check system SKU: Pass

Log
1. EXAMAX_TYPE 0V [root@240529-643-fbk12 ~]# ipmitool raw 0x30 0x7e
91

2. EXAMAX_TYPE 1V [root@240529-643-fbk12 ~]# ipmitool raw 0x30 0x7e
91

3. EXAMAX_TYPE 1.25V [root@240529-643-fbk12 ~]# ipmitool raw 0x30 0x7e
81