### PR TITLE
minerva-ag: Add sensor name for printing sensor threshold shell command

### DIFF
--- a/meta-facebook/minerva-ag/src/shell/sensor_threshold_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/sensor_threshold_shell.c
@@ -30,12 +30,14 @@ void cmd_set_sensor_threshold(const struct shell *shell, size_t argc, char **arg
 		return;
 	}
 
+	uint32_t sensor_max_count = 0;
+	sensor_max_count = plat_get_pdr_size(PLDM_NUMERIC_SENSOR_PDR);
+
 	int sensorID = strtol(argv[1], NULL, 16);
 
-	if (sensorID < SENSOR_NUM_UBC_1_TEMP_C ||
-	    sensorID > SENSOR_NUM_CPU_P1V2_VDDHTX_PCIE_PWR_W) {
-		shell_error(shell, "Help: Sensor ID: 0x%x is higher than 0x62 or lower than 0x1",
-			    sensorID);
+	if (sensorID < SENSOR_NUM_UBC_1_TEMP_C || sensorID > sensor_max_count) {
+		shell_error(shell, "Help: Sensor ID: 0x%x is higher than 0x%x or lower than 0x1",
+			    sensorID, sensor_max_count);
 		return;
 	}
 
@@ -90,11 +92,13 @@ void cmd_get_sensor_threshold(const struct shell *shell, size_t argc, char **arg
 	float critical_low = 0;
 	int result = 0;
 
+	uint32_t sensor_max_count = 0;
+	sensor_max_count = plat_get_pdr_size(PLDM_NUMERIC_SENSOR_PDR);
+
 	snprintf(threshold_all, sizeof(threshold_all), "%s", argv[1]);
 
 	if (strcmp(threshold_all, "All") == 0 || strcmp(threshold_all, "all") == 0) {
-		for (int i = SENSOR_NUM_UBC_1_TEMP_C; i <= SENSOR_NUM_CPU_P1V2_VDDHTX_PCIE_PWR_W;
-		     i++) {
+		for (int i = SENSOR_NUM_UBC_1_TEMP_C; i <= sensor_max_count; i++) {
 			result = check_supported_threshold_with_sensor_id(i);
 			if (result == 0) {
 				char sensor_name[MAX_AUX_SENSOR_NAME_LEN] = { 0 };
@@ -111,16 +115,14 @@ void cmd_get_sensor_threshold(const struct shell *shell, size_t argc, char **arg
 					i, sensor_name, critical_high, critical_low);
 				critical_high = 0;
 				critical_low = 0;
-				memset(sensor_name, 0, sizeof(sensor_name));
 			}
 		}
 	} else {
 		int sensorID = strtol(argv[1], NULL, 16);
 
-		if (sensorID < SENSOR_NUM_UBC_1_TEMP_C ||
-		    sensorID > SENSOR_NUM_CPU_P1V2_VDDHTX_PCIE_PWR_W) {
-			shell_error(shell, "Sensor ID 0x%x is higher than 0x62 or lower than 0x1",
-				    sensorID);
+		if (sensorID < SENSOR_NUM_UBC_1_TEMP_C || sensorID > sensor_max_count) {
+			shell_error(shell, "Sensor ID 0x%x is higher than 0x%x or lower than 0x1",
+				    sensorID, sensor_max_count);
 			return;
 		}
 

--- a/meta-facebook/minerva-ag/src/shell/sensor_threshold_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/sensor_threshold_shell.c
@@ -69,9 +69,11 @@ void cmd_set_sensor_threshold(const struct shell *shell, size_t argc, char **arg
 		}
 	} else {
 		shell_error(shell, "Help: Need to send <UCT/LCT>");
+		return;
 	}
 
-	shell_print(shell, "sensor_threshold set <sensor ID> <UCT/LCT> <value> success!");
+	shell_print(shell, "sensor_threshold set 0x%x %s %d success!", sensorID, threshold_type,
+		    value);
 
 	return;
 }
@@ -95,14 +97,21 @@ void cmd_get_sensor_threshold(const struct shell *shell, size_t argc, char **arg
 		     i++) {
 			result = check_supported_threshold_with_sensor_id(i);
 			if (result == 0) {
+				char sensor_name[MAX_AUX_SENSOR_NAME_LEN] = { 0 };
+
 				get_pdr_table_critical_high_and_low_with_sensor_id(
 					i, &critical_high, &critical_low);
+
+				pldm_get_sensor_name_via_sensor_id(i, sensor_name,
+								   sizeof(sensor_name));
+
 				shell_print(
 					shell,
-					"sensor ID: 0x%x  |  critical high: %10.3f  |  critical low: %10.3f",
-					i, critical_high, critical_low);
+					"sensor ID: 0x%x  |  sensor name: %-40s  |  critical high: %10.3f  |  critical low: %10.3f",
+					i, sensor_name, critical_high, critical_low);
 				critical_high = 0;
 				critical_low = 0;
+				memset(sensor_name, 0, sizeof(sensor_name));
 			}
 		}
 	} else {
@@ -125,11 +134,16 @@ void cmd_get_sensor_threshold(const struct shell *shell, size_t argc, char **arg
 			sensorID, &critical_high, &critical_low);
 		if (result != 0) {
 			shell_error(shell, "Get sensor threshold failed");
+			return;
 		}
 
-		shell_print(shell,
-			    "sensor ID: 0x%x  |  critical high: %10.3f  |  critical low: %10.3f",
-			    sensorID, critical_high, critical_low);
+		char sensor_name[MAX_AUX_SENSOR_NAME_LEN] = { 0 };
+		pldm_get_sensor_name_via_sensor_id(sensorID, sensor_name, sizeof(sensor_name));
+
+		shell_print(
+			shell,
+			"sensor ID: 0x%x  |  sensor name: %-40s  |  critical high: %10.3f  |  critical low: %10.3f",
+			sensorID, sensor_name, critical_high, critical_low);
 	}
 
 	return;


### PR DESCRIPTION
Summary:
- Add sensor name for printing sensor threshold shell command

TestPlan:
- BuildCode: PASS
- When get sensor threshold, it will show sensor name: PASS

Log:
```
uart:~$ sensor_threshold set 1 LCT 600
sensor_threshold set 0x1 LCT 600 success!

uart:~$ sensor_threshold get 1
sensor ID: 0x1  |  sensor name:   UBC_1_TEMP_C  |  critical high:      9.900  |  critical low:      0.600
```