### PR TITLE
fby4: wf: Change CXL i2c frequency to 100K

### DIFF
--- a/meta-facebook/yv4-wf/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-wf/boards/ast1030_evb.overlay
@@ -37,7 +37,7 @@
 &i2c1 {
 	pinctrl-0 = <&pinctrl_i2c1_default>;
 	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &i2c2 {
@@ -49,7 +49,7 @@
 &i2c3 {
 	pinctrl-0 = <&pinctrl_i2c3_default>;
 	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
 
 &i2c4 {


### PR DESCRIPTION
# Description
- Change i2c frequency of CXL bus form 400K to 100K.

# Motivation
- There is currently a problem of sudden decrease in I2C frequency. That causes abnormal communication with CXL.