### PR TITLE
minerva-ag: Modify platform info command to support displaying board types

### DIFF
--- a/common/shell/commands/info_shell.c
+++ b/common/shell/commands/info_shell.c
@@ -24,6 +24,11 @@
 
 #define RTOS_TYPE "Zephyr"
 
+__weak void pal_show_extra_info(const struct shell *shell)
+{
+	return;
+}
+
 int cmd_info_print(const struct shell *shell, size_t argc, char **argv)
 {
 	shell_print(
@@ -43,6 +48,7 @@ int cmd_info_print(const struct shell *shell, size_t argc, char **argv)
 	shell_print(shell, "* FW DATE:       %x%x.%x.%x", BIC_FW_YEAR_MSB, BIC_FW_YEAR_LSB,
 		    BIC_FW_WEEK, BIC_FW_VER);
 	shell_print(shell, "* FW IMAGE:      %s.bin", CONFIG_KERNEL_BIN_NAME);
+	pal_show_extra_info(shell);
 	shell_print(
 		shell,
 		"========================{SHELL COMMAND INFO}========================================");

--- a/meta-facebook/minerva-ag/src/platform/plat_class.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_class.c
@@ -286,3 +286,53 @@ void init_platform_config()
 	init_vr_vendor_type();
 	init_tmp_type();
 }
+
+void pal_show_board_types(const struct shell *shell)
+{
+	shell_print(shell, "* BOARD_TYPE:    (0x%02X)%s", board_type,
+		    (board_type == MINERVA_AEGIS_BD) ? "AEGIS" :
+		    (board_type == MINERVA_EVB_BD)   ? "EVB" :
+						       "not supported");
+
+	shell_print(shell, "* BOARD_STAGE:   (0x%02X)%s", board_stage,
+		    (board_stage == FAB1_EVT) ? "FAB1_EVT" :
+		    (board_stage == FAB2_DVT) ? "FAB2_DVT" :
+		    (board_stage == FAB3_PVT) ? "FAB3_PVT" :
+		    (board_stage == FAB4_MP)  ? "FAB4_MP" :
+						"not supported");
+
+	shell_print(shell, "* VR_VENDOR_TYPE:(0x%02X)%s", vr_vender_type,
+		    (vr_vender_type == DELTA_UBC_AND_MPS_VR) ? "DELTA_UBC_AND_MPS_VR" :
+		    (vr_vender_type == DELTA_UBC_AND_RNS_VR) ? "DELTA_UBC_AND_RNS_VR" :
+		    (vr_vender_type == MPS_UBC_AND_MPS_VR)   ? "MPS_UBC_AND_MPS_VR" :
+		    (vr_vender_type == MPS_UBC_AND_RNS_VR)   ? "MPS_UBC_AND_RNS_VR" :
+		    (vr_vender_type == FLEX_UBC_AND_MPS_VR)  ? "FLEX_UBC_AND_MPS_VR" :
+		    (vr_vender_type == FLEX_UBC_AND_RNS_VR)  ? "FLEX_UBC_AND_RNS_VR" :
+							       "not supported");
+	shell_print(shell, "* UBC_TYPE:      (0x%02X)%s", ubc_type,
+		    (ubc_type == UBC_DELTA_U50SU4P180PMDAFC) ? "DELTA_U50SU4P180PMDAFC" :
+		    (ubc_type == UBC_MPS_MPC12109)	     ? "MPS_MPC12109" :
+		    (ubc_type == UBC_FLEX_BMR313)	     ? "FLEX_BMR313" :
+							       "not supported");
+
+	shell_print(shell, "* VR_TYPE:       (0x%02X)%s", vr_type,
+		    (vr_type == VR_MPS_MP2971_MP2891)	   ? "MPS_MP2971_MP2891" :
+		    (vr_type == VR_MPS_MP2971_MP29816A)	   ? "MPS_MP2971_MP29816A" :
+		    (vr_type == VR_RNS_ISL69260_RAA228238) ? "RNS_ISL69260_RAA228238" :
+		    (vr_type == VR_RNS_ISL69260_RAA228249) ? "RNS_ISL69260_RAA228249" :
+							     "not supported");
+
+	shell_print(shell, "* TMP_TYPE:      (0x%02X)%s", tmp_type,
+		    (tmp_type == TMP_EMC1413) ? "TMP_EMC1413" :
+		    (tmp_type == TMP_TMP432)  ? "TMP_TMP432" :
+						"not supported");
+
+	return;
+}
+
+void pal_show_extra_info(const struct shell *shell)
+{
+	pal_show_board_types(shell);
+
+	return;
+}


### PR DESCRIPTION
Summary:
- Modify platform info commands to support displaying board types.

Test Plan:
- Build code: PASS