### PR TITLE
fby4: wf: Fix GetFwParams failed when CXL is not ready

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_init.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_init.c
@@ -63,8 +63,7 @@ void pal_set_sys_status()
 			set_P3V3_E1S_power_status(PWRGD_P3V3_E1S_0_R);
 		}
 		set_P12V_E1S_power_status(PWRGD_P12V_E1S_0_R);
-		set_cxl_ready_status(CXL_ID_1, true);
-		set_cxl_ready_status(CXL_ID_2, true);
+		create_check_cxl_ready_thread();
 	}
 	set_sys_ready_pin(BIC_READY_R);
 }


### PR DESCRIPTION
# Description:
- Add a pre-check for CXL readiness when getting CXL firmware version.
- Add a pre-check for VR SMBus mux select pin assigned to BIC when getting VR firmware version.
- During the WF BIC initialization process at runtime power-on, initialize the is_cxl_ready value based on the CXL heartbeat status.

# Motivation:
- Related to JIRA-1658.
- When CXL is not ready, BMC's pldmtool fw_update GetFwParams -m {WF EID} fails (RC= -8).

# Test Plan:
- Build Code: PASS.
- After performing the slot runtime power cycle, continuously query BMC with pldmtool fw_update GetFwParams -m {WF EID}. Before CXL is ready, the ActiveComponentVersionString field will display ERROR:0. Once CXL is ready, it will show the version.