### PR TITLE
common: Add nuvoton zephyr patch based on tag v2.6.0.0

### DIFF
--- a/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0001-soc-npcm4xx-add-c11-to-CMake-list.patch
+++ b/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0001-soc-npcm4xx-add-c11-to-CMake-list.patch
@@ -1,0 +1,23 @@
+From 208d705da104e20e438d9d6fb3df8b44d118a4cb Mon Sep 17 00:00:00 2001
+From: victor <Victor.Jhong@quantatw.com>
+Date: Mon, 8 Jul 2024 15:15:50 +0800
+Subject: [PATCH] soc: npcm4xx: add c11 to CMake list
+
+1. add c11 to CMake list
+---
+ boards/arm/npcm400f_evb/CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/boards/arm/npcm400f_evb/CMakeLists.txt b/boards/arm/npcm400f_evb/CMakeLists.txt
+index 3279ec6eab..182005a6c9 100644
+--- a/boards/arm/npcm400f_evb/CMakeLists.txt
++++ b/boards/arm/npcm400f_evb/CMakeLists.txt
+@@ -4,3 +4,5 @@
+ if(CONFIG_PINMUX_NPCM4XX)
+     zephyr_include_directories(.)
+ endif()
++
++set_property(GLOBAL PROPERTY CSTD c11)
+-- 
+2.25.1
+

