### PR TITLE
fby4: wf: Directly set the is_DC_on flag when DC off occurs

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
@@ -447,7 +447,7 @@ void execute_power_off_sequence()
 
 	cxl2_hb_state = HB_STATE_UNKNOWN;
 
-	set_DC_on_delayed_status();
+	set_DC_on_delayed_status_with_value(false);
 
 	ret = power_off_handler(CXL_ID_1, DIMM_POWER_OFF_STAGE_1);
 	if (ret == 0) {


### PR DESCRIPTION
# Description
- Directly set the is_DC_on flag when DC off occurs

# Motivation
- To prevent a situation where, during DC off, the sensor polling has not yet updated, causing the BMC to receive a DC off event and log a lower critical SEL.

# Test Plan
- Build: PASS