### PR TITLE
minerva-ag: Change 312M clk_gen and 100M clk_buffer init delay time

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_isr.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_isr.c
@@ -160,7 +160,7 @@ bool plat_i2c_write(uint8_t bus, uint8_t addr, uint8_t offset, uint8_t *data, ui
 void check_clk_handler()
 {
 	static uint8_t check_clk_handler_retry_count = 0;
-	uint8_t retry_max_count = 1;
+	uint8_t retry_max_count = 20;
 	uint8_t data[4] = { 0 };
 
 	if (!plat_i2c_read(I2C_BUS5, AEGIS_CPLD_ADDR, 0x0B, data, 1)) {
@@ -194,24 +194,27 @@ void check_clk_handler()
 			LOG_ERR("Failed to write 312M CLK GEN");
 			return;
 		}
+		if (check_clk_handler_retry_count == 0)
+			LOG_INF("Init 312M CLK GEN finish");
+		else
+			LOG_INF("Init 312M CLK GEN finish, retry %d times",
+				check_clk_handler_retry_count);
 		check_clk_handler_retry_count = 0;
-		LOG_INF("Init 312M CLK GEN finish");
 	} else {
 		check_clk_handler_retry_count++;
 		if (check_clk_handler_retry_count > retry_max_count) {
 			LOG_ERR("312M CLK GEN init failed");
 			check_clk_handler_retry_count = 0;
 		} else {
-			LOG_INF("312M CLK GEN init, pwrgd not ready, retry after 100ms");
-			k_work_schedule(&check_clk_work, K_MSEC(100));
+			k_work_schedule(&check_clk_work, K_MSEC(10));
 		}
 	}
 }
 
 void check_clk_buffer_handler()
 {
-	static uint8_t check_clk_handler_retry_count = 0;
-	uint8_t retry_max_count = 1;
+	static uint8_t check_clk_buffer_handler_retry_count = 0;
+	uint8_t retry_max_count = 20;
 	uint8_t data[2] = { 0 };
 
 	if (!plat_i2c_read(I2C_BUS5, AEGIS_CPLD_ADDR, 0x0B, data, 1)) {
@@ -245,16 +248,19 @@ void check_clk_buffer_handler()
 			LOG_ERR("Failed to write 100M CLK BUFFER U519");
 			return;
 		}
-		check_clk_handler_retry_count = 0;
-		LOG_INF("Init 100M CLK BUFFER finish");
+		if (check_clk_buffer_handler_retry_count == 0)
+			LOG_INF("Init 100M CLK BUFFER finish");
+		else
+			LOG_INF("Init 100M CLK BUFFER finish, retry %d times",
+				check_clk_buffer_handler_retry_count);
+		check_clk_buffer_handler_retry_count = 0;
 	} else {
-		check_clk_handler_retry_count++;
-		if (check_clk_handler_retry_count > retry_max_count) {
+		check_clk_buffer_handler_retry_count++;
+		if (check_clk_buffer_handler_retry_count > retry_max_count) {
 			LOG_ERR("100M CLK BUFFER init failed");
-			check_clk_handler_retry_count = 0;
+			check_clk_buffer_handler_retry_count = 0;
 		} else {
-			LOG_INF("100M CLK BUFFER init, pwrgd not ready, retry after 100ms");
-			k_work_schedule(&check_clk_work, K_MSEC(100));
+			k_work_schedule(&check_clk_buffer_work, K_MSEC(10));
 		}
 	}
 }
@@ -264,10 +270,10 @@ void plat_clock_init(void)
 	LOG_DBG("plat_clock_init started");
 	uint8_t board_stage = get_board_stage();
 	if (board_stage == FAB2_DVT || board_stage == FAB3_PVT || board_stage == FAB4_MP)
-		k_work_schedule(&check_clk_work, K_MSEC(300));
+		k_work_schedule(&check_clk_work, K_MSEC(200));
 
 	if (board_stage >= FAB3_PVT)
-		k_work_schedule(&check_clk_buffer_work, K_MSEC(300));
+		k_work_schedule(&check_clk_buffer_work, K_MSEC(200));
 }
 
 void plat_eusb_init(void)


### PR DESCRIPTION
Summary:
- 312M clk_gen init delay time from 300ms to 200ms
- 100M clk_buffer init delay time from 300ms to 200ms
- the retry interval is 10ms, retry times is 20

Test Plan:
- Build code: PASS