### PR TITLE
common: xdpe12284c: add vout error handle

### DIFF
--- a/common/dev/xdpe12284c.c
+++ b/common/dev/xdpe12284c.c
@@ -622,6 +622,9 @@ uint8_t xdpe12284c_read(sensor_cfg *cfg, int *reading)
 		}
 
 		actual_value = vid_to_float(val, msg.data[0]);
+		if (actual_value < 0) {
+			return SENSOR_FAIL_TO_ACCESS;
+		}
 		actual_value /= 1000; // mV to V
 		sval->integer = actual_value;
 		sval->fraction = (actual_value - sval->integer) * 1000;


### PR DESCRIPTION
Description:
- Add error handle for vid to float.

Motivation:
- Fix BIC return abnormal reading when vid_to_float return error.

Test Plan:
- Build Code - PASS