### PR TITLE
common: Fix asteralab retimer known issue

### DIFF
--- a/common/dev/pt5161l.c
+++ b/common/dev/pt5161l.c
@@ -1175,6 +1175,11 @@ uint8_t pt5161l_read_avg_temp(I2C_MSG *i2c_msg, uint8_t temp_cal_code_avg, doubl
 		LOG_INF("Avg Temperature is not ready");
 		ret = SENSOR_NOT_ACCESSIBLE;
 		goto unlock_exit;
+	} else if (adc_code == 0xFFFFFFFF) {
+		/* From Aries Errata - Known issue */
+		LOG_WRN("Some I2C transactions occured during temperature reading");
+		ret = SENSOR_NOT_ACCESSIBLE;
+		goto unlock_exit;
 	}
 
 	*avg_temperature = 110 - ((adc_code - (temp_cal_code_avg + 250)) * 0.32);

--- a/meta-facebook/at-cb/boards/ast1030_evb.overlay
+++ b/meta-facebook/at-cb/boards/ast1030_evb.overlay
@@ -181,7 +181,7 @@
 };
 
 &sram0 {
-	reg = <0 DT_SIZE_K(708)>, <DT_SIZE_K(708) DT_SIZE_K(60)>;
+	reg = <0 DT_SIZE_K(718)>, <DT_SIZE_K(718) DT_SIZE_K(50)>;
 };
 
 &tach { 


### PR DESCRIPTION
Summary:
- Add invalid data(0xFFFFFFFF) filter for chip's known issue while any I2C transaction occurred during sensor reading.

TestPlan:
- BuildCode: PASS
- Check retimer temarature ucr SEL log should not pop up by keep accessing other sensor on the same bus: PASS
