### PR TITLE
fby4: sd: Disable I3C bus internal PU

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -43,7 +43,7 @@
 SCU_CFG scu_cfg[] = {
 	//register    value
 	{ 0x7e6e2610, 0x04020000 },
-	{ 0x7e6e2618, 0x00c00000 },
+	{ 0x7e6e2618, 0x00c30000 },
 };
 
 void pal_pre_init()


### PR DESCRIPTION
# Description
- Disable I3C_BIC_HUB_SCL(I3C2SCL/GPIOK0) and I3C_BIC_HUB_SDA(I3C2SDA/GPIOK1) internal pull-up.

# Motivation
- Disable this setting, the I3c signal will have more margin.

# Test plan
- Build code: Pass
- Check I3C signal: Pass