### PR TITLE
minerva-ag: Add cpld dump shell command

### DIFF
--- a/meta-facebook/minerva-ag/src/shell/cpld_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/cpld_shell.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <shell/shell.h>
+#include "hal_i2c.h"
+#include "plat_i2c.h"
+#include <stdlib.h>
+
+#define AEGIS_CPLD_ADDR (0x4C >> 1)
+#define I2C_BUS_CPLD I2C_BUS5
+
+void cmd_cpld_dump(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc != 3) {
+		shell_warn(shell, "Help: test cpld dump <offset> <length>");
+		return;
+	}
+
+	int cpld_offset = strtol(argv[1], NULL, 16);
+	int cpld_length = strtol(argv[2], NULL, 16);
+
+	if (cpld_offset < 0x00 || cpld_offset > 0xFF) {
+		shell_error(shell, "<offset> value is out of range!");
+		return;
+	}
+
+	if (cpld_length <= 0x00 || cpld_length > 0xFF) {
+		shell_error(shell, "<length> value is out of range!");
+		return;
+	}
+
+	uint8_t retry = 3;
+	I2C_MSG i2c_msg = { 0 };
+
+	i2c_msg.bus = I2C_BUS_CPLD;
+	i2c_msg.target_addr = AEGIS_CPLD_ADDR;
+	i2c_msg.rx_len = cpld_length;
+	i2c_msg.tx_len = 1;
+	i2c_msg.data[0] = cpld_offset;
+
+	if (i2c_master_read(&i2c_msg, retry)) {
+		shell_error(shell, "Failed to test cpld dump");
+	} else {
+		shell_print(shell, "bus %d, addr 0x%x, offset 0x%x, len 0x%x.", i2c_msg.bus,
+			    i2c_msg.target_addr, cpld_offset, i2c_msg.rx_len);
+
+		shell_hexdump(shell, i2c_msg.data, i2c_msg.rx_len);
+		shell_print(shell, "");
+	}
+	return;
+}

--- a/meta-facebook/minerva-ag/src/shell/cpld_shell.h
+++ b/meta-facebook/minerva-ag/src/shell/cpld_shell.h
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-#include "plat_sensor_polling_shell.h"
-#include "cpld_shell.h"
+#ifndef CPLD_SHELL_H
+#define CPLD_SHELL_H
 
-/* Sub-command Level 1 of command test */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_test_cmds,
-			       SHELL_CMD(sensor, &sub_plat_sensor_polling_cmd,
-					 "set/get platform sensor polling command", NULL),
-			       SHELL_CMD(cpld, &sub_cpld_cmd, "cpld command", NULL),
+#include <shell/shell.h>
+
+void cmd_cpld_dump(const struct shell *shell, size_t argc, char **argv);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_cpld_cmd, SHELL_CMD(dump, NULL, "cpld dump", cmd_cpld_dump),
 			       SHELL_SUBCMD_SET_END);
 
-/* Root of command test */
-SHELL_CMD_REGISTER(test, &sub_test_cmds, "Test commands for AG", NULL);
+#endif

--- a/meta-facebook/minerva-ag/src/shell/plat_sensor_polling_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_sensor_polling_shell.c
@@ -19,8 +19,6 @@
 #include <shell/shell.h>
 #include "plat_pldm_sensor.h"
 
-LOG_MODULE_REGISTER(plat_sensor_polling_shell);
-
 void cmd_set_plat_sensor_polling_all(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc != 2) {

--- a/meta-facebook/minerva-ag/src/shell/plat_sensor_polling_shell.h
+++ b/meta-facebook/minerva-ag/src/shell/plat_sensor_polling_shell.h
@@ -17,6 +17,8 @@
 #ifndef PLAT_SENSOR_POLLING_SHELL_H
 #define PLAT_SENSOR_POLLING_SHELL_H
 
+#include <shell/shell.h>
+
 void cmd_set_plat_sensor_polling_all(const struct shell *shell, size_t argc, char **argv);
 void cmd_set_plat_sensor_polling_ubc(const struct shell *shell, size_t argc, char **argv);
 void cmd_set_plat_sensor_polling_vr(const struct shell *shell, size_t argc, char **argv);
@@ -25,5 +27,27 @@ void cmd_get_plat_sensor_polling_all(const struct shell *shell, size_t argc, cha
 void cmd_get_plat_sensor_polling_ubc(const struct shell *shell, size_t argc, char **argv);
 void cmd_get_plat_sensor_polling_vr(const struct shell *shell, size_t argc, char **argv);
 void cmd_get_plat_sensor_polling_temp(const struct shell *shell, size_t argc, char **argv);
+
+/* Sub-command Level 3 of command test */
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	cmd_set_plat_sensor_polling,
+	SHELL_CMD(all, NULL, "set platform sensor polling all", cmd_set_plat_sensor_polling_all),
+	SHELL_CMD(ubc, NULL, "set platform sensor polling ubc", cmd_set_plat_sensor_polling_ubc),
+	SHELL_CMD(vr, NULL, "set platform sensor polling vr", cmd_set_plat_sensor_polling_vr),
+	SHELL_CMD(temp, NULL, "set platform sensor polling temp", cmd_set_plat_sensor_polling_temp),
+	SHELL_SUBCMD_SET_END);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(cmd_get_plat_sensor_polling,
+			       SHELL_CMD(all, NULL, "get platform sensor polling all",
+					 cmd_get_plat_sensor_polling_all),
+			       SHELL_SUBCMD_SET_END);
+
+/* Sub-command Level 2 of command test */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_plat_sensor_polling_cmd,
+			       SHELL_CMD(set_sensor_polling, &cmd_set_plat_sensor_polling,
+					 "set platform sensor polling", NULL),
+			       SHELL_CMD(get_sensor_polling, &cmd_get_plat_sensor_polling,
+					 "get platform sensor polling", NULL),
+			       SHELL_SUBCMD_SET_END);
 
 #endif


### PR DESCRIPTION
Summary:
- Add cpld dump shell command

Test Plan:
- Build code: PASS
- CPLD dump test: PASS

CPLD dump:
```
uart:~$ test cpld dump 0 40
bus 4, addr 0x26, offset 0x0, len 0x40.
00000000: ff 00 00 00 00 00 80 00  00 00 00 00 00 00 00 00 |........ ........|
00000010: 00 00 00 00 00 0f 00 00  00 00 00 00 00 00 00 00 |........ ........|
00000020: 00 00 00 00 ff ff ff ff  ff ff ff ff ff ff df ff |........ ........|
00000030: 27 ef c0 5f ff 40 ff ff  ff ff ff ff ff ff ff ff |'.._.@.. ........|
```