### PR TITLE
fby4: sd: Change CPLD IO Expander source for bootdrive_access

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -128,6 +128,7 @@ void pal_set_sys_status()
 	set_DC_status(PWRGD_CPU_LVC3);
 	set_DC_on_delayed_status();
 	set_post_status(FM_BIOS_POST_CMPLT_BIC_N);
+	set_bootdrive_exist_status();
 	sync_bmc_ready_pin();
 	apml_init();
 

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
@@ -35,7 +35,6 @@
 #define ADDR_X8_RETIMER (0x46 >> 1)
 #define ADDR_X16_RETIMER (0x40 >> 1)
 #define ADDR_NVME (0xD4 >> 1)
-#define ADDR_CPLD_IOE (0x46 >> 1)
 
 #define OFFSET_TMP75_TEMP 0x00
 #define OFFSET_NVME_TEMP 0x00
@@ -83,5 +82,7 @@ void plat_init_pldm_disabled_sensors();
 void plat_pldm_sensor_change_dimm_dev();
 void plat_pldm_sensor_clear_vr_fault(uint8_t vr_addr, uint8_t vr_bus, uint8_t page_cnt);
 bool bootdrive_access(uint8_t sensor_num);
+void set_bootdrive_exist_status();
+bool get_bootdrive_exist_status();
 
 #endif


### PR DESCRIPTION
# Description
- Related to JIRA-1752
- Change bootdrive presence detection to use the CPLD IO Expander on another bus.
- Change to only checks the boot drive presence during the platform initialization stage instead of performing continuous polling.

# Motivation
- To prevent both BMC and BIC from accessing the CPLD on the same bus, which may cause SD CPLD update failures due to multi-master conflicts.

# Test Plan:
- Build code - Pass
- Verified fan duty changes to 100% if boot drive is missing - Pass
- SD CPLD update - Pass