### PR TITLE
minerva-ag: Support get vr fw version

### DIFF
--- a/common/dev/include/mp2891.h
+++ b/common/dev/include/mp2891.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -13,19 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef MP2891_H
+#define MP2891_H
 
-#include "plat_sensor_polling_shell.h"
-#include "cpld_shell.h"
-#include "plat_pldm_fw_version_shell.h"
+#include "stdint.h"
 
-/* Sub-command Level 1 of command test */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_test_cmds,
-			       SHELL_CMD(sensor, &sub_plat_sensor_polling_cmd,
-					 "set/get platform sensor polling command", NULL),
-			       SHELL_CMD(cpld, &sub_cpld_cmd, "cpld command", NULL),
-			       SHELL_CMD(get_fw_version, &sub_get_fw_version_cmd,
-					 "get fw version command", NULL),
-			       SHELL_SUBCMD_SET_END);
+bool mp2891_get_fw_version(uint8_t bus, uint8_t addr, uint32_t *rev);
 
-/* Root of command test */
-SHELL_CMD_REGISTER(test, &sub_test_cmds, "Test commands for AG", NULL);
+#endif

--- a/meta-facebook/minerva-ag/CMakeLists.txt
+++ b/meta-facebook/minerva-ag/CMakeLists.txt
@@ -34,3 +34,4 @@ target_include_directories(app PRIVATE src/shell)
 # Fail build if there are any warnings 
 target_compile_options(app PRIVATE -Werror)
 
+add_compile_definitions(PLDM_MAX_DATA_SIZE=1024)

--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_fw_update.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <logging/log.h>
 #include "libutil.h"
+#include "sensor.h"
 #include "pldm.h"
 #include "pldm_firmware_update.h"
 #include "mctp_ctrl.h"
@@ -28,11 +29,60 @@
 #include "plat_i2c.h"
 #include "plat_gpio.h"
 #include "plat_pldm_sensor.h"
+#include "mp2971.h"
+#include "mp2891.h"
+#include "raa229621.h"
+#include "plat_class.h"
+#include "pldm_sensor.h"
 
 LOG_MODULE_REGISTER(plat_fwupdate);
 
