### PR TITLE
yv4: sd: Support entity auxiliary name PDR

### DIFF
--- a/common/service/sensor/pdr.h
+++ b/common/service/sensor/pdr.h
@@ -121,6 +121,17 @@ typedef struct __attribute__((packed)) {
 } PDR_sensor_auxiliary_names;
 
 typedef struct __attribute__((packed)) {
+	PDR_common_header pdr_common_header;
+	uint16_t entity_type;
+	uint16_t entity_instance_number;
+	uint16_t container_id;
+	uint8_t shared_name_count;
+	uint8_t nameStringCount;
+	char nameLanguageTag[MAX_LANGUAGE_TAG_LEN];
+	char16_t entityName[];
+} PDR_entity_auxiliary_names;
+
+typedef struct __attribute__((packed)) {
 	uint8_t repository_state;
 	uint8_t update_time[TIMESTAMP104_SIZE];
 	uint8_t oem_update_time[TIMESTAMP104_SIZE];
@@ -135,6 +146,10 @@ uint32_t get_record_count();
 uint32_t plat_get_pdr_size(uint8_t pdr_type);
 void plat_load_numeric_sensor_pdr_table(PDR_numeric_sensor *numeric_sensor_table);
 void plat_load_aux_sensor_names_pdr_table(PDR_sensor_auxiliary_names *aux_sensor_name_table);
+void plat_load_entity_aux_names_pdr_table(PDR_entity_auxiliary_names *entity_aux_name_table);
 int get_pdr_table_via_record_handle(uint8_t *record_data, uint32_t record_handle);
+void plat_init_entity_aux_names_pdr_table();
+uint16_t plat_get_pdr_entity_aux_names_size();
+PDR_entity_auxiliary_names *get_entity_auxiliary_names_table();
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -6573,6 +6573,22 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 	}
 };
 
