### PR TITLE
minerva-ag/support_vout_val_range_get_set_shell_command

### DIFF
--- a/common/dev/include/isl69259.h
+++ b/common/dev/include/isl69259.h
@@ -17,6 +17,7 @@
 #define ISL69259_H
 
 #include "stdint.h"
+#include "sensor.h"
 
 #define TWO_COMPLEMENT_NEGATIVE_BIT BIT(15)
 #define ADJUST_IOUT_RANGE 2
@@ -26,9 +27,15 @@ struct isl69259_config {
 	uint32_t len;
 };
 
+bool isl69260_get_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool isl69260_get_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool isl69260_set_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool isl69260_set_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
 bool isl69259_fwupdate(uint8_t bus, uint8_t addr, uint8_t *img_buff, uint32_t img_size);
 bool isl69259_get_raa_hex_mode(uint8_t bus, uint8_t addr, uint8_t *mode);
 bool isl69259_get_raa_crc(uint8_t bus, uint8_t addr, uint8_t mode, uint32_t *crc);
 bool get_raa_remaining_wr(uint8_t bus, uint8_t addr, uint8_t mode, uint16_t *remain);
+bool isl69260_get_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool isl69260_set_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
 
 #endif

--- a/common/dev/include/mp2971.h
+++ b/common/dev/include/mp2971.h
@@ -17,8 +17,15 @@
 #define MP2971_H
 
 #include "stdint.h"
+#include "sensor.h"
 
 bool mp2971_fwupdate(uint8_t bus, uint8_t addr, uint8_t *img_buff, uint32_t img_size);
+bool mp2971_get_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool mp2971_get_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool mp2971_set_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool mp2971_set_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
 bool mp2971_get_checksum(uint8_t bus, uint8_t addr, uint32_t *checksum);
+bool mp2971_get_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool mp2971_set_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
 
 #endif

--- a/common/dev/include/mp29816a.h
+++ b/common/dev/include/mp29816a.h
@@ -17,8 +17,15 @@
 #define MP29816A_H
 
 #include "stdint.h"
+#include "sensor.h"
 
 bool mp29816a_get_fw_version(uint8_t bus, uint8_t addr, uint32_t *rev);
+bool mp29816a_get_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool mp29816a_get_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool mp29816a_set_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool mp29816a_set_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
 bool mp29816a_fwupdate(uint8_t bus, uint8_t addr, uint8_t *img_buff, uint32_t img_size);
+bool mp29816a_get_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool mp29816a_set_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
 
 #endif

--- a/common/dev/include/raa228249.h
+++ b/common/dev/include/raa228249.h
@@ -17,9 +17,16 @@
 #define RAA228249_H
 
 #include "stdint.h"
+#include "sensor.h"
 
 bool raa228249_get_crc(uint8_t bus, uint8_t addr, uint32_t *crc);
+bool raa228249_get_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool raa228249_get_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool raa228249_set_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool raa228249_set_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
 int raa228249_get_remaining_wr(uint8_t bus, uint8_t addr, uint8_t *remain);
 bool raa228249_fwupdate(uint8_t bus, uint8_t addr, uint8_t *img_buff, uint32_t img_size);
+bool raa228249_get_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
+bool raa228249_set_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt);
 
 #endif

--- a/common/dev/include/raa229621.h
+++ b/common/dev/include/raa229621.h
@@ -17,6 +17,7 @@
 #define RAA229621_H
 
 #include "stdint.h"
+#include "sensor.h"
 
 bool raa229621_fwupdate(uint8_t bus, uint8_t addr, uint8_t *img_buff, uint32_t img_size);
 bool raa229621_get_crc(uint8_t bus, uint8_t addr, uint32_t *crc);

--- a/common/dev/mp29816a.c
+++ b/common/dev/mp29816a.c
@@ -29,10 +29,15 @@ LOG_MODULE_REGISTER(mp29816a);
 
 #define READ_VOUT_MASK GENMASK(11, 0)
 #define MFR_VID_RES_MASK GENMASK(12, 10)
-#define MFR_VOUT_LOOP_CTRL 0x29
+#define MFR_VOUT_SCALE_LOOP 0x29
+#define MFR_VOUT_LOOP_CTRL 0x8D
+#define MFR_VDIFF_GAIN_HALF_R2_BIT BIT(10)
 
 #define VR_MPS_PAGE_0 0x00
 #define VR_MPS_PAGE_1 0x01
+
+#define MP29816A_VOUT_MAX_REG 0x24
+#define MP29816A_VOUT_MIN_REG 0x2B
 
 /* --------- PAGE1 ---------- */
 #define VR_REG_EXPECTED_USER_CRC 0xED
@@ -65,6 +70,8 @@ static int cnt_char(char *s, char c)
 	}
 	return cnt;
 }
+
+float mp29816a_get_vout_min_max_resolution(sensor_cfg *cfg);
 
 uint8_t parsing_line(char *str, uint16_t len, struct cfg_data *cfg_data)
 {
@@ -216,6 +223,98 @@ bool mp29816a_set_page(uint8_t bus, uint8_t addr, uint8_t page)
 	if (i2c_master_write(&i2c_msg, retry)) {
 		LOG_ERR("Failed to set mp29816a page, bus: %d, addr: 0x%x, page: 0x%x", bus, addr,
 			page);
+		return false;
+	}
+
+	return true;
+}
+
+bool mp29816a_get_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	uint8_t data[2] = { 0 };
+	if (!mp29816a_i2c_read(cfg->port, cfg->target_addr, MP29816A_VOUT_MAX_REG, data,
+			       sizeof(data))) {
+		return false;
+	}
+
+	uint16_t read_value = data[0] | (data[1] << 8);
+	float resolution = mp29816a_get_vout_min_max_resolution(cfg);
+	if (resolution == 0)
+		return false;
+	float val = (float)read_value * resolution;
+	uint16_t val_int = (uint16_t)val;
+
+	*millivolt = val_int;
+
+	return true;
+}
+
+bool mp29816a_get_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	uint8_t data[2] = { 0 };
+	if (!mp29816a_i2c_read(cfg->port, cfg->target_addr, MP29816A_VOUT_MIN_REG, data,
+			       sizeof(data))) {
+		return false;
+	}
+
+	uint16_t read_value = data[0] | (data[1] << 8);
+	float resolution = mp29816a_get_vout_min_max_resolution(cfg);
+	if (resolution == 0)
+		return false;
+	float val = (float)read_value * resolution;
+	uint16_t val_int = (uint16_t)val;
+
+	*millivolt = val_int;
+
+	return true;
+}
+
+bool mp29816a_set_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	float resolution = mp29816a_get_vout_min_max_resolution(cfg);
+	if (resolution == 0)
+		return false;
+	float write_val = (float)*millivolt / resolution;
+	uint16_t write_val_int = (uint16_t)write_val;
+
+	uint8_t data[2] = { 0 };
+	data[0] = write_val_int & 0xFF;
+	data[1] = (write_val_int >> 8) & 0xFF;
+
+	if (!mp29816a_i2c_write(cfg->port, cfg->target_addr, MP29816A_VOUT_MAX_REG, data,
+				sizeof(data))) {
+		return false;
+	}
+
+	return true;
+}
+
+bool mp29816a_set_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	float resolution = mp29816a_get_vout_min_max_resolution(cfg);
+	if (resolution == 0)
+		return false;
+	float write_val = (float)*millivolt / resolution;
+	uint16_t write_val_int = (uint16_t)write_val;
+
+	uint8_t data[2] = { 0 };
+	data[0] = write_val_int & 0xFF;
+	data[1] = (write_val_int >> 8) & 0xFF;
+
+	if (!mp29816a_i2c_write(cfg->port, cfg->target_addr, MP29816A_VOUT_MIN_REG, data,
+				sizeof(data))) {
 		return false;
 	}
 