+static bool get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len);
+void find_sensor_id_and_name_by_firmware_comp_id(uint8_t comp_identifier, uint8_t *sensor_id,
+						 char *sensor_name);
+
 enum FIRMWARE_COMPONENT {
 	AG_COMPNT_BIC,
+	AG_COMPNT_OSFP_P3V3,
+	AG_COMPNT_CPU_P0V85_PVDD,
+	AG_COMPNT_CPU_P0V75_PVDD_CH_N,
+	AG_COMPNT_CPU_P0V75_PVDD_CH_S,
+	AG_COMPNT_CPU_P0V75_TRVDD_ZONEA,
+	AG_COMPNT_CPU_P0V75_TRVDD_ZONEB,
+	AG_COMPNT_CPU_P1V1_VDDC_HBM0_2_4,
+	AG_COMPNT_CPU_P0V9_TRVDD_ZONEA,
+	AG_COMPNT_CPU_P0V9_TRVDD_ZONEB,
+	AG_COMPNT_CPU_P1V1_VDDC_HBM1_3_5,
+	AG_COMPNT_CPU_P0V8_VDDA_PCIE,
+};
+
+typedef struct aegis_compnt_mapping_sensor {
+	uint8_t firmware_comp_id;
+	uint8_t plat_pldm_sensor_id;
+	char sensor_name[MAX_AUX_SENSOR_NAME_LEN];
+} aegis_compnt_mapping_sensor;
+
+aegis_compnt_mapping_sensor aegis_compnt_mapping_sensor_table[] = {
+	{ AG_COMPNT_OSFP_P3V3, SENSOR_NUM_OSFP_P3V3_TEMP_C, "SENSOR_NUM_OSFP_P3V3" },
+	{ AG_COMPNT_CPU_P0V85_PVDD, SENSOR_NUM_CPU_P0V85_PVDD_TEMP_C, "SENSOR_NUM_CPU_P0V85_PVDD" },
+	{ AG_COMPNT_CPU_P0V75_PVDD_CH_N, SENSOR_NUM_CPU_P0V75_PVDD_CH_N_TEMP_C,
+	  "SENSOR_NUM_CPU_P0V75_PVDD_CH_N" },
+	{ AG_COMPNT_CPU_P0V75_PVDD_CH_S, SENSOR_NUM_CPU_P0V75_PVDD_CH_S_TEMP_C,
+	  "SENSOR_NUM_CPU_P0V75_PVDD_CH_S" },
+	{ AG_COMPNT_CPU_P0V75_TRVDD_ZONEA, SENSOR_NUM_CPU_P0V75_TRVDD_ZONEA_TEMP_C,
+	  "SENSOR_NUM_CPU_P0V75_TRVDD_ZONEA" },
+	{ AG_COMPNT_CPU_P0V75_TRVDD_ZONEB, SENSOR_NUM_CPU_P0V75_TRVDD_ZONEB_TEMP_C,
+	  "SENSOR_NUM_CPU_P0V75_TRVDD_ZONEB" },
+	{ AG_COMPNT_CPU_P1V1_VDDC_HBM0_2_4, SENSOR_NUM_CPU_P1V1_VDDC_HBM0_2_4_TEMP_C,
+	  "SENSOR_NUM_CPU_P1V1_VDDC_HBM0_2_4" },
+	{ AG_COMPNT_CPU_P0V9_TRVDD_ZONEA, SENSOR_NUM_CPU_P0V9_TRVDD_ZONEA_TEMP_C,
+	  "SENSOR_NUM_CPU_P0V9_TRVDD_ZONEA" },
+	{ AG_COMPNT_CPU_P0V9_TRVDD_ZONEB, SENSOR_NUM_CPU_P0V9_TRVDD_ZONEB_TEMP_C,
+	  "SENSOR_NUM_CPU_P0V9_TRVDD_ZONEB" },
+	{ AG_COMPNT_CPU_P1V1_VDDC_HBM1_3_5, SENSOR_NUM_CPU_P1V1_VDDC_HBM1_3_5_TEMP_C,
+	  "SENSOR_NUM_CPU_P1V1_VDDC_HBM1_3_5" },
+	{ AG_COMPNT_CPU_P0V8_VDDA_PCIE, SENSOR_NUM_CPU_P0V8_VDDA_PCIE_TEMP_C,
+	  "SENSOR_NUM_CPU_P0V8_VDDA_PCIE" },
 };
 
 /* PLDM FW update table */
@@ -49,6 +99,171 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.activate_method = COMP_ACT_SELF,
 		.self_act_func = pldm_bic_activate,
 		.get_fw_version_fn = NULL,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = AG_COMPNT_OSFP_P3V3,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = AG_COMPNT_CPU_P0V85_PVDD,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = AG_COMPNT_CPU_P0V75_PVDD_CH_N,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = AG_COMPNT_CPU_P0V75_PVDD_CH_S,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = AG_COMPNT_CPU_P0V75_TRVDD_ZONEA,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = AG_COMPNT_CPU_P0V75_TRVDD_ZONEB,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = AG_COMPNT_CPU_P1V1_VDDC_HBM0_2_4,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = AG_COMPNT_CPU_P0V9_TRVDD_ZONEA,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = AG_COMPNT_CPU_P0V9_TRVDD_ZONEB,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = AG_COMPNT_CPU_P1V1_VDDC_HBM1_3_5,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_vr_fw_version,
+		.self_apply_work_func = NULL,
+		.comp_version_str = NULL,
+	},
+	{
+		.enable = true,
+		.comp_classification = COMP_CLASS_TYPE_DOWNSTREAM,
+		.comp_identifier = AG_COMPNT_CPU_P0V8_VDDA_PCIE,
+		.comp_classification_index = 0x00,
+		.pre_update_func = NULL,
+		.update_func = NULL,
+		.pos_update_func = NULL,
+		.inf = COMP_UPDATE_VIA_I2C,
+		.activate_method = COMP_ACT_AC_PWR_CYCLE,
+		.self_act_func = NULL,
+		.get_fw_version_fn = get_vr_fw_version,
 		.self_apply_work_func = NULL,
 		.comp_version_str = NULL,
 	},
