### PR TITLE
minerva-ag: Modify cpld ASIC_OC_WARN_2_REG(0x98) dc off default value to 0xdf

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_event.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_event.c
@@ -78,7 +78,7 @@ aegis_cpld_info aegis_cpld_info_table[] = {
 	{ LEAK_DETCTION_REG, 				0xDF, 0xDF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
 
 	{ TEMPERATURE_IC_OVERT_FAULT_2_REG, 0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
-	{ ASIC_OC_WARN_2_REG, 				0xFF, 0xDF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
+	{ ASIC_OC_WARN_2_REG, 				0xDF, 0xDF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
 	{ SYSTEM_ALERT_FAULT_2_REG, 		0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
 	{ VR_SMBUS_ALERT_3_REG, 			0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },
 	{ VR_SMBUS_ALERT_4_REG, 			0xFF, 0xFF, true, 0x00, false, false, 0x00,  .status_changed_cb = vr_error_callback },	


### PR DESCRIPTION
Summary:
- Modify cpld ASIC_OC_WARN_2_REG(0x98) dc off default value to 0xdf

Test Plan:
- Build code: PASS