### PR TITLE
fby4: wf: Remove set_dev_endpoint 2 times

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.c
@@ -282,12 +282,11 @@ uint8_t get_mctp_info(uint8_t dest_endpoint, mctp **mctp_inst, mctp_ext_params *
 
 void set_dev_endpoint_thread(void *arg1, void *arg2, void *arg3)
 {
-	/* init the device endpoint */
-	set_dev_endpoint();
 	ARG_UNUSED(arg1);
 	ARG_UNUSED(arg2);
 	ARG_UNUSED(arg3);
 
+	/* init the device endpoint */
 	set_dev_endpoint();
 }
 


### PR DESCRIPTION
# Description
- Remove one time set_dev_endpoint

# Motivation
For JIRA-1631 - [SD/WF_BIC 2025.11.01] CXL might be reset after DC on
- This is because set_dev_endpoint two times to CXL may cause CXL restart

# Test Plan:
Build Code: PASS.
