### PR TITLE
op2: gl/op: Revise NXP I3C Hub driver function

### DIFF
--- a/common/dev/include/p3h284x.h
+++ b/common/dev/include/p3h284x.h
@@ -22,6 +22,12 @@
 
 #define P3H284X_DEFAULT_STATIC_ADDRESS 0x70
 
+// P3H2840 Device setting
+#define P3H2840_DEVICE_INFO 0x1530
+#define P3H2840_I3C_LDO_VOLT 0x0A // 1.2V
+#define P3H2840_I2C_MODE 0
+#define P3H2840_BYPASS_MODE 1
+
 #define P3H284X_DEVICE_INFO0_REG 0x0
 #define P3H284X_DEVICE_INFO1_REG 0x1
 #define P3H284X_PROTECTION_REG 0x10
@@ -34,11 +40,12 @@
 #define P3H284X_TARGET_PORTS_PULLUP_SETTING 0x19
 #define P3H284X_TARGET_PORTS_GPIO_ENABLE 0x1E
 #define P3H284X_TARGET_PORTSHUB_NETWORK_CONNECTION 0x51
+#define P3H284X_BYPASS_MODE_ENABLE 0x52
 #define P3H284X_TARGET_PORTS_PULLUP_ENABLE 0x53
 
 /* 0x10 : Unlock Device Configuration Protection Code */
 #define P3H284X_PROTECTION_LOCK 0x00
-#define P3H284X_PROTECTION_UNLOCK 0x6A
+#define P3H284X_PROTECTION_UNLOCK 0x69
 
 /* 0x15 : Master Side Port Configuration */
 #define P3H284X_HUB_NETWORK_ALWAYS_I3C 5
@@ -73,7 +80,7 @@ enum p3g284x_pull_up_resistor {
 };
 
 bool p3h284x_i2c_mode_only_init(uint8_t bus, uint8_t slave_port, uint8_t ldo_volt,
-				uint8_t pullup_resistor);
+				uint8_t pullup_resistor, uint8_t mode);
 bool p3h284x_select_slave_port_connect(uint8_t bus, uint8_t slave_port);
 bool p3h284x_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt);
 bool p3h284x_set_slave_port(uint8_t bus, uint8_t addr, uint8_t setting);

--- a/meta-facebook/op2-op/src/platform/plat_class.c
+++ b/meta-facebook/op2-op/src/platform/plat_class.c
@@ -182,7 +182,8 @@ void init_i3c_hub_type(void)
 	if (rg3mxxb12_get_device_info(I2C_BUS2, &i3c_hub_type) &&
 	    (i3c_hub_type == RG3M87B12_DEVICE_INFO)) {
 		LOG_INF("I3C hub type: rg3mxxb12");
-	} else if (p3h284x_get_device_info(I2C_BUS2, &i3c_hub_type)) {
+	} else if (p3h284x_get_device_info(I2C_BUS2, &i3c_hub_type) &&
+		   (i3c_hub_type == P3H2840_DEVICE_INFO)) {
 		LOG_INF("I3C hub type: p3h284x");
 	} else {
 		LOG_ERR("I3C hub get device type fail");
@@ -208,7 +209,8 @@ void set_clock_buffer_bypass_mode()
 		if (i2c_master_write(&msg, retry) != 0) {
 			LOG_ERR("Failed to set Exp A clock buffer to bypass mode!");
 			// send event log to BMC
-			send_system_status_event(IPMI_OEM_EVENT_TYPE_NOTIFY,IPMI_EVENT_OFFSET_SYS_EXPA_CLOCK_BUFFER,0);
+			send_system_status_event(IPMI_OEM_EVENT_TYPE_NOTIFY,
+						 IPMI_EVENT_OFFSET_SYS_EXPA_CLOCK_BUFFER, 0);
 
 			return;
 		}

--- a/meta-facebook/op2-op/src/platform/plat_init.c
+++ b/meta-facebook/op2-op/src/platform/plat_init.c
@@ -80,20 +80,26 @@ void pal_pre_init()
 		slave_port = BIT(0) | BIT(1) | BIT(2) | BIT(3) | BIT(4);
 		break;
 	default:
-		printk("No need to initialize I3C hub rg3mxxb12\n");
+		printk("No need to initialize I3C hub\n");
 		return;
 	}
 
