### PR TITLE
common: Fix OEM command to read spi data with opcode bug

### DIFF
--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -2354,6 +2354,7 @@ __weak void OEM_1S_CLEAR_CMET(ipmi_msg *msg)
 	return;
 }
 
+#ifdef CONFIG_SPI_ASPEED
 __weak void OEM_1S_SPI_REGISTER_READ(ipmi_msg *msg)
 {
 	/*********************************
@@ -2385,7 +2386,6 @@ __weak void OEM_1S_SPI_REGISTER_READ(ipmi_msg *msg)
 		goto end;
 	}
 
-#ifdef CONFIG_SPI_ASPEED
 	const struct device *flash_dev;
 	int32_t ret = 0;
 
@@ -2418,15 +2418,12 @@ __weak void OEM_1S_SPI_REGISTER_READ(ipmi_msg *msg)
 	memcpy(&msg->data[0], buf, msg->data_len);
 
 	msg->completion_code = CC_SUCCESS;
-#else
-	msg->data_len = 0;
-	msg->completion_code = CC_INVALID_CMD;
-#endif
 
 end:
 	SAFE_FREE(buf);
 	return;
 }
+#endif
 
 void IPMI_OEM_1S_handler(ipmi_msg *msg)
 {
@@ -2726,10 +2723,12 @@ void IPMI_OEM_1S_handler(ipmi_msg *msg)
 		LOG_DBG("Received CLEAR CMET command");
 		OEM_1S_CLEAR_CMET(msg);
 		break;
+#ifdef CONFIG_SPI_ASPEED
 	case CMD_OEM_1S_SPI_REGISTER_READ:
 		LOG_DBG("Received SPI REGISTER READ command");
 		OEM_1S_SPI_REGISTER_READ(msg);
 		break;
+#endif
 	default:
 		LOG_ERR("Invalid OEM message, netfn(0x%x) cmd(0x%x)", msg->netfn, msg->cmd);
 		msg->data_len = 0;

--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -2385,6 +2385,7 @@ __weak void OEM_1S_SPI_REGISTER_READ(ipmi_msg *msg)
 		goto end;
 	}
 
+#ifdef CONFIG_SPI_ASPEED
 	const struct device *flash_dev;
 	int32_t ret = 0;
 
@@ -2417,6 +2418,10 @@ __weak void OEM_1S_SPI_REGISTER_READ(ipmi_msg *msg)
 	memcpy(&msg->data[0], buf, msg->data_len);
 
 	msg->completion_code = CC_SUCCESS;
+#else
+	msg->data_len = 0;
+	msg->completion_code = CC_INVALID_CMD;
+#endif
 
 end:
 	SAFE_FREE(buf);


### PR DESCRIPTION
Summary:
- Add Macro config to OEM command that can read spi data with opcode(#2066)

TestPlan:
- BuildCode: PASS