### PR TITLE
common: Support shell command list_all_sensor for pldm sensor

### DIFF
--- a/common/service/sensor/pdr.h
+++ b/common/service/sensor/pdr.h
@@ -147,6 +147,7 @@ uint32_t plat_get_pdr_size(uint8_t pdr_type);
 void plat_load_numeric_sensor_pdr_table(PDR_numeric_sensor *numeric_sensor_table);
 void plat_load_aux_sensor_names_pdr_table(PDR_sensor_auxiliary_names *aux_sensor_name_table);
 void plat_load_entity_aux_names_pdr_table(PDR_entity_auxiliary_names *entity_aux_name_table);
+int pldm_get_sensor_name_via_sensor_id(uint16_t sensor_id, char *sensor_name, size_t max_length);
 int get_pdr_table_via_record_handle(uint8_t *record_data, uint32_t record_handle);
 void plat_init_entity_aux_names_pdr_table();
 uint16_t plat_get_pdr_entity_aux_names_size();

--- a/common/service/sensor/pldm_sensor.c
+++ b/common/service/sensor/pldm_sensor.c
@@ -70,6 +70,51 @@ bool pldm_sensor_is_interval_ready(pldm_sensor_info *pldm_sensor_list)
 	return true;
 }
 
+int pldm_sensor_get_info_via_sensor_thread_and_sensor_pdr_index(
+	int thread_id, int sensor_pdr_index, uint16_t *sensor_id, real32_t *resolution,
+	real32_t *offset, int8_t *unit_modifier, real32_t *poll_time, uint32_t *update_time,
+	uint8_t *type, int *cache, uint8_t *cache_status, char *check_access)
+{
+	CHECK_NULL_ARG_WITH_RETURN(sensor_id, -1);
+	CHECK_NULL_ARG_WITH_RETURN(resolution, -1);
+	CHECK_NULL_ARG_WITH_RETURN(offset, -1);
+	CHECK_NULL_ARG_WITH_RETURN(unit_modifier, -1);
+	CHECK_NULL_ARG_WITH_RETURN(poll_time, -1);
+	CHECK_NULL_ARG_WITH_RETURN(type, -1);
+	CHECK_NULL_ARG_WITH_RETURN(cache, -1);
+	CHECK_NULL_ARG_WITH_RETURN(cache_status, -1);
+	CHECK_NULL_ARG_WITH_RETURN(check_access, -1);
+
+	int pldm_sensor_count = plat_pldm_sensor_get_sensor_count(thread_id);
+	if (sensor_pdr_index >= pldm_sensor_count) {
+		return -1;
+	}
+
+	// Get from numeric sensor PDR
+	*sensor_id = pldm_sensor_list[thread_id][sensor_pdr_index].pdr_numeric_sensor.sensor_id;
+	*resolution = pldm_sensor_list[thread_id][sensor_pdr_index].pdr_numeric_sensor.resolution;
+	*offset = pldm_sensor_list[thread_id][sensor_pdr_index].pdr_numeric_sensor.offset;
+	*unit_modifier =
+		pldm_sensor_list[thread_id][sensor_pdr_index].pdr_numeric_sensor.unit_modifier;
+	*poll_time =
+		pldm_sensor_list[thread_id][sensor_pdr_index].pdr_numeric_sensor.update_interval;
+
+	// Get from update time
+	*update_time = pldm_sensor_list[thread_id][sensor_pdr_index].update_time;
+
+	// Get from sensor config
+	*type = pldm_sensor_list[thread_id][sensor_pdr_index].pldm_sensor_cfg.type;
+	*cache = pldm_sensor_list[thread_id][sensor_pdr_index].pldm_sensor_cfg.cache;
+	*cache_status = pldm_sensor_list[thread_id][sensor_pdr_index].pldm_sensor_cfg.cache_status;
+	*check_access =
+		(pldm_sensor_list[thread_id][sensor_pdr_index].pldm_sensor_cfg.access_checker(
+			 *sensor_id) ?
+			 'O' :
+			 'X');
+
+	return 0;
+}
+
 int pldm_sensor_get_info_via_sensor_id(uint16_t sensor_id, float *resolution, float *offset,
 				       int8_t *unit_modifier, int *cache,
 				       uint8_t *sensor_operational_state)

