### PR TITLE
fby35: cl: remove m.2 device sensor polling

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.c
@@ -33,6 +33,7 @@
 LOG_MODULE_REGISTER(plat_class);
 
 static uint8_t system_class = SYS_CLASS_1;
+static uint8_t system_sku = 0;
 static uint8_t board_revision = 0x0F;
 static uint8_t hsc_module = HSC_MODULE_UNKNOWN;
 static CARD_STATUS _1ou_status = { false, TYPE_1OU_UNKNOWN };
@@ -41,6 +42,11 @@ static CARD_STATUS _2ou_status = { false, TYPE_2OU_UNKNOWN };
 uint8_t get_system_class()
 {
 	return system_class;
+}
+
+uint8_t get_system_sku()
+{
+	return system_sku;
 }
 
 CARD_STATUS get_1ou_status()
@@ -328,6 +334,16 @@ void init_platform_config()
 	}
 	printk("BIC class type(class-%d), 1ou present status(%d), 2ou present status(%d), board revision(0x%x)\n",
 	       system_class, (int)_1ou_status.present, (int)_2ou_status.present, board_revision);
+
+	tx_len = 1;
+	rx_len = 1;
+	data[0] = CPLD_SYSTEM_SKU_REG;
+	i2c_msg = construct_i2c_message(I2C_BUS1, CPLD_ADDR, tx_len, data, rx_len);
+	if (i2c_master_read(&i2c_msg, retry) == 0) {
+		system_sku = i2c_msg.data[0];
+	} else {
+		LOG_ERR("Failed to read system sku from CPLD");
+	}
 
 	/* BIC judges the 1OU card type according the ADC-6(0-based) voltage.
 	 * The 1OU card type is

--- a/meta-facebook/yv35-cl/src/platform/plat_class.h
+++ b/meta-facebook/yv35-cl/src/platform/plat_class.h
@@ -26,6 +26,7 @@
 #define CPLD_ADDR 0x21 // 7-bit address
 #define CPLD_CLASS_TYPE_REG 0x05
 #define CPLD_2OU_EXPANSION_CARD_REG 0x06
+#define CPLD_SYSTEM_SKU_REG 0x07
 #define CPLD_BOARD_REV_ID_REG 0x08
 #define CPLD_1OU_CARD_DETECTION 0x09
 #define CPLD_1OU_VPP_POWER_STATUS 0x11
@@ -96,7 +97,12 @@ enum BIC_CARD_PRESENT {
 	CARD_PRESENT = true,
 };
 
+enum SYSTEM_SKU {
+	SYS_TYPE_EMR = 6,
+};
+
 uint8_t get_system_class();
+uint8_t get_system_sku();
 CARD_STATUS get_1ou_status();
 CARD_STATUS get_2ou_status();
 uint8_t get_board_revision();

--- a/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_sensor_table.c
@@ -58,6 +58,14 @@ dimm_pmic_mapping_cfg dimm_pmic_map_table[] = {
 	{ SENSOR_NUM_TEMP_DIMM_A7, SENSOR_NUM_PWR_DIMMA7_PMIC },
 };
 
+bool m2_access(uint8_t sensor_num)
+{
+	if (get_system_sku() == SYS_TYPE_EMR) {
+		return false;
+	}
+	return get_post_status();
+}
+
 sensor_cfg plat_sensor_config[] = {
 	/* number,                  type,       port,      address,      offset,
 	   access check arg0, arg1, sample_count, cache, cache_status, mux_ADDRess, mux_offset,
@@ -75,7 +83,7 @@ sensor_cfg plat_sensor_config[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, NULL },
 
 	// NVME
-	{ SENSOR_NUM_TEMP_SSD0, sensor_dev_nvme, I2C_BUS2, SSD0_ADDR, SSD0_OFFSET, post_access, 0,
+	{ SENSOR_NUM_TEMP_SSD0, sensor_dev_nvme, I2C_BUS2, SSD0_ADDR, SSD0_OFFSET, m2_access, 0,
 	  0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS,
 	  pre_nvme_read, &mux_conf_addr_0xe2[1], NULL, NULL, NULL },
 


### PR DESCRIPTION
# Description
As title.

# Motivation
EMR project move boot drive from M.2 to E1.S device.

# Test plan
Build and test pass on fby35

1. check all sensor reading is expected.

uart:~$ platform sensor list_all_sensor
--------------------------------------------------------------------------------- Table name: common sensor table | index: 0x0  | sensor count: 0x36 | access[O]

[0x1 ] MB_INLET_TEMP_C          : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    30.000
[0x2 ] MB_OUTLET_TEMP_C         : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    37.000
[0x3 ] FIO_FRONT_TEMP_C         : tmp75      | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    27.000
[0xd ] MB_SSD0_M2A_TEMP_C       : nvme       | access[X] | poll[O] 1    sec | not_accesible)            | na
[0x5 ] MB_SOC_CPU_TEMP_C        : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    38.000
[0x14] MB_SOC_THERMAL_MARGIN_C  : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.000
[0x15] MB_SOC_TJMAX_C           : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    78.000
[0x38] MB_SOC_PACKAGE_PWR_W     : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    28.000
[0x6 ] MB_DIMMA0_TEMP_C         : peci       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x7 ] MB_DIMMA2_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    34.000
[0x9 ] MB_DIMMA3_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    34.000
[0xa ] MB_DIMMA4_TEMP_C         : peci       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0xb ] MB_DIMMA6_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    33.000
[0xc ] MB_DIMMA7_TEMP_C         : peci       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    33.000
[0x20] MB_ADC_P12V_STBY_VOLT_V  : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.276
[0x22] MB_ADC_P3V3_STBY_VOLT_V  : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.348
[0x24] MB_ADC_P1V05_PCH_VOLT_V  : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.054
[0x21] MB_ADC_P3V_BAT_VOLT_V    : adc        | access[O] | poll[O] 3600 sec | 4byte_acur_read_success   |     3.171
[0x25] MB_ADC_P5V_STBY_VOLT_V   : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.937
[0x26] MB_ADC_P12V_DIMM_VOLT_V  : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.130
[0x27] MB_ADC_P1V2_STBY_VOLT_V  : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.191
[0x28] MB_ADC_P3V3_M2_VOLT_V    : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.300
[0x23] MB_ADC_P1V8_STBY_VOLT_V  : adc        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.791
[0x2e] MB_VR_VCCD_VOLT_V        : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.143
[0x2f] MB_VR_FAON_VOLT_V        : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.052
[0x2d] MB_VR_EHV_VOLT_V         : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.799
[0x2a] MB_VR_VCCIN_VOLT_V       : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.622
[0x2c] MB_VR_FIVRA_VOLT_V       : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.817
[0x34] MB_VR_VCCD_CURR_A        : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.200
[0x35] MB_VR_FAON_CURR_A        : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     7.500
[0x33] MB_VR_EHV_CURR_A         : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.500
[0x31] MB_VR_VCCIN_CURR_A       : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     8.500
[0x32] MB_VR_FIVRA_CURR_A       : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.400
[0x12] MB_VR_VCCD_TEMP_C        : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    37.000
[0x13] MB_VR_FAON_TEMP_C        : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    40.000
[0x11] MB_VR_EHV_TEMP_C         : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    36.000
[0xf ] MB_VR_VCCIN_TEMP_C       : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    42.000
[0x10] MB_VR_FIVRA_TEMP_C       : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    41.000
[0x3e] MB_VR_VCCD_PWR_W         : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     2.000
[0x3f] MB_VR_FAON_PWR_W         : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     7.000
[0x3d] MB_VR_EHV_PWR_W          : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.000
[0x3a] MB_VR_VCCIN_PWR_W        : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    26.000
[0x3c] MB_VR_FIVRA_PWR_W        : isl69259   | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     4.000
[0x4 ] MB_PCH_TEMP_C            : pch        | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    42.000
[0x1e] MB_VR_DIMMA0_PMIC_PWR_W  : pmic       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x1f] MB_VR_DIMMA2_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.250
[0x36] MB_VR_DIMMA3_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.375
[0x37] MB_VR_DIMMA4_PMIC_PWR_W  : pmic       | access[O] | poll[X] 1    sec | sensor_not_present        | na
[0x42] MB_VR_DIMMA6_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     0.750
[0x47] MB_VR_DIMMA7_PMIC_PWR_W  : pmic       | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     1.375
[0xe ] MB_HSC_TEMP_C            : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    36.000
[0x29] MB_HSC_INPUT_VOLT_V      : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    12.125
[0x30] MB_HSC_OUTPUT_CURR_A     : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |     3.500
[0x39] MB_HSC_INPUT_PWR_W       : mp5990     | access[O] | poll[O] 1    sec | 4byte_acur_read_success   |    42.000