### PR TITLE
minerva-ag: Modify bootstrap commands

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_hook.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.h
@@ -260,8 +260,8 @@ bool vr_status_enum_get(uint8_t *name, uint8_t *num);
 bool strap_name_get(uint8_t rail, uint8_t **name);
 bool strap_enum_get(uint8_t *name, uint8_t *num);
 bool find_bootstrap_by_rail(uint8_t rail, bootstrap_mapping_register *result);
-bool set_bootstrap_table(uint8_t rail, uint8_t *change_setting_value, uint8_t drive_index_level,
-			 bool is_perm);
-bool get_drive_level(int rail, int *drive_level);
+bool set_bootstrap_table_and_user_settings(uint8_t rail, uint8_t *change_setting_value,
+					   uint8_t drive_index_level, bool is_perm);
+bool get_bootstrap_change_drive_level(int rail, int *drive_level);
 
 #endif

--- a/meta-facebook/minerva-ag/src/shell/plat_perm_config_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_perm_config_shell.c
@@ -82,18 +82,13 @@ static int cmd_perm_config_get(const struct shell *shell, size_t argc, char **ar
 	}
 
 	for (int i = 0; i < STRAP_INDEX_MAX; i++) {
-		// bit 8: not perm(0); perm(1)
-		if ((bootstrap_user_settings.user_setting_value[i] >> 8) == 0x01) {
+		if (bootstrap_user_settings.user_setting_value[i] != 0xffff) {
 			uint8_t *rail_name = NULL;
 			if (!strap_name_get((uint8_t)i, &rail_name)) {
 				LOG_ERR("Can't find strap_rail_name by rail index: %x", i);
 				continue;
 			}
-			int drive_level = -1;
-			if (!get_drive_level(i, &drive_level)) {
-				LOG_ERR("Can't get_drive_level by rail index: %x", i);
-				continue;
-			}
+			uint8_t drive_level = bootstrap_user_settings.user_setting_value[i] & 0xff;
 			shell_print(shell, "[%2d]%-50s val=%d", i, rail_name, drive_level);
 			config_count++;
 		}


### PR DESCRIPTION
Summary:
- Modify bootstrap_user_settings storage format, ex: 0x0101 -> set high perm; ex: 0x0100 -> set low perm
- Modify bootstrap function name

Test Plan:
- Build code: PASS