### PR TITLE
pldm_firmware_update: revise get_downstream_firmware_parameters

### DIFF
--- a/common/service/pldm/pldm_firmware_update.c
+++ b/common/service/pldm/pldm_firmware_update.c
@@ -1492,12 +1492,11 @@ static uint8_t get_downstream_firmware_parameters(void *mctp_inst, uint8_t *buf,
 			return PLDM_SUCCESS;
 		}
 
-		struct component_parameter_table *comp_table_p =
-			(struct component_parameter_table *)curr_downstream_device;
-		curr_downstream_device += sizeof(struct component_parameter_table);
+		struct downstream_device_parameter_table *comp_table_p =
+			(struct downstream_device_parameter_table *)curr_downstream_device;
+		curr_downstream_device += sizeof(struct downstream_device_parameter_table);
 
-		comp_table_p->comp_identifier = comp_config[i].comp_identifier;
-		comp_table_p->comp_classification = comp_config[i].comp_classification;
+		comp_table_p->downstream_device_index = comp_config[i].comp_identifier;
 		comp_table_p->active_comp_ver_str_type = PLDM_COMP_ASCII;
 		comp_table_p->pending_comp_ver_str_type = PLDM_COMP_ASCII;
 		comp_table_p->pending_comp_ver_str_len = 0x00;
@@ -1509,7 +1508,7 @@ static uint8_t get_downstream_firmware_parameters(void *mctp_inst, uint8_t *buf,
 			memcpy(curr_downstream_device, &error_code, sizeof(error_code));
 		}
 
-		param_table_len += sizeof(struct component_parameter_table) +
+		param_table_len += sizeof(struct downstream_device_parameter_table) +
 				   comp_table_p->active_comp_ver_str_len;
 		curr_downstream_device += comp_table_p->active_comp_ver_str_len;
 

--- a/common/service/pldm/pldm_firmware_update.h
+++ b/common/service/pldm/pldm_firmware_update.h
@@ -637,10 +637,65 @@ struct pldm_get_downstream_firmware_parameters_resp {
 			/* Bit [31:9] reserved */
 			uint8_t : 7;
 			uint16_t : 16;
-		};
+		} __attribute__((packed));
 		uint32_t fdp_capabilities_during_update;
-	};
+	} __attribute__((packed));
 	uint16_t downstream_device_count;
+} __attribute__((packed));
+
+/** @struct pldm_downstream_device_parameters_entry
+ *
+ *  Structure representing downstream device parameter table entry defined in
+ *  Table 21 - DownstreamDeviceParameterTable in DSP0267_1.1.0
+ *
+ *  Clients should not allocate memory for this struct to decode the response,
+ *  use `pldm_downstream_device_parameter_entry_versions` instead to make sure
+ *  that the active and pending component version strings are copied from the
+ *  message buffer.
+ */
+struct downstream_device_parameter_table {
+	uint16_t downstream_device_index;
+	uint32_t active_comp_comparison_stamp;
+	uint8_t active_comp_ver_str_type;
+	uint8_t active_comp_ver_str_len;
+	/* Append 1 bytes for null termination so that it can be used as a
+	 * Null-terminated string.
+	 */
+	char active_comp_release_date[8];
+	uint32_t pending_comp_comparison_stamp;
+	uint8_t pending_comp_ver_str_type;
+	uint8_t pending_comp_ver_str_len;
+	/* Append 1 bytes for null termination so that it can be used as a
+	 * Null-terminated string.
+	 */
+	char pending_comp_release_date[8];
+
+	union {
+		struct {
+			uint8_t automatic : 1;
+			uint8_t self_contained : 1;
+			uint8_t medium_specific_reset : 1;
+			uint8_t system_reboot : 1;
+			uint8_t dc_power_cycle : 1;
+			uint8_t ac_power_cycle : 1;
+			uint8_t supports_activate_pending_image : 1;
+			/* Bit [15:7] reserved */
+			uint8_t : 1;
+			uint8_t : 8;
+		} __attribute__((packed));
+		uint16_t comp_activation_methods;
+	} __attribute__((packed));
+	union {
+		struct {
+			uint8_t downstream_device_apply_state_func : 1;
+			uint8_t downstream_device_is_updateable : 1;
+			uint8_t comp_downgrade_capability : 1;
+			/* Bit [31:3] reserved */
+			uint16_t : 13;
+			uint16_t : 16;
+		} __attribute__((packed));
+		uint32_t capabilities_during_update;
+	} __attribute__((packed));
 } __attribute__((packed));
 
 uint8_t pldm_fw_update_handler_query(uint8_t code, void **ret_fn);


