### PR TITLE
fby4: sd: Ignore VR Alert for Iout OC Warning in the SEL

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -547,23 +547,21 @@ void process_vr_pmalert_ocp_sel(struct k_work *work_item)
 			continue;
 		}
 
-		if (vr_dev == sensor_dev_tps53689) {
-			/* 1. check if trigger reason is IOUT fault */
-			if (((status_word_msb & VR_IOUT_FAULT_MASK) >> 6) == 1) {
-				/* 2. IOUT fault, check if OC Warning is set */
-				msg.tx_len = 1;
-				msg.rx_len = 1;
-				msg.data[0] = PMBUS_STATUS_IOUT;
-				ret = i2c_master_read(&msg, retry);
-				if (ret != 0) {
-					LOG_ERR("Get vr status iout fail, bus: 0x%x, addr: 0x%x",
-						msg.bus, msg.target_addr);
-					continue;
-				}
-				if (((msg.data[0] & VR_TPS_OCW_MASK) >> 5) == 1) {
-					/* only OC Warn is triggered, skip to prevent false event */
-					continue;
-				}
+		/* 1. check if trigger reason is IOUT fault */
+		if (((status_word_msb & VR_IOUT_FAULT_MASK) >> 6) == 1) {
+			/* 2. IOUT fault, check if OC Warning is set */
+			msg.tx_len = 1;
+			msg.rx_len = 1;
+			msg.data[0] = PMBUS_STATUS_IOUT;
+			ret = i2c_master_read(&msg, retry);
+			if (ret != 0) {
+				LOG_ERR("Get vr status iout fail, bus: 0x%x, addr: 0x%x",
+					msg.bus, msg.target_addr);
+				continue;
+			}
+			if (((msg.data[0] & VR_TPS_OCW_MASK) >> 5) == 1) {
+				/* only OC Warn is triggered, skip to prevent false event */
+				continue;
 			}
 		}
 


### PR DESCRIPTION
# Description:
- It's related JIRA-1420 & JIRA1491
- Ignore VR Alert for Iout OC Warning in the SEL.

# Motivation:
- The system should not log an event in the SEL when a PMALERT assertion occurs, provided that the alert is solely caused by an Iout OC warning.

# Test Plan:
- Build Code: PASS.
- Intentionally trigger a PMALERT by using I2C to set the IOUT_OC_WARN_LIMIT to a very low value on the VR device. Verify that no SEL event is logged  as a result of this PMBus alert.