### PR TITLE
minerva-ag: Fix VR VENDOR TYPE 02 display RNS VR driver issue

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_class.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_class.c
@@ -67,25 +67,32 @@ void get_vr_vendor_type(void)
 	case DELTA_UBC_AND_MPS_VR:
 		ubc_type = UBC_DELTA_U50SU4P180PMDAFC;
 		vr_type = VR_MPS_MP2971_MP2891;
+		LOG_INF("VR_VENDOR_TYPE 0 UBC_TYPE = 0x%02X, VR_TYPE = 0x%02X", ubc_type, vr_type);
 		break;
 	case DELTA_UBC_AND_RNS_VR:
 		ubc_type = UBC_DELTA_U50SU4P180PMDAFC;
 		vr_type = VR_RNS_ISL69260_RAA228238;
+		LOG_INF("VR_VENDOR_TYPE 1 UBC_TYPE = 0x%02X, VR_TYPE = 0x%02X", ubc_type, vr_type);
 		break;
 	case MPS_UBC_AND_MPS_VR:
 		ubc_type = UBC_MPS_MPC12109;
 		vr_type = VR_MPS_MP2971_MP2891;
+		LOG_INF("VR_VENDOR_TYPE 2 UBC_TYPE = 0x%02X, VR_TYPE = 0x%02X", ubc_type, vr_type);
+		break;
 	case MPS_UBC_AND_RNS_VR:
 		ubc_type = UBC_MPS_MPC12109;
 		vr_type = VR_RNS_ISL69260_RAA228238;
+		LOG_INF("VR_VENDOR_TYPE 3 UBC_TYPE = 0x%02X, VR_TYPE = 0x%02X", ubc_type, vr_type);
 		break;
 	case FLEX_UBC_AND_MPS_VR:
 		ubc_type = UBC_FLEX_BMR313;
 		vr_type = VR_MPS_MP2971_MP2891;
+		LOG_INF("VR_VENDOR_TYPE 4 UBC_TYPE = 0x%02X, VR_TYPE = 0x%02X", ubc_type, vr_type);
 		break;
 	case FLEX_UBC_AND_RNS_VR:
 		ubc_type = UBC_FLEX_BMR313;
 		vr_type = VR_RNS_ISL69260_RAA228238;
+		LOG_INF("VR_VENDOR_TYPE 5 UBC_TYPE = 0x%02X, VR_TYPE = 0x%02X", ubc_type, vr_type);
 		break;
 	default:
 		LOG_WRN("vr vendor type not supported: 0x%x", vr_vender_type);

--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
@@ -8675,6 +8675,7 @@ void plat_pldm_sensor_change_vr_addr()
 	uint8_t addr;
 
 	if (vr_type == VR_RNS_ISL69260_RAA228238) {
+		LOG_INF("change vr addr for RNS_ISL69260_RAA228238");
 		for (int index = 0; index < plat_pldm_sensor_get_sensor_count(VR_SENSOR_THREAD_ID);
 		     index++) {
 			find_vr_addr_by_sensor_id(


### PR DESCRIPTION
Summary:
- Adjusted plat_hook to resolve the issue where VR VENDOR TYPE 02 displays the RNS VR driver.
- Added UBC and VR type log prints for better visibility.

Test Plan:
- Build code: PASS
- Pout test: PASS