### PR TITLE
aalc: modify ads112c rack temp formula

### DIFF
--- a/meta-facebook/aalc-rpu/src/platform/plat_fsc.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_fsc.c
@@ -245,14 +245,14 @@ uint8_t get_fsc_poll_count(uint8_t zone, uint8_t *count)
 /* set the zone_cfg stored data to default */
 static void zone_init(void)
 {
-	for (int i = 0; i < zone_table_size; i++) {
+	for (uint8_t i = 0; i < zone_table_size; i++) {
 		zone_cfg *zone_p = zone_table + i;
 
 		zone_p->is_init = false;
 
 		// init stepwise last temp
-		for (int j = 0; j < zone_p->sw_tbl_num; j++) {
-			stepwise_cfg *p = zone_p->sw_tbl + i;
+		for (uint8_t j = 0; j < zone_p->sw_tbl_num; j++) {
+			stepwise_cfg *p = zone_p->sw_tbl + j;
 			if (p)
 				p->last_temp = FSC_TEMP_INVALID;
 		}

--- a/meta-facebook/aalc-rpu/src/platform/plat_fsc_table.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_fsc_table.c
@@ -4,10 +4,7 @@
 #include "plat_pwm.h"
 #include "plat_hwmon.h"
 
-#define FAN_TABLE_TBD 0
-
 pid_cfg hex_fan_pid_table[] = {
-#if FAN_TABLE_TBD
 	{
 		.sensor_num = SENSOR_NUM_BPB_RPU_COOLANT_OUTLET_TEMP_C,
 		.setpoint_type = SETPOINT_AIR_INTEL_AVG_C,
@@ -19,11 +16,9 @@ pid_cfg hex_fan_pid_table[] = {
 		.pos_hyst = 1,
 		.neg_hyst = 1,
 	},
-#endif
 };
 
 stepwise_cfg hex_fan_stepwise_table[] = {
-#if FAN_TABLE_TBD
 	{
 		.sensor_num = SENSOR_NUM_SB_HEX_AIR_INLET_AVG_TEMP_C,
 		.step = {
@@ -66,11 +61,9 @@ stepwise_cfg hex_fan_stepwise_table[] = {
 			{40, 30},
 		},
 	},
-#endif
 };
 
 pid_cfg pump_pid_table[] = {
-#if FAN_TABLE_TBD
 	{
 		.sensor_num = SENSOR_NUM_BPB_RPU_COOLANT_OUTLET_TEMP_C,
 		.setpoint_type = SETPOINT_FLOW_RATE_LPM,
@@ -82,11 +75,9 @@ pid_cfg pump_pid_table[] = {
 		.pos_hyst = 1,
 		.neg_hyst = 1,
 	},
-#endif
 };
 
 stepwise_cfg pump_stepwise_table[] = {
-#if FAN_TABLE_TBD
 	{
 		.sensor_num = SENSOR_NUM_SB_HEX_AIR_INLET_AVG_TEMP_C,
 		.step = {
@@ -129,11 +120,9 @@ stepwise_cfg pump_stepwise_table[] = {
 			{45, 35},
 		},
 	},
-#endif
 };
 
 stepwise_cfg rpu_fan_stepwise_table[] = {
-#if FAN_TABLE_TBD
 	{
 		.sensor_num = SENSOR_NUM_SB_HEX_AIR_INLET_AVG_TEMP_C,
 		.step = {
@@ -155,7 +144,6 @@ stepwise_cfg rpu_fan_stepwise_table[] = {
 			{40, 40},
 		},
 	},
-#endif
 };
 
 zone_cfg zone_table[] = {

--- a/meta-facebook/aalc-rpu/src/platform/plat_hook.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_hook.c
@@ -1043,7 +1043,7 @@ bool post_ads112c_read(sensor_cfg *cfg, void *args, int *reading)
 		val = 6.89475729 * val;
 		break;
 	case PLATFORM_ADS112C_TEMP_RACK:
-		val = (rawValue - 16140) * 0.015873;
+		val = (rawValue - 15664) * 0.015873;
 		val = 1.0678 * val - 5.8373;
 		val = 1.0031 * val + 0.1566;
 		break;

--- a/meta-facebook/aalc-rpu/src/platform/plat_sensor_table.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_sensor_table.c
@@ -413,7 +413,7 @@ sensor_cfg plat_sensor_config[] = {
 	  POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL,
 	  post_quick_sensor_read, &ads112c_post_args[3], &ads112c_init_args[0] },
 	{ SENSOR_NUM_SB_TTV_COOLANT_LEAKAGE_1_VOLT_V, sensor_dev_ads112c, I2C_BUS9,
-	  SB_ADS112C_2_ADDR, ADS112C_READ_OUTPUT_RAW, stby_access, ENABLE_RESET_CFG_REG, 0,
+	  SB_ADS112C_1_ADDR, ADS112C_READ_OUTPUT_RAW, stby_access, ENABLE_RESET_CFG_REG, 0,
 	  SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  pre_PCA9546A_read, &bus_9_PCA9546A_configs[0], post_ads112c_read, &ads112c_post_args[4],
 	  &ads112c_init_args[0] },

--- a/meta-facebook/aalc-rpu/src/platform/plat_util.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_util.c
@@ -27,6 +27,7 @@
 #include "sensor.h"
 #include "plat_gpio.h"
 #include "plat_pwm.h"
+#include "plat_fsc.h"
 
 #define I2C_MASTER_READ_BACK_MAX_SIZE 16 // 16 registers
 
@@ -95,12 +96,14 @@ void plat_enable_sensor_poll(void)
 {
 	enable_sensor_poll();
 	nct7363_wdt_all_enable();
+	controlFSC(FSC_ENABLE);
 }
 
 void plat_disable_sensor_poll(void)
 {
 	nct7363_wdt_all_disable();
 	disable_sensor_poll();
+	controlFSC(FSC_DISABLE);
 }
 
 void set_rpu_ready()


### PR DESCRIPTION
Summary:
- modify ads112c rack temp formula
- fix SB_TTV_COOLANT_LEAKAGE_1_VOLT_V to correct device
- add enable/disable fsc to poll control
- fix zone_init function

Test Plan:
- Build code: PASS