### PR TITLE
aalc: modify total power scale to 1

### DIFF
--- a/meta-facebook/aalc-rpu/src/platform/plat_modbus.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_modbus.c
@@ -766,7 +766,7 @@ modbus_command_mapping modbus_command_table[] = {
 	  SENSOR_NUM_BPB_RPU_COOLANT_INLET_P_KPA, 1, -1, 1 },
 	{ MODBUS_RPU_PWR_W_ADDR, NULL, modbus_get_senser_reading, SENSOR_NUM_RPU_PWR_W, 1, -1, 1 },
 	{ MODBUS_AALC_TOTAL_PWR_W_ADDR, NULL, modbus_get_senser_reading,
-	  SENSOR_NUM_AALC_TOTAL_PWR_W, 1, -1, 1 },
+	  SENSOR_NUM_AALC_TOTAL_PWR_W, 1, 0, 1 },
 	{ MODBUS_RPU_INPUT_VOLT_V_ADDR, NULL, modbus_get_senser_reading,
 	  SENSOR_NUM_BPB_HSC_P48V_VIN_VOLT_V, 1, -1, 1 },
 	{ MODBUS_MB_RPU_AIR_INLET_TEMP_ADDR, NULL, modbus_get_senser_reading,

--- a/meta-facebook/aalc-rpu/src/platform/plat_threshold.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_threshold.c
@@ -1095,18 +1095,16 @@ static uint32_t get_pump_standard_rpm(uint8_t duty)
 
 void pump_change_threshold(uint8_t sensor_num, uint8_t duty)
 {
-	sensor_threshold *p = find_threshold_tbl_entry(sensor_num);
-	if (p == NULL)
+	// don't change when pump failure
+	if (get_threshold_status(sensor_num))
 		return;
-
-	// don't change when pump failure causes 0 tach
-	for (uint8_t i = PUMP_FAIL_PUMP1_UCR; i <= PUMP_FAIL_TWO_PUMP_LCR; i++) {
-		if ((get_status_flag(STATUS_FLAG_FAILURE) >> i) & 0x01)
-			return;
-	}
 
 	// don't change for sit test
 	if (get_status_flag(STATUS_FLAG_DEBUG_MODE) & BIT(DEBUG_MODE_PUMP_THRESHOLD))
+		return;
+
+	sensor_threshold *p = find_threshold_tbl_entry(sensor_num);
+	if (p == NULL)
 		return;
 
 	uint32_t standard_val = get_pump_standard_rpm(duty);


### PR DESCRIPTION
Summary:
- modify AALC_TOTAL_PWR scale from 0.1 to 1
- modify the logic for stopping pump threshold dynamic changes

Test Plan:
- Build code: PASS