### PR TITLE
fby4: sd: Set response data length for app command

### DIFF
--- a/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv4-sd/src/ipmi/plat_ipmi.c
@@ -87,6 +87,7 @@ void APP_SET_ACPI_POWER(ipmi_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
 
+	msg->data_len = 0;
 	msg->completion_code = CC_SUCCESS;
 	return;
 }
@@ -95,6 +96,7 @@ void APP_CLEAR_MESSAGE_FLAGS(ipmi_msg *msg)
 {
 	CHECK_NULL_ARG(msg);
 
+	msg->data_len = 0;
 	msg->completion_code = CC_SUCCESS;
 	return;
 }


### PR DESCRIPTION
# Description:
- Set msg->datalen to 0 for APP_CLEAR_MESSAGE_FLAGS and APP_SET_ACPI_POWER command handlers to reply the correct response to BIOS.

# Motivation:
- BIOS team observe BIC reply incorrect data length for some IPMI commands that cause BIOS report error messages. To prevent those error messages, BIC needs to correct the data length of IPMI response.

# Test Plan:
1. Build and test pass on YV4 system - pass
2. Get correct result with IPMI Clear_Message_Flags command - pass

# Test Log:
[root@241108-690-fbk1 ~]# ipmitool raw 0x06 0x06 0x7f 0x7f

[root@241108-690-fbk1 ~]# ipmitool raw 0x06 0x30

[root@241108-690-fbk1 ~]#