### PR TITLE
minerva-ag/Modify vr fw access prerequisites log level

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_fw_update.c
@@ -467,7 +467,7 @@ static bool get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 	/* is_mb_dc_on() is to start VR FW accessing when all VRs are enabled PW GD */
 	if (is_mb_dc_on() == false) {
 		if ((gpio_get(FM_PLD_UBC_EN_R) == GPIO_LOW) || !is_ubc_enabled_delayed_enabled()) {
-			LOG_ERR("Comp id %d FW version request failed due to UBC is not enabled",
+			LOG_INF("Comp id %d FW version request failed due to UBC is not enabled",
 				p->comp_identifier);
 			return ret;
 		}


### PR DESCRIPTION
Summary:
- Modify vr fw access prerequisites log level

Test Plan:
- Build code: Pass

LOG:
```
uart:~$ [00:00:55.530,000] <inf> plat_fwupdate: pldm_query_device_identifiers
[00:00:55.530,000] <inf> plat_fwupdate: pldm_query_device_identifiers done
[00:00:55.539,000] <inf> plat_fwupdate: Comp id 1 FW version request failed due to UBC is not enabled
[00:00:55.539,000] <inf> plat_fwupdate: Comp id 2 FW version request failed due to UBC is not enabled
[00:00:55.539,000] <inf> plat_fwupdate: Comp id 3 FW version request failed due to UBC is not enabled
[00:00:55.539,000] <inf> plat_fwupdate: Comp id 4 FW version request failed due to UBC is not enabled
[00:00:55.539,000] <inf> plat_fwupdate: Comp id 5 FW version request failed due to UBC is not enabled
[00:00:55.539,000] <inf> plat_fwupdate: Comp id 6 FW version request failed due to UBC is not enabled
[00:00:55.539,000] <inf> plat_fwupdate: Comp id 7 FW version request failed due to UBC is not enabled
[00:00:55.539,000] <inf> plat_fwupdate: Comp id 8 FW version request failed due to UBC is not enabled
[00:00:55.539,000] <inf> plat_fwupdate: Comp id 9 FW version request failed due to UBC is not enabled
[00:00:55.539,000] <inf> plat_fwupdate: Comp id 10 FW version request failed due to UBC is not enabled
[00:00:55.539,000] <inf> plat_fwupdate: Comp id 11 FW version request failed due to UBC is not enabled
[00:00:55.892,000] <inf> plat_fwupdate: Comp id 1 FW version request failed due to UBC is not enabled
[00:00:55.892,000] <inf> plat_fwupdate: Comp id 2 FW version request failed due to UBC is not enabled
[00:00:55.892,000] <inf> plat_fwupdate: Comp id 3 FW version request failed due to UBC is not enabled
[00:00:55.892,000] <inf> plat_fwupdate: Comp id 4 FW version request failed due to UBC is not enabled
[00:00:55.892,000] <inf> plat_fwupdate: Comp id 5 FW version request failed due to UBC is not enabled
[00:00:55.892,000] <inf> plat_fwupdate: Comp id 6 FW version request failed due to UBC is not enabled
[00:00:55.892,000] <inf> plat_fwupdate: Comp id 7 FW version request failed due to UBC is not enabled
[00:00:55.892,000] <inf> plat_fwupdate: Comp id 8 FW version request failed due to UBC is not enabled
[00:00:55.892,000] <inf> plat_fwupdate: Comp id 9 FW version request failed due to UBC is not enabled
[00:00:55.892,000] <inf> plat_fwupdate: Comp id 10 FW version request failed due to UBC is not enabled
[00:00:55.892,000] <inf> plat_fwupdate: Comp id 11 FW version request failed due to UBC is not enabled

```