### PR TITLE
fby4: sd: fix VR sensor disable problem

### DIFF
--- a/common/service/sensor/pldm_sensor.c
+++ b/common/service/sensor/pldm_sensor.c
@@ -380,6 +380,9 @@ void pldm_sensor_polling_handler(void *arug0, void *arug1, void *arug2)
 		}
 
 		for (sensor_num = 0; sensor_num < pldm_sensor_count; sensor_num++) {
+			if (get_sensor_poll_enable_flag() == false) {
+				break;
+			}
 			if (pldm_polling_sensor_reading(&pldm_sensor_list[thread_id][sensor_num],
 							pldm_sensor_count, thread_id,
 							sensor_num) != 0) {

--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -580,7 +580,7 @@ void process_vr_pmalert_ocp_sel(struct k_work *work_item)
 	uint8_t status_info[status_array_size];
 
 	for (int page = 0; page < work_info->page_cnt; ++page) {
-		set_vr_monitor_status(false);
+		disable_sensor_poll();
 		// wait 10ms for vr monitor stop
 		k_msleep(10);
 
@@ -672,7 +672,7 @@ void process_vr_pmalert_ocp_sel(struct k_work *work_item)
 				status_info[status_array_size - 1]);
 		}
 
-		set_vr_monitor_status(true);
+		enable_sensor_poll();
 
 		struct pldm_addsel_data sel_msg = { 0 };
 
@@ -749,6 +749,8 @@ void process_vr_pmalert_ocp_sel(struct k_work *work_item)
 			};
 		}
 	}
+	// make sure enable polling
+	enable_sensor_poll();
 }
 
 void ISR_PVDDCR_CPU0_OCP()


### PR DESCRIPTION
Description:
- FIX JIRA-1402
- VR sensor will be disabled when BIC read VR version or dump data
- change to diable polling instead of disable sensor

Test Plan:
- Build code - Pass
- Get VR sensor
- Get VR version
- Trigger VR pmalert