@@ -147,6 +362,109 @@ void load_pldmupdate_comp_config(void)
 	memcpy(comp_config, PLDMUPDATE_FW_CONFIG_TABLE, sizeof(PLDMUPDATE_FW_CONFIG_TABLE));
 }
 
+static bool get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(info_p, false);
+	CHECK_NULL_ARG_WITH_RETURN(buf, false);
+	CHECK_NULL_ARG_WITH_RETURN(len, false);
+
+	pldm_fw_update_info_t *p = (pldm_fw_update_info_t *)info_p;
+
+	bool ret = false;
+	uint8_t bus = 0;
+	uint8_t addr = 0;
+	uint8_t sensor_id = 0;
+	uint8_t sensor_dev = 0;
+	char sensor_name[MAX_AUX_SENSOR_NAME_LEN] = { 0 };
+	find_sensor_id_and_name_by_firmware_comp_id(p->comp_identifier, &sensor_id, sensor_name);
+	find_vr_addr_and_bus_and_sensor_dev_by_sensor_id(sensor_id, &bus, &addr, &sensor_dev);
+
+	uint8_t type = get_vr_type();
+	uint32_t version = 0;
+	uint16_t remain = 0xFFFF;
+	switch (type) {
+	case VR_RNS_ISL69260_RAA228238: {
+		if (sensor_dev == sensor_dev_isl69259) {
+			if (!raa229621_get_crc(bus, addr, &version)) {
+				LOG_ERR("The VR ISL69260 version reading failed");
+				return ret;
+			}
+			if (raa229621_get_remaining_wr(bus, addr, (uint8_t *)&remain) < 0) {
+				LOG_ERR("The VR ISL69260 remaining reading failed");
+				return ret;
+			}
+		} else if (sensor_dev == sensor_dev_raa228238) {
+			if (!raa229621_get_crc(bus, addr, &version)) {
+				LOG_ERR("The VR RAA228238 version reading failed");
+				return ret;
+			}
+			if (raa229621_get_remaining_wr(bus, addr, (uint8_t *)&remain) < 0) {
+				LOG_ERR("The VR RAA228238 remaining reading failed");
+				return ret;
+			}
+		}
+		break;
+	}
+	case VR_MPS_MP2971_MP2891: {
+		if (sensor_dev == sensor_dev_mp2971) {
+			if (!mp2971_get_checksum(bus, addr, &version)) {
+				LOG_ERR("The VR MPS2971 version reading failed");
+				return ret;
+			}
+		} else if (sensor_dev == sensor_dev_mp2891) {
+			if (!mp2891_get_fw_version(bus, addr, &version)) {
+				LOG_ERR("The VR MPS2891 version reading failed");
+				return ret;
+			}
+		}
+		break;
+	}
+	default:
+		LOG_ERR("Unsupport VR type(%d)", type);
+		return ret;
+	}
+
+	if (sensor_dev == sensor_dev_mp2891)
+		version = sys_cpu_to_be16(version);
+	else
+		version = sys_cpu_to_be32(version);
+
+	const char *vr_name[] = {
+		[VR_RNS_ISL69260_RAA228238] = "Renesas ",
+		[VR_MPS_MP2971_MP2891] = "MPS ",
+	};
+
+	const char *remain_str_p = ", Remaining Write: ";
+	uint8_t *buf_p = buf;
+	const uint8_t *vr_name_p = vr_name[type];
+	*len = 0;
+
+	if (!vr_name_p) {
+		LOG_ERR("The pointer of VR string name is NULL");
+		return ret;
+	}
+
+	memcpy(buf_p, vr_name_p, strlen(vr_name_p));
+	buf_p += strlen(vr_name_p);
+
+	if (sensor_dev == sensor_dev_mp2891)
+		*len += bin2hex((uint8_t *)&version, 2, buf_p, 4) + strlen(vr_name_p);
+	else
+		*len += bin2hex((uint8_t *)&version, 4, buf_p, 8) + strlen(vr_name_p);
+	buf_p += 8;
+
+	if (remain != 0xFFFF) {
+		memcpy(buf_p, remain_str_p, strlen(remain_str_p));
+		buf_p += strlen(remain_str_p);
+		remain = (uint8_t)((remain % 10) | (remain / 10 << 4));
+		*len += bin2hex((uint8_t *)&remain, 1, buf_p, 2) + strlen(remain_str_p);
+		buf_p += 2;
+	}
+
+	ret = true;
+	return ret;
+}
+
 void clear_pending_version(uint8_t activate_method)
 {
 	if (!comp_config || !comp_config_count) {
@@ -158,4 +476,24 @@ void clear_pending_version(uint8_t activate_method)
 		if (comp_config[i].activate_method == activate_method)
 			SAFE_FREE(comp_config[i].pending_version_p);
 	}
+}
+
+void find_sensor_id_and_name_by_firmware_comp_id(uint8_t comp_identifier, uint8_t *sensor_id,
+						 char *sensor_name)
+{
+	for (uint8_t i = 0; i < ARRAY_SIZE(aegis_compnt_mapping_sensor_table); i++) {
+		if (aegis_compnt_mapping_sensor_table[i].firmware_comp_id == comp_identifier) {
+			*sensor_id = aegis_compnt_mapping_sensor_table[i].plat_pldm_sensor_id;
+			strncpy(sensor_name, aegis_compnt_mapping_sensor_table[i].sensor_name,
+				MAX_AUX_SENSOR_NAME_LEN);
+		}
+	}
+	return;
+}
+
+int get_aegis_compnt_mapping_sensor_table_count(void)
+{
+	int count = 0;
+	count = ARRAY_SIZE(aegis_compnt_mapping_sensor_table);
+	return count;
 }

