### PR TITLE
fby35: ji: Fix AL retimer read failed before post completed

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_isr.c
@@ -154,6 +154,7 @@ void check_host_reboot_status()
 	if (get_DC_status() == true) {
 		LOG_WRN("Host reboot detected!");
 		start_satmc_access_poll();
+		retimer_addr_loss();
 	}
 }
 
@@ -377,6 +378,7 @@ void ISR_PWRGD_CPU()
 		start_satmc_access_poll();
 	} else {
 		set_satmc_status(false);
+		retimer_addr_loss();
 
 		/* Pull high virtual bios complete pin */
 		handle_post_status(GPIO_HIGH, true);

--- a/meta-facebook/yv35-ji/src/platform/plat_power_status.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_power_status.h
@@ -30,5 +30,7 @@ void set_satmc_status(bool status);
 bool get_satmc_status();
 bool retimer_access(uint8_t sensor_num);
 bool get_retimer_status();
+uint8_t scan_retimer_addr();
+void retimer_addr_loss();
 
 #endif

--- a/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sensor_table.c
@@ -263,34 +263,10 @@ bool modify_sensor_cfg()
 		}
 	}
 
-	uint8_t addr_list[10] = { 0 };
-	uint8_t addr_len = 0;
-	uint8_t retimer_module = RETIMER_MODULE_UNKNOWN;
-
-	i2c_scan(I2C_BUS2, addr_list, &addr_len);
-
-	int i = 0;
-	for (i = 0; i < addr_len; i++) {
-		if (addr_list[i] == (AL_RETIMER_ADDR << 1)) {
-			LOG_WRN("Found AL retimer device at 0x40");
-			retimer_module = RETIMER_MODULE_PT4080L;
-			break;
-		} else if (addr_list[i] == (TI_RETIMER_ADDR << 1)) {
-			LOG_WRN("Found TI retimer device at 0x20");
-			retimer_module = RETIMER_MODULE_DS160PT801;
-			break;
-		}
-	}
-
-	if (i == ARRAY_SIZE(addr_list)) {
-		LOG_WRN("No retimer device found!!");
-		return false;
-	}
-
-	set_retimer_module(retimer_module);
+	scan_retimer_addr();
 
 	sensor_cfg *retimer_cfg = NULL;
-	retimer_cfg = change_retimer_sensor_cfg(retimer_module);
+	retimer_cfg = change_retimer_sensor_cfg(get_retimer_module());
 	if (!retimer_cfg) {
 		LOG_WRN("Retimer sensor config not found!!");
 		return false;

--- a/meta-facebook/yv35-ji/src/platform/plat_ssif.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_ssif.c
@@ -43,7 +43,7 @@ void ssif_init(void)
 	ssif_device_init(ssif_cfg_table, ARRAY_SIZE(ssif_cfg_table));
 
 	if (ssif_inst_get_by_bus(SSIF_I2C_BUS))
-		LOG_WRN("SSIF ready!");
+		LOG_INF("SSIF ready!");
 }
 
 void pal_bios_post_complete()


### PR DESCRIPTION
Summary:
- Fix astera labs retimer sensor can't read issue by adding address filter.

TestPlan:
- BuildCode: PASS
- Check AL retimer sensor reading before post complete: PASS
