### PR TITLE
fby35: ji: Modify some sensors' threshold

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sdr_table.c
@@ -754,7 +754,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x39, // UCT
+		0x3A, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x34, // LCT
@@ -815,10 +815,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x74, // UCT
+		0x6C, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x4C, // LCT
+		0x4A, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -940,7 +940,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x7E, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x48, // LCT
+		0x45, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -998,10 +998,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x7F, // UCT
+		0x84, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x71, // LCT
+		0x6C, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1059,7 +1059,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x39, // UCT
+		0x3A, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x34, // LCT
@@ -1425,10 +1425,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x60, // UCT
+		0x66, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x54, // LCT
+		0x4F, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1551,7 +1551,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x7E, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x48, // LCT
+		0x45, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1609,10 +1609,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x74, // UCT
+		0x6C, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x4C, // LCT
+		0x4A, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1673,7 +1673,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x17, // UCT
+		0x28, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -1784,12 +1784,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x7D, // [7:0] M bits
+		0x02, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
+		0x00, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -1797,7 +1797,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x17, // UCT
+		0xF0, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -1907,7 +1907,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x02, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -1920,7 +1920,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0xB4, // UCT
+		0xE7, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT


### PR DESCRIPTION
Summary:
- Modify some sensors' threshold.
  - Voltage
    - MB_ADC_P3V3_STBY_VOLT_V
    - MB_ADC_SOCVDD_VOLT_V
    - MB_ADC_CPUVDD_VOLT_V
    - MB_ADC_1V2_VOLT_V
    - MB_ADC_VDD_3V3_VOLT_V
    - MB_ADC_CPU_DVDD_VOLT_V
    - MB_CPUVDD_VOLT_V
    - MB_SOCVDD_VOLT_V
  - Current
    - MB_HSC_OUTPUT_CURR_A
  - Power
    - MB_CPU_PWR_W
    - MB_HSC_INPUT_PWR_W

TestPlan:
- BuildCode: PASS
- Check threshold from BMC console: PASS

