### PR TITLE
fby4: sd: Modify thermtrip event condition

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -417,7 +417,7 @@ void ISR_MB_THROTTLE()
 
 void ISR_SOC_THMALTRIP()
 {
-	if (gpio_get(RST_CPU_RESET_BIC_N) == GPIO_HIGH) {
+	if (gpio_get(RST_RSMRST_BMC_N) == GPIO_HIGH) {
 		LOG_INF("ISR_SOC_THMALTRIP assert");
 		hw_event_register[3]++;
 		add_sel_info *event_item = find_event_work_items(FM_CPU_BIC_THERMTRIP_N);


### PR DESCRIPTION
# Description
- It's related to JIRA-1451
- Modified the judgment formula of the SD BIC send event when FM_CPU_BIC_THERMTRIP_N is falling. Change the condition RST_CPU_RESET_BIC_N = H to RST_RSMRST_BMC_N = H.

# Motivation
- BIC didn't send the thermtrip event becuase it will only record the thermtrip event when RST_CPU_RESET_BIC_N is high.

Test plan
- Build code: Pass
- Trigger event: Pass

# Log
    "11": {
        "additional_data": [],
        "event_id": "",
        "message": "Event: Host8 CPU Thermal Trip, ASSERTED",
        "resolution": "",
        "resolved": false,
        "severity": "xyz.openbmc_project.Logging.Entry.Level.Error",
        "timestamp": "2024-02-28T03:31:29.123000000Z",
        "updated_timestamp": "2024-02-28T03:31:29.123000000Z"
    },