### PR TITLE
fby35: ji: Modify some sensors' threshold

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sdr_table.c
@@ -201,7 +201,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x28, // UCT
+		0x2D, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x05, // LCT
@@ -632,10 +632,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x8F, // UNRT
-		0x85, // UCT
+		0x88, // UCT
 		0x84, // UNCT
 		0x65, // LNRT
-		0x6B, // LCT
+		0x69, // LCT
 		0x6C, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -696,7 +696,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0xC6, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0xA0, // LCT
+		0x9e, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -741,7 +741,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x06, // [7:0] M bits
+		0x02, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -754,10 +754,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x3A, // UCT
+		0xb1, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x34, // LCT
+		0x9a, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -807,7 +807,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xE0, // Rexp, Bexp
+		0x00, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -815,10 +815,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x6C, // UCT
+		0x00, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x4A, // LCT
+		0x00, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -863,12 +863,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x05, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xF0, // Rexp, Bexp
+		0xE0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -876,10 +876,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x24, // UCT
+		0x43, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x1B, // LCT
+		0x35, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -929,7 +929,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0xE0, // Rexp, Bexp
+		0x00, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -937,10 +937,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x7E, // UCT
+		0x00, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x45, // LCT
+		0x00, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -998,10 +998,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x84, // UCT
+		0x81, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x6C, // LCT
+		0x6f, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1046,7 +1046,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x06, // [7:0] M bits
+		0x02, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -1059,10 +1059,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x3A, // UCT
+		0xb1, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x34, // LCT
+		0x9a, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1120,10 +1120,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x7F, // UCT
+		0x81, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x71, // LCT
+		0x6f, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1181,7 +1181,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x3A, // UCT
+		0x3b, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x2E, // LCT
@@ -1242,10 +1242,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x71, // UCT
+		0x73, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x64, // LCT
+		0x62, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1303,10 +1303,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0xC4, // UCT
+		0xC7, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0xA9, // LCT
+		0xa6, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1351,7 +1351,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_VOL, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x19, // [7:0] M bits
+		0x05, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -1364,10 +1364,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x15, // UCT
+		0x6b, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x13, // LCT
+		0x5d, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1428,7 +1428,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x66, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x4F, // LCT
+		0x4e, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1548,10 +1548,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x7E, // UCT
+		0x77, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x45, // LCT
+		0x42, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold
@@ -1609,10 +1609,10 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x6C, // UCT
+		0x71, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
-		0x4A, // LCT
+		0x44, // LCT
 		0x00, // LNCT
 		0x00, // positive-going threshold
 		0x00, // negative-going threshold


### PR DESCRIPTION
Summary:
- Modify some sensors' threshold.
  - Temperature
    - MB_FIO_FRONT_TEMP_C
  - Voltage
    - MB_ADC_P12V_STBY_VOLT_V
    - MB_ADC_VDD_1V8_VOLT_V
    - MB_ADC_P3V3_STBY_VOLT_V
    - MB_ADC_SOCVDD_VOLT_V (**remove**)
    - MB_ADC_P3V_BAT_VOLT_V
    - MB_ADC_CPUVDD_VOLT_V (**remove**)
    - MB_ADC_1V2_VOLT_V
    - MB_ADC_VDD_3V3_VOLT_V
    - MB_ADC_P1V2_STBY_VOLT_V
    - MB_ADC_FBVDDQ_VOLT_V
    - MB_ADC_FBVDDP2_VOLT_V
    - MB_ADC_FBVDD1_VOLT_V
    - MB_ADC_P5V_STBY_VOLT_V
    - MB_ADC_CPU_DVDD_VOLT_V
    - MB_CPUVDD_VOLT_V
    - MB_SOCVDD_VOLT_V

TestPlan:
- BuildCode: PASS
- Check threshold from BMC console: PASS

