### PR TITLE
fby4: sd: Add 2nd source RTQ6056

### DIFF
--- a/common/dev/include/rtq6056.h
+++ b/common/dev/include/rtq6056.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __RTQ6056__
+#define __RTQ6056__
+
+#define RTQ6056_BUS_VOL_OFFSET 0x02
+#define RTQ6056_PWR_OFFSET 0x03
+#define RTQ6056_CUR_OFFSET 0x04
+#define RTQ6056_CALIBRATION_OFFSET 0x05
+#define RTQ6056_MFR_ID_REG 0xFE
+
+extern uint8_t RTQ6056_DEVICE_ID[2];
+
+#endif

--- a/common/dev/rtq6056.c
+++ b/common/dev/rtq6056.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <logging/log.h>
+#include "sensor.h"
+#include "pmbus.h"
+#include "hal_i2c.h"
+#include "rtq6056.h"
+
+#define RTQ6056_BUS_VOLTAGE_LSB 0.00125 // 1.25 mV.
+
+LOG_MODULE_REGISTER(dev_rtq6056);
+
+uint8_t RTQ6056_DEVICE_ID[2] = { 0x12, 0x14 };
+
+uint8_t rtq6056_read(sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(cfg->init_args, SENSOR_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("sensor num: 0x%x is invalid", cfg->num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	rtq6056_init_arg *init_arg = (rtq6056_init_arg *)cfg->init_args;
+	if (init_arg->is_init != true) {
+		LOG_ERR("device isn't initialized");
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	uint8_t retry = 5;
+	int ret = 0;
+	int16_t val = 0;
+	float parameter = 0;
+	I2C_MSG msg;
+	memset(&msg, 0, sizeof(I2C_MSG));
+	*reading = 0;
+	uint8_t offset = cfg->offset;
+	sensor_val *sval = (sensor_val *)reading;
+
+	switch (cfg->offset) {
+	case PMBUS_READ_VOUT:
+		offset = RTQ6056_BUS_VOL_OFFSET;
+		parameter = RTQ6056_BUS_VOLTAGE_LSB;
+		break;
+	case PMBUS_READ_IOUT:
+		offset = RTQ6056_CUR_OFFSET;
+		parameter = init_arg->current_lsb;
+		break;
+	case PMBUS_READ_POUT:
+		offset = RTQ6056_PWR_OFFSET;
+		parameter = init_arg->current_lsb * 25;
+		break;
+	default:
+		LOG_ERR("Offset not supported: 0x%x", offset);
+		return SENSOR_FAIL_TO_ACCESS;
+		break;
+	}
+
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = offset;
+	ret = i2c_master_read(&msg, retry);
+	if (ret != 0) {
+		LOG_ERR("i2c read fail ret: %d", ret);
+		return SENSOR_FAIL_TO_ACCESS;
+	}
+
+	val = (msg.data[0] << 8) | msg.data[1];
+	if (offset == RTQ6056_CUR_OFFSET) {
+		if (GETBIT(msg.data[0], 7)) {
+			// If raw value is negative, set it zero.
+			val = 0;
+		}
+	}
+
+	sval->integer = val * parameter;
+	sval->fraction = ((val * parameter) - sval->integer) * 1000;
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t rtq6056_init(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(cfg->init_args, SENSOR_INIT_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+
+	int ret = 0;
+	int retry = 5;
+	I2C_MSG msg = { 0 };
+
+	rtq6056_init_arg *init_arg = (rtq6056_init_arg *)cfg->init_args;
+
+	if (init_arg->is_init != true) {
+		memset(&msg, 0, sizeof(I2C_MSG));
+		uint16_t calibration = 0;
+
+		msg.bus = cfg->port;
+		msg.target_addr = cfg->target_addr;
+		msg.tx_len = 3;
+		msg.data[0] = RTQ6056_CALIBRATION_OFFSET;
+
+		// Calibration formula = (0.00512 / (current_lsb * r_shunt))
+		calibration = (uint16_t)(5120 /
+					 (1000 * init_arg->current_lsb * 1000 * init_arg->r_shunt));
+		msg.data[1] = (calibration >> 8) & 0xFF;
+		msg.data[2] = calibration & 0xFF;
+
+		ret = i2c_master_write(&msg, retry);
+		if (ret != 0) {
+			LOG_ERR("i2c write CALIBRATION register fail ret: %d, sensor num: 0x%x",
+				ret, cfg->num);
+			return SENSOR_INIT_UNSPECIFIED_ERROR;
+		}
+		init_arg->is_init = true;
+	}
+
+	cfg->read = rtq6056_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -145,6 +145,7 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(mp2891)
 	sensor_name_to_num(raa228238)
 	sensor_name_to_num(mpc12109)
+	sensor_name_to_num(rtq6056)
 };
 // clang-format on
 
@@ -344,6 +345,9 @@ SENSOR_DRIVE_INIT_DECLARE(raa228238);
 #endif
 #ifdef ENABLE_MPC12109
 SENSOR_DRIVE_INIT_DECLARE(mpc12109);
+#endif
+#ifdef ENABLE_RTQ6056
+SENSOR_DRIVE_INIT_DECLARE(rtq6056);
 #endif
 
 // The sequence needs to same with SENSOR_DEV ID
@@ -681,6 +685,12 @@ sensor_drive_api sensor_drive_tbl[] = {
 #else
 	SENSOR_DRIVE_TYPE_UNUSE(mpc12109),
 #endif
+#ifdef ENABLE_RTQ6056
+	SENSOR_DRIVE_TYPE_INIT_MAP(rtq6056),
+#else
+	SENSOR_DRIVE_TYPE_UNUSE(rtq6056),
+#endif
+
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -183,6 +183,7 @@ enum SENSOR_DEV {
 	sensor_dev_mp2891 = 0x41,
 	sensor_dev_raa228238 = 0x42,
 	sensor_dev_mpc12109 = 0x43,
+	sensor_dev_rtq6056 = 0x44,
 	sensor_dev_max
 };
 
@@ -469,6 +470,12 @@ typedef struct _pmic_init_arg {
 	uint8_t smbus_bus_identifier;
 	uint8_t smbus_addr;
 } pmic_init_arg;
+
+typedef struct _rtq6056_init_arg_ {
+	bool is_init;
+	float current_lsb;
+	float r_shunt;
+} rtq6056_init_arg;
 
 typedef struct _ina233_init_arg_ {
 	bool is_init;

--- a/meta-facebook/yv4-sd/src/platform/plat_def.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_def.h
@@ -65,6 +65,8 @@
 #define DISABLE_XDP710
 #define DISABLE_ADC128D818
 
+#define ENABLE_RTQ6056
+
 #define HOST_KCS_PORT kcs3
 #define BMC_USB_PORT "CDC_ACM_0"
 #define MCTP_I3C_PEC_ENABLE 1

--- a/meta-facebook/yv4-sd/src/platform/plat_hook.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_hook.c
@@ -90,6 +90,29 @@ ina233_init_arg ina233_init_args[] = {
 	},
 };
 
+rtq6056_init_arg rtq6056_init_args[] = {
+	[0] = {
+		.is_init = false,
+		.current_lsb = 0.001,
+		.r_shunt = 0.002,
+	},
+	[1] = {
+		.is_init = false,
+		.current_lsb = 0.001,
+		.r_shunt = 0.002,
+	},
+	[2] = {
+		.is_init = false,
+		.current_lsb = 0.001,
+		.r_shunt = 0.002,
+	},
+	[3] = {
+		.is_init = false,
+		.current_lsb = 0.001,
+		.r_shunt = 0.002,
+	},
+};
+
 pt5161l_init_arg pt5161l_init_args[] = { [0] = { .is_init = false,
 						 .temp_cal_code_pma_a = { 0, 0, 0, 0 },
 						 .temp_cal_code_pma_b = { 0, 0, 0, 0 },

--- a/meta-facebook/yv4-sd/src/platform/plat_hook.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_hook.h
@@ -27,6 +27,7 @@ extern adc_asd_init_arg ast_adc_init_args[];
 extern apml_mailbox_init_arg apml_mailbox_init_args[];
 extern vr_pre_proc_arg vr_pre_read_args[];
 extern ina233_init_arg ina233_init_args[];
+extern rtq6056_init_arg rtq6056_init_args[];
 extern pt5161l_init_arg pt5161l_init_args[];
 
 bool pre_vr_read(sensor_cfg *cfg, void *args);

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
@@ -66,9 +66,11 @@ int plat_pldm_sensor_get_sensor_count(int thread_id);
 void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
 					     PDR_numeric_sensor *numeric_sensor_table);
 uint8_t plat_pldm_sensor_get_vr_dev(uint8_t *vr_dev);
+uint8_t plat_pldm_sensor_get_ina_dev();
 void plat_pldm_sensor_change_vr_dev();
 void plat_pldm_sensor_change_ssd_dev();
 void plat_pldm_sensor_change_cpu_bus();
 void plat_pldm_sensor_change_retimer_dev();
+void plat_pldm_sensor_change_ina_dev();
 
 #endif


### PR DESCRIPTION
Description
- Add 2nd source RTQ6056 to replace INA233

Motivation
- Add 2nd source RTQ6056 to replace INA233

Test plan
- Build code pass
- sensor pass with RTQ6056
- sensor pass with INA233

Test log
----With RTQ6056----
  current_MB_INA233_E1S_Boot_CURR_A_71_30 |0.27390000 |
  current_MB_INA233_E1S_Data_CURR_A_72_30 |       0.2 |
    power_MB_INA233_E1S_Boot_PWR_W_100_30 |       3.2 |
    power_MB_INA233_E1S_Data_PWR_W_101_30 |       2.9 |
  voltage_MB_INA233_E1S_Boot_VOLT_V_50_30 |12.1330000 |
  voltage_MB_INA233_E1S_Data_VOLT_V_51_30 |12.1330000 |
----With INA233----
  current_MB_INA233_E1S_Boot_CURR_A_71_30 |     0.272 |
  current_MB_INA233_E1S_Data_CURR_A_72_30 |       0.2 |
    power_MB_INA233_E1S_Boot_PWR_W_100_30 |       3.2 |
    power_MB_INA233_E1S_Data_PWR_W_101_30 |      3.27 |
  voltage_MB_INA233_E1S_Boot_VOLT_V_50_30 |    12.156 |
  voltage_MB_INA233_E1S_Data_VOLT_V_51_30 |    12.159 |