### PR TITLE
fby4: sd: Clear VR fault bit after AC cycling

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -110,6 +110,15 @@ void pal_post_init()
 	start_get_dimm_info_thread();
 	set_sys_ready_pin(BIC_READY_R);
 	reset_usb_hub();
+
+	if (is_ac_lost()) {
+		// Clear VR_CPU0 fault bit
+		plat_pldm_sensor_clear_vr_fault(ADDR_VR_CPU0, I2C_BUS4, 2);
+		// Clear VR_CPU1 fault bit
+		plat_pldm_sensor_clear_vr_fault(ADDR_VR_CPU1, I2C_BUS4, 2);
+		// Clear VR_PVDD11 fault bit
+		plat_pldm_sensor_clear_vr_fault(ADDR_VR_PVDD11, I2C_BUS4, 1);
+	}
 }
 
 void pal_set_sys_status()

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
@@ -79,5 +79,6 @@ void plat_pldm_sensor_change_ina_dev();
 void plat_init_pldm_sensor_table();
 void plat_init_pldm_disabled_sensors();
 void plat_pldm_sensor_change_dimm_dev();
+void plat_pldm_sensor_clear_vr_fault(uint8_t vr_addr, uint8_t vr_bus, uint8_t page_cnt);
 
 #endif


### PR DESCRIPTION
# Description
- Clear VR fault bit after slot AC cycling.

# Motivation
- MPS VR sets fault bit by default, and it will cause VR fault event during AMD FHC test. Clear VR fault bit to presnt VR fault event during AMD FHC test.

# Test Plan
- Build code: Pass
- Check VR STATUS_WORD: Pass