@@ -412,6 +511,19 @@ bool mp29816a_get_fw_version(uint8_t bus, uint8_t addr, uint32_t *rev)
 	return true;
 }
 
+float mp29816a_get_vout_min_max_resolution(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_FAIL_TO_ACCESS);
+
+	float reso = 0;
+
+	//TODO: get vout min max resolution, not support now
+
+	reso = 6.25;
+
+	return reso;
+}
+
 float mp29816a_get_resolution(sensor_cfg *cfg)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_FAIL_TO_ACCESS);
@@ -428,15 +540,14 @@ float mp29816a_get_resolution(sensor_cfg *cfg)
 
 	switch (offset) {
 	case PMBUS_READ_VOUT:
-		msg.data[0] = MFR_VOUT_LOOP_CTRL;
+		msg.data[0] = MFR_VOUT_SCALE_LOOP;
 
 		if (i2c_master_read(&msg, i2c_max_retry)) {
 			LOG_WRN("I2C read failed");
 			break;
 		}
-		uint16_t mfr_vout_loop_ctrl = (msg.data[1] << 8) | msg.data[0];
-
-		switch ((mfr_vout_loop_ctrl & MFR_VID_RES_MASK) >> 10) {
+		uint16_t mfr_vout_scale_loop = (msg.data[1] << 8) | msg.data[0];
+		switch ((mfr_vout_scale_loop & MFR_VID_RES_MASK) >> 10) {
 		case 0:
 			reso = 0.00625;
 			break;
@@ -462,7 +573,7 @@ float mp29816a_get_resolution(sensor_cfg *cfg)
 			reso = 0.0009765625;
 			break;
 		default:
-			LOG_WRN("vout_reso_set not supported: 0x%x", mfr_vout_loop_ctrl);
+			LOG_WRN("vout_reso_set not supported: 0x%x", mfr_vout_scale_loop);
 			return reso;
 		}
 		return reso;
@@ -470,8 +581,51 @@ float mp29816a_get_resolution(sensor_cfg *cfg)
 		LOG_WRN("offset not supported: 0x%x", offset);
 		break;
 	}
-
 	return reso;
+}
+
+bool mp29816a_get_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	uint8_t data[2] = { 0 };
+	if (!mp29816a_i2c_read(cfg->port, cfg->target_addr, PMBUS_VOUT_COMMAND, data,
+			       sizeof(data))) {
+		return false;
+	}
+
+	uint16_t read_value = data[0] | (data[1] << 8);
+
+	float resolution = mp29816a_get_resolution(cfg);
+	if (resolution == 0)
+		return false;
+	float val = read_value * resolution * 1000;
+	*millivolt = (int)val;
+	return true;
+}
+
+bool mp29816a_set_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	float resolution = mp29816a_get_resolution(cfg);
+	if (resolution == 0)
+		return false;
+	uint16_t read_value = (*millivolt / resolution) / 1000;
+	read_value = read_value & READ_VOUT_MASK;
+
+	uint8_t data[2] = { 0 };
+	data[0] = read_value & 0xFF;
+	data[1] = (read_value >> 8) & 0xFF;
+
+	if (!mp29816a_i2c_write(cfg->port, cfg->target_addr, PMBUS_VOUT_COMMAND, data,
+				sizeof(data))) {
+		return false;
+	}
+
+	return true;
 }
 
 uint8_t mp29816a_read(sensor_cfg *cfg, int *reading)

--- a/common/dev/raa228249.c
+++ b/common/dev/raa228249.c
@@ -48,6 +48,9 @@ LOG_MODULE_REGISTER(raa228249);
 
 #define MAX_CMD_LINE 1500
 
+#define RAA228249_VOUT_MAX_REG 0x24
+#define RAA228249_VOUT_MIN_REG 0x2B
+
 struct raa_data {
 	union {
 		uint8_t raw[32];
@@ -81,6 +84,120 @@ static uint8_t ascii_to_byte(uint8_t *ascii_buf)
 {
 	CHECK_NULL_ARG_WITH_RETURN(ascii_buf, SENSOR_UNSPECIFIED_ERROR);
 	return ascii_to_val(ascii_buf[0]) << 4 | ascii_to_val(ascii_buf[1]);
+}
+
+bool raa228249_i2c_read(uint8_t bus, uint8_t addr, uint8_t reg, uint8_t *data, uint8_t len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(data, false);
+
+	memset(data, 0, len);
+
+	I2C_MSG i2c_msg = { 0 };
+	uint8_t retry = 5;
+	i2c_msg.bus = bus;
+	i2c_msg.target_addr = addr;
+	i2c_msg.tx_len = 1;
+	i2c_msg.rx_len = len;
+	i2c_msg.data[0] = reg;
+
+	if (i2c_master_read(&i2c_msg, retry)) {
+		LOG_ERR("Failed to read mp29816a, bus: %d, addr: 0x%x, reg: 0x%x", bus, addr, reg);
+		return false;
+	}
+
+	memcpy(data, i2c_msg.data, len);
+	return true;
+}
+
+bool raa228249_i2c_write(uint8_t bus, uint8_t addr, uint8_t reg, uint8_t *data, uint8_t len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(data, false);
+
+	I2C_MSG i2c_msg = { 0 };
+	uint8_t retry = 5;
+	i2c_msg.bus = bus;
+	i2c_msg.target_addr = addr;
+	i2c_msg.tx_len = len + 1;
+
+	i2c_msg.data[0] = reg;
+
+	if (len > 0)
+		memcpy(&i2c_msg.data[1], data, len);
+
+	if (i2c_master_write(&i2c_msg, retry)) {
+		LOG_ERR("Failed to write mp29816a, bus: %d, addr: 0x%x, reg: 0x%x", bus, addr, reg);
+		return false;
+	}
+
+	return true;
+}
+
+bool raa228249_get_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	uint8_t data[2] = { 0 };
+	if (!raa228249_i2c_read(cfg->port, cfg->target_addr, RAA228249_VOUT_MAX_REG, data,
+				sizeof(data))) {
+		return false;
+	}
+
+	uint16_t val = data[0] | (data[1] << 8);
+	*millivolt = val; // 1mV / LSB
+
+	return true;
+}
+
+bool raa228249_get_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	uint8_t data[2] = { 0 };
+	if (!raa228249_i2c_read(cfg->port, cfg->target_addr, RAA228249_VOUT_MIN_REG, data,
+				sizeof(data))) {
+		return false;
+	}
+
+	uint16_t val = data[0] | (data[1] << 8);
+	*millivolt = val; // 1mV / LSB
+
+	return true;
+}
+
+bool raa228249_set_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	uint8_t data[2] = { 0 };
+	data[0] = *millivolt & 0xFF;
+	data[1] = (*millivolt >> 8) & 0xFF;
+
+	if (!raa228249_i2c_write(cfg->port, cfg->target_addr, RAA228249_VOUT_MAX_REG, data,
+				 sizeof(data))) {
+		return false;
+	}
+
+	return true;
+}
+
+bool raa228249_set_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	uint8_t data[2] = { 0 };
+	data[0] = *millivolt & 0xFF;
+	data[1] = (*millivolt >> 8) & 0xFF;
+
+	if (!raa228249_i2c_write(cfg->port, cfg->target_addr, RAA228249_VOUT_MIN_REG, data,
+				 sizeof(data))) {
+		return false;
+	}
+
+	return true;
 }
 
 static int raa_dma_rd(uint8_t bus, uint8_t addr, uint8_t *reg, uint8_t *resp)
