### PR TITLE
fby4: sd: add sel for power fault

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_isr.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.h
@@ -21,8 +21,8 @@
 
 extern uint8_t hw_event_register[13];
 
-#define VR_FAULT_STATUS_LSB_MASK 0x3C
-#define VR_FAULT_STATUS_MSB_MASK 0xE0
+#define VR_FAULT_STATUS_LSB_MASK 0x3F
+#define VR_FAULT_STATUS_MSB_MASK 0xF0
 #define VR_IOUT_FAULT_MASK 0x40
 #define VR_TPS_OCW_MASK 0x20
 


### PR DESCRIPTION
# Description
- Related to JIRA-1654.
- Implement functionality to read specific PMBus statuses for different VR sources. Additionally, send events based on the results of reading all implemented registers when the GPIO is triggered.
- The first SEL entry corresponds to the status_word (0x79), which consists of 2 bytes. Subsequent SEL entries represent the remaining registers, each containing only 1 byte, and are placed immediately after their respective register addresses.

# Motivation
- When a fault or alert is detected on the SD BIC, read the power status through the registers listed below and add the information to the SEL log. 
+---------+------+------+------+------+------+------+------+------+------+
|   MPS      | 0x78 | 0x79  | 0x7A  | 0x7B | 0x7C  | 0x7D | 0x7E  |          |           |
+---------+------+------+------+------+------+------+------+------+------+
| RENESAS| 0x78 | 0x79  | 0x7A  | 0x7B | 0x7C  | 0x7D | 0x7E  | 0x80  |          |
+---------+------+------+------+------+------+------+------+------+------+
|   TI          | 0x78 | 0x79  | 0x7A  | 0x7B | 0x7C  | 0x7D | 0x7E  | 0x7F  | 0x80  |
+---------+------+------+------+------+------+------+------+------+------+

# Test Plan:
- Build code: Pass
- Verify if the SEL is displayed as expected: Pass
- Log: 

"295": { "additional_data": {}, "event_id": "", "message": "Event: Host1 PMALERT Assertion : PVDD11_S3 status: 0x0002, ASSERTED", "resolution": "", "resolved": false, "severity": "xyz.openbmc_project.Logging.Entry.Level.Error", "timestamp": "2025-03-27T09:10:50.267000000Z", "updated_timestamp": "2025-03-27T09:10:50.267000000Z" }, 

"296": { "additional_data": {}, "event_id": "", "message": "Event: Host1 PMALERT Assertion : PVDD11_S3 status: 0x7802, ASSERTED", "resolution": "", "resolved": false, "severity": "xyz.openbmc_project.Logging.Entry.Level.Error", "timestamp": "2025-03-27T09:10:50.299000000Z", "updated_timestamp": "2025-03-27T09:10:50.299000000Z" }, 

"297": { "additional_data": {}, "event_id": "", "message": "Event: Host1 PMALERT Assertion : PVDD11_S3 status: 0x7a00, ASSERTED", "resolution": "", "resolved": false, "severity": "xyz.openbmc_project.Logging.Entry.Level.Error", "timestamp": "2025-03-27T09:10:50.351000000Z", "updated_timestamp": "2025-03-27T09:10:50.351000000Z" }, 

"298": { "additional_data": {}, "event_id": "", "message": "Event: Host1 PMALERT Assertion : PVDD11_S3 status: 0x7b00, ASSERTED", "resolution": "", "resolved": false, "severity": "xyz.openbmc_project.Logging.Entry.Level.Error", "timestamp": "2025-03-27T09:10:50.400000000Z", "updated_timestamp": "2025-03-27T09:10:50.400000000Z" }, 

"299": { "additional_data": {}, "event_id": "", "message": "Event: Host1 PMALERT Assertion : PVDD11_S3 status: 0x7c00, ASSERTED", "resolution": "", "resolved": false, "severity": "xyz.openbmc_project.Logging.Entry.Level.Error", "timestamp": "2025-03-27T09:10:50.460000000Z", "updated_timestamp": "2025-03-27T09:10:50.460000000Z" }, 

"300": { "additional_data": {}, "event_id": "", "message": "Event: Host1 PMALERT Assertion : PVDD11_S3 status: 0x7d00, ASSERTED", "resolution": "", "resolved": false, "severity": "xyz.openbmc_project.Logging.Entry.Level.Error", "timestamp": "2025-03-27T09:10:50.694000000Z", "updated_timestamp": "2025-03-27T09:10:50.694000000Z" }, 

"301": { "additional_data": {}, "event_id": "", "message": "Event: Host1 PMALERT Assertion : PVDD11_S3 status: 0x7e02, ASSERTED", "resolution": "", "resolved": false, "severity": "xyz.openbmc_project.Logging.Entry.Level.Error", "timestamp": "2025-03-27T09:10:51.031000000Z", "updated_timestamp": "2025-03-27T09:10:51.031000000Z" }, 

"302": { "additional_data": {}, "event_id": "", "message": "Event: Host1 PMALERT Assertion : PVDD11_S3 status: 0x8000, ASSERTED", "resolution": "", "resolved": false, "severity": "xyz.openbmc_project.Logging.Entry.Level.Error", "timestamp": "2025-03-27T09:10:51.176000000Z", "updated_timestamp": "2025-03-27T09:10:51.176000000Z" } }