### PR TITLE
fby4: sd: Adjust priorities of threads

### DIFF
--- a/common/dev/apml_mailbox.c
+++ b/common/dev/apml_mailbox.c
@@ -32,7 +32,7 @@ typedef struct _dimm_temp_priv_data {
 	float ts0_temp;
 } dimm_temp_priv_data;
 
-void apml_read_fail_cb(apml_msg *msg)
+void apml_read_fail_cb(const apml_msg *msg)
 {
 	if ((msg == NULL) || (msg->ptr_arg == NULL)) {
 		LOG_DBG("msg passed in as NULL");
@@ -53,7 +53,7 @@ void apml_read_fail_cb(apml_msg *msg)
 	}
 }
 
-void cpu_power_write(apml_msg *msg)
+void cpu_power_write(const apml_msg *msg)
 {
 	if ((msg == NULL) || (msg->ptr_arg == NULL)) {
 		LOG_DBG("msg passed in as NULL");
@@ -88,7 +88,7 @@ void cpu_power_write(apml_msg *msg)
 #endif
 }
 
-void dimm_pwr_write(apml_msg *msg)
+void dimm_pwr_write(const apml_msg *msg)
 {
 	if ((msg == NULL) || (msg->ptr_arg == NULL)) {
 		LOG_DBG("msg passed in as NULL");
@@ -118,7 +118,7 @@ void dimm_pwr_write(apml_msg *msg)
 	cfg->cache_status = SENSOR_READ_4BYTE_ACUR_SUCCESS;
 }
 
-void dimm_temp_write(apml_msg *msg)
+void dimm_temp_write(const apml_msg *msg)
 {
 	if ((msg == NULL) || (msg->ptr_arg == NULL)) {
 		LOG_DBG("msg passed in as NULL");
@@ -186,7 +186,7 @@ uint8_t apml_mailbox_read(sensor_cfg *cfg, int *reading)
 		return SENSOR_UNSPECIFIED_ERROR;
 	}
 
-	apml_mailbox_init_arg *init_arg = (apml_mailbox_init_arg *)cfg->init_args;
+	const apml_mailbox_init_arg *init_arg = (const apml_mailbox_init_arg *)cfg->init_args;
 
 	apml_msg mailbox_msg;
 	memset(&mailbox_msg, 0, sizeof(apml_msg));

--- a/common/dev/pcc.c
+++ b/common/dev/pcc.c
@@ -207,7 +207,7 @@ void check_ABL_error(uint32_t postcode)
 	SAFE_FREE(msg);
 #else
 	// record Unified SEL
-	uint8_t bmc_bus = I2C_BUS_BMC, bmc_interface = BMC_INTERFACE_I2C;;
+	uint8_t bmc_bus = I2C_BUS_BMC, bmc_interface = BMC_INTERFACE_I2C;
 	mctp_ext_params ext_params = { 0 };
 	uint8_t data[16] = { 0 };
 
@@ -444,7 +444,7 @@ void pcc_init()
 
 	k_thread_create(&process_postcode_thread_handler, process_postcode_thread,
 			K_THREAD_STACK_SIZEOF(process_postcode_thread), process_postcode, NULL,
-			NULL, NULL, CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+			NULL, NULL, K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
 	k_thread_name_set(&process_postcode_thread_handler, "process_postcode_thread");
 
 	return;

--- a/common/service/apml/apml.c
+++ b/common/service/apml/apml.c
@@ -323,7 +323,7 @@ static uint8_t write_mailbox_request(apml_msg *msg)
 	}
 
 	/* write command and data */
-	mailbox_WrData *wr_data = (mailbox_WrData *)msg->WrData;
+	const mailbox_WrData *wr_data = (const mailbox_WrData *)msg->WrData;
 	if (apml_write_byte(msg->bus, msg->target_addr, SBRMI_INBANDMSG_INST0, wr_data->command)) {
 		return APML_ERROR;
 	}
@@ -384,7 +384,8 @@ static uint8_t access_RMI_mailbox(apml_msg *msg)
 	for (i = 0; i < MAILBOX_COMPLETE_RETRY_MAX; i++) {
 		/* For TURIN, wait for SoftwareInterrupt */
 		if (command_code_len == SBRMI_CMD_CODE_LEN_TWO_BYTE) {
-			if (apml_read_byte(msg->bus, msg->target_addr, SBRMI_SOFTWARE_INTERRUPT, &status)) {
+			if (apml_read_byte(msg->bus, msg->target_addr, SBRMI_SOFTWARE_INTERRUPT,
+					   &status)) {
 				LOG_ERR("Read SoftwareInterrupt failed.");
 				return APML_ERROR;
 			}
@@ -408,9 +409,11 @@ static uint8_t access_RMI_mailbox(apml_msg *msg)
 	}
 	if (i == MAILBOX_COMPLETE_RETRY_MAX) {
 		if (command_code_len == SBRMI_CMD_CODE_LEN_TWO_BYTE) {
-			LOG_ERR("SoftwareInterrupt not be set, retry %d times.", MAILBOX_COMPLETE_RETRY_MAX);
+			LOG_ERR("SoftwareInterrupt not be set, retry %d times.",
+				MAILBOX_COMPLETE_RETRY_MAX);
 		} else {
-			LOG_ERR("SwAlertSts not be set, retry %d times.", MAILBOX_COMPLETE_RETRY_MAX);
+			LOG_ERR("SwAlertSts not be set, retry %d times.",
+				MAILBOX_COMPLETE_RETRY_MAX);
 		}
 		return APML_ERROR;
 	}
@@ -435,7 +438,7 @@ static uint8_t access_RMI_mailbox(apml_msg *msg)
 	return APML_SUCCESS;
 }
 
-void apml_request_callback(apml_msg *msg)
+void apml_request_callback(const apml_msg *msg)
 {
 	static uint8_t i = 0;
 	apml_resp_buffer[i].index = msg->ui32_arg & 0xFF;
@@ -546,7 +549,7 @@ void apml_init()
 	memset(apml_resp_buffer, 0xFF, sizeof(apml_resp_buffer));
 
 	k_thread_create(&apml_thread, apml_handler_stack, K_THREAD_STACK_SIZEOF(apml_handler_stack),
-			apml_handler, NULL, NULL, NULL, CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+			apml_handler, NULL, NULL, NULL, K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
 	k_thread_name_set(&apml_thread, "APML_handler");
 }
 

--- a/common/service/apml/apml.h
+++ b/common/service/apml/apml.h
@@ -138,8 +138,8 @@ typedef __aligned(4) struct _apml_msg_ {
 	uint8_t target_addr;
 	uint8_t WrData[7];
 	uint8_t RdData[9];
-	void (*cb_fn)(struct _apml_msg_ *msg);
-	void (*error_cb_fn)(struct _apml_msg_ *msg);
+	void (*cb_fn)(const struct _apml_msg_ *msg);
+	void (*error_cb_fn)( const struct _apml_msg_ *msg);
 	void *ptr_arg;
 	uint32_t ui32_arg;
 } __packed apml_msg;
@@ -151,7 +151,7 @@ typedef struct _apml_buffer_ {
 
 uint8_t apml_read_byte(uint8_t bus, uint8_t addr, uint8_t offset, uint8_t *read_data);
 uint8_t apml_write_byte(uint8_t bus, uint8_t addr, uint8_t offset, uint8_t write_data);
-void apml_request_callback(apml_msg *msg);
+void apml_request_callback(const apml_msg *msg);
 uint8_t get_apml_response_by_index(apml_msg *msg, uint8_t index);
 uint8_t apml_read(apml_msg *msg);
 void apml_init();

--- a/common/service/mctp/mctp_ctrl.c
+++ b/common/service/mctp/mctp_ctrl.c
@@ -63,7 +63,7 @@ uint8_t mctp_ctrl_cmd_set_endpoint_id(void *mctp_inst, uint8_t *buf, uint16_t le
 	CHECK_NULL_ARG_WITH_RETURN(resp, MCTP_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(resp_len, MCTP_ERROR);
 
-	struct _set_eid_req *req = (struct _set_eid_req *)buf;
+	const struct _set_eid_req *req = (const struct _set_eid_req *)buf;
 	struct _set_eid_resp *p = (struct _set_eid_resp *)resp;
 
 	uint8_t plat_mctp_port_count = plat_get_mctp_port_count();
@@ -215,14 +215,14 @@ static uint8_t mctp_ctrl_cmd_resp_process(mctp *mctp_inst, uint8_t *buf, uint32_
 		return MCTP_ERROR;
 	}
 
-	mctp_ctrl_hdr *hdr = (mctp_ctrl_hdr *)buf;
+	const mctp_ctrl_hdr *hdr = (const mctp_ctrl_hdr *)buf;
 	sys_snode_t *node;
 	sys_snode_t *s_node;
 	sys_snode_t *pre_node = NULL;
 	sys_snode_t *found_node = NULL;
 
 	SYS_SLIST_FOR_EACH_NODE_SAFE (&wait_recv_resp_list, node, s_node) {
-		wait_msg *p = (wait_msg *)node;
+		const wait_msg *p = (const wait_msg *)node;
 		/* found the proper handler */
 		if ((p->msg.hdr.inst_id == hdr->inst_id) && (p->mctp_inst == mctp_inst) &&
 		    (p->msg.hdr.cmd == hdr->cmd)) {
@@ -481,4 +481,5 @@ exit:
 	return ret;
 }
 
-K_THREAD_DEFINE(monitor_tid, 1024, mctp_ctrl_msg_timeout_monitor, NULL, NULL, NULL, 0, 0, 0);
+K_THREAD_DEFINE(monitor_tid, 1024, mctp_ctrl_msg_timeout_monitor, NULL, NULL, NULL,
+		K_PRIO_PREEMPT(1), 0, 0);

--- a/common/service/sensor/pldm_sensor.c
+++ b/common/service/sensor/pldm_sensor.c
@@ -86,8 +86,15 @@ int pldm_sensor_get_info_via_sensor_thread_and_sensor_pdr_index(
 	CHECK_NULL_ARG_WITH_RETURN(cache_status, -1);
 	CHECK_NULL_ARG_WITH_RETURN(check_access, -1);
 
+	if (thread_id < 0) {
+		LOG_ERR("Invalid thread_id: %d", thread_id);
+		return -1;
+	}
+
 	int pldm_sensor_count = plat_pldm_sensor_get_sensor_count(thread_id);
-	if (sensor_pdr_index >= pldm_sensor_count) {
+	if ((sensor_pdr_index < 0) || (sensor_pdr_index >= pldm_sensor_count)) {
+		LOG_ERR("Invalid sensor_pdr_index: %d for thread_id: %d. Max allowed: %d",
+			sensor_pdr_index, thread_id, pldm_sensor_count);
 		return -1;
 	}
 
@@ -395,7 +402,7 @@ void pldm_sensor_poll_thread_init()
 			k_thread_create(&pldm_sensor_polling_thread[i], pldm_sensor_poll_stacks[i],
 					K_THREAD_STACK_SIZEOF(pldm_sensor_poll_stacks[i]),
 					pldm_sensor_polling_handler, (void *)i, NULL, NULL,
-					CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+					K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
 		k_thread_name_set(&pldm_sensor_polling_thread[i],
 				  pldm_sensor_thread_list[i].thread_name);
 

--- a/common/service/usb/usb.c
+++ b/common/service/usb/usb.c
@@ -203,7 +203,7 @@ void usb_dev_init(void)
 	uart_irq_rx_enable(dev);
 
 	k_thread_create(&usb_thread, usb_handler_stack, K_THREAD_STACK_SIZEOF(usb_handler_stack),
-			usb_handler, NULL, NULL, NULL, CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+			usb_handler, NULL, NULL, NULL, K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
 	k_thread_name_set(&usb_thread, "USB_handler");
 
 	uint8_t init_sem_count = RING_BUF_SIZE / RX_BUFF_SIZE;

--- a/meta-facebook/yv35-hd/src/platform/plat_apml.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_apml.c
@@ -71,7 +71,7 @@ uint8_t pal_get_apml_bus()
 	return APML_BUS;
 }
 
-static void read_cpuid_callback(apml_msg *msg)
+static void read_cpuid_callback(const apml_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
 	cpuid_RdData *rd_data = (cpuid_RdData *)msg->RdData;
@@ -79,7 +79,7 @@ static void read_cpuid_callback(apml_msg *msg)
 	memcpy(&cpuid[exc_value * 8], rd_data->data_out, 8);
 }
 
-static void read_cpuid_error_callback(apml_msg *msg)
+static void read_cpuid_error_callback(const apml_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
 	uint8_t exc_value = (uint8_t)msg->ui32_arg;

--- a/meta-facebook/yv35-hd/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_hook.c
@@ -293,7 +293,7 @@ bool post_mp5990_pwr_read(sensor_cfg *cfg, void *args, int *reading)
 	return true;
 }
 
-void apml_report_fail_cb(apml_msg *msg)
+void apml_report_fail_cb(const apml_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
 	CHECK_NULL_ARG(msg->ptr_arg);
@@ -302,7 +302,7 @@ void apml_report_fail_cb(apml_msg *msg)
 	LOG_ERR("Failed to report DIMM power/temperature to CPU, sensor number 0x%x.", cfg->num);
 }
 
-void apml_report_result_check(apml_msg *msg)
+void apml_report_result_check(const apml_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
 	CHECK_NULL_ARG(msg->ptr_arg);
@@ -362,13 +362,13 @@ bool post_ddr5_pwr_read(sensor_cfg *cfg, void *args, int *reading)
 	return true;
 }
 
-void set_dram_throttle_fail_cb(apml_msg *msg)
+void set_dram_throttle_fail_cb(const apml_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
 	LOG_ERR("Failed to set dram throttle to 0x%x.", msg->ui32_arg);
 }
 
-void set_dram_throttle_cb(apml_msg *msg)
+void set_dram_throttle_cb(const apml_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
 

--- a/meta-facebook/yv4-sd/src/platform/plat_apml.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_apml.c
@@ -153,7 +153,7 @@ void set_tsi_threshold()
 	is_threshold_set = true;
 }
 
-static void read_cpuid_callback(apml_msg *msg)
+static void read_cpuid_callback(const apml_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
 	cpuid_RdData *rd_data = (cpuid_RdData *)msg->RdData;
@@ -161,7 +161,7 @@ static void read_cpuid_callback(apml_msg *msg)
 	memcpy(&cpuid[exc_value * 8], rd_data->data_out, 8);
 }
 
-static void read_cpuid_error_callback(apml_msg *msg)
+static void read_cpuid_error_callback(const apml_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
 	uint8_t exc_value = (uint8_t)msg->ui32_arg;

--- a/meta-facebook/yv4-sd/src/platform/plat_dimm.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_dimm.c
@@ -53,7 +53,7 @@ void start_get_dimm_info_thread()
 	get_dimm_info_tid =
 		k_thread_create(&get_dimm_info_thread, get_dimm_info_stack,
 				K_THREAD_STACK_SIZEOF(get_dimm_info_stack), get_dimm_info_handler,
-				NULL, NULL, NULL, CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+				NULL, NULL, NULL, K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
 	k_thread_name_set(&get_dimm_info_thread, "get_dimm_info_thread");
 }
 

--- a/meta-facebook/yv4-sd/src/platform/plat_i3c.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_i3c.c
@@ -30,7 +30,7 @@ void start_setaasa()
 	LOG_INF("Start a thread to send setaasa");
 	tid = k_thread_create(&send_setaasa_thread, send_setaasa_stack,
 			      K_THREAD_STACK_SIZEOF(send_setaasa_stack), send_setaasa, NULL, NULL,
-			      NULL, CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+			      NULL, K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
 	k_thread_name_set(&send_setaasa_thread, "send_setaasa_thread");
 }
 

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -95,7 +95,7 @@ void pal_pre_init()
 	init_vr_event_work();
 	init_event_work();
 	init_pmic_event_work();
-	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
+	init_plat_worker(K_PRIO_PREEMPT(2)); // work queue for low priority jobs
 
 	plat_init_pldm_sensor_table();
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_pmic.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pmic.c
@@ -170,7 +170,7 @@ void start_monitor_pmic_error_thread()
 		k_thread_create(&monitor_pmic_error_thread, monitor_pmic_error_stack,
 				K_THREAD_STACK_SIZEOF(monitor_pmic_error_stack),
 				monitor_pmic_error_via_i3c_handler, NULL, NULL, NULL,
-				CONFIG_MAIN_THREAD_PRIORITY, 0, K_NO_WAIT);
+				K_PRIO_PREEMPT(1), 0, K_NO_WAIT);
 
 	k_thread_name_set(&monitor_pmic_error_thread, "monitor_pmic_error_thread");
 }


### PR DESCRIPTION
# Description
- Adjust the priority of general threads to 1, and keep higher-priority threads (e.g., IPMI, KCS) to 0 or -1 (e.g., sysworkq).

# Motivation
- Most threads had priority 0, which caused delays in processing IPMI request from the host and led to unexpected errors.

# Test Plan
- Build code and test on yv4: passed.