@@ -348,6 +465,41 @@ bool raa228249_fwupdate(uint8_t bus, uint8_t addr, uint8_t *img_buff, uint32_t i
 exit:
 	SAFE_FREE(dev_cfg.pdata);
 	return ret;
+}
+
+bool raa228249_get_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	uint8_t data[2] = { 0 };
+	if (!raa228249_i2c_read(cfg->port, cfg->target_addr, PMBUS_VOUT_COMMAND, data,
+				sizeof(data))) {
+		return false;
+	}
+
+	uint16_t val = data[0] | (data[1] << 8);
+
+	*millivolt = val;
+
+	return true;
+}
+
+bool raa228249_set_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	uint8_t data[2] = { 0 };
+	data[0] = *millivolt & 0xFF;
+	data[1] = (*millivolt >> 8) & 0xFF;
+
+	if (!raa228249_i2c_write(cfg->port, cfg->target_addr, PMBUS_VOUT_COMMAND, data,
+				 sizeof(data))) {
+		return false;
+	}
+
+	return true;
 }
 
 uint8_t raa228249_read(sensor_cfg *cfg, int *reading)

--- a/common/service/ipmi/oem_1s_handler.c
+++ b/common/service/ipmi/oem_1s_handler.c
@@ -2368,7 +2368,7 @@ __weak void OEM_1S_SPI_REGISTER_READ(ipmi_msg *msg)
 	CHECK_NULL_ARG(msg);
 
 	uint8_t *buf = NULL;
-
+#ifdef CONFIG_SPI_ASPEED
 	if (msg->data_len != 3) {
 		msg->completion_code = CC_INVALID_LENGTH;
 		return;
@@ -2418,8 +2418,12 @@ __weak void OEM_1S_SPI_REGISTER_READ(ipmi_msg *msg)
 	memcpy(&msg->data[0], buf, msg->data_len);
 
 	msg->completion_code = CC_SUCCESS;
-
 end:
+#else
+	msg->data_len = 0;
+	msg->completion_code = CC_INVALID_CMD;
+#endif
+
 	SAFE_FREE(buf);
 	return;
 }

--- a/meta-facebook/minerva-ag/src/platform/plat_hook.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.c
@@ -20,10 +20,17 @@
 #include "ast_adc.h"
 #include "sensor.h"
 #include "hal_i2c.h"
+#include "plat_i2c.h"
 #include "plat_gpio.h"
 #include "plat_sensor_table.h"
 #include "plat_hook.h"
 #include <logging/log.h>
+#include "mp2971.h"
+#include "isl69259.h"
+#include "raa228249.h"
+#include "mp29816a.h"
+#include "plat_pldm_sensor.h"
+#include "plat_class.h"
 
 LOG_MODULE_REGISTER(plat_hook);
 
@@ -133,3 +140,386 @@ void vr_mutex_init(void)
 			pre_proc_args->vr_page);
 	}
 }
