### PR TITLE
fby4: sd: add access_checker for bootdrive related sensor

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
@@ -35,9 +35,11 @@
 #define ADDR_X8_RETIMER (0x46 >> 1)
 #define ADDR_X16_RETIMER (0x40 >> 1)
 #define ADDR_NVME (0xD4 >> 1)
+#define ADDR_CPLD_IOE (0x46 >> 1)
 
 #define OFFSET_TMP75_TEMP 0x00
 #define OFFSET_NVME_TEMP 0x00
+#define OFFSET_CARD_PRSNT 0x04
 
 #define NUM_SOC_PACKAGE_PWR 0x0055
 
@@ -80,5 +82,6 @@ void plat_init_pldm_sensor_table();
 void plat_init_pldm_disabled_sensors();
 void plat_pldm_sensor_change_dimm_dev();
 void plat_pldm_sensor_clear_vr_fault(uint8_t vr_addr, uint8_t vr_bus, uint8_t page_cnt);
+bool bootdrive_access(uint8_t sensor_num);
 
 #endif


### PR DESCRIPTION
# Summary
- Related to JIRA-1577.
- Add a new access_checker to read Bootdrive present pin before post-complete. If bootdrive exist, then follow the original flow to access sensor after post complete. If not, set the sensor failed.

# Motivation
- When the boot drive is not inserted, POST complete never occurs, causing related sensors to stay in init state. This prevents BMC from detecting failure and entering failsafe mode.

