### PR TITLE
fby4: sd: Refactor I3C hub initialization command flow

### DIFF
--- a/common/dev/rg3mxxb12.c
+++ b/common/dev/rg3mxxb12.c
@@ -230,7 +230,7 @@ out:
 	return ret;
 }
 
-bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt, uint8_t pullup_val)
+__weak bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt, uint8_t pullup_val)
 {
 	bool ret = false;
 


### PR DESCRIPTION
# Description
- Moved port disable/enable commands to the beginning and end of the command list.
- Ensured network connection and port enable commands are executed only for the necessary ports.

# Motivation
- Addressed an issue where I3C frequently became unresponsive after initializing the port with the 2k ohm pull-up setting.

# Test Plan
- Build code: Pass