### PR TITLE
common: Fix ISL69259/ISL69260 power reading issue while using vout scale

### DIFF
--- a/common/dev/isl69259.c
+++ b/common/dev/isl69259.c
@@ -564,6 +564,7 @@ uint8_t isl69259_read(sensor_cfg *cfg, int *reading)
 	uint8_t offset = cfg->offset;
 	val = (msg.data[1] << 8) | msg.data[0];
 	float vout_val;
+	float pout_val;
 
 	switch (offset) {
 	case PMBUS_READ_VOUT:
@@ -601,7 +602,13 @@ uint8_t isl69259_read(sensor_cfg *cfg, int *reading)
 			return SENSOR_UNSPECIFIED_ERROR;
 		}
 
-		sval->integer = val;
+		/* If the Vout exceeds the VR's operating range, you may add a voltage divider. 
+		The VR will read the divided voltage and calculate power (P) based on this adjusted voltage, not the original Vout. 
+		So, you might need to adjust Pout to reflect the actual output power. */
+		pout_val = ((float)val) / vout_scale;
+
+		sval->integer = pout_val;
+		sval->fraction = (pout_val - sval->integer) * 1000;
 		break;
 	default:
 		LOG_ERR("Not support offset: 0x%x", offset);

--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
@@ -47,7 +47,8 @@ plat_sensor_vr_extend_info plat_sensor_vr_extend_table[] = {
 	{ SENSOR_NUM_OSFP_P3V3_VOLT_V, P3V3_ISL69260_ADDR, .mps_vr_init_args = &mp2971_init_args[0],
 	  .rns_vr_init_args = &isl69259_init_args[0] },
 	{ SENSOR_NUM_OSFP_P3V3_CURR_A, P3V3_ISL69260_ADDR },
-	{ SENSOR_NUM_OSFP_P3V3_PWR_W, P3V3_ISL69260_ADDR },
+	{ SENSOR_NUM_OSFP_P3V3_PWR_W, P3V3_ISL69260_ADDR, .mps_vr_init_args = &mp2971_init_args[0],
+	  .rns_vr_init_args = &isl69259_init_args[0] },
 
 	{ SENSOR_NUM_CPU_P0V85_PVDD_TEMP_C, P0V85_PVDD_RAA228238_ADDR },
 	{ SENSOR_NUM_CPU_P0V85_PVDD_VOLT_V, P0V85_PVDD_RAA228238_ADDR },
@@ -8655,8 +8656,10 @@ void plat_pldm_sensor_change_vr_init_args()
 
 	for (int index = 0; index < plat_pldm_sensor_get_sensor_count(VR_SENSOR_THREAD_ID);
 	     index++) {
-		if (plat_pldm_sensor_vr_table[index].pdr_numeric_sensor.sensor_id ==
-		    SENSOR_NUM_OSFP_P3V3_VOLT_V) {
+		if ((plat_pldm_sensor_vr_table[index].pdr_numeric_sensor.sensor_id ==
+		     SENSOR_NUM_OSFP_P3V3_VOLT_V) ||
+		    (plat_pldm_sensor_vr_table[index].pdr_numeric_sensor.sensor_id ==
+		     SENSOR_NUM_OSFP_P3V3_PWR_W)) {
 			find_init_args_by_sensor_id(
 				plat_pldm_sensor_vr_table[index].pldm_sensor_cfg.num, &init_args);
 			plat_pldm_sensor_vr_table[index].pldm_sensor_cfg.init_args = init_args;


### PR DESCRIPTION
Summary:
- If the Vout exceeds the VR's operating range, we may add a voltage divider. The VR will read the divided voltage and calculate power based on this adjusted voltage, not the original Vout. So, we might need to adjust Pout to reflect the actual output power.
- Modify ISL69259(ISL69260) sensor driver and platform sensor init arg.

Test Plan:
- Build code: PASS
- Pout test: PASS