### PR TITLE
minerva-ag: Modify AC DC on log level

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_event.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_event.c
@@ -358,7 +358,7 @@ void plat_set_ac_on_log()
 {
 	uint16_t error_code = (AC_ON_TRIGGER_CAUSE << 13);
 	error_log_event(error_code, LOG_ASSERT);
-	LOG_ERR("Generated AC on error code: 0x%x", error_code);
+	LOG_INF("Generated AC on error code: 0x%x", error_code);
 }
 
 void plat_set_dc_on_log(bool is_assert)
@@ -367,7 +367,7 @@ void plat_set_dc_on_log(bool is_assert)
 	error_log_event(error_code, (is_assert ? LOG_ASSERT : LOG_DEASSERT));
 
 	if (is_assert == LOG_ASSERT) {
-		LOG_ERR("Generated DC on error code: 0x%x", error_code);
+		LOG_INF("Generated DC on error code: 0x%x", error_code);
 	} else if (is_assert == LOG_DEASSERT) {
 		LOG_INF("DC on error code deasserted");
 	}


### PR DESCRIPTION
Summary:
- Modify AC DC on log level

Test Plan:
- Build code: Pass

log:
```
uart:~$ [00:00:02.636,000] <inf> plat_log: Next log position: 22, next index: 22
[00:00:02.663,000] <inf> plat_event: Generated AC on error code: 0x4000
[00:00:02.664,000] <inf> plat_init: Init done

uart:~$
uart:~$
uart:~$ test aegis_power off
plat power control finish
uart:~$ [00:02:32.621,000] <inf> plat_isr: RST_ATH_PWR_ON_PLD_R1_N = 0
[00:02:32.932,000] <inf> plat_isr: FM_PLD_UBC_EN_R = 0
[00:02:32.932,000] <inf> plat_log: Duplicate or no log needed for error_code: 0x6000
[00:02:32.932,000] <inf> plat_event: DC on error code deasserted
test aegis_power on
plat power control finish
uart:~$ [00:02:42.542,000] <inf> plat_isr: FM_PLD_UBC_EN_R = 1
[00:02:42.570,000] <inf> plat_event: Generated DC on error code: 0x6000
[00:02:42.755,000] <err> hal_i2c: I2C 0 master write retry reach max with ret -6
[00:02:42.755,000] <err> plat_isr: Failed to write reg, bus: 0, addr: 0x9, reg: 0xfc
[00:02:42.755,000] <err> plat_isr: Failed to write 312M CLK GEN
[00:02:42.757,000] <inf> plat_isr: Init 100M CLK BUFFER finish, retry 1 times
[00:02:42.824,000] <inf> plat_isr: RST_ATH_PWR_ON_PLD_R1_N = 1

```