### PR TITLE
minerva-ag: Fix sensor addr replacing error

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
@@ -211,6 +211,7 @@ pldm_sensor_info plat_pldm_sensor_ubc_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_UBC_1_TEMP_C,
 			.type = sensor_dev_u50su4p180pmdafc,
 			.port = I2C_BUS1,
 			.target_addr = DC_BRICK_1_ADDR,
@@ -280,6 +281,7 @@ pldm_sensor_info plat_pldm_sensor_ubc_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_UBC_1_P50V_VIN_VOLT_V,
 			.type = sensor_dev_u50su4p180pmdafc,
 			.port = I2C_BUS1,
 			.target_addr = DC_BRICK_1_ADDR,
@@ -349,6 +351,7 @@ pldm_sensor_info plat_pldm_sensor_ubc_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_UBC_1_P12V_VOUT_VOLT_V,
 			.type = sensor_dev_u50su4p180pmdafc,
 			.port = I2C_BUS1,
 			.target_addr = DC_BRICK_1_ADDR,
@@ -418,6 +421,7 @@ pldm_sensor_info plat_pldm_sensor_ubc_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_UBC_1_P12V_CURR_A,
 			.type = sensor_dev_u50su4p180pmdafc,
 			.port = I2C_BUS1,
 			.target_addr = DC_BRICK_1_ADDR,
@@ -487,6 +491,7 @@ pldm_sensor_info plat_pldm_sensor_ubc_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_UBC_1_P12V_PWR_W,
 			.type = sensor_dev_u50su4p180pmdafc,
 			.port = I2C_BUS1,
 			.target_addr = DC_BRICK_1_ADDR,
@@ -556,6 +561,7 @@ pldm_sensor_info plat_pldm_sensor_ubc_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_UBC_2_TEMP_C,
 			.type = sensor_dev_u50su4p180pmdafc,
 			.port = I2C_BUS1,
 			.target_addr = DC_BRICK_2_ADDR,
@@ -625,6 +631,7 @@ pldm_sensor_info plat_pldm_sensor_ubc_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_UBC_2_P50V_VIN_VOLT_V,
 			.type = sensor_dev_u50su4p180pmdafc,
 			.port = I2C_BUS1,
 			.target_addr = DC_BRICK_2_ADDR,
@@ -694,6 +701,7 @@ pldm_sensor_info plat_pldm_sensor_ubc_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_UBC_2_P12V_VOUT_VOLT_V,
 			.type = sensor_dev_u50su4p180pmdafc,
 			.port = I2C_BUS1,
 			.target_addr = DC_BRICK_2_ADDR,
@@ -763,6 +771,7 @@ pldm_sensor_info plat_pldm_sensor_ubc_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_UBC_2_P12V_CURR_A,
 			.type = sensor_dev_u50su4p180pmdafc,
 			.port = I2C_BUS1,
 			.target_addr = DC_BRICK_2_ADDR,
@@ -832,6 +841,7 @@ pldm_sensor_info plat_pldm_sensor_ubc_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_UBC_2_P12V_PWR_W,
 			.type = sensor_dev_u50su4p180pmdafc,
 			.port = I2C_BUS1,
 			.target_addr = DC_BRICK_2_ADDR,
@@ -904,6 +914,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_OSFP_P3V3_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS1,
 			.target_addr = P3V3_MP2971_ADDR,
@@ -973,6 +984,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_OSFP_P3V3_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS1,
 			.target_addr = P3V3_MP2971_ADDR,
@@ -1043,6 +1055,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_OSFP_P3V3_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS1,
 			.target_addr = P3V3_MP2971_ADDR,
@@ -1112,6 +1125,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_OSFP_P3V3_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS1,
 			.target_addr = P3V3_MP2971_ADDR,
@@ -1181,6 +1195,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V85_PVDD_TEMP_C,
 			.type = sensor_dev_mp2891,
 			.port = I2C_BUS2,
 			.target_addr = P0V85_PVDD_MP2891_ADDR,