Log:
- BMC console:
```
root@bmc-oob:~# sensor-util slot1 -t
slot1:
MB_INLET_TEMP_C              (0x1) :  32.000 C     | (ok) | UCR: 60.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_OUTLET_TEMP_C             (0x2) :  61.750 C     | (ok) | UCR: 80.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_FIO_FRONT_TEMP_C          (0x3) :  30.700 C     | (ok) | UCR: 45.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_SOC_CPU_TEMP_C            (0x4) :  72.905 C     | (ok) | UCR: 85.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_E1S_SSD_TEMP_C            (0x6) :  41.000 C     | (ok) | UCR: 70.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_HSC_TEMP_C                (0x7) :  59.000 C     | (ok) | UCR: 85.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_RETIMER_TEMP_C            (0xB) :  55.019 C     | (ok) | UCR: 105.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_LPDDR5_UP_TEMP_C          (0xC) :  57.875 C     | (ok) | UCR: 80.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_LPDDR5_DOWN_TEMP_C        (0xD) :  50.187 C     | (ok) | UCR: 80.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_HSC_INPUT_VOLT_V          (0x10) :  11.968 Volts | (ok) | UCR: 13.300 | UNC: 13.200 | UNR: 14.300 | LCR: 10.700 | LNC: 10.800 | LNR: 10.100
MB_ADC_P12V_STBY_VOLT_V      (0x11) :  12.031 Volts | (ok) | UCR: 13.600 | UNC: 13.200 | UNR: 14.300 | LCR: 10.500 | LNC: 10.800 | LNR: 10.100
MB_ADC_VDD_1V8_VOLT_V        (0x12) :   1.796 Volts | (ok) | UCR: 1.980 | UNC: NA | UNR: NA | LCR: 1.580 | LNC: NA | LNR: NA
MB_ADC_P3V3_STBY_VOLT_V      (0x13) :   3.304 Volts | (ok) | UCR: 3.540 | UNC: NA | UNR: NA | LCR: 3.080 | LNC: NA | LNR: NA
MB_ADC_SOCVDD_VOLT_V         (0x14) :   0.874 Volts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_ADC_P3V_BAT_VOLT_V        (0x15) :   3.238 Volts | (ok) | UCR: 3.350 | UNC: NA | UNR: NA | LCR: 2.650 | LNC: NA | LNR: NA
MB_ADC_CPUVDD_VOLT_V         (0x16) :   1.098 Volts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_ADC_1V2_VOLT_V            (0x18) :   1.213 Volts | (ok) | UCR: 1.290 | UNC: NA | UNR: NA | LCR: 1.110 | LNC: NA | LNR: NA
MB_ADC_VDD_3V3_VOLT_V        (0x19) :   3.314 Volts | (ok) | UCR: 3.540 | UNC: NA | UNR: NA | LCR: 3.080 | LNC: NA | LNR: NA
MB_ADC_P1V2_STBY_VOLT_V      (0x1A) :   1.198 Volts | (ok) | UCR: 1.290 | UNC: NA | UNR: NA | LCR: 1.110 | LNC: NA | LNR: NA
MB_ADC_FBVDDQ_VOLT_V         (0x1B) :   0.524 Volts | (ok) | UCR: 0.590 | UNC: NA | UNR: NA | LCR: 0.460 | LNC: NA | LNR: NA
MB_ADC_FBVDDP2_VOLT_V        (0x1C) :   1.064 Volts | (ok) | UCR: 1.150 | UNC: NA | UNR: NA | LCR: 0.980 | LNC: NA | LNR: NA
MB_ADC_FBVDD1_VOLT_V         (0x1D) :   1.787 Volts | (ok) | UCR: 1.990 | UNC: NA | UNR: NA | LCR: 1.660 | LNC: NA | LNR: NA
MB_ADC_P5V_STBY_VOLT_V       (0x1E) :   4.987 Volts | (ok) | UCR: 5.350 | UNC: NA | UNR: NA | LCR: 4.650 | LNC: NA | LNR: NA
MB_ADC_CPU_DVDD_VOLT_V       (0x1F) :   0.864 Volts | (ok) | UCR: 1.020 | UNC: NA | UNR: NA | LCR: 0.780 | LNC: NA | LNR: NA
MB_E1S_SSD_VOLT_V            (0x20) :  11.976 Volts | (ok) | UCR: 13.300 | UNC: 13.200 | UNR: 14.300 | LCR: 10.700 | LNC: 10.800 | LNR: 10.100
MB_CPUVDD_VOLT_V             (0x22) :   1.087 Volts | (ok) | UCR: 1.190 | UNC: NA | UNR: NA | LCR: 0.660 | LNC: NA | LNR: NA
MB_SOCVDD_VOLT_V             (0x23) :   0.868 Volts | (ok) | UCR: 1.130 | UNC: NA | UNR: NA | LCR: 0.680 | LNC: NA | LNR: NA
MB_HSC_OUTPUT_CURR_A         (0x25) :   9.250 Amps  | (ok) | UCR: 40.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_E1S_SSD_CURR_A            (0x26) :   0.271 Amps  | (ok) | UCR: 1.200 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_CPU_PWR_W                 (0x30) :  94.962 Watts | (ok) | UCR: 462.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_PWR_W           (0x31) : 108.000 Watts | (ok) | UCR: 480.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_E1S_SSD_PWR_W             (0x32) :   3.212 Watts | (ok) | UCR: 14.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_CPUVDD_PWR_W              (0x34) :  59.936 Watts | (ok) | UCR: 180.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOCVDD_PWR_W              (0x35) :  11.472 Watts | (ok) | UCR: 90.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_CPU_THROTTLE_STA          (0x40) :   1.000       | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_PWR_BREAK_STA             (0x41) :   1.000       | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SPARE_CH_STA              (0x42) :   2.000       | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_PAGE_RETIRE_CNT           (0x43) :   0.000       | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
```