### PR TITLE
fby4: sd: Change I3C frequency of BMC to 8M

### DIFF
--- a/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
@@ -85,7 +85,9 @@
 &i3c0 {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_i3c0_default>;
-	i3c-scl-hz = <12500000>;
+	i3c-scl-hz = <8000000>;
+	i3c-pp-scl-hi-period-ns = <62>;
+	i3c-pp-scl-lo-period-ns = <63>;
 	secondary;
 	wait-pid-extra-info;
 	ibi-append-pec;


### PR DESCRIPTION
# Description
- Change the I3C frequency between BMC and SB BIC from 12.5M to 8M.

# Motivation
- Currently there are I3C communication issues between BMC and SB BIC, slow down to avoid it.

# Test plan
- Build code: Pass
- Stress: Pass