### PR TITLE
fby4: sd: Revert I3C frequency of BMC to 12.5M

### DIFF
--- a/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
@@ -85,9 +85,7 @@
 &i3c0 {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_i3c0_default>;
-	i3c-scl-hz = <8000000>;
-	i3c-pp-scl-hi-period-ns = <62>;
-	i3c-pp-scl-lo-period-ns = <63>;
+	i3c-scl-hz = <12500000>;
 	secondary;
 	wait-pid-extra-info;
 	ibi-append-pec;


### PR DESCRIPTION
Summary:
Description
- It's for JIRA-1457
- The I3C frequency is reverted back to 12.5M.

Motivation
- Based on discussions with the customer.
![image](https://github.com/user-attachments/assets/5676079d-6fc3-4e41-985e-14109cd86abf)

Test Plan:
- Build code: Pass

This reverts commit 6c2a950ab88710012dd622858dd2c192d952cb4e.