Log:
- BMC console:
```
root@bmc-oob:~# sensor-util slot2 -t
slot2:
MB_INLET_TEMP_C              (0x1) :  27.812 C     | (ok) | UCR: 60.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_OUTLET_TEMP_C             (0x2) :  39.750 C     | (ok) | UCR: 80.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_FIO_FRONT_TEMP_C          (0x3) :  27.700 C     | (ok) | UCR: 40.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_SOC_CPU_TEMP_C            (0x4) :  53.155 C     | (ok) | UCR: 85.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_E1S_SSD_TEMP_C            (0x6) :  26.000 C     | (ok) | UCR: 70.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_HSC_TEMP_C                (0x7) :  39.000 C     | (ok) | UCR: 85.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_RETIMER_TEMP_C            (0xB) :  40.980 C     | (ok) | UCR: 105.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_LPDDR5_UP_TEMP_C          (0xC) :  45.187 C     | (ok) | UCR: 80.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_LPDDR5_DOWN_TEMP_C        (0xD) :  39.312 C     | (ok) | UCR: 80.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_HSC_INPUT_VOLT_V          (0x10) :  12.031 Volts | (ok) | UCR: 13.300 | UNC: 13.200 | UNR: 14.300 | LCR: 10.700 | LNC: 10.800 | LNR: 10.100
MB_ADC_P12V_STBY_VOLT_V      (0x11) :  11.939 Volts | (ok) | UCR: 13.300 | UNC: 13.200 | UNR: 14.300 | LCR: 10.700 | LNC: 10.800 | LNR: 10.100
MB_ADC_VDD_1V8_VOLT_V        (0x12) :   1.831 Volts | (ok) | UCR: 1.980 | UNC: NA | UNR: NA | LCR: 1.600 | LNC: NA | LNR: NA
MB_ADC_P3V3_STBY_VOLT_V      (0x13) :   3.294 Volts | (ok) | UCR: 3.480 | UNC: NA | UNR: NA | LCR: 3.120 | LNC: NA | LNR: NA
MB_ADC_SOCVDD_VOLT_V         (0x14) :   0.913 Volts | (ok) | UCR: 1.080 | UNC: NA | UNR: NA | LCR: 0.740 | LNC: NA | LNR: NA
MB_ADC_P3V_BAT_VOLT_V        (0x15) :   3.232 Volts | (ok) | UCR: 3.600 | UNC: NA | UNR: NA | LCR: 2.700 | LNC: NA | LNR: NA
MB_ADC_CPUVDD_VOLT_V         (0x16) :   1.105 Volts | (ok) | UCR: 1.260 | UNC: NA | UNR: NA | LCR: 0.690 | LNC: NA | LNR: NA
MB_ADC_1V2_VOLT_V            (0x18) :   1.213 Volts | (ok) | UCR: 1.320 | UNC: NA | UNR: NA | LCR: 1.080 | LNC: NA | LNR: NA
MB_ADC_VDD_3V3_VOLT_V        (0x19) :   3.314 Volts | (ok) | UCR: 3.480 | UNC: NA | UNR: NA | LCR: 3.120 | LNC: NA | LNR: NA
MB_ADC_P1V2_STBY_VOLT_V      (0x1A) :   1.206 Volts | (ok) | UCR: 1.270 | UNC: NA | UNR: NA | LCR: 1.130 | LNC: NA | LNR: NA
MB_ADC_FBVDDQ_VOLT_V         (0x1B) :   0.512 Volts | (ok) | UCR: 0.580 | UNC: NA | UNR: NA | LCR: 0.460 | LNC: NA | LNR: NA
MB_ADC_FBVDDP2_VOLT_V        (0x1C) :   1.057 Volts | (ok) | UCR: 1.130 | UNC: NA | UNR: NA | LCR: 1.000 | LNC: NA | LNR: NA
MB_ADC_FBVDD1_VOLT_V         (0x1D) :   1.835 Volts | (ok) | UCR: 1.960 | UNC: NA | UNR: NA | LCR: 1.690 | LNC: NA | LNR: NA
MB_ADC_P5V_STBY_VOLT_V       (0x1E) :   4.987 Volts | (ok) | UCR: 5.250 | UNC: NA | UNR: NA | LCR: 4.750 | LNC: NA | LNR: NA
MB_ADC_CPU_DVDD_VOLT_V       (0x1F) :   0.881 Volts | (ok) | UCR: 1.020 | UNC: NA | UNR: NA | LCR: 0.790 | LNC: NA | LNR: NA
MB_E1S_SSD_VOLT_V            (0x20) :  11.948 Volts | (ok) | UCR: 13.300 | UNC: 13.200 | UNR: 14.300 | LCR: 10.700 | LNC: 10.800 | LNR: 10.100
MB_CPUVDD_VOLT_V             (0x22) :   1.087 Volts | (ok) | UCR: 1.260 | UNC: NA | UNR: NA | LCR: 0.690 | LNC: NA | LNR: NA
MB_SOCVDD_VOLT_V             (0x23) :   0.900 Volts | (ok) | UCR: 1.080 | UNC: NA | UNR: NA | LCR: 0.740 | LNC: NA | LNR: NA
MB_HSC_OUTPUT_CURR_A         (0x25) :   6.686 Amps  | (ok) | UCR: 40.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_E1S_SSD_CURR_A            (0x26) :   0.237 Amps  | (ok) | UCR: 1.200 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_CPU_PWR_W                 (0x30) :  86.760 Watts | (ok) | UCR: 462.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_PWR_W           (0x31) :  83.000 Watts | (ok) | UCR: 480.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_E1S_SSD_PWR_W             (0x32) :   2.850 Watts | (ok) | UCR: 14.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_CPUVDD_PWR_W              (0x34) :  68.713 Watts | (ok) | UCR: 180.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOCVDD_PWR_W              (0x35) :   6.426 Watts | (ok) | UCR: 90.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_CPU_THROTTLE_STA          (0x40) :   1.000       | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_PWR_BREAK_STA             (0x41) :   1.000       | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SPARE_CH_STA              (0x42) :   2.000       | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
```