### PR TITLE
fby35: ji: Modify satmc polling mechanism

### DIFF
--- a/common/service/pldm/pldm.c
+++ b/common/service/pldm/pldm.c
@@ -641,7 +641,7 @@ int pldm_send_ipmi_request(ipmi_msg *msg)
 	// Total data len = IANA + ipmi netfn + ipmi cmd + ipmi request data len
 	pmsg.len = sizeof(struct _ipmi_cmd_req) - 1 + msg->data_len;
 
-	uint8_t rbuf[PLDM_MAX_DATA_SIZE];
+	uint8_t rbuf[PLDM_MAX_DATA_SIZE] = { 0 };
 
 	LOG_HEXDUMP_DBG(pmsg.buf, pmsg.len, "pmsg.buf");
 	// Send request to PLDM/MCTP thread and get response

--- a/meta-facebook/yv35-ji/src/platform/plat_init.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_init.c
@@ -71,8 +71,8 @@ void pal_post_init()
 	ssif_init();
 
 	if (get_DC_status() == true) {
-		LOG_INF("Try to set satmc eid");
-		set_dev_endpoint_global();
+		LOG_INF("Try to access SatMC...");
+		satmc_status_update();
 	}
 }
 

--- a/meta-facebook/yv35-ji/src/platform/plat_mctp.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_mctp.h
@@ -45,6 +45,6 @@ void send_cmd_to_dev_handler(struct k_work *work);
 bool mctp_add_sel_to_ipmi(struct ipmi_storage_add_sel_req *sel_msg, uint8_t sel_type);
 uint8_t plat_get_mctp_port_count();
 mctp_port *plat_get_mctp_port(uint8_t index);
-void set_dev_endpoint_global();
+void satmc_status_update();
 
 #endif /* _PLAT_MCTP_h */


### PR DESCRIPTION
Summary:
- Modify SatMC polling mechanism by keep get eid from it till post end. Set eid only if received EID not expected. 
- Modify polling time interval from 8 sec to 4 sec.

TestPlan:
- BuildCode: PASS
- Test DC-cycle/Host-reboot cases: PASS
