### PR TITLE
fby35: ji: Enable i3c hot-join

### DIFF
--- a/meta-facebook/yv35-ji/src/platform/plat_class.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_class.c
@@ -22,9 +22,11 @@
 
 #include "hal_gpio.h"
 #include "hal_i2c.h"
+#include "hal_i3c.h"
 #include "libutil.h"
 #include "plat_gpio.h"
 #include "plat_i2c.h"
+#include "plat_i3c.h"
 #include "plat_sensor_table.h"
 #include "power_status.h"
 
@@ -194,4 +196,8 @@ void init_platform_config()
 	if (board_revision < SYS_BOARD_EVT) {
 		retimer_module = RETIMER_MODULE_UNKNOWN;
 	}
+
+	I3C_MSG i3c_msg;
+	i3c_msg.bus = I3C_BUS1;
+	i3c_set_pid(&i3c_msg, I3C_BUS1_PID);
 }

--- a/meta-facebook/yv35-ji/src/platform/plat_i3c.h
+++ b/meta-facebook/yv35-ji/src/platform/plat_i3c.h
@@ -23,6 +23,8 @@
 #define I3C_BUS2 1
 #define I3C_BUS3 2
 
+#define I3C_BUS1_PID 0x0 // 12-bit PID
+
 #define MCTP_I3C_BIC_ADDR 0x40 //8-bit addr
 
 #define MCTP_I3C_BMC_BUS I3C_BUS1


### PR DESCRIPTION
Summary:
- Enable I3C hot-join base on #1884 .

TestPlan:
- BuildCode: PASS
- Find whether BMC could connect to BIC after SLED-CYCLE and SLOT-CYCLE: PASS
 