@@ -1250,6 +1265,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V85_PVDD_VOLT_V,
 			.type = sensor_dev_mp2891,
 			.port = I2C_BUS2,
 			.target_addr = P0V85_PVDD_MP2891_ADDR,
@@ -1319,6 +1335,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V85_PVDD_CURR_A,
 			.type = sensor_dev_mp2891,
 			.port = I2C_BUS2,
 			.target_addr = P0V85_PVDD_MP2891_ADDR,
@@ -1388,6 +1405,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V85_PVDD_PWR_W,
 			.type = sensor_dev_mp2891,
 			.port = I2C_BUS2,
 			.target_addr = P0V85_PVDD_MP2891_ADDR,
@@ -1457,6 +1475,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_PVDD_CH_N_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_PVDD_CH_N_MP2971_ADDR,
@@ -1526,6 +1545,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_PVDD_CH_N_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_PVDD_CH_N_MP2971_ADDR,
@@ -1595,6 +1615,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_PVDD_CH_N_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_PVDD_CH_N_MP2971_ADDR,
@@ -1664,6 +1685,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_PVDD_CH_N_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_PVDD_CH_N_MP2971_ADDR,
@@ -1733,6 +1755,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_MAX_PHY_N_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_MAX_PHY_N_MP2971_ADDR,
@@ -1802,6 +1825,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_MAX_PHY_N_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_MAX_PHY_N_MP2971_ADDR,
@@ -1871,6 +1895,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_MAX_PHY_N_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_MAX_PHY_N_MP2971_ADDR,
@@ -1940,6 +1965,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_MAX_PHY_N_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_MAX_PHY_N_MP2971_ADDR,
@@ -2009,6 +2035,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_PVDD_CH_S_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_PVDD_CH_S_MP2971_ADDR,
@@ -2078,6 +2105,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_PVDD_CH_S_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_PVDD_CH_S_MP2971_ADDR,
@@ -2147,6 +2175,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_PVDD_CH_S_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_PVDD_CH_S_MP2971_ADDR,
@@ -2216,6 +2245,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_PVDD_CH_S_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_PVDD_CH_S_MP2971_ADDR,
@@ -2285,6 +2315,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_MAX_PHY_S_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_MAX_PHY_S_MP2971_ADDR,
@@ -2354,6 +2385,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_MAX_PHY_S_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_MAX_PHY_S_MP2971_ADDR,
@@ -2423,6 +2455,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_MAX_PHY_S_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_MAX_PHY_S_MP2971_ADDR,
@@ -2492,6 +2525,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_MAX_PHY_S_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_MAX_PHY_S_MP2971_ADDR,
@@ -2561,6 +2595,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_TRVDD_ZONEA_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_TRVDD_ZONEA_MP2971_ADDR,
@@ -2630,6 +2665,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_TRVDD_ZONEA_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_TRVDD_ZONEA_MP2971_ADDR,
@@ -2699,6 +2735,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_TRVDD_ZONEA_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_TRVDD_ZONEA_MP2971_ADDR,
@@ -2768,6 +2805,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_TRVDD_ZONEA_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_TRVDD_ZONEA_MP2971_ADDR,
@@ -2837,6 +2875,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V8_VPP_HBM0_2_4_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P1V8_VPP_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -2906,6 +2945,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V8_VPP_HBM0_2_4_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P1V8_VPP_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -2975,6 +3015,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V8_VPP_HBM0_2_4_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P1V8_VPP_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -3044,6 +3085,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V8_VPP_HBM0_2_4_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P1V8_VPP_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -3113,6 +3155,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_TRVDD_ZONEB_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_TRVDD_ZONEB_MP2971_ADDR,
@@ -3182,6 +3225,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_TRVDD_ZONEB_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_TRVDD_ZONEB_MP2971_ADDR,
@@ -3251,6 +3295,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_TRVDD_ZONEB_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_TRVDD_ZONEB_MP2971_ADDR,
@@ -3320,6 +3365,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_TRVDD_ZONEB_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_TRVDD_ZONEB_MP2971_ADDR,
@@ -3389,6 +3435,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V4_VDDQL_HBM0_2_4_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V4_VDDQL_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -3458,6 +3505,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V4_VDDQL_HBM0_2_4_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V4_VDDQL_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -3527,6 +3575,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V4_VDDQL_HBM0_2_4_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V4_VDDQL_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -3596,6 +3645,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V4_VDDQL_HBM0_2_4_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V4_VDDQL_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -3665,6 +3715,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V1_VDDC_HBM0_2_4_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P1V1_VDDC_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -3734,6 +3785,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V1_VDDC_HBM0_2_4_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P1V1_VDDC_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -3803,6 +3855,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V1_VDDC_HBM0_2_4_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P1V1_VDDC_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -3872,6 +3925,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V1_VDDC_HBM0_2_4_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P1V1_VDDC_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -3941,6 +3995,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_VDDPHY_HBM0_2_4_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_VDDPHY_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -4010,6 +4065,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_VDDPHY_HBM0_2_4_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_VDDPHY_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -4079,6 +4135,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_VDDPHY_HBM0_2_4_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_VDDPHY_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -4148,6 +4205,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_VDDPHY_HBM0_2_4_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS2,
 			.target_addr = P0V75_VDDPHY_HBM0_HBM2_HBM4_MP2971_ADDR,
