### PR TITLE
aalc: Add 2nd src max11617 sensor config

### DIFF
--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -750,6 +750,7 @@ typedef struct _cx7_init_arg {
 
 typedef struct _max11617_init_arg {
 	bool is_init;
+	uint8_t mode;
 	uint8_t setup_byte;
 	uint8_t config_byte;
 	float scalefactor[12];

--- a/meta-facebook/aalc-rpu/src/platform/plat_hook.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_hook.c
@@ -36,6 +36,8 @@ LOG_MODULE_REGISTER(plat_hook);
 #define FB_SIG_PRSNT_ADDR_EVEN 0x4A // 8 bit address (2, 4, 6, 8, 10, 12, 14)
 #define FB_SIG_PRSNT_ADDR_ODD 0x4E // 8 bit address (1, 3, 5, 7, 9, 11, 13)
 
+#define DIFFERENTIAL_MODE 0x01
+
 K_MUTEX_DEFINE(i2c_1_PCA9546a_mutex);
 K_MUTEX_DEFINE(i2c_2_PCA9546a_mutex);
 K_MUTEX_DEFINE(i2c_6_PCA9546a_mutex);
@@ -1186,6 +1188,16 @@ bool get_fb_present_status(uint16_t *fb_present_status)
 
 	return true;
 }
+
+max11617_init_arg max11617_init_args[] = {
+	[0] = {
+		.is_init = false,
+		.mode = DIFFERENTIAL_MODE,
+		.setup_byte = 0x80,
+		.config_byte = 0x66,
+		.scalefactor[0] = 1,
+	},
+};
 
 #if 0
 static uint8_t get_fb_index(uint8_t sen_num)

--- a/meta-facebook/aalc-rpu/src/platform/plat_hook.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_hook.h
@@ -66,6 +66,7 @@ extern hdc1080_init_arg hdc1080_init_args[];
 extern ast_tach_init_arg ast_tach_init_args[];
 extern e50sn12051_init_arg e50sn12051_init_args[];
 extern bmr4922302_803_init_arg bmr4922302_803_init_args[];
+extern max11617_init_arg max11617_init_args[];
 /**************************************************************************************************
  * POST ARGS
 **************************************************************************************************/


### PR DESCRIPTION
Summary:

- modified:   common/dev/max11617.c
- modified:   common/service/sensor/sensor.h
- modified:   meta-facebook/aalc-rpu/src/platform/plat_hook.c
- modified:   meta-facebook/aalc-rpu/src/platform/plat_hook.h
- modified:   meta-facebook/aalc-rpu/src/platform/plat_sensor_table.c

Description:
- Add 2nd src max11617 sensor reading
- Add max11617 sensor init config

Test Plan:

- Build code: PASS