### PR TITLE
yv4: sd: Add SEL for BMC cold reset

### DIFF
--- a/meta-facebook/yv4-sd/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/yv4-sd/src/ipmi/include/plat_ipmi.h
@@ -23,4 +23,6 @@ enum GET_HTTP_BOOT_ATTR {
 	GET_HTTP_BOOT_MAX = 0x02,
 };
 
+void event_resend_work_handler(struct k_work *work);
+
 #endif


### PR DESCRIPTION
# Description:
- Related to JIRA-1196
- Add a SEL for the BMC cold reset and resend the SEL after reset if it failed to send on the first try.

# Motivation:
- After executing a BMC cold reset from the OS, the BMC does not record the cold reset SEL, but the BIC has the SEL.

# Test Plan:
- Build code: pass
- Check if the SEL is recorded after BMC cold reset: pass

Log:
root@bmc:~# mfg-tool log-display
<7> Loading registries from /usr/share/redfish-registry/phosphor-dbus-interfaces <7> Finding log entries.
<7> Iterating over entries.
<7> Examining xyz.openbmc_project.Logging.Entry at /xyz/openbmc_project/logging/entry/1. <7> Examining xyz.openbmc_project.Logging.Entry at /xyz/openbmc_project/logging/entry/2. {
    "1": {
        "additional_data": {
            "NUMBER_OF_LOGS": "18",
            "_CODE_FILE": "/usr/src/debug/phosphor-logging/1.0+git/log_manager.hpp",
            "_CODE_FUNC": "virtual void phosphor::logging::Manager::deleteAll()",
            "_CODE_LINE": "361",
            "_PID": "622"
        },
        "event_id": "",
        "message": "xyz.openbmc_project.Logging.Cleared",
        "resolution": "",
        "resolved": false,
        "severity": "xyz.openbmc_project.Logging.Entry.Level.Informational",
        "timestamp": "2025-03-19T06:39:48.096000000Z",
        "updated_timestamp": "2025-03-19T06:39:48.096000000Z"
    },
    "2": {
        "additional_data": {},
        "event_id": "",
        "message": "Event: Host3 BMC comes out of cold reset, ASSERTED",
        "resolution": "",
        "resolved": false,
        "severity": "xyz.openbmc_project.Logging.Entry.Level.Error",
        "timestamp": "2025-03-19T06:40:16.959000000Z",
        "updated_timestamp": "2025-03-19T06:40:16.959000000Z"
    }
}