### PR TITLE
yv4: sd/wf: Fix BIC get abnormal reading from vr.

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_fw_update.c
@@ -525,6 +525,8 @@ static uint8_t plat_pldm_pre_vr_update(void *fw_update_param)
 
 	/* Stop sensor polling */
 	set_vr_monitor_status(false);
+	// wait 10ms for vr monitor stop
+	k_msleep(10);
 	p->bus = I2C_BUS4;
 
 	if (p->comp_id == SD_COMPNT_VR_PVDDCR_CPU1) {
@@ -605,6 +607,8 @@ static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 
 	const uint8_t *vr_name_p = vr_name[vr_type];
 	set_vr_monitor_status(false);
+	// wait 10ms for vr monitor stop
+	k_msleep(10);
 	switch (vr_type) {
 	case VR_TYPE_MPS:
 		if (!mp2971_get_checksum(bus, addr, &version)) {

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
@@ -483,6 +483,8 @@ static uint8_t plat_pldm_pre_vr_update(void *fw_update_param)
 
 	/* Stop sensor polling */
 	set_cxl_vr_access(MAX_CXL_ID, false);
+	// Wait sensor monitoring thread to stop
+	k_msleep(10);
 
 	plat_pldm_vr_i2c_info_get(p->comp_id, &p->bus, &p->addr);
 
@@ -564,6 +566,8 @@ static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 
 	const uint8_t *vr_name_p = vr_name[vr_type];
 	set_cxl_vr_access(MAX_CXL_ID, false);
+	// Wait sensor monitoring thread to stop
+	k_msleep(10);
 	switch (vr_type) {
 	case VR_TYPE_INF:
 		if (!xdpe12284c_get_checksum(bus, addr, (uint8_t *)&version)) {


### PR DESCRIPTION
# Description:
- When reading the VR version, the BIC did not wait for the sensor monitor to receive the stop flag before proceeding.
- This caused the VR page to be set incorrectly, resulting in abnormal VR readings.

# Motivation:
- Fix BIC get abnormal reading from vr.

# Test Plan:
Build code - pass
Stress test on yv4 - pass