### PR TITLE
fby4: sd: Increase SRAM

### DIFF
--- a/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
@@ -238,7 +238,7 @@
 	* It is currently written as 24KB, and Aspeed will correct to 32KB in the next version.
 	* 0xa0000 is the starting offset of the non-cacheable area.
 	*/
-	reg = <0 DT_SIZE_K(672)>, <0xa8000 DT_SIZE_K(96)>;
+	reg = <0 DT_SIZE_K(704)>, <0xB0000 DT_SIZE_K(64)>;
 };
 
 &pcc {


### PR DESCRIPTION
# Description
- Increase SRAM memory.

# Motivation
- Now the SRAM usage rate reaches the critical value.

# Log
- Before change [367/367] Linking C executable zephyr/Y4BSD.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:       61504 B        96 KB     62.57%
           FLASH:          0 GB         0 GB
            SRAM:      684560 B       672 KB     99.48%
        IDT_LIST:          0 GB         2 KB      0.00%

- After change [367/367] Linking C executable zephyr/Y4BSD.elf
Memory region         Used Size  Region Size  %age Used
         SRAM_NC:       61504 B        64 KB     93.85%
           FLASH:          0 GB         0 GB
            SRAM:      684560 B       704 KB     94.96%
        IDT_LIST:          0 GB         2 KB      0.00%