@@ -4217,6 +4275,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V9_TRVDD_ZONEA_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V9_TRVDD_ZONEA_MP2971_ADDR,
@@ -4286,6 +4345,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V9_TRVDD_ZONEA_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V9_TRVDD_ZONEA_MP2971_ADDR,
@@ -4355,6 +4415,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V9_TRVDD_ZONEA_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V9_TRVDD_ZONEA_MP2971_ADDR,
@@ -4424,6 +4485,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V9_TRVDD_ZONEA_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V9_TRVDD_ZONEA_MP2971_ADDR,
@@ -4493,6 +4555,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V8_VPP_HBM1_3_5_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V8_VPP_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -4562,6 +4625,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V8_VPP_HBM1_3_5_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V8_VPP_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -4631,6 +4695,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V8_VPP_HBM1_3_5_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V8_VPP_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -4700,6 +4765,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V8_VPP_HBM1_3_5_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V8_VPP_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -4769,6 +4835,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V9_TRVDD_ZONEB_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V9_TRVDD_ZONEB_MP2971_ADDR,
@@ -4838,6 +4905,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V9_TRVDD_ZONEB_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V9_TRVDD_ZONEB_MP2971_ADDR,
@@ -4907,6 +4975,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V9_TRVDD_ZONEB_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V9_TRVDD_ZONEB_MP2971_ADDR,
@@ -4976,6 +5045,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V9_TRVDD_ZONEB_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V9_TRVDD_ZONEB_MP2971_ADDR,
@@ -5045,6 +5115,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V4_VDDQL_HBM1_3_5_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V4_VDDQL_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5114,6 +5185,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V4_VDDQL_HBM1_3_5_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V4_VDDQL_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5183,6 +5255,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V4_VDDQL_HBM1_3_5_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V4_VDDQL_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5252,6 +5325,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V4_VDDQL_HBM1_3_5_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V4_VDDQL_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5321,6 +5395,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V1_VDDC_HBM1_3_5_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V1_VDDC_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5390,6 +5465,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V1_VDDC_HBM1_3_5_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V1_VDDC_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5459,6 +5535,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V1_VDDC_HBM1_3_5_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V1_VDDC_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5528,6 +5605,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V1_VDDC_HBM1_3_5_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V1_VDDC_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5597,6 +5675,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_VDDPHY_HBM1_3_5_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V75_VDDPHY_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5666,6 +5745,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_VDDPHY_HBM1_3_5_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V75_VDDPHY_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5735,6 +5815,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_VDDPHY_HBM1_3_5_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V75_VDDPHY_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5804,6 +5885,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V75_VDDPHY_HBM1_3_5_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V75_VDDPHY_HBM1_HBM3_HBM5_MP2971_ADDR,
@@ -5873,6 +5955,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V8_VDDA_PCIE_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V8_VDDA_PCIE_MP2971_ADDR,
@@ -5942,6 +6025,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V8_VDDA_PCIE_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V8_VDDA_PCIE_MP2971_ADDR,
@@ -6011,6 +6095,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V8_VDDA_PCIE_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V8_VDDA_PCIE_MP2971_ADDR,
@@ -6080,6 +6165,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P0V8_VDDA_PCIE_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P0V8_VDDA_PCIE_MP2971_ADDR,
@@ -6149,6 +6235,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V2_VDDHTX_PCIE_TEMP_C,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V2_VDDHTX_PCIE_MP2971_ADDR,
@@ -6218,6 +6305,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V2_VDDHTX_PCIE_VOLT_V,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V2_VDDHTX_PCIE_MP2971_ADDR,
@@ -6287,6 +6375,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V2_VDDHTX_PCIE_CURR_A,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V2_VDDHTX_PCIE_MP2971_ADDR,
@@ -6356,6 +6445,7 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_CPU_P1V2_VDDHTX_PCIE_PWR_W,
 			.type = sensor_dev_mp2971,
 			.port = I2C_BUS3,
 			.target_addr = P1V2_VDDHTX_PCIE_MP2971_ADDR,
