### PR TITLE
common: hal_i3c: Add i3c mutex lock

### DIFF
--- a/common/hal/hal_i3c.h
+++ b/common/hal/hal_i3c.h
@@ -117,6 +117,8 @@ typedef struct _i3c_ibi_dev {
 } i3c_ibi_dev;
 
 void util_init_i3c(void);
+int i3c_mutex_lock(int bus);
+int i3c_mutex_unlock(int bus);
 int i3c_smq_read(I3C_MSG *msg);
 int i3c_smq_write(I3C_MSG *msg);
 int i3c_slave_mqueue_read(const struct device *dev, uint8_t *dest, int budget);

--- a/meta-facebook/yv4-sd/src/platform/plat_class.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_class.c
@@ -232,6 +232,7 @@ void init_platform_config()
 	}
 
 	LOG_INF("Slot EID = %d, Slot ID = %d", slot_eid, slot_id);
+
 	i3c_set_pid(&i3c_msg, slot_pid);
 
 	init_retimer_type();

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -85,9 +85,6 @@ void pal_pre_init()
 
 	i3c_attach(&i3c_msg);
 
-	// Create a thread to keep sending AASA
-	start_setaasa();
-
 	// Initialize I3C HUB
 	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
 		printk("failed to initialize 1ou rg3mxxb12\n");
@@ -105,6 +102,8 @@ void pal_post_init()
 	kcs_init();
 	pldm_load_state_effecter_table(PLAT_PLDM_MAX_STATE_EFFECTER_IDX);
 	pldm_assign_gpio_effecter_id(PLAT_EFFECTER_ID_GPIO_HIGH_BYTE);
+	// Create a thread to keep sending AASA
+	start_setaasa();
 	start_get_dimm_info_thread();
 	set_sys_ready_pin(BIC_READY_R);
 	reset_usb_hub();


### PR DESCRIPTION
# Description
- Add mutex on i3c hal level file to avoid multi-threads access I3C device at the same time.

# Motivation
- The kernel driver of i3c didn't have lock mechanism.