### PR TITLE
fby4: wf: Change VR P0V8 and P0V85 power threshold

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
@@ -4056,11 +4056,11 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x000004FC, //uint32_t warning_high;
+			0x000005DC, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x0000054F, //uint32_t critical_high;
+			0x000007D0, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x00000780, //uint32_t fatal_high;
+			0x00001770, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 
 		},
@@ -4212,11 +4212,11 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x2ACD0800, //uint32_t warning_high;
+			0x2CB41780, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x2DE1622E, //uint32_t critical_high;
+			0x2FAF0800, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x4AE82221, //uint32_t fatal_high;
+			0x5F5E1000, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 
 		},
@@ -4368,11 +4368,11 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x000004FC, //uint32_t warning_high;
+			0x000005DC, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x0000054F, //uint32_t critical_high;
+			0x000007D0, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x00000780, //uint32_t fatal_high;
+			0x00001770, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 
 		},
@@ -4524,11 +4524,11 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x2ACD0800, //uint32_t warning_high;
+			0x2CB41780, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x2DE1622E, //uint32_t critical_high;
+			0x2FAF0800, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x4AE82221, //uint32_t fatal_high;
+			0x5F5E1000, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 
 		},


### PR DESCRIPTION
# Description
- Update the sensor threshold of VR P0V8 and P0V85 power.
                                   UNC     UCR     UNR
P0V8_ASIC_PWR_W    1.5      2       6
P0V85_ASIC_PWR_W   7.5      8      16

# Motivation
- Reference sensor table 20240827.

# Test Plan:
- Build code: Pass
- Get sensor threshold: Pass

# Log
- Before change ...
    "WF_VR_P0V85_ASIC1_PWR_W_84_42": {
        "critical": {
            "high": 7.69745454
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Watts",
        "value": 4.0,
        "warning": {
            "high": 7.1808000000000005
        }
    },
...
    "WF_VR_P0V85_ASIC2_PWR_W_88_42": {
        "critical": {
            "high": 7.69745454
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Watts",
        "value": 4.0,
        "warning": {
            "high": 7.1808000000000005
        }
    },
...
    "WF_VR_P0V8_ASIC1_PWR_W_82_42": {
        "critical": {
            "high": 1.359
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Watts",
        "value": 1.0,
        "warning": {
            "high": 1.276
        }
    },
...
    "WF_VR_P0V8_ASIC2_PWR_W_86_42": {
        "critical": {
            "high": 1.359
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Watts",
        "value": 1.0,
        "warning": {
            "high": 1.276
        }
    },

- After change root@bmc:~# mfg-tool sensor-display
...
    "WF_VR_P0V85_ASIC1_PWR_W_84_42": {
        "critical": {
            "high": 8.0
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Watts",
        "value": 4.0,
        "warning": {
            "high": 7.5
        }
    },
...
    "WF_VR_P0V85_ASIC2_PWR_W_88_42": {
        "critical": {
            "high": 8.0
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Watts",
        "value": 4.0,
        "warning": {
            "high": 7.5
        }
    },
...
    "WF_VR_P0V8_ASIC1_PWR_W_82_42": {
        "critical": {
            "high": 2.0
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Watts",
        "value": 1.0,
        "warning": {
            "high": 1.5
        }
    },
...
    "WF_VR_P0V8_ASIC2_PWR_W_86_42": {
        "critical": {
            "high": 2.0
        },
        "max": 0.0,
        "min": 0.0,
        "status": "ok",
        "unit": "Watts",
        "value": 1.0,
        "warning": {
            "high": 1.5
        }
    },