### PR TITLE
fby35: hd: add vr status when vr fault

### DIFF
--- a/meta-facebook/yv35-hd/src/ipmi/include/plat_ipmi.h
+++ b/meta-facebook/yv35-hd/src/ipmi/include/plat_ipmi.h
@@ -22,4 +22,11 @@ enum REQ_GET_CARD_TYPE {
 	GET_2OU_CARD_TYPE,
 };
 
+typedef struct oem_addsel_msg_t {
+	uint8_t InF_target;
+	uint8_t event_data[13];
+} oem_addsel_msg_t;
+
+bool plat_add_oem_sel_evt_record(oem_addsel_msg_t *sel_msg);
+
 #endif

--- a/meta-facebook/yv35-hd/src/platform/plat_isr.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_isr.h
@@ -17,6 +17,8 @@
 #ifndef PLAT_FUNC_H
 #define PLAT_FUNC_H
 
+#define VR_FAULT_STATUS_LSB_MASK 0x3C
+
 void ISR_POST_COMPLETE();
 void ISR_DC_ON();
 void ISR_SLP3();

--- a/meta-facebook/yv35-hd/src/platform/plat_sensor_table.c
+++ b/meta-facebook/yv35-hd/src/platform/plat_sensor_table.c
@@ -731,3 +731,13 @@ void load_sensor_config(void)
 
 	pal_extend_sensor_config();
 }
+
+sensor_cfg *plat_get_sensor_cfg_via_sensor_num(uint8_t sensor_num)
+{
+	if (sensor_config != NULL) {
+		return find_sensor_cfg_via_sensor_num(sensor_config, sensor_config_count,
+						      sensor_num);
+	}
+
+	return NULL;
+}

--- a/meta-facebook/yv35-hd/src/platform/plat_sensor_table.h
+++ b/meta-facebook/yv35-hd/src/platform/plat_sensor_table.h
@@ -18,6 +18,7 @@
 #define PLAT_SENSOR_TABLE_H
 
 #include <stdint.h>
+#include <sensor.h>
 
 /* define sensors address(7 bit) */
 #define TMP75_IN_ADDR (0x94 >> 1)
@@ -128,10 +129,12 @@
 #define SENSOR_NUM_POWER_ERROR 0x56
 #define SENSOR_NUM_PROC_FAIL 0x65
 #define SENSOR_NUM_VR_OCP 0x71
+#define SENSOR_NUM_VR_ALERT 0x72
 #define SENSOR_NUM_HDT_PRESENT 0xBD
 #define SENSOR_NUM_PMIC_ERROR 0xB4
 
 uint8_t plat_get_config_size();
 void load_sensor_config(void);
+sensor_cfg *plat_get_sensor_cfg_via_sensor_num(uint8_t sensor_num);
 
 #endif


### PR DESCRIPTION
Description
- If vr fault, add vr status sel to BMC when power off

Test plan
- Build code pass
- Test when power off

1    slot1    2018-03-09 05:54:26    ipmid            SEL Entry: FRU: 1, Record: OEM non-timestamped (0xF0), OEM Data: (72004308000000000000000000)
1    slot1    2018-03-09 05:54:26    ipmid            SEL Entry: FRU: 1, Record: OEM non-timestamped (0xF0), OEM Data: (72014348000800000000000000)
1    slot1    2018-03-09 05:54:26    ipmid            SEL Entry: FRU: 1, Record: OEM non-timestamped (0xF0), OEM Data: (72024108000000000000000000)
1    slot1    2018-03-09 05:54:26    ipmid            SEL Entry: FRU: 1, Record: OEM non-timestamped (0xF0), OEM Data: (72034308000000000000000000)
1    slot1    2018-03-09 05:54:26    ipmid            SEL Entry: FRU: 1, Record: OEM non-timestamped (0xF0), OEM Data: (72044308000000000000000000)