### PR TITLE
yv4: sd: i3c: reset pid after SIR timeout

### DIFF
--- a/common/hal/hal_i3c.h
+++ b/common/hal/hal_i3c.h
@@ -136,4 +136,6 @@ int i3c_controller_write(I3C_MSG *msg);
 int i3c_target_set_address(I3C_MSG *msg);
 int i3c_target_get_dynamic_address(I3C_MSG *msg, uint8_t *dynamic_addr);
 
+__weak bool pal_get_slot_pid(uint16_t *pid);
+
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_class.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_class.c
@@ -66,6 +66,7 @@ struct _SLOT_EID_MAPPING_TABLE _slot_eid_mapping_table[] = {
 
 uint8_t slot_eid = 0;
 uint8_t slot_id = 0;
+uint16_t slot_pid = 0;
 
 static uint8_t retimer_type = RETIMER_TYPE_ASTERALABS;
 
@@ -77,6 +78,12 @@ uint8_t get_slot_eid()
 uint8_t get_slot_id()
 {
 	return slot_id;
+}
+
+bool pal_get_slot_pid(uint16_t *pid)
+{
+	*pid = slot_pid;
+	return true;
 }
 
 bool get_blade_config(uint8_t *blade_config)
@@ -178,7 +185,6 @@ void init_platform_config()
 	I3C_MSG i3c_msg;
 	float voltage;
 	float p3v3_stby_voltage;
-	uint16_t slot_pid = 0;
 
 	i3c_msg.bus = 0;
 


### PR DESCRIPTION
# Description:
There is an issue that if BIC keep sending the I3C packets to BMC but BMC couldn't receive the packet while rebooting. There is a chance that SD BIC would get SIR timeout and reset I3C controller.

Once the I3C controller is reset, need to reset PID so that BIC could reply the PID to BMC when receiving the ENTDAA from BMC.

# Motivation:
Fix the issue that BMC couldn't receive the I3C PID from SD BIC after BMC reboot.

# Test plan:
Check that BIC will reset PID when SIR timeout and BMC could get the PID of SD BIC.

Test logs:
- BIC console [00:07:52.498,000] <wrn> i3c: SIR timeout: reset i3c controller [00:07:52.498,000] <inf> i3c: core_rate 200000000 hz (5 ns) [00:07:52.498,000] <inf> i3c: i2c-scl = 1000000, i3c-scl = 12500000 [00:07:52.498,000] <err> hal_i3c: I3C wrtie failed, ret = -5 [00:07:52.498,000] <wrn> hal_i3c: Reset PID = 19 for Bus 0 due to SIR timeout [00:07:52.499,000] <err> mctp_i3c: mctp_i3c_write_smq write failed, -5 [00:07:52.499,000] <wrn> mctp: mctp write data failed [00:07:52.499,000] <err> pldm: mctp_send_msg error!! [00:07:52.499,000] <wrn> pldm: Send msg failed!
[00:07:52.499,000] <err> hal_i3c: Failed to get address for I3C bus: 0, ret: -1 [00:07:52.499,000] <err> mctp_i3c: Failed to get dynamic address for I3C bus: 0

-BMC
root@bmc:~# find /sys/bus/i3c/devices/ -name "1-7ec80010019" /sys/bus/i3c/devices/1-7ec80010019