### PR TITLE
aalc: Add function of pump running time and clear pump running time

### DIFF
--- a/meta-facebook/aalc-rpu/src/platform/plat_hook.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_hook.h
@@ -38,11 +38,6 @@
 #define BUS_8_MUX_ADDR 0xE8 >> 1
 #define BUS_9_MUX_ADDR 0xE8 >> 1
 
-#define MUX_CHANNEL_0 1
-#define MUX_CHANNEL_1 2
-#define MUX_CHANNEL_2 4
-#define MUX_CHANNEL_3 8
-
 typedef struct _ads112c_post_arg {
 	uint8_t plat_sensor_type;
 } ads112c_post_arg;

--- a/meta-facebook/aalc-rpu/src/platform/plat_hwmon.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_hwmon.c
@@ -485,7 +485,7 @@ pump_running_time pump_running_time_info[] = {
 
 bool read_pump_running_time_data_from_eeprom(uint8_t pump_num, uint32_t *return_data)
 {
-	if (pump_num > PUMP_MAX_NUM || pump_num < 0) {
+	if (pump_num >= PUMP_MAX_NUM) {
 		LOG_ERR("unknow pump_num when read data from eeprom %d", pump_num);
 		return false;
 	}

--- a/meta-facebook/aalc-rpu/src/platform/plat_hwmon.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_hwmon.h
@@ -36,6 +36,19 @@ typedef struct _pump_reset_struct {
 	uint8_t senser_num;
 } pump_reset_struct;
 
+enum PUMP_NUM {
+	PUMP_1_UPTIME,
+	PUMP_2_UPTIME,
+	PUMP_3_UPTIME,
+	PUMP_MAX_NUM,
+};
+
+typedef struct _pump_running_time_struct {
+	uint8_t pump_num;
+	uint8_t size;
+	uint16_t eeprom_offset;
+} pump_running_time;
+
 bool clear_log_for_modbus_pump_setting(pump_reset_struct *data, uint8_t bit_val);
 bool pump_setting_pump1_reset(pump_reset_struct *data, uint8_t bit_val);
 bool pump_setting_pump2_reset(pump_reset_struct *data, uint8_t bit_val);
@@ -52,3 +65,8 @@ void set_pump_redundant_switch_time(uint8_t time);
 void set_pump_redundant_switch_time_type(uint8_t type);
 void pump_redundant_enable(uint8_t onoff);
 uint8_t pwm_control(uint8_t group, uint8_t duty);
+bool get_pump_uptime_secs(uint8_t pump_num, uint32_t *return_uptime);
+bool set_pump_uptime_secs(uint8_t pump_1_set, uint8_t pump_2_set, uint8_t pump_3_set);
+bool get_pump_last_switch_time(uint8_t pump_num, uint32_t *return_uptime);
+bool get_pump_current_boot_unrunning_time(uint8_t pump_num, uint32_t *return_uptime);
+bool modbus_clear_pump_running_time_function(pump_reset_struct *data, uint8_t bit_val);

--- a/meta-facebook/aalc-rpu/src/platform/plat_modbus.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_modbus.c
@@ -305,7 +305,7 @@ pump_reset_struct modbus_pump_setting_table[] = {
 	{ SYSTEM_STOP, close_pump, 0 },
 	{ RPU_REMOTE_POWER_CYCLE, rpu_remote_power_cycle_function, 0 },
 	{ MANUAL_CONTROL, modbus_pump_setting_unsupport_function, 0 },
-	{ CLEAR_PUMP_RUNNING_TIME, modbus_pump_setting_unsupport_function, 0 },
+	{ CLEAR_PUMP_RUNNING_TIME, modbus_clear_pump_running_time_function, 0 },
 	{ CLEAR_LOG, clear_log_for_modbus_pump_setting, 0 },
 	{ PUMP_1_RESET, pump_setting_pump1_reset, 0 },
 	{ PUMP_2_RESET, pump_setting_pump2_reset, 0 },
@@ -666,6 +666,21 @@ uint8_t modbus_read_time_since_last_on(modbus_command_mapping *cmd)
 	return MODBUS_EXC_NONE;
 }
 
+uint8_t modbus_read_pump_running_time(modbus_command_mapping *cmd)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cmd, MODBUS_EXC_ILLEGAL_DATA_VAL);
+	uint32_t pump_uptime_sec = 0;
+	if (get_pump_uptime_secs(cmd->arg0, &pump_uptime_sec)) {
+		cmd->data[0] = pump_uptime_sec >> 16;
+		cmd->data[1] = pump_uptime_sec & 0xffff;
+	} else {
+		LOG_ERR("read pump running time fail!");
+		return MODBUS_EXC_SERVER_DEVICE_FAILURE;
+	}
+
+	return MODBUS_EXC_NONE;
+}
+
 modbus_command_mapping modbus_command_table[] = {
 	// addr, write_fn, read_fn, arg0, arg1, arg2, size
 	{ MODBUS_BPB_RPU_COOLANT_FLOW_RATE_LPM_ADDR, NULL, modbus_get_senser_reading,
@@ -757,9 +772,9 @@ modbus_command_mapping modbus_command_table[] = {
 	  SENSOR_NUM_PB_3_HSC_P48V_IOUT_CURR_A, 1, -1, 1 },
 	{ MODBUS_BB_HSC_P48V_PIN_PWR_W_ADDR, NULL, modbus_get_senser_reading,
 	  SENSOR_NUM_BB_HSC_P48V_PIN_PWR_W, 1, -1, 1 },
-	{ MODBUS_PUMP_1_RUNNING_ADDR, NULL, modbus_to_do_get, 0, 0, 0, 2 },
-	{ MODBUS_PUMP_2_RUNNING_ADDR, NULL, modbus_to_do_get, 0, 0, 0, 2 },
-	{ MODBUS_PUMP_3_RUNNING_ADDR, NULL, modbus_to_do_get, 0, 0, 0, 2 },
+	{ MODBUS_PUMP_1_RUNNING_ADDR, NULL, modbus_read_pump_running_time, PUMP_1_UPTIME, 0, 0, 2 },
+	{ MODBUS_PUMP_2_RUNNING_ADDR, NULL, modbus_read_pump_running_time, PUMP_2_UPTIME, 0, 0, 2 },
+	{ MODBUS_PUMP_3_RUNNING_ADDR, NULL, modbus_read_pump_running_time, PUMP_3_UPTIME, 0, 0, 2 },
 	{ MODBUS_BPB_HSC_P48V_PIN_PWR_W_ADDR, NULL, modbus_get_senser_reading,
 	  SENSOR_NUM_BPB_HSC_P48V_PIN_PWR_W, 1, -1, 1 },
 	{ MODBUS_PB_1_HSC_P48V_PIN_PWR_W_ADDR, NULL, modbus_get_senser_reading,


### PR DESCRIPTION
Summary:

- modified:   meta-facebook/aalc-rpu/src/platform/plat_hook.h
- modified:   meta-facebook/aalc-rpu/src/platform/plat_hwmon.c
- modified:   meta-facebook/aalc-rpu/src/platform/plat_hwmon.h
- modified:   meta-facebook/aalc-rpu/src/platform/plat_isr.c
- modified:   meta-facebook/aalc-rpu/src/platform/plat_modbus.c

Description:
- Add read pump 1, 2, 3  running time.
- When power cycle, fw update or power surprise shut down it will update pump 1, 2, 3 running time in eeprom.
- Add clear pump 1, 2, 3 running time function.

Test Plan:

- Build code: PASS