### PR TITLE
yv4: sd: enable both mctp-i2c and mctp-i3c thread

### DIFF
--- a/common/service/host/kcs.c
+++ b/common/service/host/kcs.c
@@ -41,7 +41,6 @@ LOG_MODULE_REGISTER(kcs);
 
 kcs_dev *kcs;
 static bool proc_kcs_ok = false;
-static uint8_t bmc_interface = 0;
 
 void kcs_write(uint8_t index, uint8_t *buf, uint32_t buf_sz)
 {
@@ -160,8 +159,9 @@ exit:
 static int send_bios_version_to_bmc(char *bios_version, uint8_t bios_version_len)
 {
 	pldm_msg msg = { 0 };
-	uint8_t bmc_bus = I2C_BUS_BMC;
+	uint8_t bmc_bus = I2C_BUS_BMC, bmc_interface = BMC_INTERFACE_I2C;
 
+	bmc_interface = pal_get_bmc_interface();
 	if (bmc_interface == BMC_INTERFACE_I3C) {
 		bmc_bus = I3C_BUS_BMC;
 		msg.ext_params.type = MCTP_MEDIUM_TYPE_TARGET_I3C;
@@ -299,8 +299,9 @@ static void kcs_read_task(void *arvg0, void *arvg1, void *arvg2)
 				// Send SEL to BMC via PLDM over MCTP
 				mctp_ext_params ext_params = { 0 };
 				uint8_t pldm_event_length = rc - 4; // exclude netfn, cmd, record_id
-				uint8_t bmc_bus = I2C_BUS_BMC;
+				uint8_t bmc_bus = I2C_BUS_BMC,  bmc_interface = BMC_INTERFACE_I2C;
 
+				bmc_interface = pal_get_bmc_interface();
 				if (bmc_interface == BMC_INTERFACE_I3C) {
 					bmc_bus = I3C_BUS_BMC;
 					ext_params.type = MCTP_MEDIUM_TYPE_TARGET_I3C;
@@ -410,8 +411,6 @@ void kcs_device_init(char **config, uint8_t size)
 	if (!kcs)
 		return;
 	memset(kcs, 0, size * sizeof(*kcs));
-
-	bmc_interface = pal_get_bmc_interface();
 
 	/* IPMI channel target [50h-5Fh] are reserved for KCS channel.
 	 * The max channel number KCS_MAX_CHANNEL_NUM is 0xF.

--- a/common/service/pldm/pldm_oem.c
+++ b/common/service/pldm/pldm_oem.c
@@ -33,12 +33,6 @@
 
 LOG_MODULE_DECLARE(pldm, LOG_LEVEL_DBG);
 
-#ifdef ENABLE_PLDM
-#ifdef ENABLE_EVENT_TO_BMC
-static uint8_t bmc_interface = 0;
-#endif
-#endif
-
 uint8_t check_iana(const uint8_t *iana)
 {
 	CHECK_NULL_ARG_WITH_RETURN(iana, PLDM_ERROR);
@@ -160,7 +154,9 @@ uint8_t send_event_log_to_bmc(struct pldm_addsel_data sel_msg)
 {
 	pldm_msg msg = { 0 };
 	uint8_t bmc_bus = I2C_BUS_BMC;
+	uint8_t bmc_interface = 0;
 
+	bmc_interface = pal_get_bmc_interface();
 	if (bmc_interface == BMC_INTERFACE_I3C) {
 		bmc_bus = I3C_BUS_BMC;
 		msg.ext_params.type = MCTP_MEDIUM_TYPE_TARGET_I3C;


### PR DESCRIPTION
# Description:
Enable both mctp-i2c and mctp-i3c thread in BIC and check the interface to communicate with BMC every time when sending data to BMC.

# Motivation:
We are using I2C as interface between BMC and SD BIC on ASPEED BMC and using I3C as interface between BMC and SD BIC on Nuvoton BMC currently.
We would like to use the same SD BIC firmware for both ASPEED and Nuvoton BMC, so we enable both mctp-i2c and mctp-i3c thread in BIC.

# Test plan:
Check the following test cases on both ASPEED and Nuvoton.
1. Check MCTP EID of devices are correct.
2. BMC could get postcode after host DC cycle.
3. BMC could receive SEL added from host.
4. BMC could get BIOS version correctly.

# Test log:
1. Check MCTP EID of devices are correct. root@bmc:~# busctl tree xyz.openbmc_project.MCTP
└─ /xyz
  └─ /xyz/openbmc_project
    └─ /xyz/openbmc_project/mctp
      └─ /xyz/openbmc_project/mctp/1
        ├─ /xyz/openbmc_project/mctp/1/60
        ├─ /xyz/openbmc_project/mctp/1/62
        ├─ /xyz/openbmc_project/mctp/1/64
        ├─ /xyz/openbmc_project/mctp/1/65
        ├─ /xyz/openbmc_project/mctp/1/8
        └─ /xyz/openbmc_project/mctp/1/92

root@bmc:~# pldmtool base GetTID -m 60
{
    "Response": 60
}

root@bmc:~# pldmtool base GetTID -m 62
{
    "Response": 62
}

root@bmc:~# cxl-fw-update version -m 64
Get Firmware Info for EID: 64
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.9-d0f636e0f
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:

root@bmc:~# cxl-fw-update version -m 65
Get Firmware Info for EID: 65
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.9-d0f636e0f
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:

2. BMC could get postcode after host DC cycle. root@bmc:~# mfg-tool postcode-display -p 6
<6> Getting postcode entries from xyz.openbmc_project.State.Boot.PostCode6. [
    "ee0000bf",
    "ee0000a3",
    "ee0000a2",
    "ee0000b7",
    "ee0000b4",
    "ee0000a5",
    "ee0000ee",
    "ee0000a6",
    "ee0000e9",
    "ee0000ea",
...

3. BMC could receive SEL added from host. [root@20240220-643fbk2 ~]# ipmitool raw 0x0A 0x44 0x00 0x00 0xFB 0x20 0x00 0x00 0x00 0x00 0x00 0x00 0x0B 0xE0 0x00 0x00 0x50 0x01
 00 00

root@bmc:~# journalctl | grep BIOS
Aug 13 02:33:09 bmc pldmd[1373]: BIOS_IPMI_SEL: Host 6: GeneralInfo: x86/PCIeErr(0x20), Bus e0/Dev 01/Fun 03, ErrID2: 0x50, ErrID1: 0x01

4. BMC could get BIOS version correctly.
- Check BIOS version root@bmc:~# busctl introspect xyz.openbmc_project.Settings  /xyz/openbmc_project/software/host6/Sentinel_Dome_bios
NAME                                 TYPE      SIGNATURE RESULT/VALUE                             FLAGS
...
.Version                             property  s         "Y4005"                                  emits-change writable