### PR TITLE
fby4: sd: Fix PMIC fatal error doesn't record event problem

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pmic.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pmic.c
@@ -215,7 +215,7 @@ void monitor_pmic_error_via_i3c_handler()
 			}
 
 			memset(&error_data, 0, sizeof(error_data));
-			ret = get_pmic_error_data(dimm_id, error_data);
+			ret = get_pmic_error_data(dimm_id, error_data, true);
 			if (ret < 0) {
 				LOG_ERR("Fail to get PMIC error data on monitor thread, dimm: 0x%x",
 					dimm_id);
@@ -305,7 +305,7 @@ int pal_set_pmic_error_flag(uint8_t dimm_id, uint8_t error_type)
 	return SUCCESS;
 }
 
-int get_pmic_error_data(uint8_t dimm_id, uint8_t *buffer)
+int get_pmic_error_data(uint8_t dimm_id, uint8_t *buffer, uint8_t is_need_check_post_status)
 {
 	CHECK_NULL_ARG_WITH_RETURN(buffer, -1);
 	int ret = 0;
@@ -322,7 +322,7 @@ int get_pmic_error_data(uint8_t dimm_id, uint8_t *buffer)
 		return ret;
 	}
 
-	if (!get_post_status()) {
+	if ((!get_post_status()) && is_need_check_post_status) {
 		switch_i3c_dimm_mux(I3C_MUX_CPU_TO_DIMM);
 		return -1;
 	}
@@ -371,7 +371,7 @@ void read_pmic_error_when_dc_off()
 		}
 
 		memset(&error_data, 0, sizeof(error_data));
-		ret = get_pmic_error_data(dimm_id, error_data);
+		ret = get_pmic_error_data(dimm_id, error_data, false);
 		if (ret != 0) {
 			LOG_ERR("Read PMIC error data fail, dimm id: 0x%x", dimm_id);
 			continue;

--- a/meta-facebook/yv4-sd/src/platform/plat_pmic.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pmic.h
@@ -40,7 +40,7 @@ int get_pmic_fault_status();
 void read_pmic_error_when_dc_off();
 void clear_pmic_error(uint8_t dimm_id);
 void add_pmic_error_sel(uint8_t dimm_id, uint8_t error_type);
-int get_pmic_error_data(uint8_t dimm_id, uint8_t *buffer);
+int get_pmic_error_data(uint8_t dimm_id, uint8_t *buffer, uint8_t is_need_check_post_status);
 
 void init_pmic_event_work();
 


### PR DESCRIPTION
# Description
- Set a flag be used to confirm whether "post complete" needs to be judged. Let can get PMIC fatal error when host is DC off.

# Motivation
- After injecting PMIC fatal error, no PMIC-related events were recorded.

# Test plan
- Build code: Pass
- Inject fatal error: Pass

# Log
root@bmc:~# pmic-error-injection.sh slot8 --dimm dimm_A0 --error_inj SWAout_OV Read write_protect status
pldmtool: Tx: 80 3f 01 15 a0 00 e0 b1 15 a0 00 00 02 01 35 90 pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 b1 00 15 a0 00 90 Inject PMIC error Done

root@bmc:~# mfg-tool log-display
...
    "3": {
        "additional_data": {},
        "event_id": "",
        "message": "Event: Host8 DIMM PMIC Error : DIMM A0 SWAout OV, ASSERTED",
        "resolution": "",
        "resolved": false,
        "severity": "xyz.openbmc_project.Logging.Entry.Level.Error",
        "timestamp": "2025-01-09T13:39:08.409000000Z",
        "updated_timestamp": "2025-01-09T13:39:08.409000000Z"
    },

root@bmc:~# journalctl | grep PMIC
Jan 09 05:39:08 bmc pldmd[611]: Event: Host8 DIMM PMIC Error : DIMM A0 SWAout OV, ASSERTED