### PR TITLE
common: fix me not ready issue

### DIFF
--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -38,9 +38,15 @@ LOG_MODULE_REGISTER(sensor);
 
 #define SENSOR_DRIVE_INIT_DECLARE(name) uint8_t name##_init(sensor_cfg *cfg)
 
-#define SENSOR_DRIVE_TYPE_INIT_MAP(name) { sensor_dev_##name, name##_init }
+#define SENSOR_DRIVE_TYPE_INIT_MAP(name)                                                           \
+	{                                                                                          \
+		sensor_dev_##name, name##_init                                                     \
+	}
 
-#define SENSOR_DRIVE_TYPE_UNUSE(name) { sensor_dev_##name, NULL }
+#define SENSOR_DRIVE_TYPE_UNUSE(name)                                                              \
+	{                                                                                          \
+		sensor_dev_##name, NULL                                                            \
+	}
 
 #define SENSOR_READ_RETRY_MAX 3
 
@@ -1169,6 +1175,9 @@ bool me_access(uint8_t sensor_num)
 	if (get_me_mode() == ME_NORMAL_MODE) {
 		return get_post_status();
 	} else {
+		if (get_post_status()) {
+			init_me_firmware();
+		}
 		return false;
 	}
 }


### PR DESCRIPTION
# Description
Give BIC a second chance to get ME self test result after BIOS post complete.

# Motivation
BIC will get ME self test result once while BIC boot up. ME related sensor will be stopped if ME is not in normal mode.

# Test plan
1. Pass QE BIC fw update stress test.