### PR TITLE
minerva-ag: Add 5 sec delay in aegis power cycle

### DIFF
--- a/meta-facebook/minerva-ag/src/shell/plat_aegis_power_control_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_aegis_power_control_shell.c
@@ -43,6 +43,7 @@ int cmd_aegis_power_control(const struct shell *shell, size_t argc, char **argv)
 			shell_error(shell, "plat power control failed");
 			return -1;
 		}
+		k_msleep(5000);
 		if (!plat_power_control(1)) {
 			shell_error(shell, "plat power control failed");
 			return -1;


### PR DESCRIPTION
Summary:
- Add 5 sec delay in aegis power cycle

Test Plan:
- Build code: Pass