### PR TITLE
Fix linter error due to deprecated action

### DIFF
--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -324,7 +324,7 @@ jobs:
         reviewdog_version: latest 
 
     - name: Download all artifacts 
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         path: /tmp/artifacts
 


### PR DESCRIPTION
Summary:
Used v2 actions/download-artifact is deprecated and the step fails because of that. Update it to the current version.

Test Plan:
CI