### PR TITLE
minerva-ag: Modify P3V3 voltage and voltage_range with vout_scale

### DIFF
--- a/common/dev/isl69259.c
+++ b/common/dev/isl69259.c
@@ -144,13 +144,23 @@ bool isl69260_get_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
 
+	bool vout_scale_enable = false;
+	float vout_scale = 1.0;
+
+	if (cfg->init_args != NULL) {
+		isl69259_init_arg *init_arg = (isl69259_init_arg *)cfg->init_args;
+		vout_scale_enable = init_arg->vout_scale_enable;
+		if (vout_scale_enable)
+			vout_scale = init_arg->vout_scale;
+	}
+
 	uint8_t data[2] = { 0 };
 	if (!isl69260_i2c_read(cfg->port, cfg->target_addr, ISL69260_VOUT_MAX_REG, data,
 			       sizeof(data))) {
 		return false;
 	}
 
-	uint16_t val = data[0] | (data[1] << 8);
+	uint16_t val = (data[0] | (data[1] << 8)) / vout_scale;
 	*millivolt = val; // 1mV / LSB
 
 	return true;
@@ -161,13 +171,23 @@ bool isl69260_get_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
 
+	bool vout_scale_enable = false;
+	float vout_scale = 1.0;
+
+	if (cfg->init_args != NULL) {
+		isl69259_init_arg *init_arg = (isl69259_init_arg *)cfg->init_args;
+		vout_scale_enable = init_arg->vout_scale_enable;
+		if (vout_scale_enable)
+			vout_scale = init_arg->vout_scale;
+	}
+
 	uint8_t data[2] = { 0 };
 	if (!isl69260_i2c_read(cfg->port, cfg->target_addr, ISL69260_VOUT_MIN_REG, data,
 			       sizeof(data))) {
 		return false;
 	}
 
-	uint16_t val = data[0] | (data[1] << 8);
+	uint16_t val = (data[0] | (data[1] << 8)) / vout_scale;
 	*millivolt = val; // 1mV / LSB
 
 	return true;
@@ -178,9 +198,20 @@ bool isl69260_set_vout_max(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
 
+	bool vout_scale_enable = false;
+	float vout_scale = 1.0;
+
+	if (cfg->init_args != NULL) {
+		isl69259_init_arg *init_arg = (isl69259_init_arg *)cfg->init_args;
+		vout_scale_enable = init_arg->vout_scale_enable;
+		if (vout_scale_enable)
+			vout_scale = init_arg->vout_scale;
+	}
+
+	uint16_t val = *millivolt * vout_scale;
 	uint8_t data[2] = { 0 };
-	data[0] = *millivolt & 0xFF;
-	data[1] = (*millivolt >> 8) & 0xFF;
+	data[0] = val & 0xFF;
+	data[1] = (val >> 8) & 0xFF;
 
 	if (!isl69260_i2c_write(cfg->port, cfg->target_addr, ISL69260_VOUT_MAX_REG, data,
 				sizeof(data))) {
@@ -195,9 +226,19 @@ bool isl69260_set_vout_min(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
 
+	bool vout_scale_enable = false;
+	float vout_scale = 1.0;
+
+	if (cfg->init_args != NULL) {
+		isl69259_init_arg *init_arg = (isl69259_init_arg *)cfg->init_args;
+		vout_scale_enable = init_arg->vout_scale_enable;
+		if (vout_scale_enable)
+			vout_scale = init_arg->vout_scale;
+	}
+	uint16_t val = *millivolt * vout_scale;
 	uint8_t data[2] = { 0 };
-	data[0] = *millivolt & 0xFF;
-	data[1] = (*millivolt >> 8) & 0xFF;
+	data[0] = val & 0xFF;
+	data[1] = (val >> 8) & 0xFF;
 
 	if (!isl69260_i2c_write(cfg->port, cfg->target_addr, ISL69260_VOUT_MIN_REG, data,
 				sizeof(data))) {
@@ -619,13 +660,23 @@ bool isl69260_get_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivol
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
 
+	bool vout_scale_enable = false;
+	float vout_scale = 1.0;
+
+	if (cfg->init_args != NULL) {
+		isl69259_init_arg *init_arg = (isl69259_init_arg *)cfg->init_args;
+		vout_scale_enable = init_arg->vout_scale_enable;
+		if (vout_scale_enable)
+			vout_scale = init_arg->vout_scale;
+	}
+
 	uint8_t data[2] = { 0 };
 	if (!isl69260_i2c_read(cfg->port, cfg->target_addr, PMBUS_VOUT_COMMAND, data,
 			       sizeof(data))) {
 		return false;
 	}
 
-	uint16_t val = data[0] | (data[1] << 8);
+	uint16_t val = (data[0] | (data[1] << 8)) / vout_scale;
 
 	*millivolt = val;
 
@@ -637,9 +688,19 @@ bool isl69260_set_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivol
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
 
+	bool vout_scale_enable = false;
+	float vout_scale = 1.0;
+
+	if (cfg->init_args != NULL) {
+		isl69259_init_arg *init_arg = (isl69259_init_arg *)cfg->init_args;
+		vout_scale_enable = init_arg->vout_scale_enable;
+		if (vout_scale_enable)
+			vout_scale = init_arg->vout_scale;
+	}
+	uint16_t val = *millivolt * vout_scale;
 	uint8_t data[2] = { 0 };
-	data[0] = *millivolt & 0xFF;
-	data[1] = (*millivolt >> 8) & 0xFF;
+	data[0] = val & 0xFF;
+	data[1] = (val >> 8) & 0xFF;
 
 	if (!isl69260_i2c_write(cfg->port, cfg->target_addr, PMBUS_VOUT_COMMAND, data,
 				sizeof(data))) {

--- a/common/dev/mp2971.c
+++ b/common/dev/mp2971.c
@@ -919,6 +919,18 @@ bool mp2971_vid_to_direct(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
 
+	bool vout_scale_enable = false;
+	if (cfg->init_args != NULL) {
+		mp2971_init_arg *init_arg = (mp2971_init_arg *)cfg->init_args;
+		vout_scale_enable = init_arg->vout_scale_enable;
+	}
+	float vout_scale = 1.0;
+	if (vout_scale_enable == true) {
+		if (get_vout_scale(cfg, &vout_scale) == false) {
+			LOG_WRN("get vout scale failed");
+		}
+	}
+
 	bool ret = false;
 	uint8_t page = rail;
 
@@ -983,6 +995,8 @@ bool mp2971_vid_to_direct(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
 		return ret;
 	}
 
+	*millivolt = *millivolt / vout_scale;
+
 	if (mp2856_set_page(cfg->port, cfg->target_addr, page) == false) {
 		return ret;
 	}
@@ -995,6 +1009,19 @@ bool mp2971_direct_to_vid(sensor_cfg *cfg, uint8_t rail, uint16_t *millivolt)
 {
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
+
+	bool vout_scale_enable = false;
+	if (cfg->init_args != NULL) {
+		mp2971_init_arg *init_arg = (mp2971_init_arg *)cfg->init_args;
+		vout_scale_enable = init_arg->vout_scale_enable;
+	}
+	float vout_scale = 1.0;
+	if (vout_scale_enable == true) {
+		if (get_vout_scale(cfg, &vout_scale) == false) {
+			LOG_WRN("get vout scale failed");
+		}
+	}
+	*millivolt = *millivolt * vout_scale;
 
 	bool ret = false;
 	uint8_t page = rail;


### PR DESCRIPTION
Summary:
- Modify voltage and voltage_range calcutation of P3V3 with vout_scale

Test Plan:
- Build code: PASS