--- a/common/service/sensor/pldm_sensor.h
+++ b/common/service/sensor/pldm_sensor.h
@@ -44,6 +44,10 @@ void pldm_sensor_get_reading(sensor_cfg *pldm_sensor_cfg, uint32_t *update_time,
 uint8_t pldm_sensor_get_reading_from_cache(uint16_t sensor_id, int *reading,
 					   uint8_t *sensor_operational_state);
 bool pldm_sensor_is_interval_ready(pldm_sensor_info *pldm_sensor_list);
+int pldm_sensor_get_info_via_sensor_thread_and_sensor_pdr_index(
+	int thread_id, int sensor_pdr_index, uint16_t *sensor_id, real32_t *resolution,
+	real32_t *offset, int8_t *unit_modifier, real32_t *poll_time, uint32_t *update_time,
+	uint8_t *type, int *cache, uint8_t *cache_status, char *check_access);
 pldm_sensor_thread *plat_pldm_sensor_load_thread();
 pldm_sensor_info *plat_pldm_sensor_load(int thread_id);
 int plat_pldm_sensor_get_sensor_count(int thread_id);

--- a/common/shell/commands/sensor_shell.c
+++ b/common/shell/commands/sensor_shell.c
@@ -22,6 +22,13 @@
 #include <string.h>
 #include <logging/log.h>
 
+#ifdef ENABLE_PLDM_SENSOR
+#include "plat_pldm_sensor.h"
+#include "pldm_sensor.h"
+#include "pldm_monitor.h"
+#include "pdr.h"
+#endif
+
 /*
  * Constants
  *
@@ -53,6 +60,19 @@ const char *const sensor_status_name[] = {
 	sensor_name_to_num(pec_error)
 	sensor_name_to_num(parameter_not_valid)
 };
+
+#ifdef ENABLE_PLDM_SENSOR
+const char *const pldm_sensor_status_name[] = {
+	sensor_name_to_num(sensor_enabled)
+	sensor_name_to_num(sensor_disabled)
+	sensor_name_to_num(sensor_unavailable)
+	sensor_name_to_num(sensor_statusunknown) 
+	sensor_name_to_num(sensor_failed)
+	sensor_name_to_num(sensor_initializing)
+	sensor_name_to_num(sensor_shuttingdown)
+	sensor_name_to_num(sensor_intest)
+};
+#endif
 // clang-format on
 
 /*
@@ -108,6 +128,82 @@ static int get_sdr_index_by_sensor_num(uint8_t sensor_num)
 static int sensor_access(const struct shell *shell, uint16_t table_idx, sensor_cfg *cfg,
 			 enum SENSOR_ACCESS mode)
 {
+#ifdef ENABLE_PLDM_SENSOR
+	if (shell == NULL) {
+		return -1;
+	}
+
+	int t_id = 0, s_id = 0, pldm_sensor_count = 0;
+
+	for (t_id = 0; t_id < MAX_SENSOR_THREAD_ID; t_id++) {
+		pldm_sensor_count = plat_pldm_sensor_get_sensor_count(t_id);
+		for (s_id = 0; s_id < pldm_sensor_count; s_id++) {
+			uint16_t sensor_id;
+			real32_t resolution, offset, poll_time;
+			int8_t unit_modifier;
+			uint8_t type, cache_status;
+			int cache;
+			char check_access;
+			uint32_t update_time;
+			uint32_t current_time = 0, diff_time = 0;
+
+			int ret = pldm_sensor_get_info_via_sensor_thread_and_sensor_pdr_index(
+				t_id, s_id, &sensor_id, &resolution, &offset, &unit_modifier,
+				&poll_time, &update_time, &type, &cache, &cache_status,
+				&check_access);
+
+			if (ret != 0)
+				continue;
+
+			char sensor_name[MAX_AUX_SENSOR_NAME_LEN] = { 0 };
+			pldm_get_sensor_name_via_sensor_id(sensor_id, sensor_name,
+							   sizeof(sensor_name));
+			char sign = ' ';
+
+			current_time = k_uptime_get_32() / 1000;
+			diff_time = current_time - update_time;
+			if (diff_time < 1)
+				diff_time = 1;
+
+			if ((check_access == 'O') && (cache_status == PLDM_SENSOR_ENABLED)) {
+				sensor_val cache_reading;
+				cache_reading.integer = (int16_t)(cache & 0xFFFF);
+				cache_reading.fraction = (int16_t)((cache >> 16) & 0xFFFF);
+
+				if (cache_reading.fraction < 0) {
+					cache_reading.fraction = -cache_reading.fraction;
+					if (cache_reading.integer == 0) {
+						sign = '-';
+					}
+				}
+				if (cache_reading.integer < 0) {
+					cache_reading.integer = -cache_reading.integer;
+					sign = '-';
+				}
+
+				shell_print(
+					shell,
+					"[0x%-2x] %-40s: %-18s | access[%c] | poll %4d(%2d) sec | %-21s | %c%5d.%03d",
+					sensor_id, sensor_name, sensor_type_name[type],
+					check_access, diff_time, (int)poll_time,
+					pldm_sensor_status_name[cfg->cache_status], sign,
+					cache_reading.integer, cache_reading.fraction);
+
+				continue;
+			}
+
+			shell_print(
+				shell,
+				"[0x%-2x] %-40s: %-18s | access[%c] | poll %4d(%2d) sec | %-21s | na",
+				sensor_id, sensor_name, sensor_type_name[type], check_access,
+				diff_time, (int)poll_time,
+				pldm_sensor_status_name[cfg->cache_status]);
+			continue;
+		}
+	}
+
+#else
+
 	if (shell == NULL || cfg == NULL) {
 		return -1;
 	}
@@ -178,6 +274,7 @@ static int sensor_access(const struct shell *shell, uint16_t table_idx, sensor_c
 		break;
 	}
 
+#endif
 	return 0;
 }
 
@@ -224,6 +321,9 @@ void cmd_sensor_cfg_list_all_sensor(const struct shell *shell, size_t argc, char
 		return;
 	}
 
+#ifdef ENABLE_PLDM_SENSOR
+	sensor_access(shell, 0, 0, SENSOR_READ);
+#else
 	int sdr_index = -1;
 	uint16_t table_idx = 0;
 	uint8_t sensor_idx = 0;
@@ -284,6 +384,7 @@ void cmd_sensor_cfg_list_all_sensor(const struct shell *shell, size_t argc, char
 			shell,
 			"---------------------------------------------------------------------------------");
 	}
+#endif
 }
 
 void cmd_sensor_cfg_get_table_all_sensor(const struct shell *shell, size_t argc, char **argv)


### PR DESCRIPTION
Summary:

- Support shell command list_all_sensor for pldm sensor.

Test Plan:

- Build code: pass
- Test list all sensor on minerva-ag: pass

Test Log:

- List all sensor

```
uart:~$ platform sensor list_all_sensor
[0x1 ] AEGIS_UBC_1_TEMP_C                      : u50su4p180pmdafc   | access[O] | poll    1( 1) sec | sensor_enabled        |     35.000
[0x2 ] AEGIS_UBC_1_P50V_VIN_VOLT_V             : u50su4p180pmdafc   | access[O] | poll    1( 1) sec | sensor_enabled        |     54.875
[0x3 ] AEGIS_UBC_1_P12V_VOUT_VOLT_V            : u50su4p180pmdafc   | access[O] | poll    1( 1) sec | sensor_enabled        |     13.667
[0x4 ] AEGIS_UBC_1_P12V_CURR_A                 : u50su4p180pmdafc   | access[O] | poll    1( 1) sec | sensor_enabled        |      1.000
[0x5 ] AEGIS_UBC_1_P12V_PWR_W                  : u50su4p180pmdafc   | access[O] | poll    1( 1) sec | sensor_enabled        |     13.667
[0x6 ] AEGIS_UBC_2_TEMP_C                      : u50su4p180pmdafc   | access[O] | poll    1( 1) sec | sensor_enabled        |     35.000
[0x7 ] AEGIS_UBC_2_P50V_VIN_VOLT_V             : u50su4p180pmdafc   | access[O] | poll    1( 1) sec | sensor_enabled        |     54.750
[0x8 ] AEGIS_UBC_2_P12V_VOUT_VOLT_V            : u50su4p180pmdafc   | access[O] | poll    1( 1) sec | sensor_enabled        |     13.668
[0x9 ] AEGIS_UBC_2_P12V_CURR_A                 : u50su4p180pmdafc   | access[O] | poll    1( 1) sec | sensor_enabled        |      1.000
[0xa ] AEGIS_UBC_2_P12V_PWR_W                  : u50su4p180pmdafc   | access[O] | poll    1( 1) sec | sensor_enabled        |     13.668
[0x11] AEGIS_OSFP_P3V3_TEMP_C                  : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     32.000
[0x12] AEGIS_OSFP_P3V3_VOLT_V                  : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      3.297
[0x13] AEGIS_OSFP_P3V3_CURR_A                  : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x14] AEGIS_OSFP_P3V3_PWR_W                   : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x15] AEGIS_CPU_P0V85_PVDD_TEMP_C             : mp2891             | access[O] | poll    1( 1) sec | sensor_enabled        |     31.000
[0x16] AEGIS_CPU_P0V85_PVDD_VOLT_V             : mp2891             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.849
[0x17] AEGIS_CPU_P0V85_PVDD_CURR_A             : mp2891             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x18] AEGIS_CPU_P0V85_PVDD_PWR_W              : mp2891             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x19] AEGIS_CPU_P0V75_PVDD_CH_N_TEMP_C        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     32.000
[0x1a] AEGIS_CPU_P0V75_PVDD_CH_N_VOLT_V        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.751
[0x1b] AEGIS_CPU_P0V75_PVDD_CH_N_CURR_A        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x1c] AEGIS_CPU_P0V75_PVDD_CH_N_PWR_W         : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x1d] AEGIS_CPU_P0V75_MAX_PHY_N_TEMP_C        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     32.000
[0x1e] AEGIS_CPU_P0V75_MAX_PHY_N_VOLT_V        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.750
[0x1f] AEGIS_CPU_P0V75_MAX_PHY_N_CURR_A        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x20] AEGIS_CPU_P0V75_MAX_PHY_N_PWR_W         : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x21] AEGIS_CPU_P0V75_PVDD_CH_S_TEMP_C        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     33.000
[0x22] AEGIS_CPU_P0V75_PVDD_CH_S_VOLT_V        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.750
[0x23] AEGIS_CPU_P0V75_PVDD_CH_S_CURR_A        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x24] AEGIS_CPU_P0V75_PVDD_CH_S_PWR_W         : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x25] AEGIS_CPU_P0V75_MAX_PHY_S_TEMP_C        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     32.000
[0x26] AEGIS_CPU_P0V75_MAX_PHY_S_VOLT_V        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.750
[0x27] AEGIS_CPU_P0V75_MAX_PHY_S_CURR_A        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x28] AEGIS_CPU_P0V75_MAX_PHY_S_PWR_W         : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x29] AEGIS_CPU_P0V75_TRVDD_ZONEA_TEMP_C      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     35.000
[0x2a] AEGIS_CPU_P0V75_TRVDD_ZONEA_VOLT_V      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.751
[0x2b] AEGIS_CPU_P0V75_TRVDD_ZONEA_CURR_A      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x2c] AEGIS_CPU_P0V75_TRVDD_ZONEA_PWR_W       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x2d] AEGIS_CPU_P1V8_VPP_HBM0_2_4_TEMP_C      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     34.000
[0x2e] AEGIS_CPU_P1V8_VPP_HBM0_2_4_VOLT_V      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      1.802
[0x2f] AEGIS_CPU_P1V8_VPP_HBM0_2_4_CURR_A      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x30] AEGIS_CPU_P1V8_VPP_HBM0_2_4_PWR_W       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x31] AEGIS_CPU_P0V75_TRVDD_ZONEB_TEMP_C      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     33.000
[0x32] AEGIS_CPU_P0V75_TRVDD_ZONEB_VOLT_V      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.750
[0x33] AEGIS_CPU_P0V75_TRVDD_ZONEB_CURR_A      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x34] AEGIS_CPU_P0V75_TRVDD_ZONEB_PWR_W       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x35] AEGIS_CPU_P0V4_VDDQL_HBM0_2_4_TEMP_C    : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     31.000
[0x36] AEGIS_CPU_P0V4_VDDQL_HBM0_2_4_VOLT_V    : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.400
[0x37] AEGIS_CPU_P0V4_VDDQL_HBM0_2_4_CURR_A    : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x38] AEGIS_CPU_P0V4_VDDQL_HBM0_2_4_PWR_W     : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x39] AEGIS_CPU_P1V1_VDDC_HBM0_2_4_TEMP_C     : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     34.000
[0x3a] AEGIS_CPU_P1V1_VDDC_HBM0_2_4_VOLT_V     : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      1.101
[0x3b] AEGIS_CPU_P1V1_VDDC_HBM0_2_4_CURR_A     : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x3c] AEGIS_CPU_P1V1_VDDC_HBM0_2_4_PWR_W      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x3d] AEGIS_CPU_P0V75_VDDPHY_HBM0_2_4_TEMP_C  : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     32.000
[0x3e] AEGIS_CPU_P0V75_VDDPHY_HBM0_2_4_VOLT_V  : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.751
[0x3f] AEGIS_CPU_P0V75_VDDPHY_HBM0_2_4_CURR_A  : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x40] AEGIS_CPU_P0V75_VDDPHY_HBM0_2_4_PWR_W   : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x41] AEGIS_CPU_P0V9_TRVDD_ZONEA_TEMP_C       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     34.000
[0x42] AEGIS_CPU_P0V9_TRVDD_ZONEA_VOLT_V       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.900
[0x43] AEGIS_CPU_P0V9_TRVDD_ZONEA_CURR_A       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x44] AEGIS_CPU_P0V9_TRVDD_ZONEA_PWR_W        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x45] AEGIS_CPU_P1V8_VPP_HBM1_3_5_TEMP_C      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     34.000
[0x46] AEGIS_CPU_P1V8_VPP_HBM1_3_5_VOLT_V      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      1.802
[0x47] AEGIS_CPU_P1V8_VPP_HBM1_3_5_CURR_A      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x48] AEGIS_CPU_P1V8_VPP_HBM1_3_5_PWR_W       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.500
[0x49] AEGIS_CPU_P0V9_TRVDD_ZONEB_TEMP_C       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     35.000
[0x4a] AEGIS_CPU_P0V9_TRVDD_ZONEB_VOLT_V       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.901
[0x4b] AEGIS_CPU_P0V9_TRVDD_ZONEB_CURR_A       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x4c] AEGIS_CPU_P0V9_TRVDD_ZONEB_PWR_W        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x4d] AEGIS_CPU_P0V4_VDDQL_HBM1_3_5_TEMP_C    : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     34.000
[0x4e] AEGIS_CPU_P0V4_VDDQL_HBM1_3_5_VOLT_V    : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.401
[0x4f] AEGIS_CPU_P0V4_VDDQL_HBM1_3_5_CURR_A    : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x50] AEGIS_CPU_P0V4_VDDQL_HBM1_3_5_PWR_W     : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x51] AEGIS_CPU_P1V1_VDDC_HBM1_3_5_TEMP_C     : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     33.000
[0x52] AEGIS_CPU_P1V1_VDDC_HBM1_3_5_VOLT_V     : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      1.096
[0x53] AEGIS_CPU_P1V1_VDDC_HBM1_3_5_CURR_A     : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x54] AEGIS_CPU_P1V1_VDDC_HBM1_3_5_PWR_W      : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x55] AEGIS_CPU_P0V75_VDDPHY_HBM1_3_5_TEMP_C  : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     34.000
[0x56] AEGIS_CPU_P0V75_VDDPHY_HBM1_3_5_VOLT_V  : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.751
[0x57] AEGIS_CPU_P0V75_VDDPHY_HBM1_3_5_CURR_A  : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x58] AEGIS_CPU_P0V75_VDDPHY_HBM1_3_5_PWR_W   : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x59] AEGIS_CPU_P0V8_VDDA_PCIE_TEMP_C         : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     35.000
[0x5a] AEGIS_CPU_P0V8_VDDA_PCIE_VOLT_V         : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.800
[0x5b] AEGIS_CPU_P0V8_VDDA_PCIE_CURR_A         : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x5c] AEGIS_CPU_P0V8_VDDA_PCIE_PWR_W          : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x5d] AEGIS_CPU_P1V2_VDDHTX_PCIE_TEMP_C       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |     36.000
[0x5e] AEGIS_CPU_P1V2_VDDHTX_PCIE_VOLT_V       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      1.201
[0x5f] AEGIS_CPU_P1V2_VDDHTX_PCIE_CURR_A       : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0x60] AEGIS_CPU_P1V2_VDDHTX_PCIE_PWR_W        : mp2971             | access[O] | poll    1( 1) sec | sensor_enabled        |      0.000
[0xb ] AEGIS_TOP_INLET_TEMP_C                  : tmp75              | access[O] | poll    1( 1) sec | sensor_enabled        |     28.000
[0xc ] AEGIS_TOP_OUTLET_TEMP_C                 : tmp75              | access[O] | poll    1( 1) sec | sensor_enabled        |     27.000
[0xd ] AEGIS_BOT_INLET_TEMP_C                  : tmp75              | access[O] | poll    1( 1) sec | sensor_enabled        |     29.000
[0xe ] AEGIS_BOT_OUTLET_TEMP_C                 : tmp75              | access[O] | poll    1( 1) sec | sensor_enabled        |     30.000
[0xf ] AEGIS_ON_DIE_1_TEMP__C                  : tmp431             | access[O] | poll    1( 1) sec | sensor_enabled        |     28.312
[0x10] AEGIS_ON_DIE_2_TEMP_C                   : tmp431             | access[O] | poll    1( 1) sec | sensor_enabled        |     28.312
```