### PR TITLE
minerva-ag: Modify ubc delayed detection

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_event.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_event.c
@@ -78,15 +78,8 @@ void check_ubc_delayed(struct k_timer *timer)
 	 * 0 -> UBC is disabled
 	 */
 	bool is_ubc_enabled = (gpio_get(FM_PLD_UBC_EN_R) == GPIO_HIGH);
-	bool is_dc_on = is_mb_dc_on();
 
-	if (is_ubc_enabled != is_dc_on) {
-		error_log_event(is_ubc_enabled ? DC_ON_STATUS_FAULT : DC_OFF_STATUS_FAULT,
-				LOG_ASSERT);
-		set_dc_status_changing_status(false);
-		return;
-	}
-
+	set_dc_status_changing_status(false);
 	ubc_enabled_delayed_status = is_ubc_enabled;
 }
 

--- a/meta-facebook/minerva-ag/src/shell/plat_voltage_range_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_voltage_range_shell.c
@@ -122,8 +122,8 @@ static int cmd_voltage_range_set(const struct shell *shell, size_t argc, char **
 				    voltage_set_val_mv_backup);
 			return -1;
 		}
-		shell_print(shell, "voltage_range set %s %s: %dmV , backup: %dmV", argv[1], argv[2],
-			    voltage_set_val_mv, voltage_set_val_mv_backup);
+		shell_print(shell, "voltage_range set %s %s: %dmV", argv[1], argv[2],
+			    voltage_set_val_mv);
 	} else if (!strcmp(argv[3], "max")) {
 		/*set max range*/
 		if (!plat_set_vout_max(rail, &voltage_set_val_mv)) {
@@ -131,8 +131,8 @@ static int cmd_voltage_range_set(const struct shell *shell, size_t argc, char **
 				    voltage_set_val_mv_backup);
 			return -1;
 		}
-		shell_print(shell, "voltage_range set %s %s: %dmV , backup: %dmV", argv[1], argv[2],
-			    voltage_set_val_mv, voltage_set_val_mv_backup);
+		shell_print(shell, "voltage_range set %s %s: %dmV", argv[1], argv[2],
+			    voltage_set_val_mv);
 	} else {
 		shell_error(shell, "voltage_range set <voltage-rail> <new-voltage> min|max");
 		return -1;


### PR DESCRIPTION
Summary:
- Modify UBC delayed detection
- Assume DC on at cpld polling after UBC is enabled instead of detected by power good. 

Test Plan:
- Build code: PASS 