### PR TITLE
yv4: wf: remove space for pldm sensor name

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
@@ -5769,7 +5769,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"WF_ADC_PVPP_AB_ASIC2_VOLT_V ",
+		.sensorName = u"WF_ADC_PVPP_AB_ASIC2_VOLT_V",
 	},
 	{
 		// WF_ADC_PVPP_CD_ASIC2_VOLT_V
@@ -5786,7 +5786,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"WF_ADC_PVPP_CD_ASIC2_VOLT_V ",
+		.sensorName = u"WF_ADC_PVPP_CD_ASIC2_VOLT_V",
 	},
 	{
 		// WF_ADC_PVTT_AB_ASIC2_VOLT_V
@@ -5803,7 +5803,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"WF_ADC_PVTT_AB_ASIC2_VOLT_V ",
+		.sensorName = u"WF_ADC_PVTT_AB_ASIC2_VOLT_V",
 	},
 	{
 		// WF_ADC_PVTT_CD_ASIC2_VOLT_V
@@ -5820,7 +5820,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"WF_ADC_PVTT_CD_ASIC2_VOLT_V ",
+		.sensorName = u"WF_ADC_PVTT_CD_ASIC2_VOLT_V",
 	},
 	{
 		// WF_INA233_P12V_STBY_CURR_A


### PR DESCRIPTION
# Description:
Removed the space in the sensor name for the following sensors:
- WF_ADC_PVPP_AB_ASIC2_VOLT_V
- WF_ADC_PVPP_CD_ASIC2_VOLT_V
- WF_ADC_PVTT_AB_ASIC2_VOLT_V
- WF_ADC_PVTT_CD_ASIC2_VOLT_V

# Motivation:
Removed the space in the sensor name for the sensors so that the sensors' name would be correct in BMC.

# Test plan:
Check the PLDM sensor name in BMC are correct.

# Test logs:

Check the PLDM sensor name in BMC are correct.
- Before root@bmc:~# busctl tree xyz.openbmc_project.PLDM
	...
	├─ /xyz/openbmc_project/sensors/voltage/Wailua_Falls_Slot_6_WF_ADC_PVPP_AB_ASIC2_VOLT_V_
	├─ /xyz/openbmc_project/sensors/voltage/Wailua_Falls_Slot_6_WF_ADC_PVPP_CD_ASIC2_VOLT_V_
	├─ /xyz/openbmc_project/sensors/voltage/Wailua_Falls_Slot_6_WF_ADC_PVTT_AB_ASIC2_VOLT_V_
	├─ /xyz/openbmc_project/sensors/voltage/Wailua_Falls_Slot_6_WF_ADC_PVTT_CD_ASIC2_VOLT_V_

- After root@bmc:~# busctl tree xyz.openbmc_project.PLDM
	...
	├─ /xyz/openbmc_project/sensors/voltage/Wailua_Falls_Slot_6_WF_ADC_PVPP_AB_ASIC2_VOLT_V
	├─ /xyz/openbmc_project/sensors/voltage/Wailua_Falls_Slot_6_WF_ADC_PVPP_CD_ASIC2_VOLT_V
	├─ /xyz/openbmc_project/sensors/voltage/Wailua_Falls_Slot_6_WF_ADC_PVTT_AB_ASIC2_VOLT_V
	├─ /xyz/openbmc_project/sensors/voltage/Wailua_Falls_Slot_6_WF_ADC_PVTT_CD_ASIC2_VOLT_V