### PR TITLE
fby4: sd/wf: Adjust VR negative reading to zero

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_hook.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_hook.h
@@ -31,6 +31,7 @@ extern rtq6056_init_arg rtq6056_init_args[];
 extern pt5161l_init_arg pt5161l_init_args[];
 
 bool pre_vr_read(sensor_cfg *cfg, void *args);
+bool post_vr_read(sensor_cfg *cfg, void *args, int *const reading);
 bool post_amd_tsi_read(sensor_cfg *cfg, void *args, int *const reading);
 bool pre_p3v_bat_read(sensor_cfg *cfg, void *args);
 bool post_p3v_bat_read(sensor_cfg *cfg, void *args, int *const reading);

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -1691,6 +1691,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -1760,6 +1761,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -1829,6 +1831,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -1898,6 +1901,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -1967,6 +1971,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -2036,6 +2041,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -2105,6 +2111,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -2174,6 +2181,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -2243,6 +2251,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -2312,6 +2321,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 };

--- a/meta-facebook/yv4-wf/src/platform/plat_hook.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_hook.h
@@ -29,6 +29,7 @@ extern max11617_init_arg max11617_init_args[];
 extern adc128d818_init_arg adc128d818_init_args[];
 
 bool pre_vr_read(sensor_cfg *cfg, void *args);
+bool post_vr_read(sensor_cfg *cfg, void *args, int *const reading);
 bool post_p085v_voltage_read(sensor_cfg *cfg, void *args, int *reading);
 bool post_adc128d818_read(sensor_cfg *cfg, void *args, int *reading);
 

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
@@ -3452,6 +3452,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -3530,6 +3531,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -3608,6 +3610,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -3686,6 +3689,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -3764,6 +3768,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -3842,6 +3847,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -3920,6 +3926,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -3998,6 +4005,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -4076,6 +4084,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -4154,6 +4163,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -4232,6 +4242,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -4310,6 +4321,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -4388,6 +4400,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -4466,6 +4479,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -4544,6 +4558,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[1],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 	{
@@ -4622,6 +4637,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			.cache_status = PLDM_SENSOR_INITIALIZING,
 			.pre_sensor_read_hook = pre_vr_read,
 			.pre_sensor_read_args = &vr_pre_read_args[0],
+			.post_sensor_read_hook = post_vr_read,
 		},
 	},
 };


### PR DESCRIPTION
# Description
- Adjust VR negative reading to zero according to power team suggestion.

# Motivation
- Prevent mfg-tool sensor-display overflow.

# Test Plan:
- Build code: Pass