### PR TITLE
fby4: sd: correct the error message of bootdrive_access

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -7022,16 +7022,15 @@ bool bootdrive_access(uint8_t sensor_num)
 		return true;
 	} else {
 		bootdrive_exist = !(msg.data[0] & (1 << 6));
-		LOG_ERR("Return Value is %x, Bootdrive %s", msg.data[0], bootdrive_exist ? "exist" : "does not exist");
 	}
 
 	// If the bootdrice exist, wait for post_completed then start to monitor
 	if(bootdrive_exist)
 	{
 		return post_access(sensor_num);
-		//return get_post_status();
 	}
 
 	// If the bootdrive does not exist, let the sensor do not stock in init status
+	LOG_ERR("Return Value is %x, Bootdrive does not exist", msg.data[0]);
 	return true;
 }


### PR DESCRIPTION
# Summary
- Related to JIRA-1577.
- Correct the error message for bootdrive_access

# Motivation
- Only need to log the error message when bootdrive does not exist. If bootdrive exists, do not print anything.

# Test Plan:
- Build code: Pass
- Check there is no eror message if bootdrive exist.