### PR TITLE
yv4: sd: Fix abnormal current sensor reading from VR

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -512,6 +512,11 @@ void process_vr_pmalert_ocp_sel(struct k_work *work_item)
 	msg.target_addr = work_info->vr_addr;
 
 	for (int page = 0; page < work_info->page_cnt; ++page) {
+
+		set_vr_monitor_status(false);
+		// wait 10ms for vr monitor stop
+		k_msleep(10);
+
 		/* set page for power rail */
 		msg.tx_len = 2;
 		msg.data[0] = PMBUS_PAGE;
@@ -561,6 +566,8 @@ void process_vr_pmalert_ocp_sel(struct k_work *work_item)
 				}
 			}
 		}
+
+		set_vr_monitor_status(true);
 
 		struct pldm_addsel_data sel_msg = { 0 };
 


### PR DESCRIPTION
# Description:
- While the VR alert occurred, the BIC did not wait for the sensor monitor to receive the stop flag before proceeding.
- This might results in abnormal VR readings.

# Motivation:
- Fix the abnormal current sensor reading that the BIC receives from the VR.

# Test Plan:
Build code - pass
Stress test on yv4 - pass