### PR TITLE
fby4: wf: Correct VR sensor threshold

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
@@ -3594,11 +3594,11 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x00000320, //uint32_t warning_high;
+			0x000004E2, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x000003E8, //uint32_t critical_high;
+			0x00000546, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x00000578, //uint32_t fatal_high;
+			0x000005AA, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 
 		},
@@ -3910,11 +3910,11 @@ pldm_sensor_info plat_pldm_sensor_vr_table[] = {
 			0x00000000, //uint32_t normal_max;
 			0x00000000, //uint32_t normal_min;
 
-			0x00000320, //uint32_t warning_high;
+			0x000004E2, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x000003E8, //uint32_t critical_high;
+			0x00000546, //uint32_t critical_high;
 			0x00000000, //uint32_t critical_low;
-			0x00000578, //uint32_t fatal_high;
+			0x000005AA, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;
 
 		},


### PR DESCRIPTION
# Description
- It's related to JIRA-1530
- The thresholds for both WF_VR_ASIC1_P0V85_CURR_A and WF_VR_ASIC2_P0V85_CURR_A have been modified as follows: UNC: 12.5A, UCR: 13.5A, UNR: 14.5A.

# Motivation
- Some sensors will trigger threshold event during stressapptest.

# Test Plan:
- Thresholds shown as expected with mfg-tool sensor-display: Pass
- Build code: Pass