### PR TITLE
fby35: ji: Fix Support clear CMET Bug

### DIFF
--- a/meta-facebook/yv35-ji/src/lib/plat_spi.c
+++ b/meta-facebook/yv35-ji/src/lib/plat_spi.c
@@ -70,7 +70,7 @@ void switch_spi_freq()
 	}
 }
 
-bool switch_bios_read_write_flash_mux(int switch_mux)
+int switch_bios_read_write_flash_mux(int switch_mux)
 {
 	I2C_MSG msg = { 0 };
 	int retry = 3;
@@ -84,8 +84,8 @@ bool switch_bios_read_write_flash_mux(int switch_mux)
 	int ret = i2c_master_write(&msg, retry);
 	if (ret) {
 		LOG_ERR("Failed to switch bios read write flash mux, ret: %d", ret);
-		return false;
+		return -1;
 	}
 
-	return true;
+	return 0;
 }

--- a/meta-facebook/yv35-ji/src/lib/plat_spi.h
+++ b/meta-facebook/yv35-ji/src/lib/plat_spi.h
@@ -20,7 +20,7 @@
 #define SWITCH_MUX_TO_READ_WRITE_FLASH 0
 #define SWITCH_MUX_TO_BIOS 1
 
-bool switch_bios_read_write_flash_mux(int switch_mux);
+int switch_bios_read_write_flash_mux(int switch_mux);
 void switch_spi_freq();
 
 #endif


### PR DESCRIPTION
Summary:
- Fix fby35: ji: Support clear CMET switch Mux will failed Bug. 

TestPlan:
- BuildCode: PASS