+PDR_entity_auxiliary_names plat_pdr_entity_aux_names_table[] = { {
+	{
+		.record_handle = 0x00000000,
+		.PDR_header_version = 0x01,
+		.PDR_type = PLDM_ENTITY_AUXILIARY_NAMES_PDR,
+		.record_change_number = 0x0000,
+		.data_length = 0x0000,
+	},
+	.entity_type = 0x0000,
+	.entity_instance_number = 0x0001,
+	.container_id = 0x0000,
+	.shared_name_count = 0x0,
+	.nameStringCount = 0x1,
+	.nameLanguageTag = "en",
+} };
+
 uint32_t plat_get_pdr_size(uint8_t pdr_type)
 {
 	int total_size = 0, i = 0;
@@ -6585,6 +6601,9 @@ uint32_t plat_get_pdr_size(uint8_t pdr_type)
 		break;
 	case PLDM_SENSOR_AUXILIARY_NAMES_PDR:
 		total_size = ARRAY_SIZE(plat_pdr_sensor_aux_names_table);
+		break;
+	case PLDM_ENTITY_AUXILIARY_NAMES_PDR:
+		total_size = ARRAY_SIZE(plat_pdr_entity_aux_names_table);
 		break;
 	default:
 		break;
@@ -6714,6 +6733,83 @@ void plat_load_aux_sensor_names_pdr_table(PDR_sensor_auxiliary_names *aux_sensor
 {
 	memcpy(aux_sensor_name_table, &plat_pdr_sensor_aux_names_table,
 	       sizeof(plat_pdr_sensor_aux_names_table));
+}
+
+uint16_t plat_pdr_entity_aux_names_table_size = 0;
+
+// Custom function to calculate the length of a char16_t string
+size_t char16_strlen(const char16_t *str)
+{
+	const char16_t *s = str;
+	while (*s)
+		++s;
+	return s - str;
+}
+
+// Custom function to copy a char16_t string
+char16_t *char16_strcpy(char16_t *dest, const char16_t *src)
+{
+	char16_t *d = dest;
+	while ((*d++ = *src++))
+		;
+	return dest;
+}
+
+// Custom function to concatenate a char16_t character to a string
+char16_t *char16_strcat_char(char16_t *dest, char16_t ch)
+{
+	size_t len = char16_strlen(dest);
+	dest[len] = ch;
+	dest[len + 1] = u'\0';
+	return dest;
+}
+
+void plat_init_entity_aux_names_pdr_table()
+{
+	// Base name
+	const char16_t base_name[] = u"Sentinel_Dome_Slot_";
+
+	// Get slot ID
+	uint8_t slot_id = get_slot_id();
+
+	// Calculate the length of the base name
+	size_t base_len = char16_strlen(base_name);
+
+	// Calculate the required length for the final string (base name + 1 digit + null terminator)
+	size_t total_len = base_len + 2; // +2 for the slot ID digit and null terminator
+
+	// Ensure the final length does not exceed MAX_AUX_SENSOR_NAME_LEN
+	if (total_len > MAX_AUX_SENSOR_NAME_LEN) {
+		total_len = MAX_AUX_SENSOR_NAME_LEN;
+	}
+
+	// Create a buffer for the full name
+	char16_t full_name[MAX_AUX_SENSOR_NAME_LEN] = { 0 };
+
+	// Copy base name to full name, with length limit
+	char16_strcpy(full_name, base_name);
+
+	// Append slot ID as a character, ensuring it fits within the buffer
+	if (base_len + 1 < MAX_AUX_SENSOR_NAME_LEN) {
+		char16_strcat_char(full_name, u'0' + slot_id);
+	}
+
+	// Now copy the full name to the entityName field of your structure
+	char16_strcpy(plat_pdr_entity_aux_names_table[0].entityName, full_name);
+
+	plat_pdr_entity_aux_names_table_size =
+		sizeof(PDR_entity_auxiliary_names) + (total_len * sizeof(char16_t));
+}
+
+void plat_load_entity_aux_names_pdr_table(PDR_entity_auxiliary_names *entity_aux_name_table)
+{
+	memcpy(entity_aux_name_table, &plat_pdr_entity_aux_names_table,
+	       plat_pdr_entity_aux_names_table_size);
+}
+
+uint16_t plat_get_pdr_entity_aux_names_size()
+{
+	return plat_pdr_entity_aux_names_table_size;
 }
 
 void plat_pldm_sensor_change_vr_dev()

--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.c
@@ -20,6 +20,7 @@
 #include "cci.h"
 #include "plat_ipmb.h"
 #include "plat_power_seq.h"
+#include "plat_pldm_sensor.h"
 
 #include "hal_i2c.h"
 
@@ -368,6 +369,8 @@ void plat_update_mctp_routing_table(uint8_t eid)
 	// update cxl2 eid
 	p = plat_mctp_route_tbl + 3;
 	p->endpoint = eid + 3;
+
+	update_entity_name_with_eid(eid);
 
 	// send set eid to cxl
 	k_timer_start(&send_cmd_timer, K_MSEC(30000), K_NO_WAIT);

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.h
@@ -71,5 +71,6 @@ int plat_pldm_sensor_get_sensor_count(int thread_id);
 void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
 					     PDR_numeric_sensor *numeric_sensor_table);
 uint8_t plat_pldm_sensor_get_vr_dev(uint8_t *vr_dev);
+void update_entity_name_with_eid(uint8_t eid);
 
 #endif


### PR DESCRIPTION
# Description:
Support entity auxiliary name PDR with container ID 0x0000, which will be terminus name in pldmd in BMC.

# Motivation:
Upstream pldm sensor had be coded to regard the terminus name as mandatory. It's now utilizing entity auxiliary name PDR with container ID 0x0000 to get terminus name or from Entity Manager configuration(not implemented).

# Test Plan:
Build code - pass
Tested on YV4 - pass

# Test Log:
...
        ├─ /xyz/openbmc_project/sensors/voltage/Sentinel_Dome_Slot_3_MB_ADC_P12V_DIMM_0_VOLT_V
        ├─ /xyz/openbmc_project/sensors/voltage/Sentinel_Dome_Slot_3_MB_ADC_P12V_DIMM_1_VOLT_V
        ├─ /xyz/openbmc_project/sensors/voltage/Sentinel_Dome_Slot_3_MB_ADC_P12V_STBY_VOLT_V
        ├─ /xyz/openbmc_project/sensors/voltage/Sentinel_Dome_Slot_3_MB_ADC_P1V2_STBY_VOLT_V
        ├─ /xyz/openbmc_project/sensors/voltage/Sentinel_Dome_Slot_3_MB_ADC_P1V8_STBY_VOLT_V
        ├─ /xyz/openbmc_project/sensors/voltage/Sentinel_Dome_Slot_3_MB_ADC_P3V3_STBY_VOLT_V
...