### PR TITLE
fby35: ji: Modify retimer access timing

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_pldm_fw_update.c
@@ -33,6 +33,7 @@
 #include "plat_sensor_table.h"
 #include "plat_class.h"
 #include "plat_fru.h"
+#include "plat_power_status.h"
 #include "power_status.h"
 
 #include "mpq8746.h"
@@ -505,8 +506,8 @@ static uint8_t pldm_pre_retimer_update(void *fw_update_param)
 		return 1;
 	}
 
-	if (get_post_status() == false) {
-		LOG_WRN("Not in POST COMPLETE state, skip retimer update");
+	if (get_retimer_status() == false) {
+		LOG_WRN("Not in RETIMER-PWGOOD/POST-COMPLETE state, skip retimer update");
 		return 1;
 	}
 
@@ -579,8 +580,9 @@ static bool get_retimer_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 		LOG_WRN("Not support retimer relative function before EVT");
 		return false;
 	}
-	if (get_post_status() == false) {
-		LOG_WRN("Not in POST COMPLETE state, skip retimer fw version get");
+
+	if (get_retimer_status() == false) {
+		LOG_WRN("Not in RETIMER-PWGOOD/POST-COMPLETE state, skip retimer fw version get");
 		return false;
 	}
 

--- a/meta-facebook/yv35-ji/src/platform/plat_power_status.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_power_status.c
@@ -24,6 +24,7 @@
 #include "plat_sensor_table.h"
 #include "power_status.h"
 #include "plat_power_status.h"
+#include "util_worker.h"
 #include "logging/log.h"
 
 LOG_MODULE_REGISTER(plat_power_status);
@@ -243,4 +244,20 @@ void set_satmc_status(bool status)
 		gpio_set(VIRTUAL_SATMC_READY, GPIO_HIGH);
 	else
 		gpio_set(VIRTUAL_SATMC_READY, GPIO_LOW);
+}
+
+bool retimer_access(uint8_t sensor_num)
+{
+	return get_retimer_status();
+}
+
+bool get_retimer_status()
+{
+	if (get_DC_status() == false)
+		return false;
+
+	if (get_post_status() == true)
+		return true;
+
+	return gpio_get(VIRTUAL_RETIMER_PG);
 }

--- a/meta-facebook/yv35-ji/src/platform/plat_power_status.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_power_status.h
@@ -28,5 +28,7 @@ void power_status_monitor();
 bool satmc_access(uint8_t sensor_num);
 void set_satmc_status(bool status);
 bool get_satmc_status();
+bool retimer_access(uint8_t sensor_num);
+bool get_retimer_status();
 
 #endif

--- a/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
@@ -211,14 +211,14 @@ sensor_cfg rs31380r_temp_sensor_config_table[] = {
 
 sensor_cfg pt4080l_sensor_config_table[] = {
 	{ SENSOR_NUM_TEMP_RETIMER, sensor_dev_pt5161l, I2C_BUS2, AL_RETIMER_ADDR,
-	  PT5161L_TEMP_OFFSET, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  PT5161L_TEMP_OFFSET, retimer_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_pt4080l_read, &mux_conf_addr_0xe2[1],
 	  NULL, NULL, &pt5161l_init_args[0] },
 };
 
 sensor_cfg ds160pt801_sensor_config_table[] = {
 	{ SENSOR_NUM_TEMP_RETIMER, sensor_dev_ds160pt801, I2C_BUS2, TI_RETIMER_ADDR,
-	  DS160PT801_READ_TEMP, post_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  DS160PT801_READ_TEMP, retimer_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
 	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_ds160pt801_read, &mux_conf_addr_0xe2[1],
 	  NULL, NULL, NULL },
 };


### PR DESCRIPTION
Summary:
- Modify retimer access timing from post-end to retimer-power-good which would affect retimer's sensor access and fw-update/fw-version-read.

TestPlan:
- BuildCode: PASS
