### PR TITLE
common: patch: Disable MT25Q series hold by nvcr config

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0085-spi-aspeed-Disable-MT25Q-series-HOLD-by-NCVR.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0085-spi-aspeed-Disable-MT25Q-series-HOLD-by-NCVR.patch
@@ -1,0 +1,57 @@
+From a00ba845ac162fc1471bcea331a4812cfadd050b Mon Sep 17 00:00:00 2001
+From: MouchenHung <Mouchen.Hung@quantatw.com>
+Date: Mon, 11 Nov 2024 10:57:32 +0800
+Subject: [PATCH] spi: aspeed: Disable MT25Q series HOLD by NCVR
+
+---
+ drivers/flash/spi_nor_multi_dev.c | 17 ++++++++++++++++-
+ include/drivers/spi_nor.h         |  4 ++++
+ 2 files changed, 20 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/flash/spi_nor_multi_dev.c b/drivers/flash/spi_nor_multi_dev.c
+index 5dae866362..103fe6e730 100644
+--- a/drivers/flash/spi_nor_multi_dev.c
++++ b/drivers/flash/spi_nor_multi_dev.c
+@@ -1473,8 +1473,23 @@ static int sfdp_post_fixup(const struct device *dev)
+ 					goto end;
+ 			}
+ 		}
++	case SPI_NOR_MFR_ID_ST:
++		{
++			/* For MT25Q* series, try to disable #HOLD from DQ3 */
++			uint8_t val[2] = {0};
++			ret = spi_reg_read(dev, SPI_NOR_CMD_ST_RD_NVCR, val, 2);
++			if (ret != 0)
++				goto end;
+ 
+-		break;
++			uint16_t nvcr_val = (val[1] << 8) | val[0];
++			if (nvcr_val & BIT(4)) {
++				val[0] = (nvcr_val & ~BIT(4) & 0xFF);
++				ret = spi_reg_write(dev, SPI_NOR_CMD_ST_WR_NVCR, val, 2);
++				if (ret != 0)
++					goto end;
++			}
++			break;
++		}
+ 	default:
+ 		/* do nothing */
+ 		break;
+diff --git a/include/drivers/spi_nor.h b/include/drivers/spi_nor.h
+index aea16b6f96..ecd387c756 100644
+--- a/include/drivers/spi_nor.h
++++ b/include/drivers/spi_nor.h
+@@ -68,6 +68,10 @@
+ #define SPI_NOR_CMD_RDPD            0xAB    /* Release from Deep Power Down */
+ #define SPI_NOR_CMD_RDSFDP          0x5A    /* Read SFDP */
+ 
++/* ST opcodes */
++#define SPI_NOR_CMD_ST_WR_NVCR        0xB1    /* Write NVCR register */
++#define SPI_NOR_CMD_ST_RD_NVCR        0xB5    /* Read NVCR register */
++
+ /* Page, sector, and block size are standard, not configurable. */
+ #define SPI_NOR_PAGE_SIZE    0x0100U
+ #define SPI_NOR_SECTOR_SIZE  0x1000U
+-- 
+2.17.1
+


### PR DESCRIPTION
Summary:
- Cause of HOLD# and DQ3 are using same pin in MT25Q series, Flash may turn into HOLD status while using quad-mode. To solve this problem, adding NVCR config to spi driver initialization.

TestPlan:
- Build Code: PASS
- Bios update: PASS