### PR TITLE
fby4: sd: stop sensor polling before DC off or DC cycle

### DIFF
--- a/common/lib/power_status.c
+++ b/common/lib/power_status.c
@@ -52,6 +52,7 @@ void set_DC_on_delayed_status()
 void set_DC_on_delayed_status_with_value(bool status)
 {
 	is_DC_on_delayed = status;
+	LOG_WRN("DC_DELAYED_STATUS: %s", (is_DC_on_delayed) ? "on" : "off");
 }
 
 bool get_DC_on_delayed_status()

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_monitor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_monitor.c
@@ -145,6 +145,7 @@ void plat_pldm_do_host_button_sequence(void *power_sequence, void *pressing_inte
 		i2c_msg.data[1] = ((uint8_t *)power_sequence)[i];
 		if (i2c_master_write(&i2c_msg, retry)) {
 			LOG_ERR("Fail to do i2c master write");
+			set_DC_on_delayed_status_with_value(true);
 		}
 
 		if (i == 1) {
@@ -167,10 +168,13 @@ void plat_pldm_power_cycle(void *arg1, void *arg2, void *arg3)
 	// Do power off when current power is ON
 	if (get_DC_status() == true) {
 		// Power off
+		set_DC_on_delayed_status_with_value(false);
+
 		for (int i = 0; i < PLAT_PLDM_SEQUENCE_CNT; i++) {
 			i2c_msg.data[1] = power_sequence[i];
 			if (i2c_master_write(&i2c_msg, retry)) {
 				LOG_ERR("Fail to do i2c master write");
+				set_DC_on_delayed_status_with_value(true);
 			}
 
 			if (i == 1) {
@@ -238,6 +242,8 @@ void host_power_off()
 	if (k_sem_take(&cmd_sem, K_NO_WAIT) != 0) {
 		LOG_ERR("Ignore. Previous cmd still executing.");
 	} else {
+		set_DC_on_delayed_status_with_value(false);
+
 		set_power_sequence_tid =
 			k_thread_create(&set_power_sequence_thread, set_power_sequence_stack,
 					K_THREAD_STACK_SIZEOF(set_power_sequence_stack),
@@ -320,9 +326,12 @@ void plat_pldm_set_effecter_state_host_power_control(const uint8_t *buf, uint16_
 		host_power_reset();
 		break;
 	case EFFECTER_STATE_POWER_STATUS_GRACEFUL_SHUTDOWN:
+		set_DC_on_delayed_status_with_value(false);
+
 		if (plat_pldm_host_button_sequence(power_sequence,
 						   PLAT_PLDM_GRACEFUL_SHUTDOWN_BUTTON_MSEC) != 0) {
 			LOG_ERR("Failed to do host graceful shutdown");
+			set_DC_on_delayed_status_with_value(true);
 		}
 		break;
 	default:


### PR DESCRIPTION
# Description
- Related to JIRA-1547
- Set the vr_access flag to false before performing a DC off or DC cycle.

# Motivation
- Prevent a timing issue where the VR has already started powering down, but the sensor can still be polled.

# Test Plan:
- Build code - Pass
- Check if encounter VR CriticalLow - Pass