### PR TITLE
fby4: sd: Limit get retimer version time

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
@@ -702,6 +702,10 @@ static bool plat_get_retimer_fw_version(void *info_p, uint8_t *buf, uint8_t *len
 
 	i2c_msg.bus = I2C_BUS6;
 
+	if (!get_post_status()) {
+		return ret;
+	}
+
 	if (p->comp_identifier == SD_COMPNT_X16_RETIMER) {
 		i2c_msg.target_addr = X16_RETIMER_ADDR;
 	} else if (p->comp_identifier == SD_COMPNT_X8_RETIMER) {


### PR DESCRIPTION
# Description
- Limit the access time of getting retimer version. User can't get retimer version before post not complete.

# Motivation
- Couldn't allow access to the retimer until it is ready to avoid causing problems.

# Test plan
- Build code: Pass
- Get retimer version: Pass

# Log
- Before change root@bmc:~# mfg-tool power-control -p 3 -a cycle -s runtime <6> Attempting runtime:cycle on 3.
"success"
root@bmc:~# pldmtool raw -d 0x80 0x02 0x3a 0x22 0xff -m 30 pldmtool: Tx: 80 02 3a 22 ff
pldmtool: Rx: 00 02 3a 00 02 01 01 01 01 02 02
root@bmc:~# pldmtool fw_update GetFwParams -m 30
...
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 4,
...
            "ActiveComponentVersionString": "02080100",
            "PendingComponentVersionString": ""
        },
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 5,
...
            "ActiveComponentVersionString": "02081f00",
            "PendingComponentVersionString": ""
        },

- After change root@bmc:~# mfg-tool power-control -p 3 -a cycle -s runtime <6> Attempting runtime:cycle on 3.
"success"
root@bmc:~# pldmtool raw -d 0x80 0x02 0x3a 0x22 0xff -m 30 pldmtool: Tx: 80 02 3a 22 ff
pldmtool: Rx: 00 02 3a 00 02 01 01 01 01 02 02
root@bmc:~# pldmtool fw_update GetFwParams -m 30
...
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 4,
...
            "ActiveComponentVersionString": "ERROR:0",
            "PendingComponentVersionString": ""
},
        {
            "ComponentClassification": "Downstream Device",
            "ComponentIdentifier": 5,
...
            "ActiveComponentVersionString": "ERROR:0",
            "PendingComponentVersionString": ""
        },