### PR TITLE
minerva-ag: Temporarily remove watchdog

### DIFF
--- a/meta-facebook/minerva-ag/boards/npcm400f_evb.overlay
+++ b/meta-facebook/minerva-ag/boards/npcm400f_evb.overlay
@@ -1,5 +1,5 @@
 &twd0 {
-	status = "okay";
+	status = "disabled";
 };
 
 &adc0 {


### PR DESCRIPTION
Summary:
- The watchdog is being temporarily removed to allow us to retain the system state and troubleshoot more effectively when issues occur. It will be added back around WW50 once the firmware is more stable.

Test Plan:
- Build code: PASS