### PR TITLE
fby35: ji: Add DRAM error sel

### DIFF
--- a/common/dev/include/nvidia.h
+++ b/common/dev/include/nvidia.h
@@ -47,6 +47,12 @@ enum nv_satmc_sensor_num_table {
 	NV_SATMC_SENSOR_NUM_SPARE_CH_PRESENCE = 0x0250,
 };
 
+#ifdef ENABLE_SBMR
+#define NV_STATUS_CODE_TYPE_PROG_CODE 0x1
+#define NV_STATUS_CODE_TYPE_ERROR_CODE 0x2
+#define NV_STATUS_CODE_TYPE_DEBUG_CODE 0x3
+#endif
+
 /* Y = (mX + b) * 10^r */
 struct nv_satmc_sensor_parm {
 	uint16_t nv_satmc_sensor_id;

--- a/common/dev/include/sbmr.h
+++ b/common/dev/include/sbmr.h
@@ -44,6 +44,16 @@ typedef struct __attribute__((packed)) {
 
 #define SBMR_POSTCODE_SIZE sizeof(sbmr_boot_progress_code_t)
 
+#ifndef SMBR_UEFI_BOOT_START_POST_CODE
+#define SMBR_UEFI_BOOT_START_POST_CODE 0xc1010005
+#endif
+
+extern bool sbmr_frb3_flag_clr;
+
+#ifdef ENABLE_NVIDIA
+extern sbmr_boot_progress_code_t nv_sbmr_postcode[];
+#endif
+
 struct sbmr_cmd_send_boot_progress_code_req {
 	uint8_t group_ext_def_body;
 	sbmr_boot_progress_code_t code;

--- a/common/dev/nv_satmc.c
+++ b/common/dev/nv_satmc.c
@@ -50,6 +50,39 @@ struct nv_satmc_sensor_parm satmc_sensor_cfg_list[] = {
 
 const int SATMC_SENSOR_CFG_LIST_SIZE = ARRAY_SIZE(satmc_sensor_cfg_list);
 
+#ifdef ENABLE_SBMR
+#include "sbmr.h"
+sbmr_boot_progress_code_t nv_sbmr_postcode[] = {
+	/* POSTCODE: EFI_NV_FW_BOOT_PC_MB1_START */
+	[0] = {	.type = NV_STATUS_CODE_TYPE_PROG_CODE,
+		.rsvd = 0x0000,
+		.severity = 0x00,
+		.operation = 0x0005,
+		.sub_class = 0x01,
+		.class = 0xC1,
+		.inst = 0x00,
+	},
+	/* ERRORCODE: EFI_NV_HW_DRAM_EC_CHANNEL_LOW_COUNT */
+	[1] = {	.type = NV_STATUS_CODE_TYPE_ERROR_CODE,
+		.rsvd = 0x0000,
+		.severity = 0x90,
+		.operation = 0x0001,
+		.sub_class = 0x05,
+		.class = 0xC0,
+		.inst = 0x00,
+	},
+	/* DEBUGCODE: EFI_NV_HW_DRAM_EC_RETIRED_PAGE_OVERFLOW */
+	[2] = {	.type = NV_STATUS_CODE_TYPE_DEBUG_CODE,
+		.rsvd = 0x0000,
+		.severity = 0x01,
+		.operation = 0x0004,
+		.sub_class = 0x05,
+		.class = 0xC0,
+		.inst = 0x00,
+	},
+};
+#endif
+
 pldm_sensor_pdr_parm *find_sensor_parm_by_id(uint16_t sensor_id)
 {
 	for (int i = 0; i < SATMC_SENSOR_CFG_LIST_SIZE; i++) {

--- a/common/hal/hal_i2c_target.c
+++ b/common/hal/hal_i2c_target.c
@@ -332,6 +332,8 @@ uint8_t i2c_target_read(uint8_t bus_num, uint8_t *buff, uint16_t buff_len, uint1
 	}
 
 	if (buff_len < local_buf.msg_length) {
+		LOG_WRN("Given buff_len is not enough for read-back data, given %d, need %d",
+			buff_len, local_buf.msg_length);
 		memcpy(buff, &(local_buf.msg), buff_len);
 		*msg_len = buff_len;
 	} else {

--- a/common/service/ipmi/include/storage_handler.h
+++ b/common/service/ipmi/include/storage_handler.h
@@ -38,8 +38,26 @@ struct sel_event_record {
 	uint8_t event_data[3];
 } __attribute__((__packed__));
 
+struct oem_sel_event_record {
+	uint16_t record_id;
+	uint8_t record_type;
+	uint8_t general_info;
+	uint32_t timestamp;
+	uint8_t failure_event_type;
+	uint8_t rsv_1;
+	uint8_t rsv_2;
+	uint8_t rsv_3;
+	uint8_t failure_event_details;
+	uint8_t pxe_http_fail_type;
+	uint8_t pxe_http_error_code;
+	uint8_t rsv_4;
+} __attribute__((__packed__));
+
 struct ipmi_storage_add_sel_req {
-	struct sel_event_record event;
+	union {
+		struct sel_event_record event;
+		struct oem_sel_event_record oem_event;
+	};
 } __attribute__((__packed__));
 
 struct ipmi_storage_add_sel_resp {

--- a/meta-facebook/yv35-ji/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-ji/boards/ast1030_evb.overlay
@@ -202,5 +202,5 @@
 };
 
 &sram0 {
-	reg = <0 DT_SIZE_K(732)>, <DT_SIZE_K(732) DT_SIZE_K(36)>;
+	reg = <0 DT_SIZE_K(738)>, <DT_SIZE_K(738) DT_SIZE_K(30)>;
 };

--- a/meta-facebook/yv35-ji/src/platform/plat_mctp.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_mctp.h
@@ -23,6 +23,11 @@ struct mctp_to_ipmi_header_resp {
 } __attribute__((__packed__));
 ;
 
+enum {
+	ADD_COMMON_SEL = 0x01,
+	ADD_OEM_SEL = 0x02,
+};
+
 struct mctp_to_ipmi_sel_req {
 	struct mctp_to_ipmi_header_req header;
 	struct ipmi_storage_add_sel_req req_data;
@@ -37,7 +42,7 @@ struct mctp_to_ipmi_sel_resp {
 void plat_mctp_init(void);
 void send_cmd_to_dev(struct k_timer *timer);
 void send_cmd_to_dev_handler(struct k_work *work);
-bool mctp_add_sel_to_ipmi(common_addsel_msg_t *sel_msg);
+bool mctp_add_sel_to_ipmi(struct ipmi_storage_add_sel_req *sel_msg, uint8_t sel_type);
 uint8_t plat_get_mctp_port_count();
 mctp_port *plat_get_mctp_port(uint8_t index);
 void set_dev_endpoint_global();

--- a/meta-facebook/yv35-ji/src/platform/plat_sbmr.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sbmr.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include "sbmr.h"
+#include "pldm.h"
+#include "plat_mctp.h"
+#include "libutil.h"
+#include "util_worker.h"
+#include "storage_handler.h"
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(plat_sbmr);
+
+static void sent_pc_err_event_work_handler(void *arg1, uint32_t arg2)
+{
+	CHECK_NULL_ARG(arg1);
+	ARG_UNUSED(arg2);
+
+	struct ipmi_storage_add_sel_req *add_sel_msg = (struct ipmi_storage_add_sel_req *)arg1;
+
+	if (!mctp_add_sel_to_ipmi(add_sel_msg, ADD_OEM_SEL)) {
+		LOG_ERR("Failed to add POSTCODE error sel.");
+	}
+}
+
+void pal_sbmr_postcode_handler(sbmr_boot_progress_code_t boot_progress_code)
+{
+	bool need_add_sel = false;
+	uint8_t failure_event_type = 0xFF;
+
+	if (!memcmp(&boot_progress_code, &nv_sbmr_postcode[0], sizeof(sbmr_boot_progress_code_t))) {
+		sbmr_frb3_flag_clr = true; // Clear FRB3 flag while MB1 starts
+	} else if (!memcmp(&boot_progress_code, &nv_sbmr_postcode[1],
+			   sizeof(sbmr_boot_progress_code_t))) {
+		failure_event_type = 0x0B; // DRAM page retired
+		need_add_sel = true;
+	} else if (!memcmp(&boot_progress_code, &nv_sbmr_postcode[2],
+			   sizeof(sbmr_boot_progress_code_t))) {
+		failure_event_type = 0x0C; // DRAM channel retired
+		need_add_sel = true;
+	}
+
+	if (need_add_sel == false)
+		return;
+
+	struct ipmi_storage_add_sel_req add_sel_event_req = { 0 };
+	add_sel_event_req.oem_event.general_info = 0x28; // System post event
+	add_sel_event_req.oem_event.failure_event_type = failure_event_type;
+
+	worker_job job = { 0 };
+	job.delay_ms = 0;
+	job.fn = sent_pc_err_event_work_handler;
+	job.ptr_arg = &add_sel_event_req;
+	add_work(&job);
+
+	return;
+}


### PR DESCRIPTION
Summary:
- Add 2 DRAM error SEL from certain post code.
- Modify add-sel function.
- Add postcode list to common code.

TestPlan:
- BuildCode: PASS
- Check error SEL from BMC console: PASS

Log:
- BMC log:
  ```
  root@bmc-oob:~# log-util slot1 --print
  1    slot1    2018-03-09 04:35:43    ipmid            SEL Entry: FRU: 1, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: DRAM page retired
  1    slot1    2018-03-09 04:43:22    ipmid            SEL Entry: FRU: 1, Record: Facebook Unified SEL (0xFB), GeneralInfo: POST(0x28), POST Failure Event: DRAM channel retired
  ```