### PR TITLE
Common: Fix cppcheck with 2.13

### DIFF
--- a/scripts/linters/cppcheck/cppcheck-suppressions.txt
+++ b/scripts/linters/cppcheck/cppcheck-suppressions.txt
@@ -13,5 +13,11 @@ ConfigurationNotChecked
 // assigning a variable a value before it's used isn't very important.
 unreadVariable
 
+// CPPcheck doesn't know about relative include path
+missingInclude
+
 // CPPcheck doesn't know about standard header path.
-missingIncludeSystem 
+missingIncludeSystem
+
+// Ignore checkers report message
+checkersReport


### PR DESCRIPTION
Description
- cppcheck has some config change from 2.07 to 2.13
- add suppression to ignore including path warning and report message

Motivation
- cppcheck can't work normally

Test plan
- test some .c and .h files with cppcheck 2.13