### PR TITLE
common: patch: i3c: Check work null before init

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0086-i3c-aspeed-Check-work-null-before-init.patch
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0086-i3c-aspeed-Check-work-null-before-init.patch
@@ -1,0 +1,27 @@
+From b57248317b09c75b3dc1cefd6f565974554613f6 Mon Sep 17 00:00:00 2001
+From: Sara Lin <sara_sy_lin@wiwynn.com>
+Date: Mon, 23 Dec 2024 10:34:33 +0800
+Subject: [PATCH] i3c: aspeed: Check work null before init
+
+Check work status before execute work init.
+---
+ drivers/i3c/i3c_aspeed.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 6900effd21..89369d6c1e 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -2172,7 +2172,8 @@ static int i3c_aspeed_init(const struct device *dev)
+ 			}
+ 		}
+ 		obj->sir_allowed_by_sw = 0;
+-		k_work_init(&obj->work, sir_allowed_worker);
++		if (!obj->work.handler)
++			k_work_init(&obj->work, sir_allowed_worker);
+ 	} else {
+ 		union i3c_device_addr_s reg;
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
# Description
- Check work pointer before execute work init function.

# Motivation
- I3C Controller reset might lead to I3C target crash.

# Test Plan
- Build code: Pass
- Reset and check communicate is work: 1523 run pass
