### PR TITLE
fby4: wf: Modify sleep time of setting CXL EID thread

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.c
@@ -129,7 +129,7 @@ static void set_dev_endpoint(void)
 	bool set_eid[MAX_CXL_ID] = { false, false };
 	// The CXL FW is unstable and its booting up time is random now.
 	// Temporary add retry mechanism for it.
-	for (int attempt = 0; attempt < 10; attempt++) {
+	for (int attempt = 0; attempt < 60; attempt++) {
 		// We only need to set CXL EID.
 		for (uint8_t i = 0; i < ARRAY_SIZE(plat_mctp_route_tbl); i++) {
 			const mctp_route_entry *p = plat_mctp_route_tbl + i;
@@ -188,8 +188,8 @@ static void set_dev_endpoint(void)
 		// break if set both CXL EID success
 		if (set_eid[CXL_ID_1] == true && set_eid[CXL_ID_2] == true)
 			break;
-		// Delay for 60 seconds before the next attempt
-		k_sleep(K_SECONDS(60));
+		// Delay for 10 seconds before the next attempt
+		k_sleep(K_SECONDS(10));
 	}
 }
 


### PR DESCRIPTION
# Description
- It's related to JIRA-518
- Exchange sleep time (from 60s to 10s) and the number of retries (from 10 times to 60 times), the longest time remains unchanged (600s). Avoid waiting too long and cuasing the CXL EID to grow too late.

# Test plan
- Build code: Pass
- Check CXL EID: Pass