### PR TITLE
fby4: sd: Fix BIC read abnormal PMIC error

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pmic.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pmic.h
@@ -41,6 +41,7 @@ void read_pmic_error_when_dc_off();
 void clear_pmic_error(uint8_t dimm_id);
 void add_pmic_error_sel(uint8_t dimm_id, uint8_t error_type);
 int get_pmic_error_data(uint8_t dimm_id, uint8_t *buffer, uint8_t is_need_check_post_status);
+int get_pmic_error_data_one(uint8_t dimm_id, uint8_t *buffer, uint8_t is_need_check_post_status);
 
 void init_pmic_event_work();
 


### PR DESCRIPTION
# Description
- It's for JIRA-1459
- Read one PMIC error register at a time instead of reading all at once.

# Motivation
- Currently, BIC maigh read fake data when read all register at once.

# Test plan
- Build code: Pass
- AC cycle stress: Pass