### PR TITLE
fby4: wf: Support second source RTQ6056

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_def.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_def.h
@@ -27,6 +27,8 @@
 #define ENABLE_CCI
 #define ENABLE_VISTARA
 
+#define ENABLE_RTQ6056
+
 #define BIC_UPDATE_MAX_OFFSET 0xC0000
 
 #endif

--- a/meta-facebook/yv4-wf/src/platform/plat_hook.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_hook.c
@@ -73,6 +73,19 @@ ina233_init_arg ina233_init_args[] = {
         },
 };
 
+rtq6056_init_arg rtq6056_init_args[] = {
+	[0] = {
+		.is_init = false,
+		.current_lsb = 0.001,
+		.r_shunt = 0.005,
+	},
+	[1] = {
+		.is_init = false,
+		.current_lsb = 0.001,
+		.r_shunt = 0.005,
+	},
+};
+
 vr_pre_read_arg vr_pre_read_args[] = {
 	[0] = { 0x0 },
 	[1] = { 0x1 },

--- a/meta-facebook/yv4-wf/src/platform/plat_hook.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_hook.h
@@ -27,6 +27,7 @@ extern ina233_init_arg ina233_init_args[];
 extern vr_pre_read_arg vr_pre_read_args[];
 extern max11617_init_arg max11617_init_args[];
 extern adc128d818_init_arg adc128d818_init_args[];
+extern rtq6056_init_arg rtq6056_init_args[];
 
 bool pre_vr_read(sensor_cfg *cfg, void *args);
 bool post_p085v_voltage_read(sensor_cfg *cfg, void *args, int *reading);


### PR DESCRIPTION
# Description
- Support second source RTQ6056.

# Motivation
- Support second source RTQ6056.

# Test plan
- Build code: Pass
- Get sensor reading: Pass

# Log
- INA233 "WF_INA233_P12V_STBY_VOLT_V_32_22": { "critical": { "high": 13.32, "low": 10.73 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Volts", "value": 12.09, "warning": { "high": 13.19, "low": 10.790000000000001 } }, "WF_INA233_P12V_E1S_0_L_VOLT_V_33_22": { "critical": { "high": 13.32, "low": 10.73 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Volts", "value": 12.102, "warning": { "high": 13.19, "low": 10.790000000000001 } }, "WF_INA233_P12V_STBY_CURR_A_64_22": { "critical": { "high": 10.68 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Amperes", "value": 3.13, "warning": { "high": 10.57 } }, "WF_INA233_P12V_E1S_0_L_CURR_A_65_22": { "critical": { "high": 2.2 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Amperes", "value": 0.2, "warning": { "high": 2.1 } }, "WF_INA233_P12V_STBY_PWR_W_80_22": { "max": 0.0, "min": 0.0, "status": "ok", "unit": "Watts", "value": 37.9 }, "WF_INA233_P12V_E1S_0_L_PWR_W_81_22": { "critical": { "high": 25.75 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Watts", "value": 2.77, "warning": { "high": 25.5 } },

- RTQ6056 "WF_INA233_P12V_STBY_VOLT_V_32_32": { "critical": { "high": 13.32, "low": 10.73 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Volts", "value": 12.133000000000001, "warning": { "high": 13.19, "low": 10.790000000000001 } }, "WF_INA233_P12V_E1S_0_L_VOLT_V_33_32": { "critical": { "high": 13.32, "low": 10.73 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Volts", "value": 12.001, "warning": { "high": 13.19, "low": 10.790000000000001 } }, "WF_INA233_P12V_STBY_CURR_A_64_32": { "critical": { "high": 10.68 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Amperes", "value": 3.17, "warning": { "high": 10.57 } }, "WF_INA233_P12V_E1S_0_L_CURR_A_65_32": { "critical": { "high": 2.2 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Amperes", "value": 0.30000000000000004, "warning": { "high": 2.1 } }, "WF_INA233_P12V_STBY_PWR_W_80_32": { "max": 0.0, "min": 0.0, "status": "ok", "unit": "Watts", "value": 38.099000000000004 }, "WF_INA233_P12V_E1S_0_L_PWR_W_81_32": { "critical": { "high": 25.75 }, "max": 0.0, "min": 0.0, "status": "ok", "unit": "Watts", "value": 5.22, "warning": { "high": 25.5 } },