### PR TITLE
fby35: ji: Modify some sensors' threshold

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_sdr_table.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_sdr_table.c
@@ -1660,12 +1660,12 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_AMP, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x05, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
 		0x00, // [7:4] accuracy , [3:2] accuracy exp, [1:0] sensor direction
-		0x00, // Rexp, Bexp
+		0xF0, // Rexp, Bexp
 		0x00, // analog characteristic
 		0x00, // nominal reading
 		0x00, // normal maximum
@@ -1673,7 +1673,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x28, // UCT
+		0x77, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -1784,7 +1784,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x02, // [7:0] M bits
+		0x06, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -1797,7 +1797,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0xF0, // UCT
+		0x77, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -1968,7 +1968,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		IPMI_SENSOR_UNIT_WATT, // base unit
 		0x00, // modifier unit
 		IPMI_SDR_LINEAR_LINEAR, // linearization
-		0x01, // [7:0] M bits
+		0x05, // [7:0] M bits
 		0x00, // [9:8] M bits, tolerance
 		0x00, // [7:0] B bits
 		0x00, // [9:8] B bits, tolerance
@@ -1981,7 +1981,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0xB4, // UCT
+		0x76, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT
@@ -2042,7 +2042,7 @@ SDR_Full_sensor plat_sdr_table[] = {
 		0x00, // sensor maximum reading
 		0x00, // sensor minimum reading
 		0x00, // UNRT
-		0x5A, // UCT
+		0x7B, // UCT
 		0x00, // UNCT
 		0x00, // LNRT
 		0x00, // LCT


### PR DESCRIPTION
Summary:
- Modify some sensors' threshold.
  - Current
    - MB_HSC_OUTPUT_CURR_A
  - Power
    - MB_HSC_INPUT_PWR_W
    - MB_E1S_SSD_PWR_W
    - MB_SOCVDD_PWR_W

TestPlan:
- BuildCode: PASS
- Check threshold from BMC console: PASS

Log:
- BMC console:
```
root@bmc-oob:~# sensor-util slot1 -t
slot1:
MB_INLET_TEMP_C              (0x1) :  42.625 C     | (ok) | UCR: 60.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_OUTLET_TEMP_C             (0x2) :  62.500 C     | (ok) | UCR: 80.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_FIO_FRONT_TEMP_C          (0x3) :  28.500 C     | (ok) | UCR: 45.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_SOC_CPU_TEMP_C            (0x4) :  72.811 C     | (ok) | UCR: 85.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_E1S_SSD_TEMP_C            (0x6) :  27.000 C     | (ok) | UCR: 70.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_HSC_TEMP_C                (0x7) :  58.000 C     | (ok) | UCR: 85.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_RETIMER_TEMP_C            (0xB) :  68.719 C     | (ok) | UCR: 105.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_LPDDR5_UP_TEMP_C          (0xC) :  65.000 C     | (ok) | UCR: 80.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_LPDDR5_DOWN_TEMP_C        (0xD) :  55.625 C     | (ok) | UCR: 80.000 | UNC: NA | UNR: NA | LCR: 5.000 | LNC: NA | LNR: NA
MB_HSC_INPUT_VOLT_V          (0x10) :  12.062 Volts | (ok) | UCR: 13.300 | UNC: 13.200 | UNR: 14.300 | LCR: 10.700 | LNC: 10.800 | LNR: 10.100
MB_ADC_P12V_STBY_VOLT_V      (0x11) :  11.939 Volts | (ok) | UCR: 13.600 | UNC: 13.200 | UNR: 14.300 | LCR: 10.500 | LNC: 10.800 | LNR: 10.100
MB_ADC_VDD_1V8_VOLT_V        (0x12) :   1.835 Volts | (ok) | UCR: 1.980 | UNC: NA | UNR: NA | LCR: 1.580 | LNC: NA | LNR: NA
MB_ADC_P3V3_STBY_VOLT_V      (0x13) :   3.304 Volts | (ok) | UCR: 3.540 | UNC: NA | UNR: NA | LCR: 3.080 | LNC: NA | LNR: NA
MB_ADC_SOCVDD_VOLT_V         (0x14) :   0.900 Volts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_ADC_P3V_BAT_VOLT_V        (0x15) :   3.232 Volts | (ok) | UCR: 3.350 | UNC: NA | UNR: NA | LCR: 2.650 | LNC: NA | LNR: NA
MB_ADC_CPUVDD_VOLT_V         (0x16) :   1.103 Volts | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_ADC_1V2_VOLT_V            (0x18) :   1.232 Volts | (ok) | UCR: 1.290 | UNC: NA | UNR: NA | LCR: 1.110 | LNC: NA | LNR: NA
MB_ADC_VDD_3V3_VOLT_V        (0x19) :   3.304 Volts | (ok) | UCR: 3.540 | UNC: NA | UNR: NA | LCR: 3.080 | LNC: NA | LNR: NA
MB_ADC_P1V2_STBY_VOLT_V      (0x1A) :   1.198 Volts | (ok) | UCR: 1.290 | UNC: NA | UNR: NA | LCR: 1.110 | LNC: NA | LNR: NA
MB_ADC_FBVDDQ_VOLT_V         (0x1B) :   0.505 Volts | (ok) | UCR: 0.590 | UNC: NA | UNR: NA | LCR: 0.460 | LNC: NA | LNR: NA
MB_ADC_FBVDDP2_VOLT_V        (0x1C) :   1.049 Volts | (ok) | UCR: 1.150 | UNC: NA | UNR: NA | LCR: 0.980 | LNC: NA | LNR: NA
MB_ADC_FBVDD1_VOLT_V         (0x1D) :   1.809 Volts | (ok) | UCR: 1.990 | UNC: NA | UNR: NA | LCR: 1.660 | LNC: NA | LNR: NA
MB_ADC_P5V_STBY_VOLT_V       (0x1E) :   4.987 Volts | (ok) | UCR: 5.350 | UNC: NA | UNR: NA | LCR: 4.650 | LNC: NA | LNR: NA
MB_ADC_CPU_DVDD_VOLT_V       (0x1F) :   0.871 Volts | (ok) | UCR: 1.020 | UNC: NA | UNR: NA | LCR: 0.780 | LNC: NA | LNR: NA
MB_E1S_SSD_VOLT_V            (0x20) :  11.980 Volts | (ok) | UCR: 13.300 | UNC: 13.200 | UNR: 14.300 | LCR: 10.700 | LNC: 10.800 | LNR: 10.100
MB_CPUVDD_VOLT_V             (0x22) :   1.087 Volts | (ok) | UCR: 1.190 | UNC: NA | UNR: NA | LCR: 0.660 | LNC: NA | LNR: NA
MB_SOCVDD_VOLT_V             (0x23) :   0.881 Volts | (ok) | UCR: 1.130 | UNC: NA | UNR: NA | LCR: 0.680 | LNC: NA | LNR: NA
MB_HSC_OUTPUT_CURR_A         (0x25) :   8.250 Amps  | (ok) | UCR: 59.500 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_E1S_SSD_CURR_A            (0x26) :   0.234 Amps  | (ok) | UCR: 1.200 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_CPU_PWR_W                 (0x30) : 102.448 Watts | (ok) | UCR: 462.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_HSC_INPUT_PWR_W           (0x31) :  99.000 Watts | (ok) | UCR: 714.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_E1S_SSD_PWR_W             (0x32) :   2.800 Watts | (ok) | UCR: 14.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_CPUVDD_PWR_W              (0x34) :  86.890 Watts | (ok) | UCR: 590.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SOCVDD_PWR_W              (0x35) :   8.890 Watts | (ok) | UCR: 123.000 | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_CPU_THROTTLE_STA          (0x40) :   1.000       | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_PWR_BREAK_STA             (0x41) :   1.000       | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_SPARE_CH_STA              (0x42) :   2.000       | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
MB_PAGE_RETIRE_CNT           (0x43) :   0.000       | (ok) | UCR: NA | UNC: NA | UNR: NA | LCR: NA | LNC: NA | LNR: NA
```