### PR TITLE
fby4: sd: Remove I3C hub reinit after power cycle

### DIFF
--- a/common/dev/include/rg3mxxb12.h
+++ b/common/dev/include/rg3mxxb12.h
@@ -83,7 +83,7 @@ enum rg3mxxb12_pull_up_resistor {
 bool rg3mxxb12_i2c_mode_only_init(uint8_t bus, uint8_t slave_port, uint8_t ldo_volt,
 				  uint8_t pullup_resistor);
 bool rg3mxxb12_select_slave_port_connect(uint8_t bus, uint8_t slave_port);
-bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt);
+bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt, uint8_t pullup_val);
 bool rg3mxxb12_set_slave_port(uint8_t bus, uint8_t addr, uint8_t setting);
 bool rg3mxxb12_get_device_info(uint8_t bus, uint16_t *i3c_hub_type);
 bool rg3mxxb12_get_device_info_i3c(uint8_t bus, uint16_t *i3c_hub_type);

--- a/common/dev/rg3mxxb12.c
+++ b/common/dev/rg3mxxb12.c
@@ -230,7 +230,7 @@ out:
 	return ret;
 }
 
-bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt)
+bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt, uint8_t pullup_val)
 {
 	bool ret = false;
 
@@ -245,6 +245,7 @@ bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt)
 		{ RG3MXXB12_SSPORTS_AGENT_ENABLE, 0x0 },
 		{ RG3MXXB12_SSPORTS_GPIO_ENABLE, 0x0 },
 		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0x0 },
+		{ RG3MXXB12_SSPORTS_PULLUP_SETTING, pullup_val},
 		{ RG3MXXB12_SSPORTS_PULLUP_ENABLE, 0xFF },
 		{ RG3MXXB12_SSPORTS_OD_ONLY, 0x0 },
 		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0xFF },

--- a/meta-facebook/yv35-gl/src/platform/plat_i3c.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_i3c.c
@@ -34,7 +34,7 @@ void init_i3c_hub()
 	i3c_hub_type = get_i3c_hub_type();
 
 	if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
-		if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
+		if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT, rg3mxxb12_pullup_500_ohm)) {
 			LOG_ERR("Failed to initialize i3c hub");
 		}
 

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -88,7 +88,7 @@ void pal_pre_init()
 	i3c_attach(&i3c_msg);
 
 	// Initialize I3C HUB
-	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
+	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT, 0xF0)) {
 		printk("failed to initialize 1ou rg3mxxb12\n");
 	}
 

--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -213,7 +213,7 @@ void reinit_i3c_hub()
 	i3c_attach(&i3c_msg);
 
 	// Initialize I3C HUB
-	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
+	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT, 0xF0)) {
 		printk("failed to initialize 1ou rg3mxxb12\n");
 	}
 
@@ -270,7 +270,7 @@ void ISR_DC_ON()
 
 	if (dc_status) {
 		k_work_schedule(&set_DC_on_5s_work, K_SECONDS(DC_ON_5_SECOND));
-		k_work_submit(&reinit_i3c_work);
+		k_work_submit(&set_ffwf_eid_work);
 		k_work_submit(&switch_i3c_dimm_work);
 		k_work_schedule_for_queue(&plat_work_q, &PROC_FAIL_work,
 					  K_SECONDS(PROC_FAIL_START_DELAY_SECOND));


### PR DESCRIPTION
# Description:
- internal PU 2k & LDO Disable (0xF0)
- Remove I3C hub reinit after power cycle

# Motivation:
- I3C hub is supplied by standby power currently.

# Test Plan:
- Build Code: PASS.