### PR TITLE
YV4: sd: Revise sensor name to comply naming rule

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -5491,7 +5491,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"MB_X8_RETIMER_TEMP_C",
+		.sensorName = u"MB_X8_RTM_TEMP_C",
 	},
 	{
 		// MB_ADC_P12V_STBY_VOLT_V
@@ -5610,7 +5610,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"MB_ADC_P12V_DIMM_0_VOLT_V",
+		.sensorName = u"MB_ADC_DIMM0_P12V_VOLT_V",
 	},
 	{
 		// MB_ADC_P12V_DIMM_1_VOLT_V
@@ -5627,7 +5627,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"MB_ADC_P12V_DIMM_1_VOLT_V",
+		.sensorName = u"MB_ADC_DIMM1_P12V_VOLT_V",
 	},
 	{
 		// MB_ADC_P1V2_STBY_VOLT_V
@@ -5814,7 +5814,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"MB_INA233_E1S_BOOT_VOLT_V",
+		.sensorName = u"MB_PMON_E1S_BOOT_VOLT_V",
 	},
 	{
 		// MB_INA233_E1S_Data_VOLT_V
@@ -5831,7 +5831,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"MB_INA233_E1S_DATA_VOLT_V",
+		.sensorName = u"MB_PMON_E1S_DATA_VOLT_V",
 	},
 	{
 		// MB_VR_CPU0_CURR_A
@@ -5933,7 +5933,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"MB_INA233_X8_RTM_CURR_A",
+		.sensorName = u"MB_PMON_X8_RTM_CURR_A",
 	},
 	{
 		// MB_INA233_E1S_Boot_CURR_A
@@ -5950,7 +5950,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"MB_INA233_E1S_BOOT_CURR_A",
+		.sensorName = u"MB_PMON_E1S_BOOT_CURR_A",
 	},
 	{
 		// MB_INA233_E1S_Data_CURR_A
@@ -5967,7 +5967,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"MB_INA233_E1S_DATA_CURR_A",
+		.sensorName = u"MB_PMON_E1S_DATA_CURR_A",
 	},
 	{
 		// MB_VR_CPU0_PWR_W
@@ -6290,7 +6290,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"MB_INA233_X8_RTM_PWR_W",
+		.sensorName = u"MB_PMON_X8_RTM_PWR_W",
 	},
 	{
 		// MB_INA233_E1S_Boot_PWR_W
@@ -6307,7 +6307,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"MB_INA233_E1S_BOOT_PWR_W",
+		.sensorName = u"MB_PMON_E1S_BOOT_PWR_W",
 	},
 	{
 		// MB_INA233_E1S_Data_PWR_W
@@ -6324,7 +6324,7 @@ PDR_sensor_auxiliary_names plat_pdr_sensor_aux_names_table[] = {
 		.sensor_count = 0x1,
 		.nameStringCount = 0x1,
 		.nameLanguageTag = "en",
-		.sensorName = u"MB_INA233_E1S_DATA_PWR_W",
+		.sensorName = u"MB_PMON_E1S_DATA_PWR_W",
 	}
 };
 
@@ -6615,7 +6615,7 @@ char16_t *char16_strcat_char(char16_t *dest, char16_t ch)
 void plat_init_entity_aux_names_pdr_table()
 {
 	// Base name
-	const char16_t base_name[] = u"Sentinel_Dome_Slot_";
+	const char16_t base_name[] = u"SENTINEL_DOME_SLOT_";
 
 	// Get slot ID
 	uint8_t slot_id = get_slot_id();


### PR DESCRIPTION
Description:
- Revise the descriptor part of sensor name.
- Revise the fru name of the sensor name to be in uppercase.

Motivation:
- Revise sensor name to comply naming rules.

Note:
- Related JIRA link: https://metainfra.atlassian.net/browse/YV4T1M-1070

Test Plan:
- Build code: Pass
- Check sensor name: Pass

Test Log:
- Revised sensor name root@bmc:~# busctl tree xyz.openbmc_project.PLDM | grep SENTINEL_DOME_SLOT_1_ | wc -l 73
root@bmc:~#
root@bmc:~# busctl tree xyz.openbmc_project.PLDM | grep SENTINEL_DOME_SLOT_1_
    │ │ ├─ /xyz/openbmc_project/sensors/current/SENTINEL_DOME_SLOT_1_MB_PMON_E1S_BOOT_CURR_A
    │ │ ├─ /xyz/openbmc_project/sensors/current/SENTINEL_DOME_SLOT_1_MB_PMON_E1S_DATA_CURR_A
    │ │ ├─ /xyz/openbmc_project/sensors/current/SENTINEL_DOME_SLOT_1_MB_PMON_X8_RTM_CURR_A
    │ │ ├─ /xyz/openbmc_project/sensors/current/SENTINEL_DOME_SLOT_1_MB_VR_CPU0_CURR_A
    │ │ ├─ /xyz/openbmc_project/sensors/current/SENTINEL_DOME_SLOT_1_MB_VR_CPU1_CURR_A
    │ │ ├─ /xyz/openbmc_project/sensors/current/SENTINEL_DOME_SLOT_1_MB_VR_PVDD11_CURR_A
    │ │ ├─ /xyz/openbmc_project/sensors/current/SENTINEL_DOME_SLOT_1_MB_VR_PVDDIO_CURR_A
    │ │ ├─ /xyz/openbmc_project/sensors/current/SENTINEL_DOME_SLOT_1_MB_VR_SOC_CURR_A
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_CPU_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_A_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_B_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_C_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_D_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_E_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_F_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_G_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_H_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_I_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_J_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_K_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_DIMM_L_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_PMON_E1S_BOOT_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_PMON_E1S_DATA_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_PMON_X8_RTM_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_VR_CPU0_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_VR_CPU1_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_VR_PVDD11_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_VR_PVDDIO_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/power/SENTINEL_DOME_SLOT_1_MB_VR_SOC_PWR_W
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_CPU_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_A_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_B_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_C_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_D_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_E_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_F_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_G_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_H_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_I_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_J_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_K_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_DIMM_L_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_FIO_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_INLET_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_OUTLET_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_SSD_BOOT_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_SSD_DATA_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_VR_CPU0_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_VR_CPU1_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_VR_PVDD11_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_VR_PVDDIO_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_VR_SOC_TEMP_C
    │ │ ├─ /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_X8_RTM_TEMP_C
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_DIMM_0_P12V_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_DIMM_1_P12V_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_P12V_STBY_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_P1V2_STBY_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_P1V8_STBY_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_P3V3_STBY_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_P3V_BAT_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_P5V_STBY_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_PVDD11_S3_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_PVDD18_S5_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_PVDD33_S5_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_SIDECAR_DETECT_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_ADC_SLOT_DETECT_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_PMON_E1S_BOOT_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_PMON_E1S_DATA_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_VR_CPU0_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_VR_CPU1_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_VR_PVDD11_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_VR_PVDDIO_VOLT_V
    │   ├─ /xyz/openbmc_project/sensors/voltage/SENTINEL_DOME_SLOT_1_MB_VR_SOC_VOLT_V