### PR TITLE
yv4: Support BIOS Firmware Update through PLDM

### DIFF
--- a/common/service/pldm/pldm_firmware_update.h
+++ b/common/service/pldm/pldm_firmware_update.h
@@ -649,6 +649,7 @@ uint16_t pldm_fw_update_read(void *mctp_p, enum pldm_firmware_update_commands cm
 uint8_t pldm_bic_update(void *fw_update_param);
 uint8_t pldm_vr_update(void *fw_update_param);
 uint8_t pldm_cpld_update(void *fw_update_param);
+uint8_t pldm_bios_update(void *fw_update_param);
 uint8_t pldm_retimer_update(void *fw_update_param);
 uint8_t pldm_retimer_recovery(void *fw_update_param);
 uint8_t fw_recovery_eeprom(I2C_MSG *msg, uint32_t offset, uint16_t msg_len, uint8_t *msg_buf,

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_monitor.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_monitor.h
@@ -32,4 +32,7 @@ enum plat_pldm_effecter_id {
 };
 
 extern struct pldm_state_effecter_info plat_state_effecter_table[];
+
+void host_power_on();
+void host_power_off();
 #endif


### PR DESCRIPTION
# Description:
Support BIOS firmware update through PLDM.

# Motivation:
BIOS can also be updated through PLDM.

# Test Plan:
1. Check the version once
2. Update BIOS through PLDM
3. Check if the version has changed

# Test Logs:
- Check BIOS version:
```
[root@20240220-643fbk2 ~]# dmidecode -t bios
Getting SMBIOS data from sysfs.
SMBIOS 3.5.0 present.

Handle 0x0000, DMI type 0, 26 bytes
BIOS Information
        Vendor: American Megatrends International, LLC.
        Version: Y4004
```
- Start updating using PLDM:
```
Oct 04 00:04:53 bmc pldmd[5492]: Decoded fw request data at offset '16776780' and length '150'
Oct 04 00:04:53 bmc pldmd[5492]: Decoded fw request data at offset '16776930' and length '150'
Oct 04 00:04:53 bmc pldmd[5492]: Decoded fw request data at offset '16777080' and length '136'
Oct 04 00:04:53 bmc pldmd[5492]: Component endpoint ID '30' and version 'Y4005' transfer complete.
Oct 04 00:04:53 bmc pldmd[5492]: Component endpoint ID '30' and version 'Y4005' verification complete.
Oct 04 00:04:53 bmc pldmd[5492]: Component endpoint ID '30' with 'Y4005' apply complete.
Oct 04 00:04:53 bmc pldmd[5492]: Firmware update time: 920249.501558ms
```
- Check BIOS version is changed:
```
Version 2.22.1285. Copyright (C) 2023 AMI
BIOS Date: 12/27/2023 09:11:03 Ver: Y4005
EVALUATION COPY.
Press <DEL> or <ESC> to enter setup.
```