### PR TITLE
minerva-ag: Modify blackbox cpld dump format and add more cpld polling registers

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_event.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_event.c
@@ -73,7 +73,15 @@ aegis_cpld_info aegis_cpld_info_table[] = {
 	{ VR_SMBUS_ALERT_1_REG, 			0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
 	{ VR_SMBUS_ALERT_2_REG, 			0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
 	{ ASIC_OC_WARN_REG, 				0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
+	{ SYSTEM_ALERT_FAULT_REG, 			0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
 	{ TEMPERATURE_IC_OVERT_FAULT_REG, 	0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
+	{ LEAK_DETCTION_REG, 				0xDF, 0xDF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
+
+	{ TEMPERATURE_IC_OVERT_FAULT_2_REG, 0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
+	{ ASIC_OC_WARN_2_REG, 				0xFF, 0xDF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
+	{ SYSTEM_ALERT_FAULT_2_REG, 		0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
+	{ VR_SMBUS_ALERT_3_REG, 			0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
+	{ VR_SMBUS_ALERT_4_REG, 			0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },	
 };
 // clang-format on
 

--- a/meta-facebook/minerva-ag/src/platform/plat_event.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_event.h
@@ -172,6 +172,12 @@ bool get_cpld_polling_enable_flag(void);
 void init_cpld_polling(void);
 bool is_ubc_enabled_delayed_enabled(void);
 
+#define TEMPERATURE_IC_OVERT_FAULT_2_REG 0x97
+#define ASIC_OC_WARN_2_REG 0x98
+#define SYSTEM_ALERT_FAULT_2_REG 0x99
+#define VR_SMBUS_ALERT_3_REG 0x9A
+#define VR_SMBUS_ALERT_4_REG 0x9B
+
 typedef struct _aegis_cpld_info_ aegis_cpld_info;
 
 typedef struct _aegis_cpld_info_ {

--- a/meta-facebook/minerva-ag/src/platform/plat_log.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_log.c
@@ -32,8 +32,6 @@ LOG_MODULE_REGISTER(plat_log);
 #define LOG_MAX_INDEX 0x0FFF // recount when log index > 0x0FFF
 #define LOG_MAX_NUM 100 // total log amount: 100
 #define AEGIS_FRU_LOG_START 0x0000 // log offset: 0KB
-#define AEGIS_CPLD_REGISTER_START_OFFSET 0x00
-#define AEGIS_CPLD_REGISTER_MAX_OFFSET 0x3C
 #define EEPROM_MAX_WRITE_TIME 5 // the BR24G512 eeprom max write time is 3.5 ms
 #define AEGIS_CPLD_ADDR (0x4C >> 1)
 #define I2C_BUS_CPLD I2C_BUS5
@@ -137,7 +135,7 @@ void plat_log_read(uint8_t *log_data, uint8_t cmd_size, uint16_t order)
 
 	memcpy(log_data, &log_entry, cmd_size);
 
-	plat_err_log_mapping *p = (plat_err_log_mapping *)log_data;
+	const plat_err_log_mapping *p = (plat_err_log_mapping *)log_data;
 
 	LOG_HEXDUMP_DBG(log_data, cmd_size, "plat_log_read_before");
 
@@ -320,7 +318,6 @@ bool get_error_data(uint16_t error_code, uint8_t *data)
 void error_log_event(uint16_t error_code, bool log_status)
 {
 	bool log_todo = false;
-	uint8_t dump_data[AEGIS_CPLD_REGISTER_MAX_OFFSET - AEGIS_CPLD_REGISTER_START_OFFSET + 1];
 
 	// Check if the error_code is already logged
 	for (uint8_t i = 1; i < ARRAY_SIZE(err_code_caches); i++) {
@@ -374,13 +371,15 @@ void error_log_event(uint16_t error_code, bool log_status)
 		       sizeof(err_log_data[fru_count].error_data));
 	}
 
-	// Dump CPLD data and store it in cpld_dump
-	if (plat_dump_cpld(AEGIS_CPLD_REGISTER_START_OFFSET,
-			   (AEGIS_CPLD_REGISTER_MAX_OFFSET - AEGIS_CPLD_REGISTER_START_OFFSET + 1),
-			   dump_data)) {
-		memcpy(err_log_data[fru_count].cpld_dump, dump_data, sizeof(dump_data));
-	} else {
-		LOG_ERR("Failed to dump CPLD data");
+	if (!plat_dump_cpld(AEGIS_CPLD_REGISTER_1ST_PART_START_OFFSET,
+			    AEGIS_CPLD_REGISTER_1ST_PART_NUM, err_log_data[fru_count].cpld_dump)) {
+		LOG_ERR("Failed to dump 1st part CPLD data");
+	}
+
+	if (!plat_dump_cpld(AEGIS_CPLD_REGISTER_2ND_PART_START_OFFSET,
+			    AEGIS_CPLD_REGISTER_2ND_PART_NUM,
+			    err_log_data[fru_count].cpld_dump + AEGIS_CPLD_REGISTER_1ST_PART_NUM)) {
+		LOG_ERR("Failed to dump 2nd part CPLD data");
 	}
 
 	//dump err_log_data for debug

--- a/meta-facebook/minerva-ag/src/platform/plat_log.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_log.h
@@ -19,6 +19,13 @@
 
 #include "plat_pldm_sensor.h"
 
+#define AEGIS_CPLD_REGISTER_MAX_NUM 96
+#define AEGIS_CPLD_REGISTER_1ST_PART_START_OFFSET                                                  \
+	0x00 // first part of cpld register offset from 0x00 to 0x47
+#define AEGIS_CPLD_REGISTER_1ST_PART_NUM 72
+#define AEGIS_CPLD_REGISTER_2ND_PART_START_OFFSET 0x97
+#define AEGIS_CPLD_REGISTER_2ND_PART_NUM                                                           \
+	(AEGIS_CPLD_REGISTER_MAX_NUM - AEGIS_CPLD_REGISTER_1ST_PART_NUM)
 #define AEGIS_FRU_LOG_SIZE sizeof(plat_err_log_mapping)
 
 #define LOG_ASSERT 1
@@ -37,7 +44,7 @@ typedef struct __attribute__((packed)) _plat_err_log_mapping {
 	uint16_t err_code;
 	uint64_t sys_time;
 	uint8_t error_data[20];
-	uint8_t cpld_dump[96];
+	uint8_t cpld_dump[AEGIS_CPLD_REGISTER_MAX_NUM];
 } plat_err_log_mapping;
 
 enum LOG_ERROR_TRIGGER_CAUSE {

--- a/meta-facebook/minerva-ag/src/shell/log_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/log_shell.c
@@ -57,8 +57,13 @@ void cmd_log_dump(const struct shell *shell, size_t argc, char **argv)
 		shell_print(shell, "sys_time: %lld ms", log.sys_time);
 		shell_print(shell, "error_data:");
 		shell_hexdump(shell, log.error_data, sizeof(log.error_data));
-		shell_print(shell, "cpld register:");
-		shell_hexdump(shell, log.cpld_dump, sizeof(log.cpld_dump));
+		shell_print(shell, "cpld register: start offset 0x%02x",
+			    AEGIS_CPLD_REGISTER_1ST_PART_START_OFFSET);
+		shell_hexdump(shell, log.cpld_dump, AEGIS_CPLD_REGISTER_1ST_PART_NUM);
+		shell_print(shell, "cpld register: start offset 0x%02x",
+			    AEGIS_CPLD_REGISTER_2ND_PART_START_OFFSET);
+		shell_hexdump(shell, log.cpld_dump + AEGIS_CPLD_REGISTER_1ST_PART_NUM,
+			      AEGIS_CPLD_REGISTER_2ND_PART_NUM);
 		shell_print(
 			shell,
 			"====================================================================================");


### PR DESCRIPTION
Summary:
- Modify blackbox cpld dump format
- Due to the length of blackbox log, we can't store the full cpld dump in one log, we remove the power sequence part at cpld dump
- Add more cpld polling registers

Test Plan:
- Build code: PASS 