-	if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
+	switch (i3c_hub_type) {
+	case RG3M87B12_DEVICE_INFO:
 		if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS2, slave_port, rg3mxxb12_ldo_1_2_volt,
 						  rg3mxxb12_pullup_1k_ohm)) {
-			printk("failed to initialize rg3mxxb12\n");
+			printk("failed to initialize i3c hub rg3mxxb12\n");
 		}
-	} else {
-		if (!p3h284x_i2c_mode_only_init(I2C_BUS2, slave_port, p3g284x_ldo_1_2_volt,
-						p3g284x_pullup_1k_ohm)) {
-			printk("failed to initialize p3h284x\n");
+		break;
+	case P3H2840_DEVICE_INFO:
+		if (!p3h284x_i2c_mode_only_init(I2C_BUS2, slave_port, p3g284x_ldo_1_8_volt,
+						p3g284x_pullup_2k_ohm, P3H2840_I2C_MODE)) {
+			printk("failed to initialize i3c hub p3h284x\n");
 		}
+		break;
+	default:
+		printk("Get i3c hub type failed - initialize i3c hub\n");
+		return;
 	}
 }
 

--- a/meta-facebook/yv35-gl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-gl/src/ipmi/plat_ipmi.c
@@ -236,20 +236,29 @@ void OEM_1S_WRITE_READ_DIMM(ipmi_msg *msg)
 	uint8_t slave_port_setting =
 		(dimm_id / (MAX_COUNT_DIMM / 2)) ? I3C_HUB_TO_DIMMEFGH : I3C_HUB_TO_DIMMABCD;
 
-	if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
+	switch (i3c_hub_type) {
+	case RG3M87B12_DEVICE_INFO:
 		if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
 					      slave_port_setting)) {
-			LOG_ERR("Failed to set slave port to slave port: 0x%x", slave_port_setting);
+			LOG_ERR("Failed to set rg3mxxb12 slave port to slave port: 0x%x",
+				slave_port_setting);
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 			goto exit;
 		}
