### PR TITLE
GT: Fix get nic type error for Thor2 NIC

### DIFF
--- a/meta-facebook/gt-cc/src/platform/plat_mctp.c
+++ b/meta-facebook/gt-cc/src/platform/plat_mctp.c
@@ -444,11 +444,12 @@ void check_nic_config_by_ncsi(void)
 {
 	uint8_t config = mellanox_cx7_ncsi_get_link_type();
 
+	/* Remove this process for short term fix, will add back to support BMC get thor 2 type in the future */
 	/* Double check by fru if config is not IB_CX7 */
-	if (config == NIC_CONFIG_CX7 || config == NIC_CONFIG_UNKNOWN) {
-		LOG_INF("Double check nic type by fru");
-		config = check_nic_type_by_fru();
-	}
+	// if (config == NIC_CONFIG_CX7 || config == NIC_CONFIG_UNKNOWN) {
+	// 	LOG_INF("Double check nic type by fru");
+	// 	config = check_nic_type_by_fru();
+	// }
 
 	nic_config = config;
 	LOG_INF("NIC config is %d, 0: UNKNOWN, 1: CX7, 2: IB_CX7", nic_config);


### PR DESCRIPTION
Summary:

- Fix NIC type detection error for Thor2 NIC.
- Remove FRU check temporarily and use only the NCSI command to identify the NIC type as a short-term fix. Support for identifying the Thor2 type via BMC will be added back in the future.
- Thor2 uses a QSFP connector instead of an OSFP connector and does not have optical sensors. Therefore, we return CX7 for short-term manufacturing build usage.

Test Plan:

- Build code: pass
- Test NIC type get: pass

CX7
```
[00:00:03.121,384] <inf> plat_mctp: Set mellanox cx7 self recovery setting success eid = 0x10
[00:00:03.132,773] <inf> plat_mctp: Clear initial state success eid = 0x10
[00:00:03.138,453] <inf> plat_mctp: get link status success eid = 0x10 , link_type = 0xff, response_code = 0x3, reason_code = 0x7fff
[00:00:03.138,458] <inf> plat_mctp: eid 0x10 NIC is CX7 NIC
[00:00:03.138,469] <inf> plat_mctp: NIC config is 1, 0: UNKNOWN, 1: CX7, 2: IB_CX7

root@bmc-oob:~# pldmd-util -b 3 -e 0x0a raw 0x02 0x3A 0x00 0xD0 |grep "PLDM Data"
  PLDM Data : 0x01 0x01 0x01 0x01

```

IB CX7
```
[00:00:03.121,383] <inf> plat_mctp: Set mellanox cx7 self recovery setting success eid = 0x10
[00:00:03.132,913] <inf> plat_mctp: Clear initial state success eid = 0x10
[00:00:03.139,322] <inf> plat_mctp: get link status success eid = 0x10 , link_type = 0x1, response_code = 0x0, reason_code = 0x0
[00:00:03.139,326] <inf> plat_mctp: eid 0x10 NIC is IB_CX7 NIC
[00:00:03.139,336] <inf> plat_mctp: NIC config is 2, 0: UNKNOWN, 1: CX7, 2: IB_CX7

root@bmc-oob:~# pldmd-util -b 3 -e 0x0a raw 0x02 0x3A 0x00 0xD0 |grep "PLDM Data"
  PLDM Data : 0x01 0x01 0x02 0x02

```

Thor2
```
[00:00:12.211,512] <inf> plat_mctp: Clear initial state success eid = 0x10
[00:00:12.215,664] <inf> plat_mctp: get link status success eid = 0x10 , link_type = 0xff, response_code = 0x3, reason_code = 0x7fff
[00:00:12.215,680] <inf> plat_mctp: eid 0x10 NIC is CX7 NIC
[00:00:12.215,690] <inf> plat_mctp: NIC config is 1, 0: UNKNOWN, 1: CX7, 2: IB_CX7

root@bmc-oob:~# pldmd-util -b 3 -e 0x0a raw 0x02 0x3A 0x00 0xD0 |grep "PLDM Data"
  PLDM Data : 0x01 0x01 0x01 0x01

```