### PR TITLE
fby4: wf: Set clock buffer to bypass mode

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_init.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_init.c
@@ -16,6 +16,7 @@
 
 #include "hal_gpio.h"
 #include "util_sys.h"
+#include "util_worker.h"
 #include "pldm_monitor.h"
 #include "power_status.h"
 #include "plat_gpio.h"
@@ -77,6 +78,8 @@ void pal_pre_init()
 		}
 	}
 	scu_init(scu_cfg, sizeof(scu_cfg) / sizeof(SCU_CFG));
+
+	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
 }
 
 void pal_post_init()

--- a/meta-facebook/yv4-wf/src/platform/plat_isr.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_isr.h
@@ -16,6 +16,7 @@
 
 #include <kernel.h>
 #include "ioexp_tca9555.h"
+#include "plat_i2c.h"
 
 #ifndef PLAT_ISR_H
 #define PLAT_ISR_H
@@ -24,6 +25,10 @@
 #define ADDR_IOE2 (0x42 >> 1)
 #define ADDR_IOE3 (0x44 >> 1)
 #define ADDR_IOE4 (0x46 >> 1)
+
+#define CLK_BUFFER_ADDR 0x6B
+#define CLK_BUFFER_BUS I2C_BUS6
+#define PLL_OPERATING_OFFSET 0x00
 
 #define E1S_PRESENT_BIT BIT(2)
 #define ASIC_CLK_BIT BIT(4)
@@ -36,6 +41,8 @@
 #define IOE_SWITCH_CXL2_VR_TO_BIC 0x04
 
 #define IOE_READY_MSEC 1000
+
+#define SET_CLK_BUF_DELAY_MS 100
 
 enum set_ioe4_cmd {
 	SET_CLK = 0,


### PR DESCRIPTION
# Description
- Set clock buffer to bypass mode when host DC on.

# Motivation
- Change clock buffer default to avoid influencing PCIe error.

# Test plan
- Build code: Pass
- Check clock buffer: Pass

# Log
- Before set uart:~$ i2c read I2C_5 0x6B 0x00 0x8
00000000: 08 5a 06 ff c7 ff 03 44                          |.Z.....D         |

- After set uart:~$ i2c read I2C_5 0x6B 0x00 0x8
00000000: 08 5a 2e ff c7 ff 03 44                          |.Z.....D         |