### PR TITLE
patch:driver:i2c: soc-arm-npcm4xx-disable-interrupt-before-calling-gdm

### DIFF
--- a/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0014-soc-arm-npcm4xx-disable-interrupt-before-calling-gdm.patch
+++ b/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0014-soc-arm-npcm4xx-disable-interrupt-before-calling-gdm.patch
@@ -1,0 +1,136 @@
+From f2872434feda125757a8bb911cef1d179e5444c1 Mon Sep 17 00:00:00 2001
+From: Tyrone Ting <kfting@nuvoton.com>
+Date: Thu, 20 Mar 2025 09:34:10 +0800
+Subject: [PATCH] soc: arm: npcm4xx: disable interrupt before calling gdma
+ functions
+
+Signed-off-by: Tyrone Ting <kfting@nuvoton.com>
+---
+ soc/arm/npcm4xx/npcm400f/gdma.c | 26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/soc/arm/npcm4xx/npcm400f/gdma.c b/soc/arm/npcm4xx/npcm400f/gdma.c
+index a827166bdff6..a05af7b4f682 100644
+--- a/soc/arm/npcm4xx/npcm400f/gdma.c
++++ b/soc/arm/npcm4xx/npcm400f/gdma.c
+@@ -4,6 +4,7 @@
+  * SPDX-License-Identifier: Apache-2.0
+  */
+ 
++#include <kernel.h>
+ #include "gdma.h"
+ 
+ /*-------------------------------------------------------------------------------------------*/
+@@ -17,6 +18,8 @@ void gdma_memset_u8(uint8_t *dat, uint8_t set_val, uint32_t setlen)
+ 		return;
+ 	}
+ 
++	int key = irq_lock();
++
+ 	GDMA_SRCB0 = (uint32_t)&val;
+ 	GDMA_DSTB0 = (uint32_t)dat;
+ 	GDMA_TCNT0 = setlen;
+@@ -25,6 +28,8 @@ void gdma_memset_u8(uint8_t *dat, uint8_t set_val, uint32_t setlen)
+ 	while (GDMA_CTL0 & 0x1) {
+ 	}
+ 	GDMA_CTL0 = 0;
++
++	irq_unlock(key);
+ }
+ 
+ /*-------------------------------------------------------------------------------------------*/
+@@ -36,6 +41,8 @@ void gdma_memcpy_u8(uint8_t *dst, uint8_t *src, uint32_t cpylen)
+ 		return;
+ 	}
+ 
++	int key = irq_lock();
++
+ 	GDMA_SRCB0 = (uint32_t)src;
+ 	GDMA_DSTB0 = (uint32_t)dst;
+ 	GDMA_TCNT0 = cpylen;
+@@ -44,6 +51,8 @@ void gdma_memcpy_u8(uint8_t *dst, uint8_t *src, uint32_t cpylen)
+ 	while (GDMA_CTL0 & 0x1) {
+ 	}
+ 	GDMA_CTL0 = 0;
++
++	irq_unlock(key);
+ }
+ 
+ /*-------------------------------------------------------------------------------------------*/
+@@ -55,6 +64,8 @@ void gdma_memcpy_u32(uint8_t *dst, uint8_t *src, uint32_t cpylen)
+ 		return;
+ 	}
+ 
++	int key = irq_lock();
++
+ 	GDMA_SRCB0 = (uint32_t)src;
+ 	GDMA_DSTB0 = (uint32_t)dst;
+ 	GDMA_TCNT0 = cpylen / 4;
+@@ -63,6 +74,8 @@ void gdma_memcpy_u32(uint8_t *dst, uint8_t *src, uint32_t cpylen)
+ 	while (GDMA_CTL0 & 0x1) {
+ 	}
+ 	GDMA_CTL0 = 0;
++
++	irq_unlock(key);
+ }
+ 
+ /*-------------------------------------------------------------------------------------------*/
+@@ -76,9 +89,12 @@ void gdma_memcpy_burst_u32(uint8_t *dst, uint8_t *src, uint32_t cpylen)
+ 		return;
+ 	}
+ 
++	int key = irq_lock();
++
+ 	/* src and dst address must 16byte aligned */
+ 	if (((uint32_t)src & 0x0F) || ((uint32_t)dst & 0xF)) {
+ 		gdma_memcpy_u8(dst, src, cpylen);
++		irq_unlock(key);
+ 		return;
+ 	}
+ 
+@@ -107,6 +123,8 @@ void gdma_memcpy_burst_u32(uint8_t *dst, uint8_t *src, uint32_t cpylen)
+ 	if (cpylen) {
+ 		gdma_memcpy_u8(dst, src, cpylen);
+ 	}
++
++	irq_unlock(key);
+ }
+ 
+ /*-------------------------------------------------------------------------------------------*/
+@@ -118,6 +136,8 @@ void gdma_memcpy_u32_dstfix(uint8_t *dst, uint8_t *src, uint32_t cpylen)
+ 		return;
+ 	}
+ 
++	int key = irq_lock();
++
+ 	GDMA_SRCB0 = (uint32_t)src;
+ 	GDMA_DSTB0 = (uint32_t)dst;
+ 	GDMA_TCNT0 = cpylen / 4;
+@@ -126,6 +146,8 @@ void gdma_memcpy_u32_dstfix(uint8_t *dst, uint8_t *src, uint32_t cpylen)
+ 	while (GDMA_CTL0 & 0x1) {
+ 	}
+ 	GDMA_CTL0 = 0;
++
++	irq_unlock(key);
+ }
+ 
+ 
+@@ -138,6 +160,8 @@ void gdma_memcpy_u32_srcfix(uint8_t *dst, uint8_t *src, uint32_t cpylen)
+ 		return;
+ 	}
+ 
++	int key = irq_lock();
++
+ 	GDMA_SRCB0 = (uint32_t)src;
+ 	GDMA_DSTB0 = (uint32_t)dst;
+ 	GDMA_TCNT0 = cpylen / 4;
+@@ -146,4 +170,6 @@ void gdma_memcpy_u32_srcfix(uint8_t *dst, uint8_t *src, uint32_t cpylen)
+ 	while (GDMA_CTL0 & 0x1) {
+ 	}
+ 	GDMA_CTL0 = 0;
++
++	irq_unlock(key);
+ }
+-- 
+2.17.1
+


### PR DESCRIPTION
Summary:
- Add patch soc-arm-npcm4xx-disable-interrupt-before-calling-gdm

Test Plan:
- Build code: Pass
