### PR TITLE
fby4: wf: Correct the time point to confirm that CXL is ready

### DIFF
--- a/common/service/cci/cci.h
+++ b/common/service/cci/cci.h
@@ -117,6 +117,8 @@ void cci_read_resp_handler(void *args, uint8_t *rbuf, uint16_t rlen, uint16_t re
 bool cci_get_chip_temp(void *mctp_p, mctp_ext_params ext_params, int16_t *chip_temp);
 bool cci_get_chip_fw_version(void *mctp_p, mctp_ext_params ext_params, uint8_t *fw_version,
 			     uint8_t *return_len);
+int pal_get_cci_internal_ms();
+int pal_get_cci_timeout_ms();
 
 /* send CCI command message through mctp */
 uint8_t mctp_cci_send_msg(void *mctp_p, mctp_cci_msg *msg);

--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.c
@@ -170,10 +170,12 @@ static void set_dev_endpoint(void)
 				if (!rc) {
 					switch (p->bus) {
 					case I2C_BUS_CXL1: {
+						LOG_INF("Send set EID command to CXL1");
 						set_eid[CXL_ID_1] = true;
 						break;
 					}
 					case I2C_BUS_CXL2: {
+						LOG_INF("Send set EID command to CXL2");
 						set_eid[CXL_ID_2] = true;
 						break;
 					}
@@ -283,7 +285,6 @@ void send_cmd_to_dev_handler(struct k_work *work)
 
 void send_cmd_to_dev(struct k_timer *timer)
 {
-	LOG_INF("Send set EID command to CXL");
 	k_work_submit(&send_cmd_work);
 }
 
@@ -400,4 +401,16 @@ uint8_t plat_get_cxl_eid(uint8_t cxl_id)
 	default:
 		return UNKNOWN_CXL_EID;
 	}
+}
+
+int pal_get_cci_internal_ms()
+{
+	// 1 seconds
+	return 1000;
+}
+
+int pal_get_cci_timeout_ms()
+{
+	// 5 seconds
+	return 5000;
 }

--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
@@ -583,7 +583,8 @@ void switch_mux_to_bic(uint8_t value_to_write)
 void cxl1_ready_handler()
 {
 	const struct device *heartbeat = NULL;
-	int heartbeat_status = 0;
+	struct sensor_value hb_val;
+	int ret = 0;
 
 	heartbeat = device_get_binding(CXL1_HEART_BEAT_LABEL);
 	if (heartbeat == NULL) {
@@ -592,8 +593,19 @@ void cxl1_ready_handler()
 	}
 
 	for (int times = 0; times < CXL_READY_RETRY_TIMES; times++) {
-		heartbeat_status = sensor_sample_fetch(heartbeat);
-		if (heartbeat_status < 0) {
+		ret = sensor_sample_fetch(heartbeat);
+		if (ret < 0) {
+			k_sleep(K_SECONDS(CXL_READY_INTERVAL_SECONDS));
+			continue;
+		}
+
+		ret = sensor_channel_get(heartbeat, SENSOR_CHAN_RPM, &hb_val);
+		if (ret < 0) {
+			k_sleep(K_SECONDS(CXL_READY_INTERVAL_SECONDS));
+			continue;
+		}
+
+		if (hb_val.val1 <= 0) {
 			k_sleep(K_SECONDS(CXL_READY_INTERVAL_SECONDS));
 			continue;
 		}
@@ -607,7 +619,7 @@ void cxl1_ready_handler()
 		return;
 	}
 	LOG_ERR("Failed to read %s due to sensor_sample_fetch failed, ret: %d",
-		CXL1_HEART_BEAT_LABEL, heartbeat_status);
+		CXL1_HEART_BEAT_LABEL, ret);
 	switch_mux_to_bic(IOE_SWITCH_CXL1_VR_TO_BIC);
 	set_cxl_vr_access(CXL_ID_1, true);
 	return;
@@ -616,7 +628,8 @@ void cxl1_ready_handler()
 void cxl2_ready_handler()
 {
 	const struct device *heartbeat = NULL;
-	int heartbeat_status = 0;
+	struct sensor_value hb_val;
+	int ret = 0;
 
 	heartbeat = device_get_binding(CXL2_HEART_BEAT_LABEL);
 	if (heartbeat == NULL) {
@@ -625,8 +638,19 @@ void cxl2_ready_handler()
 	}
 
 	for (int times = 0; times < CXL_READY_RETRY_TIMES; times++) {
-		heartbeat_status = sensor_sample_fetch(heartbeat);
-		if (heartbeat_status < 0) {
+		ret = sensor_sample_fetch(heartbeat);
+		if (ret < 0) {
+			k_sleep(K_SECONDS(CXL_READY_INTERVAL_SECONDS));
+			continue;
+		}
+
+		ret = sensor_channel_get(heartbeat, SENSOR_CHAN_RPM, &hb_val);
+		if (ret < 0) {
+			k_sleep(K_SECONDS(CXL_READY_INTERVAL_SECONDS));
+			continue;
+		}
+
+		if (hb_val.val1 <= 0) {
 			k_sleep(K_SECONDS(CXL_READY_INTERVAL_SECONDS));
 			continue;
 		}
@@ -640,7 +664,7 @@ void cxl2_ready_handler()
 		return;
 	}
 	LOG_ERR("Failed to read %s due to sensor_sample_fetch failed, ret: %d",
-		CXL2_HEART_BEAT_LABEL, heartbeat_status);
+		CXL2_HEART_BEAT_LABEL, ret);
 	switch_mux_to_bic(IOE_SWITCH_CXL2_VR_TO_BIC);
 	set_cxl_vr_access(CXL_ID_2, true);
 	return;


### PR DESCRIPTION
# Description
- Correct the time when WF BIC confirm CXL is ready. It should be TACH value > 0.

# Motivation
- Currently, WF BIC send EID to CXL when get value from TACH device equal 0. However, it should be the value > 0.

# Test plan
- Build code: Pass
- Check CXL HB result: Pass

# Log
- WF BIC console uart:~$ [00:03:21.484,000] <inf> plat_power_seq: CXL2 is ready [00:03:21.486,000] <inf> plat_power_seq: CXL1 is ready mctp cci msg timeout!!
mctp cci msg timeout!!
mctp cci msg timeout!!
[00:03:30.869,000] <inf> plat_mctp: Send set EID command to CXL1 [00:03:30.871,000] <inf> plat_mctp: Send set EID command to CXL2

- Get CXL version root@bmc:~# cxl-fw-update version -m 34
Get Firmware Info for EID: 34
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.12-c26492c7
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision:
root@bmc:~#
root@bmc:~# cxl-fw-update version -m 35
Get Firmware Info for EID: 35
FW Slots Supported: 2
Active FW Slot: 1
Staged FW Slot: 2
FW Activation Capabilities: 1
Slot 1 FW Revision: 2.0.12-c26492c7
Slot 2 FW Revision:
Slot 3 FW Revision:
Slot 4 FW Revision: