### PR TITLE
yv4: wf: support downstream device descriptors

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_device_identifier.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_device_identifier.c
@@ -1,0 +1,194 @@
+#include "libutil.h"
+#include "pldm_firmware_update.h"
+#include "plat_pldm_device_identifier.h"
+
+struct pldm_descriptor_string PLDM_VR_PVDDQ_AB_ASIC1_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "WailuaFalls",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"4d50535f565200000000000000000000000000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "41425F41534943310000",
+	},
+};
+
+struct pldm_descriptor_string PLDM_VR_PVDDQ_CD_ASIC1_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "WailuaFalls",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"4d50535f565200000000000000000000000000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "43445F41534943310000",
+	},
+};
+
+struct pldm_descriptor_string PLDM_VR_PVDDQ_AB_ASIC2_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "WailuaFalls",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"4d50535f565200000000000000000000000000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "41425F41534943320000",
+	},
+};
+
+struct pldm_descriptor_string PLDM_VR_PVDDQ_CD_ASIC2_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "WailuaFalls",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"4d50535f565200000000000000000000000000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "43445F41534943320000",
+	},
+};
+
+struct pldm_descriptor_string PLDM_CXL1_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "WailuaFalls",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"43584C00000000000000000000000000000000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "31000000000000000000",
+	},
+};
+
+struct pldm_descriptor_string PLDM_CXL2_DESCRIPTORS[] = {
+	{
+		.descriptor_type = PLDM_FWUP_IANA_ENTERPRISE_ID,
+		.title_string = NULL,
+		.descriptor_data = "0000A015",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Platform",
+		.descriptor_data = "Yosemite4",
+	},
+	{
+		.descriptor_type = PLDM_FWUP_VENDOR_DEFINED,
+		.title_string = "Board",
+		.descriptor_data = "WailuaFalls",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_LONG_STRING,
+		.title_string = NULL,
+		.descriptor_data =
+			"43584C00000000000000000000000000000000000000000000000000000000000000000000000000",
+	},
+	{
+		.descriptor_type = PLDM_ASCII_MODEL_NUMBER_SHORT_STRING,
+		.title_string = NULL,
+		.descriptor_data = "32000000000000000000",
+	},
+};
+
+struct pldm_downstream_identifier_table downstream_table[] = {
+	{ .descriptor = PLDM_VR_PVDDQ_AB_ASIC1_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_VR_PVDDQ_AB_ASIC1_DESCRIPTORS) },
+	{ .descriptor = PLDM_VR_PVDDQ_CD_ASIC1_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_VR_PVDDQ_CD_ASIC1_DESCRIPTORS) },
+	{ .descriptor = PLDM_VR_PVDDQ_AB_ASIC2_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_VR_PVDDQ_AB_ASIC2_DESCRIPTORS) },
+	{ .descriptor = PLDM_VR_PVDDQ_CD_ASIC2_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_VR_PVDDQ_CD_ASIC2_DESCRIPTORS) },
+	{ .descriptor = PLDM_CXL1_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_CXL1_DESCRIPTORS) },
+	{ .descriptor = PLDM_CXL2_DESCRIPTORS,
+	  .descriptor_count = ARRAY_SIZE(PLDM_CXL2_DESCRIPTORS) },
+};
+
+const uint8_t downstream_devices_count = ARRAY_SIZE(downstream_table);

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_device_identifier.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_device_identifier.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _PLAT_PLDM_DEVICE_IDENTIFIER_H_
+#define _PLAT_PLDM_DEVICE_IDENTIFIER_H_
+
+#include "pldm_firmware_update.h"
+
+extern const uint8_t downstream_devices_count;
+
+extern struct pldm_downstream_identifier_table downstream_table[];
+
+#endif

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
@@ -32,7 +32,9 @@
 #include "xdpe12284c.h"
 #include "mp2971.h"
 #include "ioexp_tca9555.h"
+#include "cci.h"
 #include "util_spi.h"
+#include "plat_pldm_device_identifier.h"
 
 LOG_MODULE_REGISTER(plat_fwupdate);
 
@@ -40,6 +42,7 @@ static bool plat_pldm_vr_i2c_info_get(int comp_identifier, uint8_t *bus, uint8_t
 static uint8_t plat_pldm_pre_vr_update(void *fw_update_param);
 static uint8_t plat_pldm_post_vr_update(void *fw_update_param);
 static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len);
+static bool plat_get_cxl_fw_version(void *info_p, uint8_t *buf, uint8_t *len);
 static uint8_t plat_pldm_pre_cxl_update(void *fw_update_param);
 static uint8_t plat_pldm_post_cxl_update(void *fw_update_param);
 static uint8_t pldm_cxl_update(void *fw_update_param);
