### PR TITLE
fby35: ji: Modify ssif's i2c mode from dma to byte

### DIFF
--- a/meta-facebook/yv35-ji/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-ji/boards/ast1030_evb.overlay
@@ -54,7 +54,9 @@
 &i2c5 {
 	pinctrl-0 = <&pinctrl_i2c5_default>;
 	status = "okay";
-	clock-frequency = <I2C_BITRATE_FAST>;
+	smbus-timeout = < 0x0 >;
+	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	xfer-mode = "BYTE";
 };
 
 &i2c9 {


### PR DESCRIPTION
Summary:
- In order to prevent some cases that BIC failed to drop out address before data ready. Modify SSIF channel's i2c mode from DMA to BYTE.

Test Plan:
- BuildCode: PASS