--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_fw_update.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_fw_update.h
@@ -23,5 +23,8 @@
 
 void load_pldmupdate_comp_config(void);
 void clear_pending_version(uint8_t activate_method);
+void find_sensor_id_and_name_by_firmware_comp_id(uint8_t comp_identifier, uint8_t *sensor_id,
+						 char *sensor_name);
+int get_aegis_compnt_mapping_sensor_table_count(void);
 
 #endif /* _PLAT_FWUPDATE_H_ */

--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
@@ -9167,3 +9167,19 @@ bool is_vr_access(uint8_t sensor_num)
 	return (is_dc_access(sensor_num) && get_plat_sensor_vr_polling_enable_flag() &&
 		get_plat_sensor_polling_enable_flag());
 }
+
+void find_vr_addr_and_bus_and_sensor_dev_by_sensor_id(uint8_t sensor_id, uint8_t *vr_bus,
+						      uint8_t *vr_addr, uint8_t *sensor_dev)
+{
+	int pldm_sensor_count = 0;
+	pldm_sensor_count = plat_pldm_sensor_get_sensor_count(VR_SENSOR_THREAD_ID);
+	//pldm_sensor_info *plat_pldm_sensor_vr_table = plat_pldm_sensor_load(VR_SENSOR_THREAD_ID);
+	for (int index = 0; index < pldm_sensor_count; index++) {
+		if (plat_pldm_sensor_vr_table[index].pldm_sensor_cfg.num == sensor_id) {
+			*vr_addr = plat_pldm_sensor_vr_table[index].pldm_sensor_cfg.target_addr;
+			*vr_bus = plat_pldm_sensor_vr_table[index].pldm_sensor_cfg.port;
+			*sensor_dev = plat_pldm_sensor_vr_table[index].pldm_sensor_cfg.type;
+			return;
+		}
+	}
+}

--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.h
@@ -242,5 +242,7 @@ bool get_plat_sensor_vr_polling_enable_flag();
 bool is_ubc_access(uint8_t sensor_num);
 bool is_temp_access(uint8_t sensor_num);
 bool is_vr_access(uint8_t sensor_num);
+void find_vr_addr_and_bus_and_sensor_dev_by_sensor_id(uint8_t sensor_id, uint8_t *vr_bus,
+						      uint8_t *vr_addr, uint8_t *sensor_dev);
 
 #endif