@@ -140,7 +143,7 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.inf = COMP_UPDATE_VIA_SPI,
 		.activate_method = COMP_ACT_DC_PWR_CYCLE,
 		.self_act_func = NULL,
-		.get_fw_version_fn = NULL,
+		.get_fw_version_fn = plat_get_cxl_fw_version,
 	},
 	{
 		.enable = true,
@@ -153,7 +156,7 @@ pldm_fw_update_info_t PLDMUPDATE_FW_CONFIG_TABLE[] = {
 		.inf = COMP_UPDATE_VIA_SPI,
 		.activate_method = COMP_ACT_DC_PWR_CYCLE,
 		.self_act_func = NULL,
-		.get_fw_version_fn = NULL,
+		.get_fw_version_fn = plat_get_cxl_fw_version,
 	},
 };
 
@@ -252,6 +255,183 @@ uint8_t plat_pldm_query_device_identifiers(const uint8_t *buf, uint16_t len, uin
 	return PLDM_SUCCESS;
 }
 
+uint8_t plat_pldm_query_downstream_devices(const uint8_t *buf, uint16_t len, uint8_t *resp,
+					   uint16_t *resp_len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, false);
+	CHECK_NULL_ARG_WITH_RETURN(resp, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, PLDM_ERROR);
+
+	struct pldm_query_downstream_devices_resp *resp_p =
+		(struct pldm_query_downstream_devices_resp *)resp;
+
+	resp_p->completion_code = PLDM_SUCCESS;
+	resp_p->downstream_device_update_supported = PLDM_FW_UPDATE_SUPPORT_DOWNSTREAM_DEVICES;
+	resp_p->number_of_downstream_devices = 6;
+	resp_p->max_number_of_downstream_devices = 6;
+
+	resp_p->capabilities.dynamically_attached = 0;
+	resp_p->capabilities.dynamically_removed = 0;
+	resp_p->capabilities.support_update_simultaneously = 0;
+
+	*resp_len = sizeof(struct pldm_query_downstream_devices_resp);
+
+	return PLDM_SUCCESS;
+}
+
+static uint8_t get_returned_devices_start_index(struct pldm_query_downstream_identifier_req *req,
+						uint32_t *index)
+{
+	switch (req->transferoperationflag) {
+	case PLDM_FW_UPDATE_GET_FIRST_PART:
+		*(index) = 0;
+		break;
+	case PLDM_FW_UPDATE_GET_NEXT_PART:
+		if (req->datatransferhandle >= downstream_devices_count) {
+			LOG_ERR("%s:%s:%d: Invalid data transfer handle: 0x%x", __FILE__, __func__,
+				__LINE__, req->datatransferhandle);
+			return PLDM_FW_UPDATE_CC_INVALID_TRANSFER_HANDLE;
+		}
+		*(index) = req->datatransferhandle;
+		break;
+	default:
+		LOG_ERR("%s:%s:%d: Invalid transfer operation flag: 0x%x", __FILE__, __func__,
+			__LINE__, req->transferoperationflag);
+		return PLDM_FW_UPDATE_CC_INVALID_TRANSFER_OPERATION_FLAG;
+	}
+
+	return PLDM_SUCCESS;
+}
+
+static size_t calculate_descriptors_size(struct pldm_descriptor_string *descriptors, uint8_t count)
+{
+	size_t size = 0;
+	for (size_t i = 0; i < count; i++) {
+		size += strlen(descriptors[i].descriptor_data);
+		switch (descriptors[i].descriptor_type) {
+		case PLDM_FWUP_VENDOR_DEFINED:
+			size += sizeof(struct pldm_vendor_defined_descriptor_tlv) +
+						descriptors[i].title_string ?
+					strlen(descriptors[i].title_string) :
+					0;
+			break;
+		default:
+			size += sizeof(struct pldm_descriptor_tlv);
+			break;
+		}
+	}
+
+	return size;
+}
+
+static bool remaining_data_can_be_returned_in_one_transaction(uint32_t start_index,
+							      uint32_t *next_transaction_index)
+{
+	size_t total_size = sizeof(pldm_hdr) + sizeof(struct pldm_query_downstream_identifier_resp);
+	uint32_t i = start_index;
+	while (i < downstream_devices_count) {
+		total_size += sizeof(struct pldm_downstream_device) +
+			      calculate_descriptors_size(downstream_table[i].descriptor,
+							 downstream_table[i].descriptor_count);
+		if (total_size >= PLDM_MAX_DATA_SIZE) {
+			*next_transaction_index = i;
+			return false;
+		}
+
+		i++;
+	}
+	*next_transaction_index = 0;
+
+	return true;
+}
+
+uint8_t plat_pldm_query_downstream_identifiers(const uint8_t *buf, uint16_t len, uint8_t *resp,
+					       uint16_t *resp_len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(buf, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, PLDM_ERROR);
+
+	uint8_t rc = PLDM_ERROR;
+
+	struct pldm_query_downstream_identifier_req *req_p =
+		(struct pldm_query_downstream_identifier_req *)buf;
+	struct pldm_query_downstream_identifier_resp *resp_p =
+		(struct pldm_query_downstream_identifier_resp *)resp;
+
+	resp_p->completion_code = PLDM_ERROR;
+
+	uint32_t start_index = 0;
+	rc = get_returned_devices_start_index(req_p, &start_index);
+	if (rc) {
+		LOG_ERR("%s:%s:%d: Failed to get returning devices start index.", __FILE__,
+			__func__, __LINE__);
+		return rc;
+	}
+
+	uint32_t next_transaction_index = 0;
+	if (remaining_data_can_be_returned_in_one_transaction(start_index,
+							      &next_transaction_index)) {
+		resp_p->nextdatatransferhandle = 0;
+		resp_p->numbwerofdownstreamdevice = downstream_devices_count - start_index;
+		switch (req_p->transferoperationflag) {
+		case PLDM_FW_UPDATE_GET_FIRST_PART:
+			resp_p->transferflag = PLDM_FW_UPDATE_TRANSFER_START_AND_END;
+			break;
+		case PLDM_FW_UPDATE_GET_NEXT_PART:
+			resp_p->transferflag = PLDM_FW_UPDATE_TRANSFER_END;
+			break;
+		}
+	} else {
+		resp_p->nextdatatransferhandle = next_transaction_index;
+		resp_p->numbwerofdownstreamdevice = resp_p->nextdatatransferhandle - start_index;
+		switch (req_p->transferoperationflag) {
+		case PLDM_FW_UPDATE_GET_FIRST_PART:
+			resp_p->transferflag = PLDM_FW_UPDATE_TRANSFER_START;
+			break;
+		case PLDM_FW_UPDATE_GET_NEXT_PART:
+			resp_p->transferflag = PLDM_FW_UPDATE_TRANSFER_MIDDLE;
+			break;
+		}
+	}
+
+	uint32_t downstream_devices_length = 0;
+	uint8_t curr_descriptor_length = 0;
+	struct pldm_downstream_device *curr_device =
+		(struct pldm_downstream_device
+			 *)(resp + sizeof(struct pldm_query_downstream_identifier_resp));
+	struct pldm_descriptor_string *curr_descriptors_tbl;
+
+	for (uint32_t i = start_index; i < start_index + resp_p->numbwerofdownstreamdevice; i++) {
+		curr_descriptors_tbl = downstream_table[i].descriptor;
+		curr_device->downstreamdeviceindex = i + 1;
+		curr_device->downstreamdescriptorcount = downstream_table[i].descriptor_count;
+		downstream_devices_length += sizeof(struct pldm_downstream_device);
+		uint8_t *descriptor_ptr = curr_device->downstreamdescriptors;
+		for (uint32_t j = 0; j < downstream_table[i].descriptor_count; j++) {
+			rc = fill_descriptor_into_buf(&curr_descriptors_tbl[j], descriptor_ptr,
+						      &curr_descriptor_length,
+						      downstream_devices_length);
+			if (rc) {
+				LOG_ERR("%s:%s:%d: Fill device descriptor into buffer fail.",
+					__FILE__, __func__, __LINE__);
+				return PLDM_ERROR;
+			}
+			downstream_devices_length += curr_descriptor_length;
+			descriptor_ptr += curr_descriptor_length;
+		}
+
+		curr_device = (struct pldm_downstream_device *)descriptor_ptr;
+	}
+
+	resp_p->downstreamdevicelength = downstream_devices_length;
+	*resp_len =
+		sizeof(struct pldm_query_downstream_identifier_resp) + downstream_devices_length;
+	resp_p->completion_code = PLDM_SUCCESS;
+
+	return PLDM_SUCCESS;
+}
+
 void load_pldmupdate_comp_config(void)
 {
 	if (comp_config) {
@@ -316,6 +496,39 @@ static uint8_t plat_pldm_post_vr_update(void *fw_update_param)
 	set_cxl_vr_access(MAX_CXL_ID, true);
 
 	return 0;
+}
+
+static bool plat_get_cxl_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
+{
+	CHECK_NULL_ARG_WITH_RETURN(info_p, false);
+	CHECK_NULL_ARG_WITH_RETURN(buf, false);
+	CHECK_NULL_ARG_WITH_RETURN(len, false);
+
+	pldm_fw_update_info_t *p = (pldm_fw_update_info_t *)info_p;
+
+	uint8_t cxl_eid = plat_get_eid();
+	uint8_t cxl_comp_id = p->comp_identifier;
+	switch (cxl_comp_id) {
+	case WF_COMPNT_CXL1:
+		cxl_eid += 2;
+		break;
+	case WF_COMPNT_CXL2:
+		cxl_eid += 3;
+		break;
+	default:
+		LOG_ERR("Unknown CXL component ID %d", cxl_comp_id);
+		return false;
+	}
+
+	mctp *mctp_inst = NULL;
+	mctp_ext_params ext_params = { 0 };
+
+	if (!get_mctp_info_by_eid(cxl_eid, &mctp_inst, &ext_params)) {
+		LOG_ERR("Fail to get mctp info via eid: %d", cxl_eid);
+		return false;
+	}
+
+	return cci_get_chip_fw_version(mctp_inst, ext_params, buf, len);
 }
 
 static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)