# Test Plan:
- Build code: Pass
- Check fan speed would change to 100 if bootdrive is not inseted.
- Log:
```
root@bmc:~# mfg-tool sensor-display 2>/dev/null | table-sensor-display | egrep -i "pwm"
FANBOARD0_FAN0_PWM_PCT                                  ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
FANBOARD0_FAN1_PWM_PCT                                  ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
FANBOARD0_FAN4_PWM_PCT                                  ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
FANBOARD0_FAN5_PWM_PCT                                  ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
FANBOARD0_FAN8_PWM_PCT                                  ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
FANBOARD0_FAN9_PWM_PCT                                  ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
FANBOARD1_FAN10_PWM_PCT                                 ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
FANBOARD1_FAN11_PWM_PCT                                 ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
FANBOARD1_FAN2_PWM_PCT                                  ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
FANBOARD1_FAN3_PWM_PCT                                  ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
FANBOARD1_FAN6_PWM_PCT                                  ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
FANBOARD1_FAN7_PWM_PCT                                  ok              100             Percent         N/A     N/A             N/A             N/A             N/A             N/A
root@bmc:~# busctl introspect xyz.openbmc_project.PLDM /xyz/openbmc_project/sensors/temperature/SENTINEL_DOME_SLOT_1_MB_SSD_BOOT_TEMP_C
NAME                                                  TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.freedesktop.DBus.Introspectable                   interface -         -                                        -
.Introspect                                           method    -         s                                        -
org.freedesktop.DBus.Peer                             interface -         -                                        -
.GetMachineId                                         method    -         s                                        -
.Ping                                                 method    -         -                                        -
org.freedesktop.DBus.Properties                       interface -         -                                        -
.Get                                                  method    ss        v                                        -
.GetAll                                               method    s         a{sv}                                    -
.Set                                                  method    ssv       -                                        -
.PropertiesChanged                                    signal    sa{sv}as  -                                        -
xyz.openbmc_project.Association.Definitions           interface -         -                                        -
.Associations                                         property  a(sss)    1 "chassis" "all_sensors" "/xyz/openbmc… emits-change writable
xyz.openbmc_project.Sensor.Threshold.Critical         interface -         -                                        -
.CriticalAlarmHigh                                    property  b         false                                    emits-change writable
.CriticalAlarmLow                                     property  b         false                                    emits-change writable
.CriticalHigh                                         property  d         75                                       emits-change writable
.CriticalLow                                          property  d         nan                                      emits-change writable
.CriticalHighAlarmAsserted                            signal    d         -                                        -
.CriticalHighAlarmDeasserted                          signal    d         -                                        -
.CriticalLowAlarmAsserted                             signal    d         -                                        -
.CriticalLowAlarmDeasserted                           signal    d         -                                        -
xyz.openbmc_project.Sensor.Value                      interface -         -                                        -
.MaxValue                                             property  d         0                                        emits-change writable
.MinValue                                             property  d         0                                        emits-change writable
.Unit                                                 property  s         "xyz.openbmc_project.Sensor.Value.Unit.… emits-change writable
.Value                                                property  d         nan                                      emits-change writable
xyz.openbmc_project.State.Decorator.Availability      interface -         -                                        -
.Available                                            property  b         true                                     emits-change writable
xyz.openbmc_project.State.Decorator.OperationalStatus interface -         -                                        -
.Functional                                           property  b         false                                    emits-change writable
root@bmc:~#

root@bmc:/tmp# journalctl -u phosphor-pid-control -n 10                                                                                                                                                         Apr 20 07:19:05 bmc swampd[22260]: inputs: WAILUA_FALLS_SLOT_7_WF_VR_ASIC1_P0V8_TEMP_C, WAILUA_FALLS_SLOT_7_WF_VR_ASIC1_PVDDQ_CD                                                                                _TEMP_C, WAILUA_FALLS_SLOT_7_WF_VR_ASIC1_P0V85_TEMP_C, WAILUA_FALLS_SLOT_7_WF_VR_ASIC1_PVDDQ_AB_TEMP_C, WAILUA_FALLS_SLOT_7_WF_V                                                                                R_ASIC2_P0V8_TEMP_C, WAILUA_FALLS_SLOT_7_WF_VR_ASIC2_PVDDQ_CD_TEMP_C, WAILUA_FALLS_SLOT_7_WF_VR_ASIC2_P0V85_TEMP_C, WAILUA_FALLS                                                                                _SLOT_7_WF_VR_ASIC2_PVDDQ_AB_TEMP_C,
Apr 20 07:19:05 bmc swampd[22260]: PID name: Stepwise_WF_VR_Slot_8
Apr 20 07:19:05 bmc swampd[22260]: inputs: WAILUA_FALLS_SLOT_8_WF_VR_ASIC1_P0V8_TEMP_C, WAILUA_FALLS_SLOT_8_WF_VR_ASIC1_PVDDQ_CD                                                                                _TEMP_C, WAILUA_FALLS_SLOT_8_WF_VR_ASIC1_P0V85_TEMP_C, WAILUA_FALLS_SLOT_8_WF_VR_ASIC1_PVDDQ_AB_TEMP_C, WAILUA_FALLS_SLOT_8_WF_V                                                                                R_ASIC2_P0V8_TEMP_C, WAILUA_FALLS_SLOT_8_WF_VR_ASIC2_PVDDQ_CD_TEMP_C, WAILUA_FALLS_SLOT_8_WF_VR_ASIC2_P0V85_TEMP_C, WAILUA_FALLS                                                                                _SLOT_8_WF_VR_ASIC2_PVDDQ_AB_TEMP_C,
Apr 20 07:19:05 bmc swampd[22260]: Build failsafe logger for Zone 0 with initial failsafe mode: 0
Apr 20 07:19:05 bmc swampd[22260]: pushing zone 0
Apr 20 07:19:05 bmc swampd[22260]: PID Zone 0 max SetPoint 15 requested by Stepwise_CALIBRATED_MB_FIO_Slot_1 FANBOARD0_FAN0_TACH                                                                                _INLET_SPEED_RPMFANBOARD0_FAN0_PWM_PCT FANBOARD0_FAN0_TACH_OUTLET_SPEED_RPMFANBOARD0_FAN0_PWM_PCT FANBOARD0_FAN1_TACH_INLET_SPEE                                                                                D_RPMFANBOARD0_FAN1_PWM_PCT FANBOARD0_FAN1_TACH_OUTLET_SPEED_RPMFANBOARD0_FAN1_PWM_PCT FANBOARD0_FAN4_TACH_INLET_SPEED_RPMFANBOA                                                                                RD0_FAN4_PWM_PCT FANBOARD0_FAN4_TACH_OUTLET_SPEED_RPMFANBOARD0_FAN4_PWM_PCT FANBOARD0_FAN5_TACH_INLET_SPEED_RPMFANBOARD0_FAN5_PW                                                                                M_PCT FANBOARD0_FAN5_TACH_OUTLET_SPEED_RPMFANBOARD0_FAN5_PWM_PCT FANBOARD0_FAN8_TACH_INLET_SPEED_RPMFANBOARD0_FAN8_PWM_PCT FANBO                                                                                ARD0_FAN8_TACH_OUTLET_SPEED_RPMFANBOARD0_FAN8_PWM_PCT FANBOARD0_FAN9_TACH_INLET_SPEED_RPMFANBOARD0_FAN9_PWM_PCT FANBOARD0_FAN9_T                                                                                ACH_OUTLET_SPEED_RPMFANBOARD0_FAN9_PWM_PCT FANBOARD1_FAN10_TACH_INLET_SPEED_RPMFANBOARD1_FAN10_PWM_PCT FANBOARD1_FAN10_TACH_OUTL                                                                                ET_SPEED_RPMFANBOARD1_FAN10_PWM_PCT FANBOARD1_FAN11_TACH_INLET_SPEED_RPMFANBOARD1_FAN11_PWM_PCT FANBOARD1_FAN11_TACH_OUTLET_SPEE                                                                                D_RPMFANBOARD1_FAN11_PWM_PCT FANBOARD1_FAN2_TACH_INLET_SPEED_RPMFANBOARD1_FAN2_PWM_PCT FANBOARD1_FAN2_TACH_OUTLET_SPEED_RPMFANBO                                                                                ARD1_FAN2_PWM_PCT FANBOARD1_FAN3_TACH_INLET_SPEED_RPMFANBOARD1_FAN3_PWM_PCT FANBOARD1_FAN3_TACH_OUTLET_SPEED_RPMFANBOARD1_FAN3_P                                                                                WM_PCT FANBOARD1_FAN6_TACH_INLET_SPEED_RPMFANBOARD1_FAN6_PWM_PCT FANBOARD1_FAN6_TACH_OUTLET_SPEED_RPMFANBOARD1_FAN6_PWM_PCT FANB                                                                                OARD1_FAN7_TACH_INLET_SPEED_RPMFANBOARD1_FAN7_PWM_PCT FANBOARD1_FAN7_TACH_OUTLET_SPEED_RPMFANBOARD1_FAN7_PWM_PCT SENTINEL_DOME_S                                                                                LOT_1_MB_SSD_BOOT_TEMP_C
Apr 20 07:19:05 bmc swampd[22260]: Zone 0 fans, entering failsafe mode, output pwm: 100
Apr 20 07:19:05 bmc swampd[22260]: Fail sensor: SENTINEL_DOME_SLOT_1_MB_SSD_BOOT_TEMP_C, reason: Sensor reading bad
```