### PR TITLE
fby4: sd: Fix abnormal VR alert SEL during FHC stress

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_isr.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.h
@@ -21,8 +21,8 @@
 
 extern uint8_t hw_event_register[13];
 
-#define VR_FAULT_STATUS_LSB_MASK 0x3F
-#define VR_FAULT_STATUS_MSB_MASK 0xF0
+#define VR_FAULT_STATUS_LSB_MASK 0xFD
+#define VR_FAULT_STATUS_MSB_MASK 0xFF
 #define VR_IOUT_FAULT_MASK 0x40
 #define VR_TPS_OCW_MASK 0x20
 


### PR DESCRIPTION
# Description
- Add STATUS_WORD bit 1 (CML) to the whitelist
- Ignore events when STATUS_WORD is 0x0000
- Optimize code flow for VR vendor checking

# Motivation
- Related to JIRA-1753
- In previous version, only STATUS_IOUT bit 5 (OCW) was in the whitelist

# Test Plan
- Build code: Pass
- QE validation: Pass