### PR TITLE
common: patch: add i3c reset callback

### DIFF
--- a/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0088-i3c-aspeed-Add-api-to-hook-the-reset-callback
+++ b/fix_patch/tag_v00.01.06_d014527731033db477f806f5bff2e1ca5d4b2ba7/0088-i3c-aspeed-Add-api-to-hook-the-reset-callback
@@ -1,0 +1,99 @@
+From 59c49cd8b561259251beedc9299d8e5bc5fc4283 Mon Sep 17 00:00:00 2001
+From: Jerry C Chen <Jerry_C_Chen@wiwynn.com>
+Date: Thu, 24 Apr 2025 14:29:03 +0800
+Subject: [PATCH] i3c: aspeed: Add api to hook the reset callback
+
+Currently, when the I3C slave encounters a transfer error, it
+automatically enters a halt state. After that, the hardware lacks a
+recovery flow to restore the controller, so the software has to reset the
+I3C controller. To allow users to be aware of this reset event, this patch
+provides an API to hook into the reset callback. This callback can be used
+to execute a hot-join request or any user-defined behavior to reattach the
+I3C slave to the bus, ensuring that future transfers can continue without
+issues.
+---
+ drivers/i3c/i3c_aspeed.c  | 21 ++++++++++++++++++++-
+ include/drivers/i3c/i3c.h |  3 +++
+ 2 files changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i3c/i3c_aspeed.c b/drivers/i3c/i3c_aspeed.c
+index 89369d6c1e..e8d6be174d 100644
+--- a/drivers/i3c/i3c_aspeed.c
++++ b/drivers/i3c/i3c_aspeed.c
+@@ -553,6 +553,7 @@ struct i3c_aspeed_obj {
+ 	struct k_spinlock lock;
+ 	struct i3c_aspeed_xfer *curr_xfer;
+ 	struct k_work work;
++	struct k_work rst_work;
+ 	bool sir_allowed_by_sw;
+ 	struct {
+ 		uint32_t ibi_status_correct : 1;
+@@ -572,6 +573,7 @@ struct i3c_aspeed_obj {
+ 	struct i3c_slave_setup slave_data;
+ 	osEventFlagsId_t ibi_event;
+ 	osEventFlagsId_t data_event;
++	i3c_rst_cb_t rst_cb;
+ };
+ 
+ #define I3CG_REG1(x)			((x * 0x10) + 0x14)
+@@ -1831,7 +1833,7 @@ int i3c_aspeed_slave_put_read_data(const struct device *dev, struct i3c_slave_pa
+ 					    K_SECONDS(1).ticks);
+ 		if (flag_ret & osFlagsError) {
+ 			LOG_WRN("SIR timeout: reset i3c controller");
+-			i3c_aspeed_init(dev);
++			k_work_submit(&obj->rst_work);
+ 			ret = -EIO;
+ 			goto ibi_err;
+ 		}
+@@ -1939,6 +1941,13 @@ int i3c_aspeed_set_pid_extra_info(const struct device *dev, uint16_t extra_info)
+ 	return i3c_aspeed_enable(obj);
+ }
+ 
++void i3c_aspeed_hook_rst_cb(const struct device *dev, i3c_rst_cb_t cb)
++{
++	struct i3c_aspeed_obj *obj = DEV_DATA(dev);
++
++	obj->rst_cb = cb;
++}
++
+ int i3c_aspeed_slave_get_dynamic_addr(const struct device *dev, uint8_t *dynamic_addr)
+ {
+ 	struct i3c_aspeed_config *config = DEV_CFG(dev);
+@@ -2057,6 +2066,15 @@ static void sir_allowed_worker(struct k_work *work)
+ 	obj->sir_allowed_by_sw = 1;
+ }
+ 
++static void i3c_rst_worker(struct k_work *work)
++{
++	struct i3c_aspeed_obj *obj = CONTAINER_OF(work, struct i3c_aspeed_obj, rst_work);
++
++	i3c_aspeed_init(obj->dev);
++	if (obj->rst_cb)
++		obj->rst_cb(obj->dev);
++}
++
+ int i3c_aspeed_master_send_entdaa(struct i3c_dev_desc *i3cdev)
+ {
+ 	struct i3c_aspeed_obj *obj = DEV_DATA(i3cdev->bus);
+@@ -2174,6 +2192,7 @@ static int i3c_aspeed_init(const struct device *dev)
+ 		obj->sir_allowed_by_sw = 0;
+ 		if (!obj->work.handler)
+ 			k_work_init(&obj->work, sir_allowed_worker);
++		k_work_init(&obj->rst_work, i3c_rst_worker);
+ 	} else {
+ 		union i3c_device_addr_s reg;
+ 
+diff --git a/include/drivers/i3c/i3c.h b/include/drivers/i3c/i3c.h
+index 716440a6a0..a50ccf03f3 100644
+--- a/include/drivers/i3c/i3c.h
++++ b/include/drivers/i3c/i3c.h
+@@ -268,3 +268,6 @@ int i3c_jesd403_write(struct i3c_dev_desc *slave, uint8_t *addr, int addr_size,
+ 		      int data_size);
+ int i3c_i2c_read(struct i3c_dev_desc *slave, uint8_t addr, uint8_t *buf, int length);
+ int i3c_i2c_write(struct i3c_dev_desc *slave, uint8_t addr, uint8_t *buf, int length);
++typedef void (*i3c_rst_cb_t)(const struct device *dev);
++void i3c_aspeed_hook_rst_cb(const struct device *dev, i3c_rst_cb_t cb);
++#define i3c_hook_rst_cb          i3c_aspeed_hook_rst_cb
+-- 
+2.25.1
+


### PR DESCRIPTION
# Description
ASPEED hw doesn't support controller recovery.
Add software recovery flow.

# Motivation
Avoid i3c disconnect by BIC I3C controller reset

# Test plan
Running BMC root stress without BIC i3c disconnection.