### PR TITLE
minerva-ag: Fix get vr fw version display

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_fw_update.c
@@ -573,10 +573,11 @@ static bool get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 	memcpy(buf_p, vr_name_p, strlen(vr_name_p));
 	buf_p += strlen(vr_name_p);
 
-	if (sensor_dev == sensor_dev_mp2891 || sensor_dev == sensor_dev_mp29816a)
+	if (sensor_dev == sensor_dev_mp2891 || sensor_dev == sensor_dev_mp29816a) {
 		*len += bin2hex((uint8_t *)&version, 2, buf_p, 4) + strlen(vr_name_p);
-	else if (sensor_dev == sensor_dev_isl69259 || sensor_dev == sensor_dev_raa228238 ||
-		 sensor_dev == sensor_dev_raa228249 || sensor_dev == sensor_dev_mp2971)
+		*len += 4;
+	} else if (sensor_dev == sensor_dev_isl69259 || sensor_dev == sensor_dev_raa228238 ||
+		   sensor_dev == sensor_dev_raa228249 || sensor_dev == sensor_dev_mp2971)
 		*len += bin2hex((uint8_t *)&version, 4, buf_p, 8) + strlen(vr_name_p);
 	else
 		LOG_ERR("Unsupport VR type(%d)", type);
@@ -589,6 +590,11 @@ static bool get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 		remain = (uint8_t)((remain % 10) | (remain / 10 << 4));
 		*len += bin2hex((uint8_t *)&remain, 1, buf_p, 2) + strlen(remain_str_p);
 		buf_p += 2;
+	} else {
+		memcpy(buf_p, remain_str_p, strlen(remain_str_p));
+		buf_p += strlen(remain_str_p);
+		*len += bin2hex((uint8_t *)&remain, 2, buf_p, 4) + strlen(remain_str_p);
+		buf_p += 4;
 	}
 
 	ret = true;


### PR DESCRIPTION
Summary:
- Modify get_vr_fw_version function to let BMC display remaining write when it is 0xFFFF

Test Plan:
- Build code: PASS