### PR TITLE
minerva-ag: Change SMB6A to SMB6B and enable slave

### DIFF
--- a/meta-facebook/minerva-ag/boards/npcm400f_evb.overlay
+++ b/meta-facebook/minerva-ag/boards/npcm400f_evb.overlay
@@ -45,12 +45,12 @@
 };
 
 &i2c6a {
-	clock-frequency = <I2C_BITRATE_STANDARD>;
-	status = "okay";
+    status = "disabled";
 };
 
 &i2c6b {
-    status = "disabled";
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	status = "okay";
 };
 
 &i2c7a {

--- a/meta-facebook/minerva-ag/src/platform/plat_i2c_target.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_i2c_target.c
@@ -32,12 +32,12 @@
 /* I2C target init-enable table */
 const bool I2C_TARGET_ENABLE_TABLE[MAX_TARGET_NUM] = {
 	TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE, TARGET_ENABLE,
-	TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE,
+	TARGET_DISABLE, TARGET_ENABLE,	TARGET_DISABLE, TARGET_DISABLE,
 	TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE, TARGET_DISABLE,
 };
 
 /* I2C target init-config table */
 const struct _i2c_target_config I2C_TARGET_CONFIG_TABLE[MAX_TARGET_NUM] = {
-	{ 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0x40, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA },
+	{ 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0x40, 0xA }, { 0xFF, 0xA }, { 0x40, 0xA },
 	{ 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA }, { 0xFF, 0xA },
 };


### PR DESCRIPTION
Summary:
- Change SMB6A to SMB6B and enable slave

Test Plan:
- Build code: PASS