### PR TITLE
aalc: Version commit for aalc-2024.45.01

### DIFF
--- a/meta-facebook/aalc-rpu/src/platform/plat_version.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_version.h
@@ -31,7 +31,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x00
+#define FIRMWARE_REVISION_2 0x01
 
 #define IPMI_VERSION 0x02
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -42,7 +42,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x24
-#define BIC_FW_WEEK 0x44
+#define BIC_FW_WEEK 0x45
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x61 // char: a
 #define BIC_FW_platform_1 0x61 // char: a


### PR DESCRIPTION
Summary:
- Version commit for AALC RPU l05t-rpu-20244501

Test Plan:
- Build code: Pass
- Check BIC version: Pass