### PR TITLE
fby4: wf: Change VR P0V8 and P0V85 current threshold

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
@@ -3432,11 +3432,11 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x00000091, //uint32_t warning_high;
+			0x00000096, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000097, //uint32_t critical_high;
+			0x000000C8, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x000000C8, //uint32_t fatal_high;
+			0x00000258, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 
 		},
@@ -3588,11 +3588,11 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x000002EC, //uint32_t warning_high;
+			0x000002EE, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000310, //uint32_t critical_high;
+			0x00000320, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x000004B0, //uint32_t fatal_high;
+			0x000005DC, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 
 		},
@@ -3744,11 +3744,11 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x00000091, //uint32_t warning_high;
+			0x00000096, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000097, //uint32_t critical_high;
+			0x000000C8, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x000000C8, //uint32_t fatal_high;
+			0x00000258, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 
 		},
@@ -3900,11 +3900,11 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x000002EC, //uint32_t warning_high;
+			0x000002EE, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000310, //uint32_t critical_high;
+			0x00000320, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x000004B0, //uint32_t fatal_high;
+			0x000005DC, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 
 		},


### PR DESCRIPTION
# Description
- Update the sensor threshold of VR P0V8 and P0V85. UNC UCR UNR
P0V8_ASIC_CURR_A   1.5 2   6
P0V85_ASIC_CURR_A  7.5 8   15

# Motivation
- Reference sensor table 20240827.

# Test plan
- Build code: Pass
- Get sensor threshold: Pass

# Log
- Before change "WF_VR_P0V8_ASIC1_CURR_A_66_52": { "critical": { "high": 1.51 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Amperes", "value": 0.0, "warning": { "high": 1.45 } }, ...
    "WF_VR_P0V8_ASIC2_CURR_A_70_52": {
        "critical": {
            "high": 1.51
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Amperes",
        "value": 0.0,
        "warning": {
            "high": 1.45
        }
    },
...
    "WF_VR_P0V85_ASIC2_CURR_A_72_52": {
        "critical": {
            "high": 7.84
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Amperes",
        "value": 3.0,
        "warning": {
            "high": 7.48
        }
    },
...
    "WF_VR_P0V85_ASIC1_CURR_A_68_52": {
        "critical": {
            "high": 7.84
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Amperes",
        "value": 2.0,
        "warning": {
            "high": 7.48
        }
    },

- After change "WF_VR_P0V8_ASIC1_CURR_A_66_52": { "critical": { "high": 2.0 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Amperes", "value": 0.0, "warning": { "high": 1.5 } }, ...
    "WF_VR_P0V8_ASIC1_CURR_A_66_52": {
        "critical": {
            "high": 2.0
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Amperes",
        "value": 0.0,
        "warning": {
            "high": 1.5
        }
    },
...
    "WF_VR_P0V85_ASIC1_CURR_A_68_52": {
        "critical": {
            "high": 8.0
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Amperes",
        "value": 3.0,
        "warning": {
            "high": 7.5
        }
    },
...
    "WF_VR_P0V85_ASIC2_CURR_A_72_52": {
        "critical": {
            "high": 8.0
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Amperes",
        "value": 3.0,
        "warning": {
            "high": 7.5
        }
    },