### PR TITLE
YV4: sd: Push addsel work to platform workq

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_def.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_def.h
@@ -70,5 +70,6 @@
 #define MCTP_I3C_PEC_ENABLE 1
 
 #define BIC_UPDATE_MAX_OFFSET 0xC0000
+#define WORKER_STACK_SIZE 2048
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -94,6 +94,8 @@ void pal_pre_init()
 	}
 
 	init_vr_event_work();
+	init_event_work();
+	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
 }
 
 void pal_post_init()

--- a/meta-facebook/yv4-sd/src/platform/plat_isr.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.h
@@ -26,7 +26,6 @@ extern uint8_t hw_event_register[13];
 #define VR_IOUT_FAULT_MASK 0x40
 #define VR_TPS_OCW_MASK 0x20
 
-
 typedef struct _add_vr_sel_info {
 	bool is_init;
 	uint8_t gpio_num;
@@ -35,6 +34,14 @@ typedef struct _add_vr_sel_info {
 	uint8_t is_asserted;
 	struct k_work_delayable add_sel_work;
 } add_vr_sel_info;
+
+typedef struct _add_sel_info {
+	bool is_init;
+	uint8_t gpio_num;
+	uint8_t event_type;
+	uint8_t assert_type;
+	struct k_work_delayable add_sel_work;
+} add_sel_info;
 
 void ISR_DC_ON();
 void ISR_POST_COMPLETE();
@@ -58,5 +65,7 @@ void ISR_APML_ALERT();
 
 void init_vr_event_work();
 void process_vr_pmalert_ocp_sel(struct k_work *work_item);
+void init_event_work();
+void addsel_work_handler(struct k_work *work_item);
 
 #endif


### PR DESCRIPTION
Description:
- BIC should push non-urgent/more time-consuming work items to lower priority work queue to prevent non-urgent task blocking other threads.

Note:
List of events modified in ISR
- APML alert
- PLTRST event
- FRB3 Timer Expired
- Post complete
- Power-on sequence failure
- HDT_PRSNT
- FAST_PROCHOT
- SYS Throttle
- HSC OCP
- P12V_STBY UV
- PVDDCR_CPU0_OCP
- PVDDCR_CPU1_OCP
- PVDD11_S3_PMALERT
- PVDDCR_CPU0_PMALERT
- PVDDCR_CPU1_PMALERT

Test Plan:
- Build code: Pass
- Trigger event: Pass

Log:
Aug 08 00:42:16 bmc pldmd[1933]: Event: Host4 FRB3 Timer Expired, ASSERTED Aug 07 23:45:26 bmc pldmd[1933]: Event: Host4 Post-Completed, ASSERTED Aug 07 23:43:58 bmc pldmd[1933]: Event: Host4 Power-On Sequence Failure, ASSERTED Aug 08 00:04:34 bmc pldmd[1933]: Event: Host4 HDT_PRSNT Assertion, ASSERTED Aug 08 00:04:53 bmc pldmd[1933]: Event: Host4 HDT_PRSNT Assertion, DEASSERTED Aug 08 00:18:52 bmc pldmd[1933]: Event: Host4 CPU Thermal Trip, ASSERTED Aug 08 00:17:22 bmc pldmd[1933]: Event: Host4 SYS Throttle, ASSERTED Aug 08 00:17:45 bmc pldmd[1933]: Event: Host4 SYS Throttle, DEASSERTED Aug 08 00:24:33 bmc pldmd[1933]: Event: Host4 P12V_STBY UV, ASSERTED Aug 07 23:46:12 bmc pldmd[1933]: Event: Host4 P12V_STBY UV, DEASSERTED