--- a/meta-facebook/minerva-ag/src/shell/plat_pldm_fw_version_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_pldm_fw_version_shell.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <zephyr.h>
+#include <stdlib.h>
+#include <shell/shell.h>
+#include "sensor.h"
+#include "plat_class.h"
+#include "plat_pldm_sensor.h"
+#include "plat_pldm_fw_update.h"
+#include "mp2971.h"
+#include "mp2891.h"
+#include "raa229621.h"
+#include "pdr.h"
+
+LOG_MODULE_REGISTER(plat_pldm_fw_version_shell);
+
+void cmd_get_fw_version_vr(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc != 1) {
+		shell_warn(shell, "Help: test get_fw_version vr");
+		return;
+	}
+
+	/* Stop sensor polling */
+	disable_sensor_poll();
+
+	shell_print(shell, "comp_id |              sensor_name               |version |remain");
+	for (int i = 0; i < get_aegis_compnt_mapping_sensor_table_count(); i++) {
+		uint8_t comp_identifier = i + 1;
+		uint8_t bus = 0;
+		uint8_t addr = 0;
+		uint8_t sensor_id = 0;
+		uint8_t sensor_dev = 0;
+		char sensor_name[MAX_AUX_SENSOR_NAME_LEN] = { 0 };
+		find_sensor_id_and_name_by_firmware_comp_id(comp_identifier, &sensor_id,
+							    sensor_name);
+		find_vr_addr_and_bus_and_sensor_dev_by_sensor_id(sensor_id, &bus, &addr,
+								 &sensor_dev);
+		uint8_t type = get_vr_type();
+		uint32_t version = 0;
+		uint16_t remain = 0xFFFF;
+		switch (type) {
+		case VR_RNS_ISL69260_RAA228238: {
+			if (sensor_dev == sensor_dev_isl69259) {
+				if (!raa229621_get_crc(bus, addr, &version)) {
+					shell_print(shell,
+						    "The VR ISL69260 version reading failed");
+					return;
+				}
+				if (raa229621_get_remaining_wr(bus, addr, (uint8_t *)&remain) < 0) {
+					shell_print(shell,
+						    "The VR ISL69260 remaining reading failed");
+					return;
+				}
+			} else if (sensor_dev == sensor_dev_raa228238) {
+				if (!raa229621_get_crc(bus, addr, &version)) {
+					shell_print(shell,
+						    "The VR RAA228238 version reading failed");
+					return;
+				}
+				if (raa229621_get_remaining_wr(bus, addr, (uint8_t *)&remain) < 0) {
+					shell_print(shell,
+						    "The VR RAA228238 remaining reading failed");
+					return;
+				}
+			}
+			break;
+		}
+		case VR_MPS_MP2971_MP2891: {
+			if (sensor_dev == sensor_dev_mp2971) {
+				if (!mp2971_get_checksum(bus, addr, &version)) {
+					shell_print(shell, "The VR MPS2971 version reading failed");
+					return;
+				}
+			} else if (sensor_dev == sensor_dev_mp2891) {
+				if (!mp2891_get_fw_version(bus, addr, &version)) {
+					shell_print(shell, "The VR MPS289x version reading failed");
+					return;
+				}
+			}
+			break;
+		}
+		default:
+			shell_print(shell, "Unsupport VR type(%x)", type);
+			return;
+		}
+
+		if (remain != 0xFFFF) {
+			remain = (uint8_t)((remain % 10) | (remain / 10 << 4));
+		}
+
+		if (sensor_dev == sensor_dev_mp2891) {
+			shell_print(shell, "%-8x|%-40s|    %04x|%04x", comp_identifier, sensor_name,
+				    version, remain);
+		} else {
+			shell_print(shell, "%-8x|%-40s|%08x|%04x", comp_identifier, sensor_name,
+				    version, remain);
+		}
+	}
+
+	/* Start sensor polling */
+	enable_sensor_poll();
+	return;
+}

