### PR TITLE
fby4: wf: Modify CXL HB monitor

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
@@ -33,7 +33,7 @@
 #define P1V8_POWER_OFF_DELAY_MSEC 3500
 
 #define POWER_SEQ_CTRL_STACK_SIZE 1000
-#define MONITOR_INTERVAL_SECONDS 5
+#define MONITOR_INTERVAL_SECONDS 10
 typedef struct _cxl_power_control_gpio {
 	int enclk_100m_osc;
 	int p075v_asic_en;
@@ -126,6 +126,7 @@ bool cxl2_vr_access(uint8_t sensor_num);
 void create_check_cxl_ready_thread();
 void cxl1_heartbeat_monitor_handler();
 void cxl2_heartbeat_monitor_handler();
+void init_cxl_heartbeat_monitor_work();
 void plat_pldm_sensor_clear_vr_fault(uint8_t vr_addr, uint8_t vr_bus, uint8_t page_cnt);
 
 #endif


### PR DESCRIPTION
# Description
- Changed the HB monitor time from 5 seconds to 10 seconds
- Confirmed that assert/deassert SEL is only sent during power on
- Changed the HB work queue to plat_work_q

# Motivation
- Since the CXL HB monitor and execute_power_on_sequence are in the same work queue, this causes the CXL HB monitor to block the execution of execute_power_on_sequence. Additionally, retrieving CXL HB during power off causes a 7-second timeout. Therefore, when entering the CXL HB monitor, we first verify whether DC is on, and also ensure that DC is on when sending SEL.

# Test log
[00:04:04.018,000] <inf> plat_isr: PERST+
[00:04:04.023,000] <inf> plat_power_seq: MB DC (gpio num 7) status is OFF [00:04:04.023,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: yes [00:04:04.023,000] <wrn> power_status: P12V_E1S_PWR_GOOD: no [00:04:04.023,000] <wrn> power_status: DC_STATUS: off [00:04:04.023,000] <wrn> power_status: DC_DELAYED_STATUS: off [00:04:04.023,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: no [00:04:04.023,000] <wrn> power_status: P12V_E1S_PWR_GOOD: no [00:04:04.023,000] <wrn> power_status: DC_STATUS: off [00:04:04.023,000] <wrn> power_status: DC_DELAYED_STATUS: off [00:04:04.023,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: no [00:04:04.023,000] <wrn> power_status: P12V_E1S_PWR_GOOD: no [00:04:07.543,000] <inf> plat_power_seq: CXL 1 power off success [00:04:09.551,000] <inf> plat_power_seq: MB DC (gpio num 7) status is ON [00:04:09.611,000] <inf> plat_mctp: plat_eid=52
[00:04:09.611,000] <inf> plat_power_seq: CXL 2 power off success [00:04:09.611,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: no [00:04:09.611,000] <wrn> power_status: P12V_E1S_PWR_GOOD: no [00:04:09.611,000] <wrn> power_status: DC_STATUS: on [00:04:09.611,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: yes [00:04:09.611,000] <wrn> power_status: P12V_E1S_PWR_GOOD: yes [00:04:09.611,000] <inf> plat_power_seq: CXL 1 power on success [00:04:09.611,000] <inf> plat_power_seq: CXL 2 power on success [00:04:11.064,000] <wrn> power_status: DC_STATUS: on [00:04:11.064,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: no [00:04:11.064,000] <wrn> power_status: P12V_E1S_PWR_GOOD: no [00:04:11.076,000] <wrn> power_status: P3V3_E1S_PWR_GOOD: yes [00:04:11.108,000] <inf> plat_power_seq: Start monitor CXL1 ready [00:04:42.323,000] <inf> plat_power_seq: Start monitor CXL2 ready [00:04:42.323,000] <inf> plat_power_seq: CXL1 is ready [00:04:42.323,000] <inf> plat_power_seq: CXL2 is ready [00:04:42.323,000] <inf> plat_power_seq: Start to monitor CXL1 HB [00:04:42.323,000] <inf> plat_power_seq: Start to monitor CXL2 HB [00:04:44.335,000] <inf> plat_power_seq: Assert: CXL1 HB recovered [00:04:44.335,000] <inf> plat_power_seq: Assert: CXL2 HB recovered [00:04:49.615,000] <inf> plat_mctp: Send set EID command to CXL1 [00:04:49.614,000] <inf> plat_mctp: Send set EID command to CXL2 mctp cc is msg timeout!!
[00:05:24.285,000] <inf> plat_isr: PERST+