### PR TITLE
minerva-ag: Access cpld version every 5 seconds

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_event.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_event.c
@@ -26,10 +26,18 @@
 #include "plat_log.h"
 #include "plat_event.h"
 #include "plat_hook.h"
+#include "plat_isr.h"
 
 LOG_MODULE_REGISTER(plat_event);
 
 #define CPLD_POLLING_INTERVAL_MS 1000 // 1 second polling interval
+
+#ifndef AEGIS_CPLD_ADDR
+#define AEGIS_CPLD_ADDR (0x4C >> 1)
+#endif
+
+void check_cpld_handler();
+K_WORK_DELAYABLE_DEFINE(check_cpld_work, check_cpld_handler);
 
 K_TIMER_DEFINE(init_ubc_delayed_timer, check_ubc_delayed, NULL);
 K_THREAD_STACK_DEFINE(cpld_polling_stack, POLLING_CPLD_STACK_SIZE);
@@ -164,6 +172,19 @@ void poll_cpld_registers()
 	}
 }
 
+void check_cpld_handler()
+{
+	uint8_t data[4] = { 0 };
+	uint32_t version = 0;
+	if (!plat_i2c_read(I2C_BUS5, AEGIS_CPLD_ADDR, 0x44, data, 4)) {
+		LOG_ERR("Failed to read cpld version from cpld");
+	}
+	version = (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
+	LOG_DBG("The cpld version: %08x", version);
+
+	k_work_schedule(&check_cpld_work, K_MSEC(5000));
+}
+
 void init_cpld_polling(void)
 {
 	k_timer_start(&init_ubc_delayed_timer, K_MSEC(3000), K_NO_WAIT);
@@ -176,4 +197,6 @@ void init_cpld_polling(void)
                    (3-second thread start delay + 1-second CPLD_POLLING_INTERVAL_MS) 
                    to prevent DC status changes during BIC reboot */
 	k_thread_name_set(&cpld_polling_thread, "cpld_polling_thread");
+
+	k_work_schedule(&check_cpld_work, K_MSEC(100));
 }


### PR DESCRIPTION
Summary:
- The CPLD monitors whether the MCP is accessing it. If there is no access for more than 10 seconds, the CPLD assumes that the MCP has crashed. Previously, this was not an issue because polling was continuously performed. However, since the polling mechanism has been changed to a GPIO trigger, the MCP must now access the CPLD every 5 seconds to prevent it from being considered as crashed.
- Access cpld version every 5 seconds.

Test Plan:
- Build code: PASS 