### PR TITLE
minerva-ag: Modify PLDM_MAX_DATA_SIZE to fix update hang issue

### DIFF
--- a/meta-facebook/minerva-ag/CMakeLists.txt
+++ b/meta-facebook/minerva-ag/CMakeLists.txt
@@ -34,4 +34,4 @@ target_include_directories(app PRIVATE src/shell)
 # Fail build if there are any warnings 
 target_compile_options(app PRIVATE -Werror)
 
-add_compile_definitions(PLDM_MAX_DATA_SIZE=1024)
+add_compile_definitions(PLDM_MAX_DATA_SIZE=1300)


### PR DESCRIPTION
Summary:
- During the PLDM update process, the Get Firmware Parameter command exceeds the predefined PLDM max data size, which is also the allocated buffer size. This causes the system to hang.
- Modify PLDM_MAX_DATA_SIZE to fix the update hang issue.

Test Plan:
- Build code: PASS 