### PR TITLE
yv4: sd: Adjust ADC PVDD11 S3 threshold voltage

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -846,8 +846,8 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00000000, //uint32_t normal_min;
 			0x00000000, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000074, //uint32_t critical_high;
-			0x00000067, //uint32_t critical_low;
+			0x00000076, //uint32_t critical_high;
+			0x00000066, //uint32_t critical_low;
 			0x00000000, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 		},


### PR DESCRIPTION
# Description:
- Adjust ADC PVDD11 S3 threshold voltage for tolerance.

# Motivation:
- It triggers MB_ADC_PVDD11_S3_VOLT_V critical high alert, after running DIMM stress test.

# Test plan
- Build code: Pass
- Check sensor critical value: Pass

# Test Log

root@bmc:~# mfg-tool sensor-display
...
"SENTINEL_DOME_SLOT_1_MB_ADC_PVDD11_S3_VOLT_V": {
        "critical": {
            "high": 1.18,
            "low": 1.02
        },
        "max": 1.16,
        "min": 1.05,
        "status": "ok",
        "unit": "Volts",
        "value": 1.09
    },