### PR TITLE
fby4: sd: Modify MB_ADC_PVDD11_S3_VOLT_V UCR threshold

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -847,7 +847,7 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00000000, //uint32_t normal_min;
 			0x00000000, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x00000076, //uint32_t critical_high;
+			0x00000078, //uint32_t critical_high;
 			0x00000066, //uint32_t critical_low;
 			0x00000000, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;


### PR DESCRIPTION
# Description
- Related to JIRA-1729
- Modify the UCR threshold of sensor MB_ADC_PVDD11_S3_VOLT_V to 1.2V.

# Motivation
- Consider the ADC reading tolerance and VR sense compensate.
- Requirement from EE team.