### PR TITLE
common: Add filter for AL retimer temperature

### DIFF
--- a/common/dev/pt5161l.c
+++ b/common/dev/pt5161l.c
@@ -1170,14 +1170,9 @@ uint8_t pt5161l_read_avg_temp(I2C_MSG *i2c_msg, uint8_t temp_cal_code_avg, doubl
 	adc_code = (data_bytes[3] << 24) + (data_bytes[2] << 16) + (data_bytes[1] << 8) +
 		   data_bytes[0];
 
-	//return 0 means temperature is not ready
-	if (adc_code == 0) {
+	//return 0 or >= 0x3FF means temperature is not ready
+	if (adc_code == 0 || adc_code >= 0x3FF) {
 		LOG_INF("Avg Temperature is not ready");
-		ret = SENSOR_NOT_ACCESSIBLE;
-		goto unlock_exit;
-	} else if (adc_code == 0xFFFFFFFF) {
-		/* From Aries Errata - Known issue */
-		LOG_WRN("Some I2C transactions occured during temperature reading");
 		ret = SENSOR_NOT_ACCESSIBLE;
 		goto unlock_exit;
 	}

--- a/meta-facebook/yv35-ji/src/platform/plat_isr.c
+++ b/meta-facebook/yv35-ji/src/platform/plat_isr.c
@@ -154,7 +154,6 @@ void check_host_reboot_status()
 	if (get_DC_status() == true) {
 		LOG_WRN("Host reboot detected!");
 		start_satmc_access_poll();
-		retimer_addr_loss();
 	}
 }
 
@@ -174,6 +173,7 @@ void ISR_POST_COMPLETE()
 			sbmr_reset_9byte_postcode_ok();
 			reset_ssif_ok();
 			set_satmc_status(false);
+			retimer_addr_loss();
 			k_work_schedule(&check_host_reboot_work, K_SECONDS(POST_DOWN_2_SECOND));
 		}
 	}


### PR DESCRIPTION
Summary:
- According to SDK v2.16.3 provided from Asteralab, adding filter > 0x3FF for some abnormal cases caused by retimer not ready.
- Due to known issue #1924 abnormal value 0xFFFFFFFF included in this filter, remove last modification.

TestPlan:
- BuildCode: PASS