--- a/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0002-soc-npcm4xx-B0-demo-to-enter-uart-download-mode.patch
+++ b/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0002-soc-npcm4xx-B0-demo-to-enter-uart-download-mode.patch
@@ -1,0 +1,87 @@
+From 50fe2b52539c4bac3699a605b03b29c670bd3b70 Mon Sep 17 00:00:00 2001
+From: Tyrone Ting <kfting@nuvoton.com>
+Date: Tue, 4 Jun 2024 09:41:11 +0800
+Subject: [PATCH] soc: npcm4xx: B0 demo to enter uart download mode
+
+1. Use gpio B0 to enter uart download mode
+2. Restore pull setting for GPIO B0 just before leaving the hook function
+
+Signed-off-by: Tyrone Ting <kfting@nuvoton.com>
+---
+ .../common/ImageGenerator/ImageGenerator.py   |  5 ++-
+ soc/arm/npcm4xx/common/header.c               | 36 ++++++++++++++++++-
+ 2 files changed, 37 insertions(+), 4 deletions(-)
+
+diff --git a/soc/arm/npcm4xx/common/ImageGenerator/ImageGenerator.py b/soc/arm/npcm4xx/common/ImageGenerator/ImageGenerator.py
+index 370e3ace26..ed4a9f6863 100644
+--- a/soc/arm/npcm4xx/common/ImageGenerator/ImageGenerator.py
++++ b/soc/arm/npcm4xx/common/ImageGenerator/ImageGenerator.py
+@@ -274,9 +274,8 @@ def GenFWHeader():
+         ListFWHeaderCol_Sign.append(bytearray([0]*4))
+ 
+         # # hHook2Ptr
+-        # data = (int(Dict_FW_H['hHook2Ptr'], 0).to_bytes(4, byteorder='little')) if (
+-        #     Dict_FW_H['hHook2Ptr'] is not None) else Fn.getFilePoint(Dict_File['FirmwareImage'], 1204, 4)
+-        ListFWHeaderCol_Sign.append(bytearray([0]*4))
++        data = Fn.getFilePoint(Dict_File['FirmwareImage'], 1204, 4)
++        ListFWHeaderCol_Sign.append(data)
+ 
+         # hHook3Ptr
+         # data = (int(Dict_FW_H['hHook3Ptr'], 0).to_bytes(4, byteorder='little')) if (
+diff --git a/soc/arm/npcm4xx/common/header.c b/soc/arm/npcm4xx/common/header.c
+index a289fa068f..5a7adb7a0a 100644
+--- a/soc/arm/npcm4xx/common/header.c
++++ b/soc/arm/npcm4xx/common/header.c
+@@ -13,6 +13,40 @@ extern unsigned long __main_fw_seg_size__;
+ #endif
+ extern unsigned long __main_fw_seg_end__;
+ 
++void Rom_hook2(void)
++{
++#define adr_FIU_FwInfo_status	0x100c59d4
++#define bit_auth_pass		0x02
++#define M8(addr) (*((volatile uint8_t *) (addr)))
++#define M32(addr) (*((volatile unsigned long *) (addr)))
++#define DEVALT5		0x400c3015
++#define EMC_CTL		0x400c304d
++#define GPIOB0_DEVALT	6
++#define RMII_EN		0
++#define GPIOB_IN	0x40097001
++#define GPIOB_DIR	0x40097002
++#define GPIOB_PULL	0x40097003
++#define GPIOB_PUD	0x40097004
++#define GPIOB0_BIT	0
++#define BIT(x)		(1<<(x))
++
++    M8(DEVALT5) &= ~BIT(GPIOB0_DEVALT);
++    M8(EMC_CTL) &= ~BIT(RMII_EN);
++    M8(GPIOB_DIR) &= ~BIT(GPIOB0_BIT);
++    M8(GPIOB_PULL) |= BIT(GPIOB0_BIT);
++    M8(GPIOB_PUD) &= ~BIT(GPIOB0_BIT);
++
++    if(M32(adr_FIU_FwInfo_status) & bit_auth_pass)
++    {
++	if (0 == (M8(GPIOB_IN) & BIT(GPIOB0_BIT)))
++        {
++            M32(adr_FIU_FwInfo_status) &= ~bit_auth_pass;
++        }
++    }
++
++    M8(GPIOB_PULL) &= ~BIT(GPIOB0_BIT);
++}
++
+ __attribute__((section(".header"))) struct FIRMWARE_HEDAER_TYPE fw_header = {
+ 	.hUserFWEntryPoint = (uint32_t)(&_vector_table),
+ 	.hUserFWRamCodeFlashStart = CONFIG_FLASH_BASE_ADDRESS +
+@@ -29,7 +63,7 @@ __attribute__((section(".header"))) struct FIRMWARE_HEDAER_TYPE fw_header = {
+ #endif
+ 
+ 	.hRomHook1Ptr = 0, /* Hook 1 muse be flash code */
+-	.hRomHook2Ptr = 0,
++	.hRomHook2Ptr = Rom_hook2,
+ 	.hRomHook3Ptr = 0,
+ 	.hRomHook4Ptr = 0,
+ 
+-- 
+2.25.1
+

--- a/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0003-Revert-drivers-i3c-modify-i3c_dev_desc-for-OpenBic-c.patch
+++ b/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0003-Revert-drivers-i3c-modify-i3c_dev_desc-for-OpenBic-c.patch
@@ -1,0 +1,111 @@
+From 5b8d464326ef0b22f544d522d0234a08cf03fcfd Mon Sep 17 00:00:00 2001
+From: cpchiang <cpchiang1@nuvoton.com>
+Date: Mon, 8 Jul 2024 01:50:49 -0700
+Subject: [PATCH] Revert "drivers: i3c: modify i3c_dev_desc for OpenBic
+ compatibility"
+
+This reverts commit 25b970b88bc5ae2d1147da49559ab1bf046ecfde.
+---
+ drivers/i3c/i3c_npcm4xx.c | 16 ++++++++--------
+ drivers/i3c/i3c_shell.c   |  2 +-
+ include/drivers/i3c/i3c.h |  2 +-
+ 3 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/i3c/i3c_npcm4xx.c b/drivers/i3c/i3c_npcm4xx.c
+index 09a8de2ca3..8f9ddb29db 100644
+--- a/drivers/i3c/i3c_npcm4xx.c
++++ b/drivers/i3c/i3c_npcm4xx.c
+@@ -2182,7 +2182,7 @@ int i3c_npcm4xx_master_attach_device(const struct device *dev, struct i3c_dev_de
+ 		pBus = pDevice->pOwner;
+ 
+ 		/* assign dev as slave's bus controller */
+-		slave->master_dev = dev;
++		slave->bus = dev;
+ 
+ 		/* find a free position from master's hw_dat_free_pos */
+ 		for (i = 0; i < DEVICE_COUNT_MAX; i++) {
+@@ -2232,13 +2232,13 @@ int i3c_npcm4xx_master_attach_device(const struct device *dev, struct i3c_dev_de
+ 		pBus = pDeviceSlv->pOwner;
+ 
+ 		/* bus owner outside the devicetree */
+-		slave->master_dev = NULL;
++		slave->bus = NULL;
+ 	}
+ 
+ 	if (pBus == NULL)
+ 		return -ENXIO;
+ 
+-	if (slave->master_dev == NULL)
++	if (slave->bus == NULL)
+ 		return 0;
+ 
+ 	if ((slave->info.static_addr == 0x6A) || (slave->info.static_addr == 0x6B)) {
+@@ -2368,7 +2368,7 @@ int i3c_npcm4xx_master_request_ibi(struct i3c_dev_desc *i3cdev, struct i3c_ibi_c
+ 
+ int i3c_npcm4xx_master_enable_ibi(struct i3c_dev_desc *i3cdev)
+ {
+-	struct i3c_npcm4xx_obj *obj = DEV_DATA(i3cdev->master_dev);
++	struct i3c_npcm4xx_obj *obj = DEV_DATA(i3cdev->bus);
+ 	/* struct i3c_register_s *i3c_register = obj->config->base; */
+ 	struct i3c_npcm4xx_dev_priv *priv = DESC_PRIV(i3cdev);
+ 	/* union i3c_dev_addr_tbl_s dat; */
+@@ -2447,7 +2447,7 @@ int i3c_npcm4xx_master_enable_ibi(struct i3c_dev_desc *i3cdev)
+ 	 * i3c_register->intr_signal_en.value = intr_reg.value;
+ 	 */
+ 
+-	return i3c_master_send_enec(i3cdev->master_dev, i3cdev->info.dynamic_addr, I3C_CCC_EVT_SIR);
++	return i3c_master_send_enec(i3cdev->bus, i3cdev->info.dynamic_addr, I3C_CCC_EVT_SIR);
+ }
+ 
+ int i3c_npcm4xx_slave_register(const struct device *dev, struct i3c_slave_setup *slave_data)
+@@ -2999,7 +2999,7 @@ int i3c_npcm4xx_master_send_ccc(const struct device *dev, struct i3c_ccc_cmd *cc
+ int i3c_npcm4xx_master_priv_xfer(struct i3c_dev_desc *i3cdev, struct i3c_priv_xfer *xfers,
+ 	int nxfers)
+ {
+-	struct i3c_npcm4xx_obj *obj = DEV_DATA(i3cdev->master_dev);
++	struct i3c_npcm4xx_obj *obj = DEV_DATA(i3cdev->bus);
+ 	struct i3c_npcm4xx_dev_priv *priv = DESC_PRIV(i3cdev);
+ 	struct i3c_npcm4xx_xfer xfer;
+ 	struct i3c_npcm4xx_cmd *cmds, *cmd;
+@@ -3156,10 +3156,10 @@ int i3c_npcm4xx_master_send_entdaa(struct i3c_dev_desc *i3cdev)
+ 	uint16_t rxlen = 63;
+ 	uint8_t RxBuf_expected[63];
+ 
+-	config = DEV_CFG(i3cdev->master_dev);
++	config = DEV_CFG(i3cdev->bus);
+ 	port = config->inst_id;
+ 
+-	struct i3c_npcm4xx_obj *obj = DEV_DATA(i3cdev->master_dev);
++	struct i3c_npcm4xx_obj *obj = DEV_DATA(i3cdev->bus);
+ 	struct i3c_npcm4xx_dev_priv *priv = DESC_PRIV(i3cdev);
+ 	struct i3c_npcm4xx_xfer xfer;
+ 	struct i3c_npcm4xx_cmd cmd;
+diff --git a/drivers/i3c/i3c_shell.c b/drivers/i3c/i3c_shell.c
+index 8c5cbb3875..af6620a29b 100644
+--- a/drivers/i3c/i3c_shell.c
++++ b/drivers/i3c/i3c_shell.c
+@@ -35,7 +35,7 @@ static struct i3c_dev_desc *find_matching_desc(const struct device *dev, uint8_t
+ 	int i;
+ 
+ 	for (i = 0; i < I3C_SHELL_MAX_DESC_NUM; i++) {
+-		if (i3c_shell_desc_tbl[i].master_dev == dev &&
++		if (i3c_shell_desc_tbl[i].bus == dev &&
+ 		    i3c_shell_desc_tbl[i].info.dynamic_addr == desc_addr) {
+ 			desc = &i3c_shell_desc_tbl[i];
+ 			break;
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index e407c79e84..490dbb926c 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -95,7 +95,7 @@ struct i3c_device_info {
+  * @param info the device information
+  */
+ struct i3c_dev_desc {
+-	const struct device *master_dev;
++	const struct device *bus;
+ 	struct i3c_device_info info;
+ 	void *priv_data;
+ };
+-- 
+2.25.1
+

--- a/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0004-drivers-i3c-add-i3c_slave_hj_req-support-in-i3c-npcm.patch
+++ b/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0004-drivers-i3c-add-i3c_slave_hj_req-support-in-i3c-npcm.patch
@@ -1,0 +1,69 @@
+From 92ffabed2871d93689712ae0ef0614b18ebb66fb Mon Sep 17 00:00:00 2001
+From: Tyrone Ting <kfting@nuvoton.com>
+Date: Mon, 29 Jul 2024 13:28:12 +0800
+Subject: [PATCH] drivers: i3c: add i3c_slave_hj_req support in i3c npcm4xx
+ driver
+
+Support i3c_slave_hj_req.
+
+Signed-off-by: James Chiang <cpchiang1@nuvoton.com>
+Signed-off-by: Tyrone Ting <kfting@nuvoton.com>
+---
+ drivers/i3c/i3c_npcm4xx.c | 13 +++++++++++++
+ include/drivers/i3c/i3c.h |  9 +++++++++
+ 2 files changed, 22 insertions(+)
+
+diff --git a/drivers/i3c/i3c_npcm4xx.c b/drivers/i3c/i3c_npcm4xx.c
+index 8f9ddb29dbf..c2ead249519 100644
+--- a/drivers/i3c/i3c_npcm4xx.c
++++ b/drivers/i3c/i3c_npcm4xx.c
+@@ -2603,6 +2603,19 @@ int i3c_npcm4xx_slave_send_sir(const struct device *dev, struct i3c_ibi_payload
+ 	return -ENOSYS;
+ }
+ 
++int i3c_npcm4xx_slave_hj_req(const struct device *dev)
++{
++	struct i3c_npcm4xx_config *config = DEV_CFG(dev);
++	I3C_PORT_Enum port;
++
++	port = config->inst_id;
++	I3C_Slave_Insert_Task_HotJoin(port);
++
++	k_work_submit_to_queue(&npcm4xx_i3c_work_q[port], &work_send_ibi[port]);
++
++	return 0;
++}
++
+ int i3c_npcm4xx_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynamic_addr)
+ {
+ 	struct i3c_npcm4xx_config *config = DEV_CFG(dev);
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index 490dbb926cd..a998424b5ea 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -210,6 +210,14 @@ int i3c_npcm4xx_slave_get_event_enabling(const struct device *dev, uint32_t *eve
+ int i3c_aspeed_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *payload);
+ int i3c_npcm4xx_slave_send_sir(const struct device *dev, struct i3c_ibi_payload *payload);
+ 
++/**
++ * @brief slave device sends Hot-join request
++ *
++ * @param dev the I3C controller in slave mode
++ * @return int 0 = success
++ */
++int i3c_npcm4xx_slave_hj_req(const struct device *dev);
++
+ /**
+  * @brief set the static address of the i3c controller in slave mode
+  * @param dev the I3C controller in slave mode
+@@ -284,6 +292,7 @@ int i3c_master_send_getbcr(const struct device *master, uint8_t addr, uint8_t *b
+ #define i3c_slave_register		i3c_npcm4xx_slave_register
+ #define i3c_slave_set_static_addr	i3c_npcm4xx_slave_set_static_addr
+ #define i3c_slave_send_sir		i3c_npcm4xx_slave_send_sir
++#define i3c_slave_hj_req		i3c_npcm4xx_slave_hj_req
+ #define i3c_slave_put_read_data		i3c_npcm4xx_slave_put_read_data
+ #define i3c_slave_get_dynamic_addr	i3c_npcm4xx_slave_get_dynamic_addr
+ #define i3c_slave_get_event_enabling	i3c_npcm4xx_slave_get_event_enabling
+-- 
+2.17.1
+


### PR DESCRIPTION
Summary:

- Add nuvoton zephyr patch based on tag openbic-v2.6.0.0(cad6d72381ce408c40867f41a8741dba16e50bdf)

Test Plan:

- Build code: PASS