+
+/* the order is following enum VR_RAIL_E */
+vr_mapping_sensor vr_rail_table[] = {
+	{ VR_RAIL_E_OSFP_P3V3, SENSOR_NUM_OSFP_P3V3_VOLT_V, "AEGIS_OSFP_P3V3" },
+	{ VR_RAIL_E_P0V85, SENSOR_NUM_CPU_P0V85_PVDD_VOLT_V, "AEGIS_CPU_P0V85_PVDD" },
+	{ VR_RAIL_E_P0V75_PVDD_CH_N, SENSOR_NUM_CPU_P0V75_PVDD_CH_N_VOLT_V,
+	  "AEGIS_CPU_P0V75_PVDD_CH_N" },
+	{ VR_RAIL_E_P0V75_MAX_PHY_N, SENSOR_NUM_CPU_P0V75_MAX_PHY_N_VOLT_V,
+	  "AEGIS_CPU_P0V75_MAX_PHY_N" },
+	{ VR_RAIL_E_P0V75_PVDD_CH_S, SENSOR_NUM_CPU_P0V75_PVDD_CH_S_VOLT_V,
+	  "AEGIS_CPU_P0V75_PVDD_CH_S" },
+	{ VR_RAIL_E_P0V75_MAX_PHY_S, SENSOR_NUM_CPU_P0V75_MAX_PHY_S_VOLT_V,
+	  "AEGIS_CPU_P0V75_MAX_PHY_S" },
+	{ VR_RAIL_E_P0V75_TRVDD_ZONEA, SENSOR_NUM_CPU_P0V75_TRVDD_ZONEA_VOLT_V,
+	  "AEGIS_CPU_P0V75_TRVDD_ZONEA" },
+	{ VR_RAIL_E_P1V8_VPP_HBM0_2_4, SENSOR_NUM_CPU_P1V8_VPP_HBM0_2_4_VOLT_V,
+	  "AEGIS_CPU_P1V8_VPP_HBM0_2_4" },
+	{ VR_RAIL_E_P0V75_TRVDD_ZONEB, SENSOR_NUM_CPU_P0V75_TRVDD_ZONEB_VOLT_V,
+	  "AEGIS_CPU_P0V75_TRVDD_ZONEB" },
+	{ VR_RAIL_E_P0V4_VDDQL_HBM0_2_4, SENSOR_NUM_CPU_P0V4_VDDQL_HBM0_2_4_VOLT_V,
+	  "AEGIS_CPU_P0V4_VDDQL_HBM0_2_4" },
+	{ VR_RAIL_E_P1V1_VDDC_HBM0_2_4, SENSOR_NUM_CPU_P1V1_VDDC_HBM0_2_4_VOLT_V,
+	  "AEGIS_CPU_P1V1_VDDC_HBM0_2_4" },
+	{ VR_RAIL_E_P0V75_VDDPHY_HBM0_2_4, SENSOR_NUM_CPU_P0V75_VDDPHY_HBM0_2_4_VOLT_V,
+	  "AEGIS_CPU_P0V75_VDDPHY_HBM0_2_4" },
+	{ VR_RAIL_E_P0V9_TRVDD_ZONEA, SENSOR_NUM_CPU_P0V9_TRVDD_ZONEA_VOLT_V,
+	  "AEGIS_CPU_P0V9_TRVDD_ZONEA" },
+	{ VR_RAIL_E_P1V8_VPP_HBM1_3_5, SENSOR_NUM_CPU_P1V8_VPP_HBM1_3_5_VOLT_V,
+	  "AEGIS_CPU_P1V8_VPP_HBM1_3_5" },
+	{ VR_RAIL_E_P0V9_TRVDD_ZONEB, SENSOR_NUM_CPU_P0V9_TRVDD_ZONEB_VOLT_V,
+	  "AEGIS_CPU_P0V9_TRVDD_ZONEB" },
+	{ VR_RAIL_E_P0V4_VDDQL_HBM1_3_5, SENSOR_NUM_CPU_P0V4_VDDQL_HBM1_3_5_VOLT_V,
+	  "AEGIS_CPU_P0V4_VDDQL_HBM1_3_5" },
+	{ VR_RAIL_E_P1V1_VDDC_HBM1_3_5, SENSOR_NUM_CPU_P1V1_VDDC_HBM1_3_5_VOLT_V,
+	  "AEGIS_CPU_P1V1_VDDC_HBM1_3_5" },
+	{ VR_RAIL_E_P0V75_VDDPHY_HBM1_3_5, SENSOR_NUM_CPU_P0V75_VDDPHY_HBM1_3_5_VOLT_V,
+	  "AEGIS_CPU_P0V75_VDDPHY_HBM1_3_5" },
+	{ VR_RAIL_E_P0V8_VDDA_PCIE, SENSOR_NUM_CPU_P0V8_VDDA_PCIE_VOLT_V,
+	  "AEGIS_CPU_P0V8_VDDA_PCIE" },
+	{ VR_RAIL_E_P1V2_VDDHTX_PCIE, SENSOR_NUM_CPU_P1V2_VDDHTX_PCIE_VOLT_V,
+	  "AEGIS_CPU_P1V2_VDDHTX_PCIE" },
+};
+
+bool vr_rail_name_get(uint8_t rail, uint8_t **name)
+{
+	CHECK_NULL_ARG_WITH_RETURN(name, false);
+
+	if (rail >= VR_RAIL_E_MAX) {
+		*name = NULL;
+		return false;
+	}
+
+	*name = (uint8_t *)vr_rail_table[rail].sensor_name;
+	return true;
+}
+
+#define VR_VOUT_USER_SETTINGS_OFFSET 0x8000
+struct vr_vout_user_settings {
+	uint16_t vout[VR_RAIL_E_MAX];
+} __attribute__((packed));
+
+struct vr_vout_user_settings user_settings = { 0 };
+struct vr_vout_user_settings default_settings = { 0 };
+
+bool vr_rail_enum_get(uint8_t *name, uint8_t *num)
+{
+	CHECK_NULL_ARG_WITH_RETURN(name, false);
+	CHECK_NULL_ARG_WITH_RETURN(num, false);
+
+	for (int i = 0; i < VR_RAIL_E_MAX; i++) {
+		if (strcmp(name, vr_rail_table[i].sensor_name) == 0) {
+			*num = i;
+			return true;
+		}
+	}
+
+	LOG_ERR("invalid rail name %s", name);
+	return false;
+}
+
+bool vr_vout_user_settings_get(void *user_settings)
+{
+	CHECK_NULL_ARG_WITH_RETURN(user_settings, false);
+
+	/* read the user_settings from eeprom */
+	I2C_MSG msg = { 0 };
+	uint8_t retry = 5;
+	msg.bus = I2C_BUS12;
+	msg.target_addr = 0xA0 >> 1;
+	msg.tx_len = 2;
+	msg.data[0] = VR_VOUT_USER_SETTINGS_OFFSET >> 8;
+	msg.data[1] = VR_VOUT_USER_SETTINGS_OFFSET & 0xff;
+	msg.rx_len = sizeof(struct vr_vout_user_settings);
+
+	if (i2c_master_read(&msg, retry)) {
+		LOG_ERR("Failed to read eeprom, bus: %d, addr: 0x%x, reg: 0x%x", msg.bus,
+			msg.target_addr, msg.data[0]);
+		return false;
+	}
+	memcpy(user_settings, msg.data, sizeof(struct vr_vout_user_settings));
+
+	return true;
+}
+
+bool vr_vout_user_settings_set(void *user_settings)
+{
+	CHECK_NULL_ARG_WITH_RETURN(user_settings, false);
+
+	/* write the user_settings to eeprom */
+	I2C_MSG msg = { 0 };
+	uint8_t retry = 5;
+	msg.bus = I2C_BUS12;
+	msg.target_addr = 0xA0 >> 1;
+	msg.tx_len = sizeof(struct vr_vout_user_settings) + 2;
+	msg.data[0] = VR_VOUT_USER_SETTINGS_OFFSET >> 8;
+	msg.data[1] = VR_VOUT_USER_SETTINGS_OFFSET & 0xff;
+
+	memcpy(&msg.data[2], user_settings, sizeof(struct vr_vout_user_settings));
+	if (i2c_master_write(&msg, retry)) {
+		LOG_ERR("Failed to write eeprom, bus: %d, addr: 0x%x, reg: 0x%x", msg.bus,
+			msg.target_addr, msg.data[0]);
+		return false;
+	}
+
+	return true;
+}
+
+static bool vr_vout_user_settings_init(void)
+{
+	if (vr_vout_user_settings_get(&user_settings) == false) {
+		LOG_ERR("get vout user settings fail");
+		return false;
+	}
+
+	for (int i = 0; i < VR_RAIL_E_MAX; i++) {
+		if (user_settings.vout[i] != 0xffff) {
+			/* write vout */
+			uint16_t millivolt = user_settings.vout[i];
+			if (!plat_set_vout_command(i, &user_settings.vout[i], false, false)) {
+				LOG_ERR("Can't set vout[%d]=%x by user settings", i, millivolt);
+				return false;
+			}
+			LOG_INF("set [%d]%s: %dmV", i, vr_rail_table[i].sensor_name, millivolt);
+		}
+	}
+
+	return true;
+}
+
+static bool vr_vout_default_settings_init(void)
+{
+	for (int i = 0; i < VR_RAIL_E_MAX; i++) {
+		if ((get_board_type() == MINERVA_AEGIS_BD) && (i == 0)) {
+			default_settings.vout[i] = 0xffff;
+			continue; // skip osfp p3v3 on AEGIS BD
+		}
+		uint16_t vout = 0;
+		if (!plat_get_vout_command(i, &vout)) {
+			LOG_ERR("Can't find vout default by rail index: %d", i);
+			return false;
+		}
+		default_settings.vout[i] = vout;
+	}
+
+	return true;
+}
+
+/* init the user & default settings value by shell command */
+void user_settings_init(void)
+{
+	vr_vout_default_settings_init();
+	vr_vout_user_settings_init();
+}
+
+bool plat_get_vout_command(uint8_t rail, uint16_t *millivolt)
+{
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	bool ret = false;
+	uint8_t sensor_id = vr_rail_table[rail].sensor_id;
+	sensor_cfg *cfg = get_sensor_cfg_by_sensor_id(sensor_id);
+
+	if (cfg == NULL) {
+		LOG_ERR("Failed to get sensor config for sensor 0x%x", sensor_id);
+		return false;
+	}
+
+	vr_pre_proc_arg *pre_proc_args = vr_pre_read_args + rail;
+
+	if (cfg->pre_sensor_read_hook) {
+		if (!cfg->pre_sensor_read_hook(cfg, cfg->pre_sensor_read_args)) {
+			LOG_ERR("sensor id: 0x%x pre-read fail", sensor_id);
+			goto err;
+		}
+	}
+
+	switch (cfg->type) {
+	case sensor_dev_isl69259:
+		if (!isl69260_get_vout_command(cfg, pre_proc_args->vr_page, millivolt)) {
+			LOG_ERR("The VR ISL69260 vout reading failed");
+			goto err;
+		}
+		break;
+	case sensor_dev_mp2971:
+		if (!mp2971_get_vout_command(cfg, pre_proc_args->vr_page, millivolt)) {
+			LOG_ERR("The VR MPS2971 vout reading failed");
+			goto err;
+		}
+		break;
+	case sensor_dev_mp29816a:
+		if (!mp29816a_get_vout_command(cfg, pre_proc_args->vr_page, millivolt)) {
+			LOG_ERR("The VR MPS29816a vout reading failed");
+			goto err;
+		}
+		break;
+	case sensor_dev_raa228249:
+		if (!raa228249_get_vout_command(cfg, pre_proc_args->vr_page, millivolt)) {
+			LOG_ERR("The VR RAA228249 vout reading failed");
+			goto err;
+		}
+		break;
+	default:
+		LOG_ERR("Unsupport VR type(%x)", cfg->type);
+		goto err;
+	}
+
+	ret = true;
+err:
+	if (cfg->post_sensor_read_hook) {
+		if (cfg->post_sensor_read_hook(cfg, cfg->post_sensor_read_args, NULL) == false) {
+			LOG_ERR("sensor id: 0x%x post-read fail", sensor_id);
+		}
+	}
+	return ret;
+}
+
+bool plat_set_vout_command(uint8_t rail, uint16_t *millivolt, bool is_default, bool is_perm)
+{
+	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	bool ret = false;
+	uint8_t sensor_id = vr_rail_table[rail].sensor_id;
+	sensor_cfg *cfg = get_sensor_cfg_by_sensor_id(sensor_id);
+
+	if (cfg == NULL) {
+		LOG_ERR("Failed to get sensor config for sensor 0x%x", sensor_id);
+		return false;
+	}
+
+	vr_pre_proc_arg *pre_proc_args = vr_pre_read_args + rail;
+
+	if (cfg->pre_sensor_read_hook) {
+		if (!cfg->pre_sensor_read_hook(cfg, cfg->pre_sensor_read_args)) {
+			LOG_ERR("sensor id: 0x%x pre-read fail", sensor_id);
+			goto err;
+		}
+	}
+
+	if (is_default) {
+		*millivolt = default_settings.vout[rail];
+	}
+
+	switch (cfg->type) {
+	case sensor_dev_isl69259:
+		if (!isl69260_set_vout_command(cfg, pre_proc_args->vr_page, millivolt)) {
+			LOG_ERR("The VR ISL69260 vout setting failed");
+			goto err;
+		}
+		break;
+	case sensor_dev_mp2971:
+		if (!mp2971_set_vout_command(cfg, pre_proc_args->vr_page, millivolt)) {
+			LOG_ERR("The VR MPS2971 vout setting failed");
+			goto err;
+		}
+		break;
+	case sensor_dev_mp29816a:
+		if (!mp29816a_set_vout_command(cfg, pre_proc_args->vr_page, millivolt)) {
+			LOG_ERR("The VR MPS29816a vout setting failed");
+			goto err;
+		}
+		break;
+	case sensor_dev_raa228249:
+		if (!raa228249_set_vout_command(cfg, pre_proc_args->vr_page, millivolt)) {
+			LOG_ERR("The VR RAA228249 vout setting failed");
+			goto err;
+		}
+		break;
+	default:
+		LOG_ERR("Unsupport VR type(%x)", cfg->type);
+		goto err;
+	}
+
+	if (is_perm) {
+		user_settings.vout[rail] = *millivolt;
+		vr_vout_user_settings_set(&user_settings);
+	}
+
+	ret = true;
+err:
+	if (cfg->post_sensor_read_hook) {
+		if (cfg->post_sensor_read_hook(cfg, cfg->post_sensor_read_args, NULL) == false) {
+			LOG_ERR("sensor id: 0x%x post-read fail", sensor_id);
+		}
+	}
+	return ret;
+}
+
+#define PLAT_VOUT_GET_SET_HANDLER(get_set, min_max)                                                \
+	bool plat_##get_set##_vout_##min_max(uint8_t rail, uint16_t *millivolt)                    \
+	{                                                                                          \
+		CHECK_NULL_ARG_WITH_RETURN(millivolt, false);                                      \
+                                                                                                   \
+		bool ret = false;                                                                  \
+                                                                                                   \
+		uint8_t sensor_id = vr_rail_table[rail].sensor_id;                                 \
+                                                                                                   \
+		sensor_cfg *cfg = get_sensor_cfg_by_sensor_id(sensor_id);                          \
+                                                                                                   \
+		if (cfg == NULL) {                                                                 \
+			LOG_ERR("Failed to get sensor config for sensor 0x%x", sensor_id);         \
+			return false;                                                              \
+		}                                                                                  \
+                                                                                                   \
+		vr_pre_proc_arg *pre_proc_args = vr_pre_read_args + rail;                          \
+                                                                                                   \
+		if (cfg->pre_sensor_read_hook) {                                                   \
+			if (!cfg->pre_sensor_read_hook(cfg, cfg->pre_sensor_read_args)) {          \
+				goto err;                                                          \
+			}                                                                          \
+		}                                                                                  \
+                                                                                                   \
+		switch (cfg->type) {                                                               \
+		case sensor_dev_mp2971:                                                            \
+			if (!mp2971_##get_set##_vout_##min_max(cfg, pre_proc_args->vr_page,        \
+							       millivolt)) {                       \
+				LOG_ERR("The VR MPS2971 vout reading failed");                     \
+				goto err;                                                          \
+			}                                                                          \
+			break;                                                                     \
+		case sensor_dev_mp29816a:                                                          \
+			if (!mp29816a_##get_set##_vout_##min_max(cfg, pre_proc_args->vr_page,      \
+								 millivolt)) {                     \
+				LOG_ERR("The VR MPS29816a vout reading failed");                   \
+				goto err;                                                          \
+			}                                                                          \
+			break;                                                                     \
+		case sensor_dev_isl69259:                                                          \
+			if (!isl69260_##get_set##_vout_##min_max(cfg, pre_proc_args->vr_page,      \
+								 millivolt)) {                     \
+				LOG_ERR("The VR ISL69260 vout reading failed");                    \
+				goto err;                                                          \
+			}                                                                          \
+			break;                                                                     \
+		case sensor_dev_raa228249:                                                         \
+			if (!raa228249_##get_set##_vout_##min_max(cfg, pre_proc_args->vr_page,     \
+								  millivolt)) {                    \
+				LOG_ERR("The VR RAA228249 vout reading failed");                   \
+				goto err;                                                          \
+			}                                                                          \
+			break;                                                                     \
+		default:                                                                           \
+			LOG_ERR("Unsupport VR type(%x)", cfg->type);                               \
+			goto err;                                                                  \
+		}                                                                                  \
+                                                                                                   \
+		ret = true;                                                                        \
+                                                                                                   \
+	err:                                                                                       \
+		if (cfg->post_sensor_read_hook) {                                                  \
+			if (cfg->post_sensor_read_hook(cfg, cfg->post_sensor_read_args, NULL) ==   \
+			    false) {                                                               \
+				LOG_ERR("sensor id: 0x%x post-read fail", sensor_id);              \
+			}                                                                          \
+		}                                                                                  \
+		return ret;                                                                        \
+	}
+
+PLAT_VOUT_GET_SET_HANDLER(get, min);
+PLAT_VOUT_GET_SET_HANDLER(get, max);
+PLAT_VOUT_GET_SET_HANDLER(set, min);
+PLAT_VOUT_GET_SET_HANDLER(set, max);
+
+#undef PLAT_VOUT_GET_SET_HANDLER

