### PR TITLE
minerva-ag: Version commit for ob-minerva-ag-2025.10.01

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_version.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_version.h
@@ -40,8 +40,8 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x25
-#define BIC_FW_WEEK 0x07
-#define BIC_FW_VER 0x03
+#define BIC_FW_WEEK 0x10
+#define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x61 // char: a
 #define BIC_FW_platform_1 0x67 // char: g
 #define BIC_FW_platform_2 0x00 // char: '\0'


### PR DESCRIPTION
Summary:
- Version commit for Minerva Aegis BIC ob-minerva-ag-2025.10.01.

Test Plan:
- Build code: Pass
- Get BIC version: Pass

Log:
```
uart:~$ platform info
========================{SHELL COMMAND INFO}========================================
* NAME:          Platform command
* DESCRIPTION:   Commands that could be used to debug or validate.
* DATE/VERSION:  none
* CHIP/OS:       npcm400f_evb - Zephyr
* Note:          none
------------------------------------------------------------------
* PLATFORM:      Minerva-Aegis
* BOARD ID:      1
* STAGE:         1
* SYSTEM:        255
* FW VERSION:    17.0
* FW DATE:       2025.10.1
* FW IMAGE:      MINERVA_AEGIS.bin
* BOARD_TYPE:    (0x01)AEGIS
* BOARD_STAGE:   (0x02)FAB3_PVT
* VR_VENDOR_TYPE:(0x02)MPS_UBC_AND_MPS_VR
* UBC_TYPE:      (0x02)MPS_MPC12109
* VR_TYPE:       (0x01)MPS_MP2971_MP29816A
* TMP_TYPE:      (0x00)TMP_TMP432
========================{SHELL COMMAND INFO}========================================
```