### PR TITLE
Yv4:sd:support 2nd retimer bcm85658

### DIFF
--- a/common/dev/bcm85658.c
+++ b/common/dev/bcm85658.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "bcm85658.h"
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(bcm85658);
+
+K_MUTEX_DEFINE(bcm85658_mutex);
+
+bool bcm85658_get_fw_version(I2C_MSG *msg, uint8_t *version)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, false);
+	CHECK_NULL_ARG_WITH_RETURN(version, false);
+	uint8_t retry = 3;
+
+	if (k_mutex_lock(&bcm85658_mutex, K_MSEC(BCM85658_MUTEX_LOCK_MS))) {
+		LOG_ERR("bcm85658 mutex lock failed");
+		return false;
+	}
+
+	msg->tx_len = 6;
+	msg->rx_len = 9;
+	msg->data[0] = SMBUS_PROCESS_BLOCK_CMD;
+	msg->data[1] = 0x04; //byte count
+	msg->data[2] = BCM85658_VERSION_OFFSET & 0xff; //version lower offset
+	msg->data[3] = (BCM85658_VERSION_OFFSET >> 8) & 0xff; 
+	msg->data[4] = (BCM85658_VERSION_OFFSET >> 16) & 0xff;
+	msg->data[5] = (BCM85658_VERSION_OFFSET >> 24) & 0xff;
+
+	if (i2c_master_read(msg, retry)) {
+		LOG_ERR("Failed to get PCIE RETIMER version offset");
+		
+		if (k_mutex_unlock(&bcm85658_mutex)) {
+			LOG_ERR("bcm85658 mutex unlock failed");
+		}
+		return false;
+	}
+
+	for (int i = 0; i < 9; i++)
+	{
+		LOG_ERR("version data[%d]: 0x%x", i, msg->data[i]);
+	}
+	
+
+	memcpy(version, &(msg->data[5]), 4);
+
+	if (k_mutex_unlock(&bcm85658_mutex)) {
+		LOG_ERR("bcm85658 mutex unlock failed");
+		return false;
+	}
+
+	return true;
+}
+
+uint8_t bcm85658_read_temp(I2C_MSG *msg, double *avg_temperature)
+{
+	CHECK_NULL_ARG_WITH_RETURN(msg, SENSOR_UNSPECIFIED_ERROR);
+	int temp_raw_data = 0;
+	uint8_t ret = SENSOR_UNSPECIFIED_ERROR;
+	uint8_t retry = 3;
+
+	if (k_mutex_lock(&bcm85658_mutex, K_MSEC(BCM85658_MUTEX_LOCK_MS))) {
+		LOG_ERR("bcm85658 mutex lock failed");
+		return ret;
+	}
+
+	msg->tx_len = 6;
+	msg->rx_len = 9;
+	msg->data[0] = SMBUS_PROCESS_BLOCK_CMD;
+	msg->data[1] = 0x04; //byte count
+	msg->data[2] = BCM85658_TEMP_OFFSET_32B & 0xff;
+	msg->data[3] = (BCM85658_TEMP_OFFSET_32B >> 8) & 0xff; 
+	msg->data[4] = (BCM85658_TEMP_OFFSET_32B >> 16) & 0xff;
+	msg->data[5] = (BCM85658_TEMP_OFFSET_32B >> 24) & 0xff;
+
+	if (i2c_master_read(msg, retry)) {
+		LOG_ERR("Failed to set RETIMER BCM85658_TEMP_OFFSET_32B");
+		goto unlock_exit;
+	}
+
+	temp_raw_data = (msg->data[8] << 24) + (msg->data[7] << 16) + (msg->data[6] << 8) +
+			   msg->data[5];
+
+	if(IS_BCM85658_TEMP_VAILD(temp_raw_data)) {
+		*avg_temperature = (-0.30654 * BCM85658_TEMP_SENSOR_DATA_GET(temp_raw_data)) + 469.27;
+		ret = SENSOR_READ_SUCCESS;
+	} else {
+		LOG_ERR("Temperature data is not valid");
+		ret = SENSOR_NOT_ACCESSIBLE;
+	}
+
+unlock_exit:
+	if (k_mutex_unlock(&bcm85658_mutex)) {
+		LOG_ERR("bcm85658 mutex unlock failed");
+	}
+
+	return ret;
+}
+
+uint8_t bcm85658_read(sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("sensor num: 0x%x is invalid", cfg->num);
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	I2C_MSG msg = { 0 };
+
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+
+	double val = 0;
+	uint8_t ret;
+
+	switch (cfg->offset) {
+	case BCM85658_TEMP_OFFSET:
+		ret = bcm85658_read_temp(&msg, &val);
+		if (ret != SENSOR_READ_SUCCESS) {
+			return ret;
+		}
+		break;
+	default:
+		LOG_ERR("Invalid sensor 0x%x offset 0x%x", cfg->num, cfg->offset);
+		return SENSOR_NOT_FOUND;
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	memset(sval, 0, sizeof(*sval));
+
+	sval->integer = (int)val & 0xFFFF;
+	sval->fraction = (val - sval->integer) * 1000;
+
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t bcm85658_init(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+	if (cfg->num > SENSOR_NUM_MAX) {
+		LOG_ERR("bcm85658_init fail 0x%x offset 0x%x", cfg->num, cfg->offset);
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+	}
+	
+	cfg->read = bcm85658_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/dev/include/bcm85658.h
+++ b/common/dev/include/bcm85658.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BCM85658_H
+#define BCM85658_H
+
+#include "hal_i2c.h"
+
+#define BCM85658_MUTEX_LOCK_MS 1000
+#define IS_BCM85658_TEMP_VAILD(r) (((r) >> 11) & 0x1)
+#define BCM85658_TEMP_SENSOR_DATA_GET(r) ((r) & 0x7ff)
+
+#define INTEL_SMBUS_RD32_4ADDR_D 0x09
+#define SMBUS_WR_BLOCK_CMD 0xA7
+#define SMBUS_PROCESS_BLOCK_CMD 0xA9
+#define BCM85658_TEMP_OFFSET 0x981c
+#define BCM85658_TEMP_OFFSET_32B 0x6000981c
+#define BCM85658_VERSION_OFFSET 0x600004a0
+
+bool bcm85658_get_fw_version(I2C_MSG *msg, uint8_t *version);
+uint8_t pcie_retimer_fw_update(I2C_MSG *msg, uint32_t offset, uint16_t msg_len, uint8_t *msg_buf,
+			       uint8_t flag);
+
+#endif

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -144,6 +144,7 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(raa228249)
 	sensor_name_to_num(bmr4922302_803)
 	sensor_name_to_num(emc1413)
+	sensor_name_to_num(bcm85658)
 };
 // clang-format on
 
@@ -358,6 +359,9 @@ SENSOR_DRIVE_INIT_DECLARE(bmr4922302_803);
 #endif
 #ifdef ENABLE_EMC1413
 SENSOR_DRIVE_INIT_DECLARE(emc1413);
+#endif
+#ifdef ENABLE_BCM85658
+SENSOR_DRIVE_INIT_DECLARE(bcm85658);
 #endif
 
 // The sequence needs to same with SENSOR_DEV ID
@@ -720,7 +724,11 @@ sensor_drive_api sensor_drive_tbl[] = {
 #else
 	SENSOR_DRIVE_TYPE_UNUSE(emc1413),
 #endif
-
+#ifdef ENABLE_BCM85658
+	SENSOR_DRIVE_TYPE_INIT_MAP(bcm85658),
+#else
+	SENSOR_DRIVE_TYPE_UNUSE(bcm85658),
+#endif
 };
 
 static void init_sensor_num(void)

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -188,6 +188,7 @@ enum SENSOR_DEV {
 	sensor_dev_raa228249 = 0x46,
 	sensor_dev_bmr4922302_803 = 0x47,
 	sensor_dev_emc1413 = 0x48,
+	sensor_dev_bcm85658 = 0x49,
 	sensor_dev_max
 };
 

--- a/meta-facebook/yv4-sd/src/platform/plat_def.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_def.h
@@ -65,6 +65,7 @@
 #define DISABLE_ADC128D818
 
 #define ENABLE_RTQ6056
+#define ENABLE_BCM85658
 
 #define HOST_KCS_PORT kcs3
 #define BMC_USB_PORT "CDC_ACM_0"

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
@@ -31,6 +31,7 @@
 
 #include "mp2971.h"
 #include "pt5161l.h"
+#include "bcm85658.h"
 #include "raa229621.h"
 #include "plat_class.h"
 #include "plat_pldm_device_identifier.h"
@@ -723,6 +724,12 @@ static bool plat_get_retimer_fw_version(void *info_p, uint8_t *buf, uint8_t *len
 		memcpy(buf_p, version, RETIMER_PT5161L_FW_VER_LEN);
 		*len += bin2hex(version, 4, buf_p, 8);
 		buf_p += 8;
+	} else if (retimer_type == RETIMER_TYPE_BROADCOM) {
+		uint8_t *buf_p = buf;
+		ret = bcm85658_get_fw_version(&i2c_msg, version);
+		memcpy(buf_p, version, RETIMER_PT5161L_FW_VER_LEN);
+		*len += bin2hex(&version[1], 3, buf_p, 6);
+		buf_p += 6;
 	} else {
 		// TODO: Support other vendor
 	}

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -21,6 +21,7 @@
 #include "ina233.h"
 #include "sq52205.h"
 #include "pt5161l.h"
+#include "bcm85658.h"
 #include "rtq6056.h"
 #include "sensor.h"
 #include "pldm_sensor.h"
@@ -6782,9 +6783,12 @@ void plat_pldm_sensor_change_retimer_dev()
 					&plat_pldm_sensor_ina233_table[index].pldm_sensor_cfg);
 				break;
 			case RETIMER_TYPE_BROADCOM:
-				// TODO: Currently, disable sensor reading until support broadcom
-				plat_pldm_disable_sensor(
-					&plat_pldm_sensor_ina233_table[index].pldm_sensor_cfg);
+				plat_pldm_sensor_ina233_table[index].pldm_sensor_cfg.type =
+					sensor_dev_bcm85658;
+				plat_pldm_sensor_ina233_table[index].pldm_sensor_cfg.offset =
+					BCM85658_TEMP_OFFSET;
+				plat_pldm_sensor_ina233_table[index].pldm_sensor_cfg.init_args = NULL;
+				plat_pldm_sensor_ina233_table[index].pldm_sensor_cfg.pre_sensor_read_hook = NULL;
 				break;
 			default:
 				LOG_ERR("Failed to change the Retimer device due to unknown vendor.");


### PR DESCRIPTION
# Description:
- Support bcm85658 sensor monitor.

# Motivation:
- Support bcm85658 sensor monitor

# Test Plan:
- Build code: Pass
- check the sensor value