### PR TITLE
fby35: cl: fix i3c by enable hot-join

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.c
@@ -25,6 +25,7 @@
 #include "libutil.h"
 #include "plat_gpio.h"
 #include "plat_i2c.h"
+#include "plat_i3c.h"
 #include "plat_sensor_table.h"
 
 #include <logging/log.h>
@@ -442,5 +443,10 @@ void init_platform_config()
 			}
 		}
 	}
+
+	I3C_MSG i3c_msg;
+	i3c_msg.bus = I3C_BUS_BMC;
+	i3c_set_pid(&i3c_msg, I3C_BUS0_PID);
+
 	SAFE_FREE(data);
 }

--- a/meta-facebook/yv35-cl/src/platform/plat_i3c.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_i3c.h
@@ -20,5 +20,16 @@
 #include "hal_i3c.h"
 
 #define I3C_BUS4 3
+/* i3c 8-bit addr */
+#define I3C_STATIC_ADDR_BIC 0x40
+#define I3C_STATIC_ADDR_BMC 0x20
+
+/* i3c dev bus */
+#define I3C_BUS_BMC 0
+
+#define I3C_BUS0_PID 0
+
+/* mctp endpoint */
+#define MCTP_EID_BMC 0x01
 
 #endif

--- a/meta-facebook/yv35-cl/src/platform/plat_mctp.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_mctp.c
@@ -19,20 +19,9 @@
 #include "sensor.h"
 #include "plat_hook.h"
 #include "plat_ipmb.h"
-
-#include "hal_i3c.h"
+#include "plat_i3c.h"
 
 LOG_MODULE_REGISTER(plat_mctp);
-
-/* i3c 8-bit addr */
-#define I3C_STATIC_ADDR_BIC 0x40
-#define I3C_STATIC_ADDR_BMC 0x20
-
-/* i3c dev bus */
-#define I3C_BUS_BMC 0
-
-/* mctp endpoint */
-#define MCTP_EID_BMC 0x01
 
 K_TIMER_DEFINE(send_cmd_timer, send_cmd_to_dev, NULL);
 K_WORK_DEFINE(send_cmd_work, send_cmd_to_dev_handler);


### PR DESCRIPTION
# Description
As title.

# Motivation
Fix I3C handshake between BMC and BIC

# Test plan
Build and test pass on fby35.

1. Get BIC version successfully root@bmc-oob:~# fw-util slot1  --version
1OU Bridge-IC Version: oby35-vf-v2023.40.01
SB Bridge-IC Version: oby35-cl-v2024.51.01