### PR TITLE
fby35: ji: Support cpuvdd ocp sel

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_isr.c
@@ -300,6 +300,9 @@ static void read_cpu_power_seq_status(struct k_work *work)
 	}
 
 	/* CHECK2 - Try to read primary CPUVDD whether CPU shutdown by vr OCP */
+	if (get_board_revision() < SYS_BOARD_PVT) // VR run with standby power only >= PVT
+		return;
+
 	if (get_oth_module() != OTH_MODULE_PRIMARY)
 		return;
 

--- a/meta-facebook/yv35-ji/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_isr.c
@@ -28,6 +28,7 @@
 #include "pldm.h"
 #include "ssif.h"
 #include "sbmr.h"
+#include "pmbus.h"
 #include "util_worker.h"
 #include "libutil.h"
 #include "libipmi.h"
@@ -268,6 +269,7 @@ static void read_cpu_power_seq_status(struct k_work *work)
 	if (CPU_power_good() == true)
 		return;
 
+	/* CHECK1 - If cpu abnormal off, add SEL, it might trigger from CPU or VR. */
 	I2C_MSG i2c_msg = { 0 };
 	uint8_t retry = 3;
 	i2c_msg.bus = I2C_BUS1;
@@ -282,21 +284,73 @@ static void read_cpu_power_seq_status(struct k_work *work)
 	}
 
 	LOG_INF("CPU power seq state: 0x%x", i2c_msg.data[0]);
+	if (i2c_msg.data[0] != CPU_SHDN_STATE)
+		return;
 
-	/* if cpu abnormal off, add SEL, it might trigger from CPU or VR. */
-	if (i2c_msg.data[0] == CPU_SHDN_STATE) {
-		LOG_WRN("CPU abnormal off, add CPU thermal trip or VR hot sel.");
-		struct ipmi_storage_add_sel_req add_sel_msg = { 0 };
-		add_sel_msg.event.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
-		add_sel_msg.event.sensor_num = SENSOR_NUM_SYSTEM_STATUS;
-		add_sel_msg.event.event_dir_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
-		add_sel_msg.event.event_data[0] = IPMI_SYS_EVENT_OFFSET_CPU_THERM_TRIP_OR_VR_HOT;
-		add_sel_msg.event.event_data[1] = 0xFF;
-		add_sel_msg.event.event_data[2] = 0xFF;
-		if (!mctp_add_sel_to_ipmi(&add_sel_msg, ADD_COMMON_SEL)) {
-			LOG_ERR("Failed to add CPU thermal trip or VR hot sel.");
+	LOG_WRN("CPU abnormal off, add CPU thermal trip or VR hot sel.");
+	struct ipmi_storage_add_sel_req add_sel_msg = { 0 };
+	add_sel_msg.event.sensor_type = IPMI_OEM_SENSOR_TYPE_SYS_STA;
+	add_sel_msg.event.sensor_num = SENSOR_NUM_SYSTEM_STATUS;
+	add_sel_msg.event.event_dir_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
+	add_sel_msg.event.event_data[0] = IPMI_SYS_EVENT_OFFSET_CPU_THERM_TRIP_OR_VR_HOT;
+	add_sel_msg.event.event_data[1] = 0xFF;
+	add_sel_msg.event.event_data[2] = 0xFF;
+	if (!mctp_add_sel_to_ipmi(&add_sel_msg, ADD_COMMON_SEL)) {
+		LOG_ERR("Failed to add CPU thermal trip or VR hot sel.");
+	}
+
+	/* CHECK2 - Try to read primary CPUVDD whether CPU shutdown by vr OCP */
+	if (get_oth_module() != OTH_MODULE_PRIMARY)
+		return;
+
+	gpio_set(FM_VR_FW_PROGRAM_L, GPIO_LOW); // In case of CPU suddenly turns on
+	gpio_set(BIC_CPLD_VRD_MUX_SEL, GPIO_LOW);
+
+	i2c_msg.bus = I2C_BUS3;
+	i2c_msg.target_addr = (CPUVDD_I2C_ADDR >> 1);
+	i2c_msg.tx_len = 2;
+	i2c_msg.data[0] = PMBUS_PAGE;
+	i2c_msg.data[1] = PMBUS_PAGE_0;
+	if (i2c_master_write(&i2c_msg, retry)) {
+		LOG_ERR("Failed to switch CPUVDD page to 0.");
+		goto exit;
+	}
+
+	i2c_msg.tx_len = 1;
+	i2c_msg.rx_len = 1;
+	i2c_msg.data[0] = PMBUS_STATUS_BYTE;
+	if (i2c_master_read(&i2c_msg, retry)) {
+		LOG_ERR("Failed to read CPUVDD status byte.");
+		goto exit;
+	}
+
+	LOG_INF("CPUVDD byte status: 0x%x", i2c_msg.data[0]);
+	if (!(i2c_msg.data[0] & BIT(4)))
+		goto exit;
+
+	LOG_WRN("CPUVDD OCP, add OCP sel.");
+	memset(&add_sel_msg, 0, sizeof(add_sel_msg));
+	add_sel_msg.event.sensor_type = IPMI_OEM_SENSOR_TYPE_VR;
+	add_sel_msg.event.sensor_num = SENSOR_NUM_VR_OCP;
+	add_sel_msg.event.event_dir_type = IPMI_EVENT_TYPE_SENSOR_SPECIFIC;
+	add_sel_msg.event.event_data[0] = IPMI_EVENT_CPUVDD_OCP_ASSERT;
+	add_sel_msg.event.event_data[1] = 0xFF;
+	add_sel_msg.event.event_data[2] = 0xFF;
+	if (!mctp_add_sel_to_ipmi(&add_sel_msg, ADD_COMMON_SEL)) {
+		LOG_ERR("Failed to add OCP sel.");
+		goto exit;
+	} else {
+		i2c_msg.tx_len = 1;
+		i2c_msg.data[0] = PMBUS_CLEAR_FAULTS;
+		if (i2c_master_write(&i2c_msg, retry)) {
+			LOG_ERR("Failed to clear CPUVDD fault.");
+			goto exit;
 		}
 	}
+
+exit:
+	gpio_set(BIC_CPLD_VRD_MUX_SEL, GPIO_HIGH);
+	gpio_set(FM_VR_FW_PROGRAM_L, GPIO_HIGH);
 }
 
 K_WORK_DELAYABLE_DEFINE(read_cpu_power_seq_status_work, read_cpu_power_seq_status);

--- a/meta-facebook/yv35-ji/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_sensor_table.h
@@ -104,9 +104,11 @@
 #define SENSOR_NUM_SYSTEM_STATUS 0x10
 #define SENSOR_NUM_POWER_ERROR 0x56
 #define SENSOR_NUM_PROC_FAIL 0x65
+#define SENSOR_NUM_VR_OCP 0x71
 #define SENSOR_NUM_CPU_FAULT 0xC0
 
 #define IPMI_EVENT_OFFSET_SYS_E1S_ALERT 0x86
+#define IPMI_EVENT_CPUVDD_OCP_ASSERT 0x06
 
 uint8_t plat_get_config_size();
 void load_sensor_config(void);


### PR DESCRIPTION
Summary:
- Support CPUVDD's ocp SEL.
- Trigger process:
  - BIC will read CPUVDD status byte(0x78) whether OCP occurred after CPU shutdown.
  - Note: VR run with standby power >= PVT1. So this feature only activated in >=PVT1.

TestPlan:
- BuildCode: PASS
- Try to trigger SEL: PASS

Log:
- BMC console:
```
# switch vr mux
bic-util slot1 --set_gpio 52 0
# stop polling
bic-util slot1 0xe0 0x30 0x15 0xa0 0x00 0x00
# set vr page to 4
bic-util slot1 0x18 0x52 0x05 0x4a 0x00 0x00 0x04
# read back MFR_OCP_SET(0xE4) to confirm that the page switch is fine
bic-util slot1 0x18 0x52 0x05 0x4a 0x02 0xe4
# set the OCP to very low
bic-util slot1 0x18 0x52 0x05 0x4a 0x00 0xe4 0x01 0x23
# read back to check the setting is success
bic-util slot1 0x18 0x52 0x05 0x4a 0x02 0xe4
# set vr page back
bic-util slot1 0x18 0x52 0x05 0x4a 0x00 0x00 0x00
# switch vr mux back
bic-util slot1 --set_gpio 52 1
# start polling
bic-util slot1 0xe0 0x30 0x15 0xa0 0x00 0x01

# get log
log-util slot1 --print
1    slot1    2018-03-14 06:27:02    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2018-03-14 06:27:02, Sensor: SYSTEM_STATUS (0x10), Event Data: (16FFFF) CPU thermal trip/VRHOT Assertion
1    slot1    2018-03-14 06:27:02    ipmid            SEL Entry: FRU: 1, Record: Standard (0x02), Time: 2018-03-14 06:27:02, Sensor: VR_OCP (0x71), Event Data: (06FFFF) CPUVDD Assertion
```