### PR TITLE
yv4: sd: Change to I2C to access DIMM

### DIFF
--- a/common/hal/hal_i2c.h
+++ b/common/hal/hal_i2c.h
@@ -175,6 +175,7 @@ int i2c_master_read(I2C_MSG *msg, uint8_t retry);
 int i2c_master_read_without_mutex(I2C_MSG *msg, uint8_t retry);
 int i2c_master_write(I2C_MSG *msg, uint8_t retry);
 int i2c_master_write_without_mutex(I2C_MSG *msg, uint8_t retry);
+int i2c_spd_reg_read(I2C_MSG *msg, bool is_nvm);
 void i2c_scan(uint8_t bus, uint8_t *target_addr, uint8_t *target_addr_len);
 void util_init_I2C(void);
 int check_i2c_bus_valid(uint8_t bus);

--- a/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-sd/boards/ast1030_evb.overlay
@@ -108,14 +108,12 @@
 	assigned-address = <0x8>;
 };
 
-&i3c2 {
+&i2c12 {
+	pinctrl-0 = <&pinctrl_i2c12_default>;
 	status = "okay";
-	pinctrl-0 = <&pinctrl_i3c2_default>;
-	i3c-scl-hz = <1000000>;
-	assigned-address = <0x11>;
-	i3c-pp-scl-hi-period-ns = <500>;
-	i3c-pp-scl-lo-period-ns = <500>;
+	clock-frequency = <I2C_BITRATE_STANDARD>;
 };
+
 
 &i2c13 {
 	pinctrl-0 = <&pinctrl_i2c13_default>;

--- a/meta-facebook/yv4-sd/src/platform/plat_i2c.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_i2c.h
@@ -30,6 +30,7 @@
 #define I2C_BUS7 6
 #define I2C_BUS8 7
 #define I2C_BUS10 9
+#define I2C_BUS13 12
 #define I2C_BUS14 13
 
 #define CPLD_IO_I2C_BUS I2C_BUS5

--- a/meta-facebook/yv4-sd/src/platform/plat_pmic.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pmic.c
@@ -310,7 +310,7 @@ int pal_set_pmic_error_flag(uint8_t dimm_id, uint8_t error_type)
 int get_pmic_error_data_one(uint8_t dimm_id, uint8_t *buffer, uint8_t is_need_check_post_status)
 {
 	CHECK_NULL_ARG_WITH_RETURN(buffer, -1);
-	I3C_MSG i3c_msg = { 0 };
+	I2C_MSG msg = { 0 };
 	int ret = 0;
 
 	if (get_dimm_present(dimm_id) == DIMM_NOT_PRSNT) {
@@ -329,33 +329,21 @@ int get_pmic_error_data_one(uint8_t dimm_id, uint8_t *buffer, uint8_t is_need_ch
 		return -1;
 	}
 
-	i3c_msg.bus = I3C_BUS3;
-	i3c_msg.target_addr = pmic_i3c_addr_list[dimm_id % (DIMM_ID_MAX / 2)];
-
-	i3c_attach(&i3c_msg);
-	ret = all_brocast_ccc(&i3c_msg);
-	if (ret != 0) {
-		LOG_ERR("Failed to brocast CCC, ret%d bus%d", ret, i3c_msg.bus);
-		i3c_detach(&i3c_msg);
-		return ret;
-	}
+	memset(&msg, 0, sizeof(I2C_MSG));
+	msg.bus = I2C_BUS13;
+	msg.target_addr = pmic_i3c_addr_list[dimm_id % (DIMM_ID_MAX / 2)];
 
 	// Read one PMIC register at once
 	for (int i = 0; i < MAX_COUNT_PMIC_ERROR_OFFSET; i++) {
-		// Read PMIC error via I3C
-		i3c_msg.tx_len = 1;
-		i3c_msg.rx_len = 1;
-		i3c_msg.data[0] = pmic_i3c_err_offset[i];
-		ret = i3c_transfer(&i3c_msg);
+		msg.tx_len = 1;
+		msg.rx_len = 1;
+		msg.data[0] = pmic_i3c_err_offset[i];
+		ret = i2c_master_read(&msg, 3);
 		if (ret != 0) {
-			LOG_ERR("Failed to read PMIC error via I3C");
-			break;
+			LOG_ERR("Failed to read PMIC error %d", dimm_id);
 		}
-
-		buffer[pmic_i3c_err_data_index[i]] = i3c_msg.data[0];
+		buffer[pmic_i3c_err_data_index[i]] = msg.data[0];
 	}
-
-	i3c_detach(&i3c_msg);
 
 	return ret;
 }
@@ -364,7 +352,7 @@ int get_pmic_error_data(uint8_t dimm_id, uint8_t *buffer, uint8_t is_need_check_
 {
 	CHECK_NULL_ARG_WITH_RETURN(buffer, -1);
 	int ret = 0;
-	I3C_MSG i3c_msg = { 0 };
+	I2C_MSG msg = { 0 };
 
 	if (get_dimm_present(dimm_id) == DIMM_NOT_PRSNT) {
 		return -1;
@@ -382,29 +370,19 @@ int get_pmic_error_data(uint8_t dimm_id, uint8_t *buffer, uint8_t is_need_check_
 		return -1;
 	}
 
-	i3c_msg.bus = I3C_BUS3;
-	i3c_msg.target_addr = pmic_i3c_addr_list[dimm_id % (DIMM_ID_MAX / 2)];
-
-	i3c_attach(&i3c_msg);
-	ret = all_brocast_ccc(&i3c_msg);
-	if (ret != 0) {
-		LOG_ERR("Failed to brocast CCC, ret%d bus%d", ret, i3c_msg.bus);
-		i3c_detach(&i3c_msg);
-		return ret;
-	}
-
-	// Read PMIC error via I3C
-	i3c_msg.tx_len = 1;
-	i3c_msg.rx_len = MAX_LEN_I3C_GET_PMIC_ERR;
-	i3c_msg.data[0] = PMIC_POR_ERROR_LOG_ADDR_VAL;
-	ret = i3c_transfer(&i3c_msg);
-	i3c_detach(&i3c_msg);
+	memset(&msg, 0, sizeof(I2C_MSG));
+	msg.bus = I2C_BUS13;
+	msg.target_addr = pmic_i3c_addr_list[dimm_id % (DIMM_ID_MAX / 2)];
+	msg.tx_len = 1;
+	msg.rx_len = MAX_LEN_I3C_GET_PMIC_ERR;
+	msg.data[0] = PMIC_POR_ERROR_LOG_ADDR_VAL;
+	ret = i2c_master_read(&msg, 3);
 
 	if (ret != 0) {
-		LOG_ERR("Failed to read PMIC error via I3C");
+		LOG_ERR("Failed to read PMIC error %d", dimm_id);
 	}
+	memcpy(buffer, msg.data, msg.rx_len);
 
-	memcpy(buffer, i3c_msg.data, i3c_msg.rx_len);
 	return ret;
 }
 
@@ -450,7 +428,7 @@ void read_pmic_error_when_dc_off()
 void clear_pmic_error(uint8_t dimm_id)
 {
 	int ret = 0;
-	I3C_MSG i3c_msg = { 0 };
+	uint8_t retry = 3;
 
 	if (k_mutex_lock(&i3c_dimm_mutex, K_MSEC(I3C_DIMM_MUTEX_TIMEOUT_MS))) {
 		LOG_ERR("Failed to lock I3C dimm MUX");
@@ -466,81 +444,77 @@ void clear_pmic_error(uint8_t dimm_id)
 		return;
 	}
 
-	i3c_msg.bus = I3C_BUS3;
-	i3c_msg.target_addr = pmic_i3c_addr_list[dimm_id % (DIMM_ID_MAX / 2)];
+	I2C_MSG *msg = (I2C_MSG *)malloc(sizeof(I2C_MSG));
 
-	i3c_attach(&i3c_msg);
-	all_brocast_ccc(&i3c_msg);
-	i3c_msg.tx_len = 2;
-	i3c_msg.rx_len = 1;
-
-	memset(&i3c_msg.data, 0, 2);
 	/* Set R35 to clear error injection */
-	i3c_msg.data[0] = PMIC_CLEAR_ERROR_INJECTION_CFG_OFFSET;
-	i3c_msg.data[1] = 0x00;
-	ret = i3c_transfer(&i3c_msg);
-	if (ret != 0) {
-		LOG_ERR("Failed to transfer I3C clear pmic error command: 0x%x",
-			PMIC_CLEAR_ERROR_INJECTION_CFG_OFFSET);
+	memset(msg, 0, sizeof(*msg));
+	msg->bus = I2C_BUS13;
+	msg->target_addr = pmic_i3c_addr_list[dimm_id % (DIMM_ID_MAX / 2)];
+	msg->tx_len = 2;
+	msg->rx_len = 1;
+	msg->data[0] = PMIC_CLEAR_ERROR_INJECTION_CFG_OFFSET;
+	msg->data[1] = 0x00;
+
+	if (i2c_master_write(msg, retry)) {
+		LOG_ERR("Failed to set PMIC R35 to 0x00. dimm_id:%x", dimm_id);
 	}
 
 	if (is_critical_error(dimm_id)) {
-		uint8_t index = 0;
-		for (index = 0; index < CLEAR_MTP_RETRY_MAX; index++) {
-			// Set R39 to clear registers R04 ~ R07
-			// Host Region Codes: 0x74
-			// Clear Registers R04 to R07, Erase MTP memory for R04 Register
-			i3c_msg.tx_len = 2;
-			i3c_msg.rx_len = 1;
-			i3c_msg.data[0] = PMIC_VENDOR_PASSWORD_CONTROL_OFFSET;
-			i3c_msg.data[1] = 0x74;
+		uint8_t i = 0;
+		for (; i < CLEAR_MTP_RETRY_MAX; i++) {
+			/* Set R39 to clear MTP and R04-R07 */
+			memset(msg, 0, sizeof(*msg));
+			msg->bus = I2C_BUS13;
+			msg->target_addr = pmic_i3c_addr_list[dimm_id % (DIMM_ID_MAX / 2)];
+			msg->tx_len = 2;
+			msg->data[0] = PMIC_VENDOR_PASSWORD_CONTROL_OFFSET;
+			msg->data[1] = 0x74;
 
-			ret = i3c_transfer(&i3c_msg);
-			if (ret != 0) {
-				LOG_ERR("Failed to transfer I3C clear pmic error command: 0x%x",
-					PMIC_VENDOR_PASSWORD_CONTROL_OFFSET);
+			if (i2c_master_write(msg, retry)) {
+				LOG_ERR("Failed to set PMIC R39 to 0x74. dimm_id:%x", dimm_id);
 				continue;
 			}
 
 			k_msleep(CLEAR_MTP_DELAY_MS);
 			// Check R04 ~ R07 status
-			i3c_msg.tx_len = 1;
-			i3c_msg.rx_len = 4;
-			i3c_msg.data[0] = PMIC_ERROR_STATUS_START_OFFSET;
+			memset(msg, 0, sizeof(*msg));
+			msg->bus = I2C_BUS13;
+			msg->target_addr = pmic_i3c_addr_list[dimm_id % (DIMM_ID_MAX / 2)];
+			msg->tx_len = 1;
+			msg->rx_len = 4;
+			msg->data[0] = PMIC_ERROR_STATUS_START_OFFSET;
 
-			ret = i3c_transfer(&i3c_msg);
-			if (ret != 0) {
-				LOG_ERR("Failed to transfer I3C clear pmic error command: 0x%x",
-					PMIC_VENDOR_PASSWORD_CONTROL_OFFSET);
+			if (i2c_master_read(msg, retry)) {
+				LOG_ERR("Failed to read PMIC R39. dimm_id:%x", dimm_id);
 				continue;
 			}
 
-			if (!(i3c_msg.data[0] || i3c_msg.data[1] || i3c_msg.data[2] ||
-			      i3c_msg.data[3])) {
+			if (!(msg->data[0] || msg->data[1] || msg->data[2] || msg->data[3])) {
 				break;
 			}
 		}
 
-		if (index == CLEAR_MTP_RETRY_MAX) {
+		if (i == CLEAR_MTP_RETRY_MAX) {
 			LOG_ERR("Failed to clear MTP, retry reach max.");
 		}
 	}
-	// Set R14 to clear registers R08 ~ R0B, R33
-	// R14[0]: GLOBAL_CLEAR_STATUS, Clear all status bits
-	i3c_msg.tx_len = 2;
-	i3c_msg.rx_len = 1;
-	i3c_msg.data[0] = PMIC_CLEAR_STATUS_BITS4_OFFSET;
-	i3c_msg.data[1] = 0x01;
 
-	ret = i3c_transfer(&i3c_msg);
-	if (ret != 0) {
-		LOG_ERR("Failed to transfer I3C clear pmic error command: 0x%x",
-			PMIC_CLEAR_STATUS_BITS4_OFFSET);
+	/* Set R14 to clear R08-R0B, R33 */
+	memset(msg, 0, sizeof(*msg));
+	msg->bus = I2C_BUS13;
+	msg->target_addr = pmic_i3c_addr_list[dimm_id % (DIMM_ID_MAX / 2)];
+	msg->tx_len = 2;
+	msg->data[0] = PMIC_CLEAR_STATUS_BITS4_OFFSET;
+	msg->data[1] = 0x01;
+
+	if (i2c_master_write(msg, retry)) {
+		LOG_ERR("Failed to set PMIC R14 to 0x01. dimm_id:%x", dimm_id);
 	}
 
-	i3c_detach(&i3c_msg);
 	if (k_mutex_unlock(&i3c_dimm_mutex)) {
 		LOG_ERR("Failed to unlock I3C dimm MUX");
 	}
+	SAFE_FREE(msg);
+
 	return;
 }


### PR DESCRIPTION
Description:
- Change from I3C to I2C to access DIMM

Test Plan:
- Build code: pass
- Sensor polling: pass
- Pmic error injection: pass

                   power_SENTINEL_DOME_SLOT_3_DIMM_A0_PWR_W |      0.12 |
                  power_SENTINEL_DOME_SLOT_3_DIMM_A10_PWR_W |      0.25 |
                   power_SENTINEL_DOME_SLOT_3_DIMM_A1_PWR_W |      0.25 |
                   power_SENTINEL_DOME_SLOT_3_DIMM_A2_PWR_W |      0.12 |
                   power_SENTINEL_DOME_SLOT_3_DIMM_A3_PWR_W |       0.0 |
                   power_SENTINEL_DOME_SLOT_3_DIMM_A4_PWR_W |       0.0 |
                   power_SENTINEL_DOME_SLOT_3_DIMM_A6_PWR_W |      0.37 |
                   power_SENTINEL_DOME_SLOT_3_DIMM_A7_PWR_W |      0.12 |
                   power_SENTINEL_DOME_SLOT_3_DIMM_A8_PWR_W |      0.12 |
                   power_SENTINEL_DOME_SLOT_3_DIMM_A9_PWR_W |      0.37 |
             temperature_SENTINEL_DOME_SLOT_3_DIMM_A0_TEMP_C |      38.0 |
            temperature_SENTINEL_DOME_SLOT_3_DIMM_A10_TEMP_C |      28.0 |
             temperature_SENTINEL_DOME_SLOT_3_DIMM_A1_TEMP_C |      37.0 |
             temperature_SENTINEL_DOME_SLOT_3_DIMM_A2_TEMP_C |      37.0 |
             temperature_SENTINEL_DOME_SLOT_3_DIMM_A3_TEMP_C |      37.0 |
             temperature_SENTINEL_DOME_SLOT_3_DIMM_A4_TEMP_C |      35.0 |
             temperature_SENTINEL_DOME_SLOT_3_DIMM_A6_TEMP_C |      30.0 |
             temperature_SENTINEL_DOME_SLOT_3_DIMM_A7_TEMP_C |      30.0 |
             temperature_SENTINEL_DOME_SLOT_3_DIMM_A8_TEMP_C |      30.0 |

root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0xB1 0x15 0xA0 0x00 0 0 2 0x31 pldmtool: Tx: 80 3f 01 15 a0 00 e0 b1 15 a0 00 00 00 02 31 pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 b1 00 15 a0 00 78 02 root@bmc:~# pldmtool raw -m 30 -d 0x80 0x3f 0x1 0x15 0xa0 0x00 0xE0 0xB1 0x15 0xA0 0x00 0 0 5 0x00 pldmtool: Tx: 80 3f 01 15 a0 00 e0 b1 15 a0 00 00 00 05 00 pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 b1 00 15 a0 00 51 18 0a 86 32

root@bmc:~# ./pmic-error-injection.sh  slot3 --dimm dimm_A --error_inj high_temp Read write_protect status
pldmtool: Tx: 80 3f 01 15 a0 00 e0 b1 15 a0 00 00 02 01 35 83 pldmtool: Rx: 00 3f 01 00 15 a0 00 e4 b1 00 15 a0 00 83

    "2": {
        "additional_data": [],
        "event_id": "",
        "message": "Event: Host3 DIMM PMIC Error : DIMM A High Temp Warning, ASSERTED",
        "resolution": "",
        "resolved": false,
        "severity": "xyz.openbmc_project.Logging.Entry.Level.Error",
        "timestamp": "2025-03-25T06:16:57.216000000Z",
        "updated_timestamp": "2025-03-25T06:16:57.216000000Z"
    }