### PR TITLE
minerva-ag: Version commit for ob-minerva-ag-2025.15.01

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_version.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_version.h
@@ -40,7 +40,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x25
-#define BIC_FW_WEEK 0x14
+#define BIC_FW_WEEK 0x15
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x61 // char: a
 #define BIC_FW_platform_1 0x67 // char: g


### PR DESCRIPTION
Summary:
- Version commit for Minerva Aegis BIC ob-minerva-ag-2025.03.01.

Test Plan:
- Build code: Pass
- Get BIC version: Pass

Log:
```
uart:~$ platform info
========================{SHELL COMMAND INFO}========================================
* NAME:          Platform command
* DESCRIPTION:   Commands that could be used to debug or validate.
* DATE/VERSION:  none
* CHIP/OS:       npcm400f_evb - Zephyr
* Note:          none
------------------------------------------------------------------
* PLATFORM:      Minerva-Aegis
* BOARD ID:      1
* STAGE:         1
* SYSTEM:        255
* FW VERSION:    17.0
* FW DATE:       2025.15.1
* FW IMAGE:      MINERVA_AEGIS.bin
* BOARD_TYPE:    (0x01)AEGIS
* BOARD_STAGE:   (0x02)FAB3_PVT
* VR_VENDOR_TYPE:(0x05)FLEX_UBC_AND_RNS_VR
* UBC_TYPE:      (0x01)FLEX_BMR313
* VR_TYPE:       (0x03)RNS_ISL69260_RAA228249
* TMP_TYPE:      (0x00)TMP_TMP432
========================{SHELL COMMAND INFO}========================================
```