### PR TITLE
fby4: sd: Refactor I3C hub initialization command flow

### DIFF
--- a/common/dev/rg3mxxb12.c
+++ b/common/dev/rg3mxxb12.c
@@ -230,11 +230,11 @@ out:
 	return ret;
 }
 
-bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt, uint8_t pullup_val)
+__weak bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt, uint8_t pullup_val)
 {
 	bool ret = false;
 
-	uint8_t cmd_unprotect[2] = { RG3MXXB12_PROTECTION_REG, 0x69 };
+	const uint8_t cmd_unprotect[2] = { RG3MXXB12_PROTECTION_REG, 0x69 };
 	uint8_t cmd_protect[2] = { RG3MXXB12_PROTECTION_REG, 0x00 };
 	uint8_t cmd_initial[][2] = {
 		/* 
@@ -245,7 +245,7 @@ bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt, uint8_t pu
 		{ RG3MXXB12_SSPORTS_AGENT_ENABLE, 0x0 },
 		{ RG3MXXB12_SSPORTS_GPIO_ENABLE, 0x0 },
 		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0x0 },
-		{ RG3MXXB12_SSPORTS_PULLUP_SETTING, pullup_val},
+		{ RG3MXXB12_SSPORTS_PULLUP_SETTING, pullup_val },
 		{ RG3MXXB12_SSPORTS_PULLUP_ENABLE, 0xFF },
 		{ RG3MXXB12_SSPORTS_OD_ONLY, 0x0 },
 		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0xFF },
@@ -287,7 +287,7 @@ bool rg3mxxb12_set_slave_port(uint8_t bus, uint8_t addr, uint8_t setting)
 {
 	I3C_MSG i3c_msg = { 0 };
 	int ret = 0;
-	uint8_t cmd_unprotect[2] = { RG3MXXB12_PROTECTION_REG, 0x69 };
+	const uint8_t cmd_unprotect[2] = { RG3MXXB12_PROTECTION_REG, 0x69 };
 	uint8_t cmd_protect[2] = { RG3MXXB12_PROTECTION_REG, 0x00 };
 
 	i3c_msg.bus = bus;

--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -183,6 +183,59 @@ static add_sel_info *find_event_work_items(uint8_t gpio_num)
 	return NULL;
 }
 
+bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt, uint8_t pullup_val)
+{
+	bool ret = false;
+
+	const uint8_t cmd_unprotect[2] = { RG3MXXB12_PROTECTION_REG, 0x69 };
+	uint8_t cmd_protect[2] = { RG3MXXB12_PROTECTION_REG, 0x00 };
+	uint8_t cmd_initial[][2] = {
+		/* 
+		 * Refer to RG3MxxB12 datasheet page 13, LDO voltage depends
+		 * on each project's hard design
+		 */
+		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0x0 },
+		{ RG3MXXB12_VOLT_LDO_SETTING, ldo_volt },
+		{ RG3MXXB12_SSPORTS_AGENT_ENABLE, 0x0 },
+		{ RG3MXXB12_SSPORTS_GPIO_ENABLE, 0x0 },
+		{ RG3MXXB12_SSPORTS_PULLUP_SETTING, pullup_val },
+		{ RG3MXXB12_SSPORTS_PULLUP_ENABLE, 0xFF },
+		{ RG3MXXB12_SSPORTS_OD_ONLY, 0x0 },
+		{ RG3MXXB12_SSPORTS_HUB_NETWORK_CONNECTION, 0x01 },
+		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0x01 },
+	};
+
+	i3c_msg->tx_len = 2;
+	memcpy(i3c_msg->data, cmd_unprotect, 2);
+	int initial_cmd_size = sizeof(cmd_initial) / sizeof(cmd_initial[0]);
+
+	// Unlock protected regsiter
+	if (i3c_controller_write(i3c_msg) != 0) {
+		goto out;
+	}
+
+	for (int cmd = 0; cmd < initial_cmd_size; cmd++) {
+		i3c_msg->tx_len = 2;
+		memcpy(i3c_msg->data, cmd_initial[cmd], 2);
+		if (i3c_controller_write(i3c_msg) != 0) {
+			LOG_ERR("Failed to initial i3c mode. offset = 0x%02x, value = 0x%02x",
+				cmd_initial[cmd][0], cmd_initial[cmd][1]);
+			goto out;
+		}
+		k_msleep(10);
+	}
+
+	ret = true;
+out:
+	memcpy(i3c_msg->data, cmd_protect, 2);
+	if (i3c_controller_write(i3c_msg) != 0) {
+		LOG_ERR("Failed to set protect. offset = 0x%02x, value = 0x%02x", cmd_protect[0],
+			cmd_protect[1]);
+	}
+
+	return ret;
+}
+
 /*
  *	TODO: I3C hub is supplied by DC power currently. When DC off, it can't be initialized.
  *  	  Therefore, BIC needs to implement a workaround to reinitialize the I3C hub during DC on.
@@ -512,7 +565,6 @@ void process_vr_pmalert_ocp_sel(struct k_work *work_item)
 	msg.target_addr = work_info->vr_addr;
 
 	for (int page = 0; page < work_info->page_cnt; ++page) {
-
 		set_vr_monitor_status(false);
 		// wait 10ms for vr monitor stop
 		k_msleep(10);
@@ -555,8 +607,8 @@ void process_vr_pmalert_ocp_sel(struct k_work *work_item)
 			msg.data[0] = PMBUS_STATUS_IOUT;
 			ret = i2c_master_read(&msg, retry);
 			if (ret != 0) {
-				LOG_ERR("Get vr status iout fail, bus: 0x%x, addr: 0x%x",
-					msg.bus, msg.target_addr);
+				LOG_ERR("Get vr status iout fail, bus: 0x%x, addr: 0x%x", msg.bus,
+					msg.target_addr);
 				continue;
 			}
 			if (((msg.data[0] & VR_TPS_OCW_MASK) >> 5) == 1) {


### PR DESCRIPTION
# Description
- Moved port disable/enable commands to the beginning and end of the command list.
- Ensured network connection and port enable commands are executed only for the necessary ports.

# Motivation
- Addressed an issue where I3C frequently became unresponsive after initializing the port with the 2k ohm pull-up setting.

# Test Plan
- Build code: Pass