--- a/meta-facebook/minerva-ag/src/shell/plat_pldm_fw_version_shell.h
+++ b/meta-facebook/minerva-ag/src/shell/plat_pldm_fw_version_shell.h
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-#include "plat_sensor_polling_shell.h"
-#include "cpld_shell.h"
-#include "plat_pldm_fw_version_shell.h"
+#ifndef PLAT_PLDM_FW_VERSION_SHELL_H
+#define PLAT_PLDM_FW_VERSION_SHELL_H
 
-/* Sub-command Level 1 of command test */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_test_cmds,
-			       SHELL_CMD(sensor, &sub_plat_sensor_polling_cmd,
-					 "set/get platform sensor polling command", NULL),
-			       SHELL_CMD(cpld, &sub_cpld_cmd, "cpld command", NULL),
-			       SHELL_CMD(get_fw_version, &sub_get_fw_version_cmd,
-					 "get fw version command", NULL),
+#include <shell/shell.h>
+
+void cmd_get_fw_version_vr(const struct shell *shell, size_t argc, char **argv);
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_get_fw_version_cmd,
+			       SHELL_CMD(vr, NULL, "get fw version vr", cmd_get_fw_version_vr),
 			       SHELL_SUBCMD_SET_END);
-
-/* Root of command test */
-SHELL_CMD_REGISTER(test, &sub_test_cmds, "Test commands for AG", NULL);
+#endif


### PR DESCRIPTION
Summary:
- Support get vr fw version shell command
- Support get vr fw version through pldm get firmware parameter

Test Plan:
- Build code: PASS
- Get vr fw version: PASS

Get vr fw version:
```
[MPS]
uart:~$ test get_fw_version vr
comp_id |              sensor_name               |version |remain
1       |SENSOR_NUM_OSFP_P3V3                    |4f0dcae4|ffff
2       |SENSOR_NUM_CPU_P0V85_PVDD               |    88b7|ffff
3       |SENSOR_NUM_CPU_P0V75_PVDD_CH_N          |57fd8847|ffff
4       |SENSOR_NUM_CPU_P0V75_PVDD_CH_S          |8409b147|ffff
5       |SENSOR_NUM_CPU_P0V75_TRVDD_ZONEA        |cbba068b|ffff
6       |SENSOR_NUM_CPU_P0V75_TRVDD_ZONEB        |b72f985d|ffff
7       |SENSOR_NUM_CPU_P1V1_VDDC_HBM0_2_4       |3400a5ee|ffff
8       |SENSOR_NUM_CPU_P0V9_TRVDD_ZONEA         |e450cef7|ffff
9       |SENSOR_NUM_CPU_P0V9_TRVDD_ZONEB         |179b048f|ffff
a       |SENSOR_NUM_CPU_P1V1_VDDC_HBM1_3_5       |36233243|ffff
b       |SENSOR_NUM_CPU_P0V8_VDDA_PCIE           |2dedfd8f|ffff

[RNS]
uart:~$ test get_fw_version vr
comp_id |             sensor_name                |version |remain
1       |SENSOR_NUM_OSFP_P3V3                    |3c66ab6d|0019
2       |SENSOR_NUM_CPU_P0V85_PVDD               |3d1c73b9|0026
3       |SENSOR_NUM_CPU_P0V75_PVDD_CH_N          |7b73e0ad|0023
4       |SENSOR_NUM_CPU_P0V75_PVDD_CH_S          |54aea408|0023
5       |SENSOR_NUM_CPU_P0V75_TRVDD_ZONEA        |6583f0e7|0024
6       |SENSOR_NUM_CPU_P0V75_TRVDD_ZONEB        |796919bb|0024
7       |SENSOR_NUM_CPU_P1V1_VDDC_HBM0_2_4       |a327cd41|0025
8       |SENSOR_NUM_CPU_P0V9_TRVDD_ZONEA         |d16f6c72|0022
9       |SENSOR_NUM_CPU_P0V9_TRVDD_ZONEB         |306fe4e4|0024
a       |SENSOR_NUM_CPU_P1V1_VDDC_HBM1_3_5       |fff7bda3|0023
b       |SENSOR_NUM_CPU_P0V8_VDDA_PCIE           |a01c6c8a|0024
```