### PR TITLE
minerva-ag: Fix temp_threshold after AC power cycle

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_hook.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.c
@@ -814,8 +814,8 @@ void user_settings_init(void)
 	alert_level_user_settings_init();
 	vr_vout_default_settings_init();
 	vr_vout_user_settings_init();
-	temp_threshold_user_settings_init();
 	temp_threshold_default_settings_init();
+	temp_threshold_user_settings_init();
 	soc_pcie_perst_user_settings_init();
 }
 


### PR DESCRIPTION
Summary:
- Fix temp_threshold issue where it does not restore to default after AC power cycle when set to permanent, even after clearing perm_config.

Test Plan:
- Build code: PASS