### PR TITLE
fby4: wf: Correct sensor threshold and reading time

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_isr.c
@@ -120,10 +120,10 @@ void ISR_MB_PCIE_RST()
 		k_timer_start(&set_eid_timer, K_MSEC(10000), K_NO_WAIT);
 	} else {
 		// host reset, cxl also reset
-		if (get_DC_status()) {
-			set_cxl_ready_status(CXL_ID_1, false);
-			set_cxl_ready_status(CXL_ID_2, false);
-		}
+		set_cxl_ready_status(CXL_ID_1, false);
+		set_cxl_ready_status(CXL_ID_2, false);
+		set_cxl_vr_access(CXL_ID_1, false);
+		set_cxl_vr_access(CXL_ID_2, false);
 	}
 }
 

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
@@ -1809,7 +1809,7 @@ pldm_sensor_info plat_pldm_sensor_ina233_table[] = {
 			.port = I2C_BUS6,
 			.target_addr = ADDR_INA233_E1S,
 			.offset = PMBUS_READ_VOUT,
-			.access_checker = stby_access,
+			.access_checker = dc_access,
 			.sample_count = SAMPLE_COUNT_DEFAULT,
 			.cache = 0,
 			.cache_status = PLDM_SENSOR_INITIALIZING,
@@ -3433,9 +3433,9 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x000000C8, //uint32_t warning_high;
+			0x0000012C, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x0000015E, //uint32_t critical_high;
+			0x00000190, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
 			0x000001F4, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
@@ -3749,9 +3749,9 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x000000C8, //uint32_t warning_high;
+			0x0000012C, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x0000015E, //uint32_t critical_high;
+			0x00000190, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
 			0x000001F4, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
@@ -4065,9 +4065,9 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x000007D0, //uint32_t warning_high;
+			0x00000BB8, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000DAC, //uint32_t critical_high;
+			0x00000FA0, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
 			0x00001388, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
@@ -4381,9 +4381,9 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x000007D0, //uint32_t warning_high;
+			0x00000BB8, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000DAC, //uint32_t critical_high;
+			0x00000FA0, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
 			0x00001388, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;

--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
@@ -29,6 +29,8 @@
 LOG_MODULE_REGISTER(plat_power_seq);
 
 K_WORK_DELAYABLE_DEFINE(set_dc_on_5s_work, set_DC_on_delayed_status);
+K_WORK_DELAYABLE_DEFINE(set_cxl1_vr_ready_work, set_cxl1_vr_access_delayed_status);
+K_WORK_DELAYABLE_DEFINE(set_cxl2_vr_ready_work, set_cxl2_vr_access_delayed_status);
 K_WORK_DELAYABLE_DEFINE(cxl1_ready_thread, cxl1_ready_handler);
 K_WORK_DELAYABLE_DEFINE(cxl2_ready_thread, cxl2_ready_handler);
 K_WORK_DELAYABLE_DEFINE(enable_asic1_rst_work, enable_asic1_rst);
@@ -600,7 +602,7 @@ void cxl1_ready_handler()
 		LOG_INF("CXL1 is ready");
 		/* Switch muxs to BIC*/
 		switch_mux_to_bic(IOE_SWITCH_CXL1_VR_TO_BIC);
-		set_cxl_vr_access(CXL_ID_1, true);
+		k_work_schedule(&set_cxl1_vr_ready_work, K_SECONDS(VR_READY_DELAY_SEC));
 
 		return;
 	}
@@ -633,7 +635,7 @@ void cxl2_ready_handler()
 		LOG_INF("CXL2 is ready");
 		/* Switch muxs to BIC*/
 		switch_mux_to_bic(IOE_SWITCH_CXL2_VR_TO_BIC);
-		set_cxl_vr_access(CXL_ID_2, true);
+		k_work_schedule(&set_cxl2_vr_ready_work, K_SECONDS(VR_READY_DELAY_SEC));
 
 		return;
 	}
@@ -654,6 +656,16 @@ void set_cxl_vr_access(uint8_t cxl_id, bool value)
 	}
 	is_cxl_vr_accessible[cxl_id] = value;
 	return;
+}
+
+void set_cxl1_vr_access_delayed_status()
+{
+	set_cxl_vr_access(CXL_ID_1, true);
+}
+
+void set_cxl2_vr_access_delayed_status()
+{
+	set_cxl_vr_access(CXL_ID_2, true);
 }
 
 bool cxl1_vr_access(uint8_t sensor_num)

--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
@@ -20,6 +20,7 @@
 #include "plat_gpio.h"
 
 #define DC_ON_DELAY5_SEC 5
+#define VR_READY_DELAY_SEC 7
 #define CXL_READY_SECONDS 30
 #define CXL_READY_RETRY_TIMES 10
 #define CXL1_HEART_BEAT_LABEL "HB0"
@@ -111,6 +112,8 @@ bool get_cxl_ready_status(uint8_t cxl_id);
 bool cxl1_ready_access(uint8_t sensor_num);
 bool cxl2_ready_access(uint8_t sensor_num);
 void set_cxl_vr_access(uint8_t cxl_id, bool value);
+void set_cxl1_vr_access_delayed_status();
+void set_cxl2_vr_access_delayed_status();
 bool cxl1_vr_access(uint8_t sensor_num);
 bool cxl2_vr_access(uint8_t sensor_num);
 void create_check_cxl_ready_thread();


### PR DESCRIPTION
Summary:
\# Description:
- Correct the threshold of following sensors: VR_P0V8_ASIC1_CURR_A, VR_P0V8_ASIC2_CURR_A, VR_P0V8_ASIC1_PWR_W, and VR_P0V8_ASIC2_PWR_W.
- Correct the access time of INA233_P12V_E1S_0_L_VOLT_V and ADC_P3V3_E1S_0_VOLT_V.
- Delay the reading time of VR-related sensors for 7 seconds after CXL ready.

\# Motivation:
- Some sensors will trigger threshold event after AC/DC cycle.

Test Plan:
- Build code: Pass