### PR TITLE
op2:gl:Revise thermal margin UCR value

### DIFF
--- a/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_sdr_table.c
@@ -1197,7 +1197,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // discrete reading mask/ settable
 		IPMI_SDR_UCT_SETTABLE | IPMI_SDR_LCT_SETTABLE | IPMI_SDR_UCT_READABLE |
 			IPMI_SDR_LCT_READABLE, // threshold mask/ readable threshold mask
-		0x00, // sensor unit
+		0x80, // sensor unit
 		IPMI_SENSOR_UNIT_DEGREE_C, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
@@ -1206,7 +1206,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xD0, // Rexp, Bexp
+		0x00, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -1214,7 +1214,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x01, // UCT
+		-0x02, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT


### PR DESCRIPTION
# Description:
 Fan CPU sensor detect change to use thermal margin.

# Motivatioin:
 Comply with Intel’s recommended settings.

# Test plan:
 1. Build and test pass on OLP2.0 system - pass
 2. Validated by our Thermal team - pass
 3. Check the thermal margin UCR value - pass

# Log:
 1.Origin:
 root@bmc-oob:~# sensor-util all --threshold | grep MB_SOC_THERMAL_MARGIN_C
 MB_SOC_THERMAL_MARGIN_C      (0x15) : -48.000 C     | (ok) | UCR: 0.001 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA

 2.Revise:
 root@bmc-oob:/home# sensor-util all --threshold | grep MB_SOC_THERMAL_MARGIN_C
 MB_SOC_THERMAL_MARGIN_C      (0x15) : -49.000 C     | (ok) | UCR: -2.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA