### PR TITLE
fby4: wf: After Runtime on, there will be sensor reading issues if Ru…

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
@@ -425,6 +425,14 @@ void execute_power_off_sequence()
 		LOG_ERR("Failed to cancel cxl2_ready_thread");
 	}
 
+	if (k_work_cancel_delayable(&set_cxl1_vr_ready_work) != 0) {
+		LOG_WRN("Failed to cancel set_cxl1_vr_ready_work");
+	}
+
+	if (k_work_cancel_delayable(&set_cxl2_vr_ready_work) != 0) {
+		LOG_WRN("Failed to cancel set_cxl2_vr_ready_work");
+	}
+
 	if (k_work_cancel_delayable(&cxl1_hb_monitor_work) != 0) {
 		LOG_ERR("Failed to cancel cxl1_hb_monitor_work");
 	}


### PR DESCRIPTION
# Description
- To avoid incorrect is_cxl_vr_accessible status caused by too short intervals between power on and power off, which results in PLDM continuously reading VR sensor status even during power off.

# Motivation
- After runtime on, if runtime off occurs within 7 seconds, it will be affected by the 7-second delay of set_cxl1_vr_ready_work in the CXL ready handler. Even after power off has set is_cxl_vr_accessible to false, the CXL ready handler will still change it back to true after a 7-second delay.

# Test log
[01:16:53.079,000] <inf> plat_power_seq: MB DC (gpio num 7) status is ON [01:16:53.079,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: no [01:16:53.079,000] <wrn> power_status: P12V_E1S_PWR_GOOD: no [01:16:53.086,000] <wrn> power_status: P12V_E1S_PWR_GOOD: yes [01:16:53.092,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: yes [01:16:53.102,000] <inf> plat_power_seq: CXL 1 power on success [01:16:53.125,000] <inf> plat_power_seq: CXL 2 power on success [01:16:53.125,000] <wrn> power_status: DC_STATUS: on [01:16:53.131,000] <inf> plat_mctp: plat_eid= 42
[01:16:53.131,000] <err> plat_mctp: Delete exited thread [01:16:53.079,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: no [01:16:53.079,000] <wrn> power_status: P12V_E1S_PWR_GOOD: no [01:16:53.086,000] <wrn> power_status: P12V_E1S_PWR_GOOD: yes [01:16:53.092,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: yes [01:16:53.125,000] <wrn> power_status: DC_STATUS: on [01:16:53.131,000] <err> plat_mctp: Delete exited thread uart:~$ [01:17:23.125,000] <inf> plat_power_seq: Start monitor CXL1 ready [01:17:23.125,000] <inf> plat_power_seq: Start monitor CXL2 ready [01:17:24.156,000] <inf> plat_power_seq: CXL1 is ready mctp cci msg timeout!!
[01:17:33.133,000] <inf> plat_mctp: Send set EID command to CXL1 mctp cci msg timeout!!
mctp ctrl msg timeout!!
cmd 1, inst_id 1f
[01:17:35.446,000] <inf> plat_power_seq: MB DC (gpio num 7) status is OFF [01:17:35.446,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: yes [01:17:35.446,000] <wrn> power_status: P12V_E1S_PWR_GOOD: no [01:17:35.446,000] <wrn> power_status: DC_STATUS: off [01:17:35.446,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: no [01:17:35.446,000] <wrn> power_status: P12V_E1S_PWR_GOOD: no [01:17:35.446,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: yes [01:17:35.446,000] <wrn> power_status: P12V_E1S_PWR_GOOD: no [01:17:35.446,000] <wrn> power_status: DC_STATUS: off [01:17:35.446,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: no [01:17:35.446,000] <wrn> power_status: P12V_E1S_PWR_GOOD: no uart:~$ [01:17:38.966,000] <inf> plat_power_seq: CXL 1 power off success [01:17:42.486,000] <inf> plat_power_seq: CXL 2 power off success