--- a/meta-facebook/minerva-ag/src/platform/plat_hook.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.c
@@ -43,9 +43,17 @@ static struct k_mutex vr_mutex[VR_MAX_NUM];
 	}
 
 vr_pre_proc_arg vr_pre_read_args[] = {
-	// mutex, vr_page
-
-	FOR_EACH (VR_PRE_READ_ARG, (, ), 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+	{ .mutex = vr_mutex + 0, .vr_page = 0x0 },  { .mutex = vr_mutex + 0, .vr_page = 0x1 },
+	{ .mutex = vr_mutex + 1, .vr_page = 0x0 },  { .mutex = vr_mutex + 1, .vr_page = 0x1 },
+	{ .mutex = vr_mutex + 2, .vr_page = 0x0 },  { .mutex = vr_mutex + 2, .vr_page = 0x1 },
+	{ .mutex = vr_mutex + 3, .vr_page = 0x0 },  { .mutex = vr_mutex + 3, .vr_page = 0x1 },
+	{ .mutex = vr_mutex + 4, .vr_page = 0x0 },  { .mutex = vr_mutex + 4, .vr_page = 0x1 },
+	{ .mutex = vr_mutex + 5, .vr_page = 0x0 },  { .mutex = vr_mutex + 5, .vr_page = 0x1 },
+	{ .mutex = vr_mutex + 6, .vr_page = 0x0 },  { .mutex = vr_mutex + 6, .vr_page = 0x1 },
+	{ .mutex = vr_mutex + 7, .vr_page = 0x0 },  { .mutex = vr_mutex + 7, .vr_page = 0x1 },
+	{ .mutex = vr_mutex + 8, .vr_page = 0x0 },  { .mutex = vr_mutex + 8, .vr_page = 0x1 },
+	{ .mutex = vr_mutex + 9, .vr_page = 0x0 },  { .mutex = vr_mutex + 9, .vr_page = 0x1 },
+	{ .mutex = vr_mutex + 10, .vr_page = 0x0 }, { .mutex = vr_mutex + 10, .vr_page = 0x1 }
 };
 
 mp2971_init_arg mp2971_init_args[] = {

--- a/meta-facebook/minerva-ag/src/platform/plat_hook.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.h
@@ -22,6 +22,8 @@
 #define VR_MAX_NUM 11
 #define VR_MUTEX_LOCK_TIMEOUT_MS 1000
 
+#include "plat_pldm_sensor.h"
+
 enum VR_INDEX_E {
 	VR_INDEX_E_OSFP_P3V3 = 0,
 	VR_INDEX_E_P0V85,
@@ -37,6 +39,38 @@ enum VR_INDEX_E {
 	VR_INDEX_MAX,
 };
 
+enum VR_RAIL_E {
+	VR_RAIL_E_OSFP_P3V3 = 0,
+	VR_RAIL_E_P0V85,
+	VR_RAIL_E_P0V75_PVDD_CH_N,
+	VR_RAIL_E_P0V75_MAX_PHY_N,
+	VR_RAIL_E_P0V75_PVDD_CH_S,
+	VR_RAIL_E_P0V75_MAX_PHY_S,
+	VR_RAIL_E_P0V75_TRVDD_ZONEA,
+	VR_RAIL_E_P1V8_VPP_HBM0_2_4,
+	VR_RAIL_E_P0V75_TRVDD_ZONEB,
+	VR_RAIL_E_P0V4_VDDQL_HBM0_2_4,
+	VR_RAIL_E_P1V1_VDDC_HBM0_2_4,
+	VR_RAIL_E_P0V75_VDDPHY_HBM0_2_4,
+	VR_RAIL_E_P0V9_TRVDD_ZONEA,
+	VR_RAIL_E_P1V8_VPP_HBM1_3_5,
+	VR_RAIL_E_P0V9_TRVDD_ZONEB,
+	VR_RAIL_E_P0V4_VDDQL_HBM1_3_5,
+	VR_RAIL_E_P1V1_VDDC_HBM1_3_5,
+	VR_RAIL_E_P0V75_VDDPHY_HBM1_3_5,
+	VR_RAIL_E_P0V8_VDDA_PCIE,
+	VR_RAIL_E_P1V2_VDDHTX_PCIE,
+	VR_RAIL_E_MAX,
+};
+
+typedef struct vr_mapping_sensor {
+	uint8_t index;
+	uint8_t sensor_id;
+	uint8_t *sensor_name;
+} vr_mapping_sensor;
+
+extern vr_mapping_sensor vr_rail_table[];
+
 typedef struct _vr_pre_proc_arg {
 	void *mutex;
 	uint8_t vr_page;
@@ -46,10 +80,20 @@ extern vr_pre_proc_arg vr_pre_read_args[];
 extern mp2971_init_arg mp2971_init_args[];
 extern isl69259_init_arg isl69259_init_args[];
 
+bool plat_get_vout_min(uint8_t rail, uint16_t *millivolt);
+bool plat_get_vout_max(uint8_t rail, uint16_t *millivolt);
+bool plat_set_vout_min(uint8_t rail, uint16_t *millivolt);
+bool plat_set_vout_max(uint8_t rail, uint16_t *millivolt);
 bool pre_vr_read(sensor_cfg *cfg, void *args);
 bool post_vr_read(sensor_cfg *cfg, void *args, int *reading);
 bool is_mb_dc_on();
 void *vr_mutex_get(enum VR_INDEX_E vr_index);
 void vr_mutex_init(void);
+bool vr_rail_name_get(uint8_t rail, uint8_t **name);
+bool vr_rail_enum_get(uint8_t *name, uint8_t *num);
+bool vr_vout_user_settings_get(void *user_settings);
+void user_settings_init(void);
+bool plat_get_vout_command(uint8_t rail, uint16_t *millivolt);
+bool plat_set_vout_command(uint8_t rail, uint16_t *millivolt, bool is_default, bool is_perm);
 
 #endif

--- a/meta-facebook/minerva-ag/src/platform/plat_init.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_init.c
@@ -48,7 +48,6 @@ void pal_pre_init()
 				index, (struct _i2c_target_config *)&I2C_TARGET_CONFIG_TABLE[index],
 				1);
 	}
-
 	init_platform_config();
 	plat_led_init();
 	vr_mutex_init();
@@ -64,6 +63,7 @@ void pal_set_sys_status()
 void pal_post_init()
 {
 	plat_mctp_init();
+	user_settings_init();
 	pldm_load_state_effecter_table(MAX_STATE_EFFECTER_IDX);
 	pldm_assign_gpio_effecter_id(PLAT_EFFECTER_ID_GPIO_HIGH_BYTE);
 	init_load_eeprom_log();

--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.c
@@ -9535,6 +9535,38 @@ bool get_sensor_info_by_sensor_id(uint8_t sensor_id, uint8_t *vr_bus, uint8_t *v
 	return false;
 }
 
+sensor_cfg *get_sensor_cfg_by_sensor_id(uint8_t sensor_id)
+{
+	int pldm_sensor_count = 0;
+
+	if (sensor_id >= SENSOR_NUM_UBC_1_TEMP_C && sensor_id <= SENSOR_NUM_UBC_2_P12V_PWR_W) {
+		pldm_sensor_count = plat_pldm_sensor_get_sensor_count(UBC_SENSOR_THREAD_ID);
+		for (int index = 0; index < pldm_sensor_count; index++) {
+			if (plat_pldm_sensor_ubc_table[index].pldm_sensor_cfg.num == sensor_id) {
+				return &plat_pldm_sensor_ubc_table[index].pldm_sensor_cfg;
+			}
+		}
+	} else if (sensor_id >= SENSOR_NUM_TOP_INLET_TEMP_C &&
+		   sensor_id <= SENSOR_NUM_ON_DIE_4_TEMP_C) {
+		pldm_sensor_count = plat_pldm_sensor_get_sensor_count(TEMP_SENSOR_THREAD_ID);
+		for (int index = 0; index < pldm_sensor_count; index++) {
+			if (plat_pldm_sensor_temp_table[index].pldm_sensor_cfg.num == sensor_id) {
+				return &plat_pldm_sensor_temp_table[index].pldm_sensor_cfg;
+			}
+		}
+	} else if (sensor_id >= SENSOR_NUM_OSFP_P3V3_TEMP_C &&
+		   sensor_id <= SENSOR_NUM_CPU_P1V2_VDDHTX_PCIE_PWR_W) {
+		pldm_sensor_count = plat_pldm_sensor_get_sensor_count(VR_SENSOR_THREAD_ID);
+		for (int index = 0; index < pldm_sensor_count; index++) {
+			if (plat_pldm_sensor_vr_table[index].pldm_sensor_cfg.num == sensor_id) {
+				return &plat_pldm_sensor_vr_table[index].pldm_sensor_cfg;
+			}
+		}
+	}
+
+	return NULL;
+}
+
 bool is_osfp_3v3_access(uint8_t sensor_num)
 {
 	/* OSFP 3V3 is only accessible on EVB */

--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_sensor.h
@@ -18,6 +18,7 @@
 #define PLAT_PLDM_SENSOR_H
 
 #include "pdr.h"
+#include "sensor.h"
 #define ADDR_UNKNOWN (0xFF >> 1)
 
 /* Define sensors address(7 bit) */
@@ -230,6 +231,7 @@ enum GET_VR_DEV_STATUS {
 };
 
 int plat_pldm_sensor_get_sensor_count(int thread_id);
+sensor_cfg *get_sensor_cfg_by_sensor_id(uint8_t sensor_id);
 void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
 					     PDR_numeric_sensor *numeric_sensor_table);
 uint8_t plat_pldm_sensor_get_vr_dev(uint8_t *vr_dev);

--- a/meta-facebook/minerva-ag/src/shell/plat_voltage_range_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_voltage_range_shell.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <shell/shell.h>
+#include <stdlib.h>
+#include <logging/log.h>
+#include "sensor.h"
+#include "plat_hook.h"
+#include "plat_class.h"
+
+LOG_MODULE_REGISTER(plat_voltage_range_shell, LOG_LEVEL_DBG);
+
+static int cmd_voltage_range_get(const struct shell *shell, size_t argc, char **argv)
+{
+	if (!((argc == 2) || (argc == 3))) {
+		shell_error(shell, "voltage_range get all");
+		shell_error(shell, "voltage_range get <voltage-rail> min|max");
+		return -1;
+	}
+
+	if ((argc == 2)) {
+		if (!strcmp(argv[1], "all")) {
+			/* print all range */
+			for (int i = 0; i < VR_RAIL_E_MAX; i++) {
+				if ((get_board_type() == MINERVA_AEGIS_BD) && (i == 0))
+					continue;
+
+				uint8_t *rail_name = NULL;
+				if (!vr_rail_name_get((uint8_t)i, &rail_name)) {
+					shell_print(shell,
+						    "Can't find vr_rail_name by rail index: %d", i);
+					continue;
+				}
+
+				uint16_t millivolt = 0xFFFF;
+				plat_get_vout_min(i, &millivolt);
+				shell_print(shell, "%-40s vout min: %dmV", rail_name, millivolt);
+				plat_get_vout_max(i, &millivolt);
+				shell_print(shell, "%-40s vout max: %dmV", rail_name, millivolt);
+			}
+			return 0;
+		} else {
+			shell_error(shell, "voltage_range get all");
+			shell_error(shell, "voltage_range get <voltage-rail> min|max");
+			return -1;
+		}
+	}
+
+	/* covert rail string to enum */
+	enum VR_RAIL_E rail;
+	if (vr_rail_enum_get(argv[1], &rail) == false) {
+		shell_error(shell, "Invalid rail name: %s", argv[1]);
+		return -1;
+	}
+
+	if ((get_board_type() == MINERVA_AEGIS_BD) && (rail == 0)) {
+		shell_print(shell, "There is no osfp p3v3 on AEGIS BD");
+		return 0;
+	}
+
+	uint16_t millivolt = 0xFFFF;
+
+	if (!strcmp(argv[2], "min")) {
+		/*get min range*/
+		plat_get_vout_min(rail, &millivolt);
+
+	} else if (!strcmp(argv[2], "max")) {
+		/*get max range*/
+		plat_get_vout_max(rail, &millivolt);
+	} else {
+		shell_error(shell, "voltage_range get all");
+		shell_error(shell, "voltage_range get <voltage-rail> min|max");
+		return -1;
+	}
+
+	shell_print(shell, "voltage_range get %s %s: %dmV", argv[1], argv[2], millivolt);
+
+	return 0;
+}
+
+static int cmd_voltage_range_set(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc != 4) {
+		shell_error(shell, "voltage_range set <voltage-rail> <new-voltage> min|max");
+		return -1;
+	}
+
+	/* covert rail string to enum */
+	enum VR_RAIL_E rail;
+	if (vr_rail_enum_get(argv[1], &rail) == false) {
+		shell_error(shell, "Invalid rail name: %s", argv[1]);
+		return -1;
+	}
+
+	if ((get_board_type() == MINERVA_AEGIS_BD) && (rail == 0)) {
+		shell_print(shell, "There is no osfp p3v3 on AEGIS BD");
+		return 0;
+	}
+
+	/* covert voltage to millivolt */
+	uint16_t voltage_set_val_mv = strtol(argv[2], NULL, 0);
+
+	uint16_t voltage_set_val_mv_backup = voltage_set_val_mv;
+
+	if (!strcmp(argv[3], "min")) {
+		/*set min range*/
+		if (!plat_set_vout_min(rail, &voltage_set_val_mv)) {
+			shell_error(shell, "voltage_range set %s %s: %dmV failed", argv[1], argv[2],
+				    voltage_set_val_mv_backup);
+			return -1;
+		}
+		shell_print(shell, "voltage_range set %s %s: %dmV , backup: %dmV", argv[1], argv[2],
+			    voltage_set_val_mv, voltage_set_val_mv_backup);
+	} else if (!strcmp(argv[3], "max")) {
+		/*set max range*/
+		if (!plat_set_vout_max(rail, &voltage_set_val_mv)) {
+			shell_error(shell, "voltage_range set %s %s: %dmV failed", argv[1], argv[2],
+				    voltage_set_val_mv_backup);
+			return -1;
+		}
+		shell_print(shell, "voltage_range set %s %s: %dmV , backup: %dmV", argv[1], argv[2],
+			    voltage_set_val_mv, voltage_set_val_mv_backup);
+	} else {
+		shell_error(shell, "voltage_range set <voltage-rail> <new-voltage> min|max");
+		return -1;
+	}
+
+	return 0;
+}
+
+static void vr_rname_get_for_get_voltrage(size_t idx, struct shell_static_entry *entry)
+{
+	if ((get_board_type() == MINERVA_AEGIS_BD))
+		idx++;
+
+	uint8_t *name = NULL;
+	vr_rail_name_get((uint8_t)idx, &name);
+
+	if (idx == VR_RAIL_E_MAX)
+		name = (uint8_t *)"all";
+
+	entry->syntax = (name) ? (const char *)name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}
+
+static void vr_rname_get_for_set_voltrage(size_t idx, struct shell_static_entry *entry)
+{
+	if ((get_board_type() == MINERVA_AEGIS_BD))
+		idx++;
+
+	uint8_t *name = NULL;
+	vr_rail_name_get((uint8_t)idx, &name);
+
+	entry->syntax = (name) ? (const char *)name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}
+
+SHELL_DYNAMIC_CMD_CREATE(vr_rname_for_get_voltrage, vr_rname_get_for_get_voltrage);
+SHELL_DYNAMIC_CMD_CREATE(vr_rname_for_set_voltrage, vr_rname_get_for_set_voltrage);
+
+/* level 1 */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_voltage_range_cmds,
+			       SHELL_CMD(get, &vr_rname_for_get_voltrage,
+					 "get all|<voltage-rail> min|max", cmd_voltage_range_get),
+			       SHELL_CMD(set, &vr_rname_for_set_voltrage,
+					 "set <voltage-rail> <new-voltage> min|max",
+					 cmd_voltage_range_set),
+			       SHELL_SUBCMD_SET_END);
+
+/* Root of command test */
+SHELL_CMD_REGISTER(voltage_range, &sub_voltage_range_cmds, "voltage_range set/get commands", NULL);

--- a/meta-facebook/minerva-ag/src/shell/plat_voltage_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_voltage_shell.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <shell/shell.h>
+#include <stdlib.h>
+#include <logging/log.h>
+#include "sensor.h"
+#include "plat_hook.h"
+#include "plat_class.h"
+
+LOG_MODULE_REGISTER(plat_voltage_shell, LOG_LEVEL_DBG);
+
+static int cmd_voltage_get_all(const struct shell *shell, size_t argc, char **argv)
+{
+	shell_print(shell, "  id|              sensor_name               |vout(mV) ");
+	/* list all vr sensor value */
+	for (int i = 0; i < VR_RAIL_E_MAX; i++) {
+		if ((get_board_type() == MINERVA_AEGIS_BD) && (i == 0))
+			continue; // skip osfp p3v3 on AEGIS BD
+
+		uint16_t vout = 0;
+		uint8_t *rail_name = NULL;
+		if (!vr_rail_name_get((uint8_t)i, &rail_name)) {
+			shell_print(shell, "Can't find vr_rail_name by rail index: %d", i);
+			continue;
+		}
+
+		if (!plat_get_vout_command(i, &vout)) {
+			shell_print(shell, "Can't find vout by rail index: %d", i);
+			continue;
+		}
+
+		shell_print(shell, "%4d|%-40s|%4d", i, rail_name, vout);
+	}
+
+	return 0;
+}
+
+static int cmd_voltage_set(const struct shell *shell, size_t argc, char **argv)
+{
+	bool is_default = false;
+	bool is_perm = false;
+
+	if (argc == 4) {
+		if (!strcmp(argv[3], "perm")) {
+			is_perm = true;
+		} else {
+			shell_error(shell, "The last argument must be <perm>");
+			return -1;
+		}
+	}
+
+	/* covert rail string to enum */
+	enum VR_RAIL_E rail;
+	if (vr_rail_enum_get(argv[1], &rail) == false) {
+		shell_error(shell, "Invalid rail name: %s", argv[1]);
+		return -1;
+	}
+
+	uint16_t millivolt = strtol(argv[2], NULL, 0);
+	if (!strcmp(argv[2], "default")) {
+		is_default = true;
+		shell_info(shell, "Set %s(%d) to default, %svolatile\n", argv[1], rail,
+			   (argc == 4) ? "non-" : "");
+	} else {
+		shell_info(shell, "Set %s(%d) to %d mV, %svolatile\n", argv[1], rail, millivolt,
+			   (argc == 4) ? "non-" : "");
+	}
+
+	/* set the vout */
+	if ((get_board_type() == MINERVA_AEGIS_BD) && (rail == 0)) {
+		shell_print(shell, "There is no osfp p3v3 on AEGIS BD");
+		return 0;
+	}
+	if (!plat_set_vout_command(rail, &millivolt, is_default, is_perm)) {
+		shell_print(shell, "Can't set vout by rail index: %d", rail);
+		return -1;
+	}
+
+	return 0;
+}
+
+static void voltage_rname_get(size_t idx, struct shell_static_entry *entry)
+{
+	if ((get_board_type() == MINERVA_AEGIS_BD))
+		idx++;
+
+	uint8_t *name = NULL;
+	vr_rail_name_get((uint8_t)idx, &name);
+
+	entry->syntax = (name) ? (const char *)name : NULL;
+	entry->handler = NULL;
+	entry->help = NULL;
+	entry->subcmd = NULL;
+}
+
+SHELL_DYNAMIC_CMD_CREATE(voltage_rname, voltage_rname_get);
+
+/* level 2 */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_voltage_get_cmds,
+			       SHELL_CMD(all, NULL, "get voltage all vout command",
+					 cmd_voltage_get_all),
+			       SHELL_SUBCMD_SET_END);
+
+/* level 1 */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_voltage_cmds,
+			       SHELL_CMD(get, &sub_voltage_get_cmds, "get voltage all", NULL),
+			       SHELL_CMD_ARG(set, &voltage_rname,
+					     "set <voltage-rail> <new-voltage>|default [perm]",
+					     cmd_voltage_set, 3, 1),
+			       SHELL_SUBCMD_SET_END);
+
+/* Root of command test */
+SHELL_CMD_REGISTER(voltage, &sub_voltage_cmds, "voltage set/get commands", NULL);


### PR DESCRIPTION
Summary:
- Support Vout set/get command
- Support Vout range set/get command
- Add mp2971 mp29816a isl69260 raa228249 vout settings API

Test Plan:
- Build code: PASS
- Vout set/get: PASS
- Vout range set/get: PASS