### PR TITLE
YV4: sd: Switch i3c mux to CPU after getting DIMM data

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_dimm.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_dimm.c
@@ -179,6 +179,7 @@ void get_dimm_info_handler()
 			i3c_detach(&i3c_msg);
 		}
 
+		switch_i3c_dimm_mux(I3C_MUX_CPU_TO_DIMM);
 		if (k_mutex_unlock(&i3c_dimm_mutex)) {
 			LOG_ERR("Failed to unlock I3C dimm MUX");
 		}

--- a/meta-facebook/yv4-sd/src/platform/plat_pmic.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pmic.c
@@ -202,6 +202,7 @@ void monitor_pmic_error_via_i3c_handler()
 
 		for (dimm_id = 0; dimm_id < DIMM_ID_MAX; dimm_id++) {
 			if (!get_post_status()) {
+				switch_i3c_dimm_mux(I3C_MUX_CPU_TO_DIMM);
 				break;
 			}
 
@@ -224,6 +225,7 @@ void monitor_pmic_error_via_i3c_handler()
 			}
 		}
 
+		switch_i3c_dimm_mux(I3C_MUX_CPU_TO_DIMM);
 		if (k_mutex_unlock(&i3c_dimm_mutex)) {
 			LOG_ERR("Failed to unlock I3C dimm MUX");
 		}
@@ -375,12 +377,11 @@ void read_pmic_error_when_dc_off()
 		}
 	}
 
+	switch_i3c_dimm_mux(I3C_MUX_CPU_TO_DIMM);
 	if (k_mutex_unlock(&i3c_dimm_mutex)) {
 		LOG_ERR("Failed to unlock I3C dimm MUX");
 	}
 
-	// Switch I3C MUX to CPU after read finish
-	switch_i3c_dimm_mux(I3C_MUX_CPU_TO_DIMM);
 	return;
 }
 


### PR DESCRIPTION
# Description:
- Switch i3c mux to CPU after getting DIMM related information.

# Motivation:
- Switch i3c mux to CPU when BIC doesn't need to access DIMM to avoid errors.

# Test Plan:
- Build code: Pass
- Get DIMM sensors value: Pass

Log:
- Get DIMM sensors value
[0x5 ] MB_DIMM_A_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     34.000
[0x6 ] MB_DIMM_B_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     34.000
[0x7 ] MB_DIMM_C_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     33.750
[0x8 ] MB_DIMM_D_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     35.750
[0x9 ] MB_DIMM_E_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     37.000
[0xa ] MB_DIMM_F_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     36.750
[0xb ] MB_DIMM_G_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     34.000
[0xc ] MB_DIMM_H_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     34.000
[0xd ] MB_DIMM_I_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     34.500
[0xe ] MB_DIMM_J_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     36.000
[0xf ] MB_DIMM_K_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     35.750
[0x10] MB_DIMM_L_TEMP_C                        : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |     35.750
[0x56] MB_DIMM_A_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      1.125
[0x57] MB_DIMM_B_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      1.125
[0x58] MB_DIMM_C_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      0.875
[0x59] MB_DIMM_D_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      1.625
[0x5a] MB_DIMM_E_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      2.125
[0x5b] MB_DIMM_F_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      2.000
[0x5c] MB_DIMM_G_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      1.000
[0x5d] MB_DIMM_H_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      1.125
[0x5e] MB_DIMM_I_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      1.125
[0x5f] MB_DIMM_J_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      1.375
[0x60] MB_DIMM_K_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      1.250
[0x61] MB_DIMM_L_PWR_W                         : i3c_dimm           | access[O] | poll    1( 1) sec | sensor_enabled        |      1.750