### PR DESCRIPTION
# Description:
This commit is pushed to revise the response body of the `get_downstream_firmware_parameters` response from `component_parameter_table` to `downstream_device_parameter_table`, to reach the current DMTF standard.

# Motivation:
There is an incorrect implementation refers to the current `get_downstream_firmware_parameters` response, which against the DMTF DSP0267 standard and needs to be corrected.

# Test Plan:
A special version of pldmd is created to list all of the downstream device index in the journal, if all of the indexes match where it's pre-defined, that means the revised format of the response is good. (because the each variable size of the bodies in the liniar sequence match as expected and not drifting, not causing data corruption) Futhermore, in the pldm formal update implementation (in the upcoming pldm release), some of the elements would be captured and showed as D-Bus properties, if the properties match as expected, it means the response is good.

# Test Logs:
The journal of the pldmd below:
```
...
Jan 04 23:25:39 bmc pldmd[8890]: Downstream device name exists for EID=70, DownstreamDeviceIndex=1
Jan 04 23:25:39 bmc pldmd[8890]: Downstream device name exists for EID=70, DownstreamDeviceIndex=2
Jan 04 23:25:39 bmc pldmd[8890]: Downstream device name exists for EID=70, DownstreamDeviceIndex=3
Jan 04 23:25:39 bmc pldmd[8890]: Downstream device name exists for EID=70, DownstreamDeviceIndex=4
Jan 04 23:25:39 bmc pldmd[8890]: Downstream device name exists for EID=70, DownstreamDeviceIndex=5
Jan 04 23:25:39 bmc pldmd[8890]: Downstream device name exists for EID=70, DownstreamDeviceIndex=6
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=10, DownstreamDeviceIndex=1
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=10, DownstreamDeviceIndex=2
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=10, DownstreamDeviceIndex=3
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=10, DownstreamDeviceIndex=4
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=10, DownstreamDeviceIndex=5
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=10, DownstreamDeviceIndex=6
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=22, DownstreamDeviceIndex=1
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=22, DownstreamDeviceIndex=2
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=22, DownstreamDeviceIndex=3
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=22, DownstreamDeviceIndex=4
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=22, DownstreamDeviceIndex=5
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=22, DownstreamDeviceIndex=6
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=62, DownstreamDeviceIndex=1
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=62, DownstreamDeviceIndex=2
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=62, DownstreamDeviceIndex=3
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=62, DownstreamDeviceIndex=4
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=62, DownstreamDeviceIndex=5
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=62, DownstreamDeviceIndex=6
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=52, DownstreamDeviceIndex=1
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=52, DownstreamDeviceIndex=2
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=52, DownstreamDeviceIndex=3
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=52, DownstreamDeviceIndex=4
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=52, DownstreamDeviceIndex=5
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=52, DownstreamDeviceIndex=6
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=72, DownstreamDeviceIndex=1
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=72, DownstreamDeviceIndex=2
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=72, DownstreamDeviceIndex=3
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=72, DownstreamDeviceIndex=4
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=72, DownstreamDeviceIndex=5
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=72, DownstreamDeviceIndex=6
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=82, DownstreamDeviceIndex=1
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=82, DownstreamDeviceIndex=2
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=82, DownstreamDeviceIndex=3
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=82, DownstreamDeviceIndex=4
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=82, DownstreamDeviceIndex=5
Jan 04 23:25:40 bmc pldmd[8890]: Downstream device name exists for EID=82, DownstreamDeviceIndex=6
Jan 04 23:25:41 bmc pldmd[8890]: Downstream device name exists for EID=40, DownstreamDeviceIndex=1
Jan 04 23:25:41 bmc pldmd[8890]: Downstream device name exists for EID=40, DownstreamDeviceIndex=2
Jan 04 23:25:41 bmc pldmd[8890]: Downstream device name exists for EID=40, DownstreamDeviceIndex=3
Jan 04 23:25:41 bmc pldmd[8890]: Downstream device name exists for EID=40, DownstreamDeviceIndex=4
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=40, DownstreamDeviceIndex=5
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=40, DownstreamDeviceIndex=6
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=60, DownstreamDeviceIndex=1
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=60, DownstreamDeviceIndex=2
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=60, DownstreamDeviceIndex=3
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=60, DownstreamDeviceIndex=4
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=60, DownstreamDeviceIndex=5
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=60, DownstreamDeviceIndex=6
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=30, DownstreamDeviceIndex=1
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=30, DownstreamDeviceIndex=2
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=30, DownstreamDeviceIndex=3
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=30, DownstreamDeviceIndex=4
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=30, DownstreamDeviceIndex=5
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=30, DownstreamDeviceIndex=6
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=32, DownstreamDeviceIndex=1
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=32, DownstreamDeviceIndex=2
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=32, DownstreamDeviceIndex=3
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=32, DownstreamDeviceIndex=4
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=32, DownstreamDeviceIndex=5
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=32, DownstreamDeviceIndex=6
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=80, DownstreamDeviceIndex=1
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=80, DownstreamDeviceIndex=2
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=80, DownstreamDeviceIndex=3
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=80, DownstreamDeviceIndex=4
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=80, DownstreamDeviceIndex=5
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=80, DownstreamDeviceIndex=6
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=42, DownstreamDeviceIndex=1
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=42, DownstreamDeviceIndex=2
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=42, DownstreamDeviceIndex=3
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=42, DownstreamDeviceIndex=4
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=42, DownstreamDeviceIndex=5
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=42, DownstreamDeviceIndex=6
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=12, DownstreamDeviceIndex=1
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=12, DownstreamDeviceIndex=2
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=12, DownstreamDeviceIndex=3
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=12, DownstreamDeviceIndex=4
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=12, DownstreamDeviceIndex=5
Jan 04 23:25:42 bmc pldmd[8890]: Downstream device name exists for EID=12, DownstreamDeviceIndex=6
Jan 04 23:25:44 bmc pldmd[8890]: Downstream device name exists for EID=50, DownstreamDeviceIndex=1
Jan 04 23:25:44 bmc pldmd[8890]: Downstream device name exists for EID=50, DownstreamDeviceIndex=2
Jan 04 23:25:44 bmc pldmd[8890]: Downstream device name exists for EID=50, DownstreamDeviceIndex=3
Jan 04 23:25:44 bmc pldmd[8890]: Downstream device name exists for EID=50, DownstreamDeviceIndex=4
Jan 04 23:25:44 bmc pldmd[8890]: Downstream device name exists for EID=50, DownstreamDeviceIndex=5
Jan 04 23:25:44 bmc pldmd[8890]: Downstream device name exists for EID=50, DownstreamDeviceIndex=6
...
```
where all of the endpoint devices have 6 downstream devices in this case, showed as expected.

