### PR TITLE
Yv4: sd: add sensor polling disable/enable

### DIFF
--- a/common/service/sensor/pldm_sensor.c
+++ b/common/service/sensor/pldm_sensor.c
@@ -19,6 +19,7 @@
 #include "libutil.h"
 #include "pldm_monitor.h"
 #include "plat_def.h"
+#include "sensor.h"
 
 #ifdef ENABLE_PLDM_SENSOR
 #include "plat_pldm_sensor.h"
@@ -365,6 +366,12 @@ void pldm_sensor_polling_handler(void *arug0, void *arug1, void *arug2)
 	}
 
 	while (1) {
+		// Check sensor poll enable
+		if (get_sensor_poll_enable_flag() == false) {
+			k_msleep(PLDM_SENSOR_POLL_TIME_DEFAULT_MS);
+			continue;
+		}
+
 		for (sensor_num = 0; sensor_num < pldm_sensor_count; sensor_num++) {
 			if (pldm_polling_sensor_reading(&pldm_sensor_list[thread_id][sensor_num],
 							pldm_sensor_count, thread_id,

--- a/meta-facebook/yv4-sd/src/platform/plat_dimm.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_dimm.c
@@ -69,6 +69,12 @@ void get_dimm_info_handler()
 		int ret = 0;
 		uint8_t dimm_id;
 
+		// Check sensor poll enable
+		if (get_sensor_poll_enable_flag() == false) {
+			k_msleep(GET_DIMM_INFO_TIME_MS);
+			continue;
+		}
+
 		// Avoid to get wrong thus only monitor after post complete
 		if (!get_post_status()) {
 			k_msleep(GET_DIMM_INFO_TIME_MS);

--- a/meta-facebook/yv4-sd/src/platform/plat_pmic.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pmic.c
@@ -194,6 +194,11 @@ void monitor_pmic_error_via_i3c_handler()
 	while (1) {
 		k_msleep(MONITOR_PMIC_ERROR_TIME_MS);
 
+		// Check sensor poll enable
+		if (get_sensor_poll_enable_flag() == false) {
+			continue;
+		}
+
 		// Check which PMIC is error
 		if (k_mutex_lock(&i3c_dimm_mutex, K_MSEC(I3C_DIMM_MUTEX_TIMEOUT_MS))) {
 			LOG_ERR("Failed to lock I3C dimm MUX");


### PR DESCRIPTION
Summary:
Description:
- Add sensor polling disable/enable.

Motivation:
- Disable polling that we can switch DIMM mux to CPU side or debug.

Test Plan:
- Build code: Pass
- enable/disable polling, and check the sensor value

Disable:
root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0x30 0x15 0xA0 0x00 0x00 pldmtool: Tx: 80 3f 01 15 a0 00 e0 30 15 a0 00 00
pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 30 00 15 a0 00 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x02 0x11 0x32 0x00 0x00 pldmtool: Tx: 80 02 11 32 00 00
pldmtool: Rx: 00 02 11 00 04 00 01 01 01 01 83 2f 00 00 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x02 0x11 0x32 0x00 0x00 pldmtool: Tx: 80 02 11 32 00 00
pldmtool: Rx: 00 02 11 00 04 00 01 01 01 01 83 2f 00 00 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x02 0x11 0x32 0x00 0x00 pldmtool: Tx: 80 02 11 32 00 00
pldmtool: Rx: 00 02 11 00 04 00 01 01 01 01 83 2f 00 00 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x02 0x11 0x32 0x00 0x00

Enable:
root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0x30 0x15 0xA0 0x00 0x01 pldmtool: Tx: 80 3f 01 15 a0 00 e0 30 15 a0 00 01
pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 30 00 15 a0 00 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x02 0x11 0x32 0x00 0x00 pldmtool: Tx: 80 02 11 32 00 00
pldmtool: Rx: 00 02 11 00 04 00 01 01 01 01 71 2f 00 00 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x02 0x11 0x32 0x00 0x00 pldmtool: Tx: 80 02 11 32 00 00
pldmtool: Rx: 00 02 11 00 04 00 01 01 01 01 81 2f 00 00 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x02 0x11 0x32 0x00 0x00 pldmtool: Tx: 80 02 11 32 00 00
pldmtool: Rx: 00 02 11 00 04 00 01 01 01 01 7d 2f 00 00