-	} else {
+		break;
+	case P3H2840_DEVICE_INFO:
 		if (!p3h284x_set_slave_port(I3C_BUS4, P3H284X_DEFAULT_STATIC_ADDRESS,
 					    slave_port_setting)) {
-			LOG_ERR("Failed to set slave port to slave port: 0x%x", slave_port_setting);
+			LOG_ERR("Failed to set p3h284x slave port to slave port: 0x%x",
+				slave_port_setting);
 			msg->completion_code = CC_UNSPECIFIED_ERROR;
 			goto exit;
 		}
+		break;
+	default:
+		LOG_ERR("Get i3c hub type failed - set slave port to slave port");
+		msg->completion_code = CC_UNSPECIFIED_ERROR;
+		goto exit;
 	}
 
 	switch (device_type) {

--- a/meta-facebook/yv35-gl/src/platform/plat_class.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_class.c
@@ -38,7 +38,8 @@ static uint8_t hsc_module = HSC_MODULE_UNKNOWN;
 static CARD_STATUS _1ou_status = { false, TYPE_1OU_UNKNOWN };
 static CARD_STATUS _2ou_status = { false, TYPE_2OU_UNKNOWN };
 static uint16_t i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
-static uint16_t exp_i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
+static uint16_t exp_1ou_i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
+static uint16_t exp_2ou_i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
 
 uint8_t get_system_class()
 {
@@ -70,9 +71,14 @@ uint16_t get_i3c_hub_type()
 	return i3c_hub_type;
 }
 
-uint16_t get_exp_i3c_hub_type()
+uint16_t get_exp_1ou_i3c_hub_type()
 {
-	return exp_i3c_hub_type;
+	return exp_1ou_i3c_hub_type;
+}
+
+uint16_t get_exp_2ou_i3c_hub_type()
+{
+	return exp_2ou_i3c_hub_type;
 }
 
 /* ADC information for each channel
@@ -320,18 +326,33 @@ void init_platform_config()
 
 void init_i3c_hub_type(void)
 {
-	if (rg3mxxb12_get_device_info(I2C_BUS8, &exp_i3c_hub_type)) {
-		LOG_INF("Expansion I3C hub type: rg3mxxb12");
-	} else if (p3h284x_get_device_info(I2C_BUS8, &exp_i3c_hub_type)) {
-		LOG_INF("Expansion I3C hub type: p3h284x");
+	// get 1ou expansion i3c hub type
+	if (rg3mxxb12_get_device_info(I2C_BUS8, &exp_1ou_i3c_hub_type) &&
+	    (exp_1ou_i3c_hub_type == RG3M87B12_DEVICE_INFO)) {
+		LOG_INF("Expansion 1OU I3C hub type: rg3mxxb12");
+	} else if (p3h284x_get_device_info(I2C_BUS8, &exp_1ou_i3c_hub_type) &&
+		   (exp_1ou_i3c_hub_type == P3H2840_DEVICE_INFO)) {
+		LOG_INF("Expansion 1OU I3C hub type: p3h284x");
 	} else {
-		LOG_ERR("Expansion I3C hub get device type fail");
+		LOG_ERR("Expansion 1OU I3C hub get device type fail");
+	}
+
+	// get 3ou expansion i3c hub type
+	if (rg3mxxb12_get_device_info(I2C_BUS9, &exp_2ou_i3c_hub_type) &&
+	    (exp_2ou_i3c_hub_type == RG3M87B12_DEVICE_INFO)) {
+		LOG_INF("Expansion 3OU I3C hub type: rg3mxxb12");
+	} else if (p3h284x_get_device_info(I2C_BUS9, &exp_2ou_i3c_hub_type) &&
+		   (exp_2ou_i3c_hub_type == P3H2840_DEVICE_INFO)) {
+		LOG_INF("Expansion 3OU I3C hub type: p3h284x");
+	} else {
+		LOG_ERR("Expansion 3OU I3C hub get device type fail");
 	}
 
 	if (rg3mxxb12_get_device_info_i3c(I3C_BUS4, &i3c_hub_type) &&
 	    (i3c_hub_type == RG3M87B12_DEVICE_INFO)) {
 		LOG_INF("I3C hub type: rg3mxxb12");
-	} else if (p3h284x_get_device_info_i3c(I3C_BUS4, &i3c_hub_type)) {
+	} else if (p3h284x_get_device_info_i3c(I3C_BUS4, &i3c_hub_type) &&
+		   (i3c_hub_type == P3H2840_DEVICE_INFO)) {
 		LOG_INF("I3C hub type: p3h284x");
 	} else {
 		LOG_ERR("I3C hub get device type fail");

--- a/meta-facebook/yv35-gl/src/platform/plat_class.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_class.h
@@ -91,7 +91,8 @@ bool get_adc_voltage(int channel, float *voltage);
 uint8_t get_board_revision();
 void init_platform_config();
 uint16_t get_i3c_hub_type();
-uint16_t get_exp_i3c_hub_type();
+uint16_t get_exp_1ou_i3c_hub_type();
+uint16_t get_exp_2ou_i3c_hub_type();
 void init_i3c_hub_type();
 
 #endif

--- a/meta-facebook/yv35-gl/src/platform/plat_dimm.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_dimm.c
@@ -126,24 +126,31 @@ void get_dimm_info_handler()
 							     I3C_HUB_TO_DIMMEFGH :
 							     I3C_HUB_TO_DIMMABCD;
 
-			if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
+			switch (i3c_hub_type) {
+			case RG3M87B12_DEVICE_INFO:
 				if (!rg3mxxb12_set_slave_port(I3C_BUS4,
 							      RG3MXXB12_DEFAULT_STATIC_ADDRESS,
 							      slave_port_setting)) {
 					clear_unaccessible_dimm_data(dimm_id);
-					LOG_ERR("Failed to set slave port to slave port: 0x%x",
+					LOG_ERR("Failed to set rg3mxxb12 slave port to slave port: 0x%x",
 						slave_port_setting);
 					continue;
 				}
-			} else {
+				break;
+			case P3H2840_DEVICE_INFO:
 				if (!p3h284x_set_slave_port(I3C_BUS4,
 							    P3H284X_DEFAULT_STATIC_ADDRESS,
 							    slave_port_setting)) {
 					clear_unaccessible_dimm_data(dimm_id);
-					LOG_ERR("Failed to set slave port to slave port: 0x%x",
+					LOG_ERR("Failed to set p3h284x slave port to slave port: 0x%x",
 						slave_port_setting);
 					continue;
 				}
+				break;
+			default:
+				LOG_ERR("Get i3c hub type failed - set slave port to slave port");
+				clear_unaccessible_dimm_data(dimm_id);
+				continue;
 			}
 
 			memset(&i3c_msg, 0, sizeof(I3C_MSG));

--- a/meta-facebook/yv35-gl/src/platform/plat_i3c.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_i3c.c
@@ -33,23 +33,29 @@ void init_i3c_hub()
 	init_i3c_hub_type();
 	i3c_hub_type = get_i3c_hub_type();
 
-	if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
+	switch (i3c_hub_type) {
+	case RG3M87B12_DEVICE_INFO:
 		if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT, rg3mxxb12_pullup_500_ohm)) {
-			LOG_ERR("Failed to initialize i3c hub");
+			LOG_ERR("Failed to initialize rg3mxxb12 i3c hub");
 		}
 
 		if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
 					      DEFAULT_SLAVE_PORT_SETTING)) {
-			LOG_ERR("Error to set slave port");
+			LOG_ERR("Error to set rg3mxxb12 i3c hub slave port");
 		}
-	} else {
-		if (!p3h284x_i3c_mode_only_init(&i3c_msg, LDO_VOLT)) {
-			LOG_ERR("Failed to initialize i3c hub");
+		break;
+	case P3H2840_DEVICE_INFO:
+		if (!p3h284x_i3c_mode_only_init(&i3c_msg, P3H2840_I3C_LDO_VOLT)) {
+			LOG_ERR("Failed to initialize p3h284x i3c hub");
 		}
 
 		if (!p3h284x_set_slave_port(I3C_BUS4, P3H284X_DEFAULT_STATIC_ADDRESS,
 					    DEFAULT_SLAVE_PORT_SETTING)) {
-			LOG_ERR("Error to set slave port");
+			LOG_ERR("Error to set p3h284x i3c hub slave port");
 		}
+		break;
+	default:
+		LOG_ERR("Get i3c hub type failed - initialize I3C HUB");
+		break;
 	}
 }

--- a/meta-facebook/yv35-gl/src/platform/plat_init.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_init.c
@@ -58,39 +58,57 @@ SCU_CFG scu_cfg[] = {
 
 void pal_pre_init()
 {
-	uint16_t exp_i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
+	// for op2 project _1ou_status and _2ou_status means connected 1ou and 3ou
+	uint16_t exp_1ou_i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
+	uint16_t exp_2ou_i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
 	init_platform_config();
 	init_i3c_hub_type();
 	init_i3c_hub();
-	exp_i3c_hub_type = get_exp_i3c_hub_type();
+	exp_1ou_i3c_hub_type = get_exp_1ou_i3c_hub_type();
+	exp_2ou_i3c_hub_type = get_exp_2ou_i3c_hub_type();
 	CARD_STATUS _1ou_status = get_1ou_status();
 	CARD_STATUS _2ou_status = get_2ou_status();
 	if (_1ou_status.present && (_1ou_status.card_type == TYPE_1OU_OLMSTED_POINT)) {
-		if (exp_i3c_hub_type == RG3M87B12_DEVICE_INFO) {
+		switch (exp_1ou_i3c_hub_type) {
+		case RG3M87B12_DEVICE_INFO:
 			// Initialize I3C HUB (HD BIC connects to Olympic2 1ou expension-A and B)
 			if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS8, BIT(2), rg3mxxb12_ldo_1_8_volt,
 							  rg3mxxb12_pullup_1k_ohm)) {
-				printk("failed to initialize 1ou rg3mxxb12\n");
+				printk("failed to initialize 1ou i3c hub rg3mxxb12\n");
 			}
-		} else {
+			break;
+		case P3H2840_DEVICE_INFO:
+			// Initialize I3C HUB (HD BIC connects to Olympic2 1ou expension-A and B)
 			if (!p3h284x_i2c_mode_only_init(I2C_BUS8, BIT(2), p3g284x_ldo_1_8_volt,
-							p3g284x_pullup_1k_ohm)) {
-				printk("failed to initialize 1ou p3h284x\n");
+							p3g284x_pullup_2k_ohm,
+							P3H2840_BYPASS_MODE)) {
+				printk("failed to initialize 1ou i3c hub p3h284x\n");
 			}
+			break;
+		default:
+			printk("Get i3c hub type failed - initialize 1ou i3c hub\n");
+			break;
 		}
 	}
 	if (_2ou_status.present && (_1ou_status.card_type == TYPE_1OU_OLMSTED_POINT)) {
 		// Initialize I3C HUB (HD BIC connects to Olympic2 3ou expension-A and B)
-		if (exp_i3c_hub_type == RG3M87B12_DEVICE_INFO) {
+		switch (exp_2ou_i3c_hub_type) {
+		case RG3M87B12_DEVICE_INFO:
 			if (!rg3mxxb12_i2c_mode_only_init(I2C_BUS9, BIT(2), rg3mxxb12_ldo_1_8_volt,
 							  rg3mxxb12_pullup_1k_ohm)) {
-				printk("failed to initialize 3ou rg3mxxb12\n");
+				printk("failed to initialize 3ou i3c hub rg3mxxb12\n");
 			}
-		} else {
+			break;
+		case P3H2840_DEVICE_INFO:
 			if (!p3h284x_i2c_mode_only_init(I2C_BUS9, BIT(2), p3g284x_ldo_1_8_volt,
-							p3g284x_pullup_1k_ohm)) {
-				printk("failed to initialize 1ou p3h284x\n");
+							p3g284x_pullup_2k_ohm,
+							P3H2840_BYPASS_MODE)) {
+				printk("failed to initialize 3ou i3c hub p3h284x\n");
 			}
+			break;
+		default:
+			printk("Get i3c hub type failed - initialize 3ou i3c hub\n");
+			break;
 		}
 	}
 	scu_init(scu_cfg, ARRAY_SIZE(scu_cfg));

--- a/meta-facebook/yv35-gl/src/platform/plat_pmic.c
+++ b/meta-facebook/yv35-gl/src/platform/plat_pmic.c
@@ -110,7 +110,7 @@ void monitor_pmic_error_via_i3c_handler()
 	}
 }
 
-int compare_pmic_error(uint8_t dimm_id, uint8_t *pmic_err_data, uint8_t pmic_err_data_len)
+int compare_pmic_error(uint8_t dimm_id, const uint8_t *pmic_err_data, uint8_t pmic_err_data_len)
 {
 	uint8_t err_index = 0, reg_index = 0, data_index = 0;
 	uint8_t pattern = 0;
@@ -355,20 +355,24 @@ void clear_pmic_error()
 						     I3C_HUB_TO_DIMMEFGH :
 						     I3C_HUB_TO_DIMMABCD;
 
-		if (i3c_hub_type == RG3M87B12_DEVICE_INFO) {
+		switch (i3c_hub_type) {
+		case RG3M87B12_DEVICE_INFO:
 			if (!rg3mxxb12_set_slave_port(I3C_BUS4, RG3MXXB12_DEFAULT_STATIC_ADDRESS,
 						      slave_port_setting)) {
-				LOG_ERR("Failed to set slave port to slave port: 0x%x",
-					slave_port_setting);
+				LOG_ERR("Failed to change rg3mxxb12 I3C HUB (I2C mode) channel");
 				continue;
 			}
-		} else {
+			break;
+		case P3H2840_DEVICE_INFO:
 			if (!p3h284x_set_slave_port(I3C_BUS4, P3H284X_DEFAULT_STATIC_ADDRESS,
 						    slave_port_setting)) {
-				LOG_ERR("Failed to set slave port to slave port: 0x%x",
-					slave_port_setting);
+				LOG_ERR("Failed to change p3h284x I3C HUB (I2C mode) channel");
 				continue;
 			}
+			break;
+		default:
+			LOG_ERR("Get i3c hub type failed - change I3C HUB (I2C mode) channel");
+			continue;
 		}
 
 		// Broadcast CCC after switch DIMM mux

--- a/meta-facebook/yv35-gl/src/platform/plat_pmic.h
+++ b/meta-facebook/yv35-gl/src/platform/plat_pmic.h
@@ -32,7 +32,7 @@
 
 void start_monitor_pmic_error_thread();
 void monitor_pmic_error_via_i3c_handler();
-int compare_pmic_error(uint8_t dimm_id, uint8_t *pmic_err_data, uint8_t pmic_err_data_len);
+int compare_pmic_error(uint8_t dimm_id, const uint8_t *pmic_err_data, uint8_t pmic_err_data_len);
 void add_pmic_error_sel(uint8_t dimm_id, uint8_t error_type);
 int get_pmic_fault_status();
 void read_pmic_error_when_dc_off();


### PR DESCRIPTION
op2: gl/op: Revise NXP I3C Hub driver function

Description:
 Modify p3h284x driver for support new NXP type I3C Hub.

Motivation:
 For support new NXP I3C Hub in OP2.0 system for second source I3C Hub.

Test Plan:
 Build and test pass on OLP2.0 system pass.