The downstream devices parameters show as D-Bus properties below:
```
root@bmc:~# busctl introspect -l xyz.openbmc_project.PLDM /xyz/openbmc_project/software/Yosemite_4_Sentinel_Dome_T2_Slot_1_BIC_b9d681d8
NAME                                        TYPE      SIGNATURE RESULT/VALUE                                                                                              FLAGS
org.freedesktop.DBus.Introspectable         interface -         -                                                                                                         -
.Introspect                                 method    -         s                                                                                                         -
org.freedesktop.DBus.Peer                   interface -         -                                                                                                         -
.GetMachineId                               method    -         s                                                                                                         -
.Ping                                       method    -         -                                                                                                         -
org.freedesktop.DBus.Properties             interface -         -                                                                                                         -
.Get                                        method    ss        v                                                                                                         -
.GetAll                                     method    s         a{sv}                                                                                                     -
.Set                                        method    ssv       -                                                                                                         -
.PropertiesChanged                          signal    sa{sv}as  -                                                                                                         -
xyz.openbmc_project.Association.Definitions interface -         -                                                                                                         -
.Associations                               property  a(sss)    1 "running" "ran_on" "/xyz/openbmc_project/inventory/system/board/Yosemite_4_Sentinel_Dome_T2_Slot_1_BIC" emits-change writable
xyz.openbmc_project.Object.Delete           interface -         -                                                                                                         -
.Delete                                     method    -         -                                                                                                         -
xyz.openbmc_project.Software.Activation     interface -         -                                                                                                         -
.Activation                                 property  s         "xyz.openbmc_project.Software.Activation.Activations.Active"                                              emits-change writable
.RequestedActivation                        property  s         "xyz.openbmc_project.Software.Activation.RequestedActivations.None"                                       emits-change writable
xyz.openbmc_project.Software.Update         interface -         -                                                                                                         -
.StartUpdate                                method    hs        o                                                                                                         -
.AllowedApplyTimes                          property  as        0                                                                                                         emits-change
xyz.openbmc_project.Software.Version        interface -         -                                                                                                         -
.Purpose                                    property  s         "xyz.openbmc_project.Software.Version.VersionPurpose.Other"                                               emits-change writable
.Version                                    property  s         "2024.51.01"
```
where the value of `.Version` is fetched from `downstream_device_parameter_table`