### PR DESCRIPTION
# Description:
This commit provide downstream device descriptors for Wailua Falls.

# Motivation:
For PLDM formal firmware update, downstream descriptors would be queried for to expose which downstream devices does this endpoint device have.

# Test Plan:
The upcoming release version of pldmd would query downstream descriptor, and expose them in the software entries, if all the downstream devices are shown, that means the functionality of the implementation is good.

# Test Logs:
The command would be:
```
busctl tree xyz.openbmc_project.PLDM
```
The query result of software entries are shown below:
```
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_1_INF_VR_AB_ASIC2_469543ae
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_1_INF_VR_CD_ASIC1_aa4dd8fb
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_1_INF_VR_CD_ASIC2_fa259ea9
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_2_BIC_b9d681d8
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_2_CXL_1_779b3459
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_2_CXL_2_779b3459
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_2_INF_VR_AB_ASIC1_31fedb7f
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_2_INF_VR_AB_ASIC2_469543ae
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_2_INF_VR_CD_ASIC1_aa4dd8fb
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_2_INF_VR_CD_ASIC2_fa259ea9
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_3_BIC_b9d681d8
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_3_CXL_1_a2782b9a
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_3_CXL_2_a2782b9a
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_3_INF_VR_AB_ASIC1_31fedb7f
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_3_INF_VR_AB_ASIC2_469543ae
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_3_INF_VR_CD_ASIC1_aa4dd8fb
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_3_INF_VR_CD_ASIC2_fa259ea9
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_4_BIC_b9d681d8
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_4_CXL_1_779b3459
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_4_CXL_2_a2782b9a
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_4_INF_VR_AB_ASIC1_31fedb7f
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_4_INF_VR_AB_ASIC2_469543ae
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_4_INF_VR_CD_ASIC1_aa4dd8fb
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_4_INF_VR_CD_ASIC2_fa259ea9
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_5_BIC_b9d681d8
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_5_CXL_1_a2782b9a
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_5_CXL_2_a2782b9a
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_5_INF_VR_AB_ASIC1_31fedb7f
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_5_INF_VR_AB_ASIC2_469543ae
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_5_INF_VR_CD_ASIC1_aa4dd8fb
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_5_INF_VR_CD_ASIC2_fa259ea9
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_6_BIC_b9d681d8
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_6_CXL_1_a2782b9a
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_6_CXL_2_a2782b9a
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_6_INF_VR_AB_ASIC1_31fedb7f
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_6_INF_VR_AB_ASIC2_469543ae
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_6_INF_VR_CD_ASIC1_aa4dd8fb
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_6_INF_VR_CD_ASIC2_fa259ea9
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_7_BIC_b9d681d8
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_7_CXL_1_a2782b9a
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_7_CXL_2_a2782b9a
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_7_INF_VR_AB_ASIC1_31fedb7f
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_7_INF_VR_AB_ASIC2_469543ae
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_7_INF_VR_CD_ASIC1_aa4dd8fb
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_7_INF_VR_CD_ASIC2_fa259ea9
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_8_BIC_b9d681d8
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_8_CXL_1_779b3459
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_8_CXL_2_7ad8c8c0
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_8_INF_VR_AB_ASIC1_31fedb7f
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_8_INF_VR_AB_ASIC2_469543ae
      ├─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_8_INF_VR_CD_ASIC1_aa4dd8fb
      └─ /xyz/openbmc_project/software/Yosemite_4_Wailua_Falls_Slot_8_INF_VR_CD_ASIC2_fa259ea9
```
There're 2 CXL controllers and 4 VRs in each Wailua Falls, all of them are shown.