@@ -6428,6 +6518,7 @@ pldm_sensor_info plat_pldm_sensor_temp_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_TOP_INLET_TEMP_C,
 			.type = sensor_dev_tmp75,
 			.port = I2C_BUS1,
 			.target_addr = TOP_INLET_TEMP_ADDR,
@@ -6495,6 +6586,7 @@ pldm_sensor_info plat_pldm_sensor_temp_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_TOP_OUTLET_TEMP_C,
 			.type = sensor_dev_tmp75,
 			.port = I2C_BUS1,
 			.target_addr = TOP_OUTLET_TEMP_ADDR,
@@ -6562,6 +6654,7 @@ pldm_sensor_info plat_pldm_sensor_temp_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_BOT_INLET_TEMP_C,
 			.type = sensor_dev_tmp75,
 			.port = I2C_BUS1,
 			.target_addr = BOT_INLET_TEMP_ADDR,
@@ -6629,6 +6722,7 @@ pldm_sensor_info plat_pldm_sensor_temp_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_BOT_OUTLET_TEMP_C,
 			.type = sensor_dev_tmp75,
 			.port = I2C_BUS1,
 			.target_addr = BOT_OUTLET_TEMP_ADDR,
@@ -6696,6 +6790,7 @@ pldm_sensor_info plat_pldm_sensor_temp_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_ON_DIE_1_TEMP__C,
 			.type = sensor_dev_tmp431,
 			.port = I2C_BUS1,
 			.target_addr = ON_DIE_1_TEMP_ADDR,
@@ -6763,6 +6858,7 @@ pldm_sensor_info plat_pldm_sensor_temp_table[] = {
 		},
 		.update_time = 0,
 		{
+			.num = SENSOR_NUM_ON_DIE_2_TEMP_C,
 			.type = sensor_dev_tmp431,
 			.port = I2C_BUS1,
 			.target_addr = ON_DIE_2_TEMP_ADDR,


### PR DESCRIPTION
Summary:
- A misplacement of the number in the sensor configuration in the PDR table caused find_vr_addr_by_sensor_id() to insert an unexpected sensor address into the table.
- Added the correct number to each sensor configuration to resolve the issue.

Test Plan:
- Build code: PASS
- Get sensor reading: PASS