### PR TITLE
yv4: sd: update the access time for MB_ADC_PVDD11_S3_VOLT_V

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -854,7 +854,7 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 		{
 			.type = sensor_dev_ast_adc,
 			.port = ADC_PORT14,
-			.access_checker = stby_access,
+			.access_checker = dc_access,
 			.sample_count = SAMPLE_COUNT_DEFAULT,
 			.arg0 = 1,
 			.arg1 = 1,


### PR DESCRIPTION
# Description:
- As the title.

# Motivation:
- Prevent unexpected sel log afte DC cycle.

# Test plan:
- Build code : pass
- Checking the sel log after DC cycle.