### PR TITLE
fby35: cl: adjust sensor correction

### DIFF
--- a/meta-facebook/yv35-cl/src/platform/plat_hook.c
+++ b/meta-facebook/yv35-cl/src/platform/plat_hook.c
@@ -43,7 +43,7 @@ LOG_MODULE_REGISTER(plat_hook);
 
 #define ADJUST_ADM1278_POWER(x) (x * 0.98)
 #define ADJUST_ADM1278_CURRENT(x) ((x * 0.98) + 0.1)
-#define ADJUST_ADM1281_CURRENT(x) ((x * 0.98) + 0.4)
+#define ADJUST_ADM1281_CURRENT(x) ((x * 0.98) + 0.8)
 #define ADJUST_LTC4286_POWER(x) ((x * 0.99) + 1.5)
 #define ADJUST_LTC4286_CURRENT(x) ((x * 0.99) + 0.3)
 #define ADJUST_LTC4282_POWER(x) (x * 0.99)


### PR DESCRIPTION
# Description
- As title.

# Motivation
- Request from EE.

# Test Plan
- Successfully built on yv35 machine
MB_INLET_TEMP_C              (0x1) :  33.000 C     | (ok)
MB_OUTLET_TEMP_C             (0x2) :  39.000 C     | (ok)
FIO_FRONT_TEMP_C             (0x3) :  31.200 C     | (ok)
MB_PCH_TEMP_C                (0x4) :  48.000 C     | (ok)
MB_SOC_CPU_TEMP_C            (0x5) :  40.000 C     | (ok)
MB_SOC_THERMAL_MARGIN_C      (0x14) : -38.000 C     | (ok)
MB_SOC_TJMAX_C               (0x15) :  78.000 C     | (ok)
MB_DIMMA0_TEMP_C             (0x6) : NA | (na)
MB_DIMMA2_TEMP_C             (0x7) :  36.000 C     | (ok)
MB_DIMMA3_TEMP_C             (0x9) :  35.000 C     | (ok)
MB_DIMMA4_TEMP_C             (0xA) : NA | (na)
MB_DIMMA6_TEMP_C             (0xB) :  35.000 C     | (ok)
MB_DIMMA7_TEMP_C             (0xC) :  34.000 C     | (ok)
MB_HSC_TEMP_C                (0xE) :  40.000 C     | (ok)
MB_VR_VCCIN_TEMP_C           (0xF) :  42.000 C     | (ok)
MB_VR_FIVRA_TEMP_C           (0x10) :  40.000 C     | (ok)
MB_VR_EHV_TEMP_C             (0x11) :  38.000 C     | (ok)
MB_VR_VCCD_TEMP_C            (0x12) :  39.000 C     | (ok)
MB_VR_FAON_TEMP_C            (0x13) :  42.000 C     | (ok)
MB_ADC_P12V_STBY_VOLT_V      (0x20) :  12.163 Volts | (ok)
MB_ADC_P3V_BAT_VOLT_V        (0x21) :   3.162 Volts | (ok)
MB_ADC_P3V3_STBY_VOLT_V      (0x22) :   3.320 Volts | (ok)
MB_ADC_P1V8_STBY_VOLT_V      (0x23) :   1.801 Volts | (ok)
MB_ADC_P1V05_PCH_VOLT_V      (0x24) :   1.054 Volts | (ok)
MB_ADC_P5V_STBY_VOLT_V       (0x25) :   4.987 Volts | (ok)
MB_ADC_P12V_DIMM_VOLT_V      (0x26) :  12.130 Volts | (ok)
MB_ADC_P1V2_STBY_VOLT_V      (0x27) :   1.196 Volts | (ok)
MB_ADC_P3V3_M2_VOLT_V        (0x28) :   3.304 Volts | (ok)
MB_HSC_INPUT_VOLT_V          (0x29) :  12.093 Volts | (ok)
MB_VR_VCCIN_VOLT_V           (0x2A) :   1.625 Volts | (ok)
MB_VR_FIVRA_VOLT_V           (0x2C) :   1.804 Volts | (ok)
MB_VR_EHV_VOLT_V             (0x2D) :   1.798 Volts | (ok)
MB_VR_VCCD_VOLT_V            (0x2E) :   1.144 Volts | (ok)
MB_VR_FAON_VOLT_V            (0x2F) :   1.060 Volts | (ok)
MB_HSC_OUTPUT_CURR_A         (0x30) :   3.500 Amps  | (ok)
MB_VR_VCCIN_CURR_A           (0x31) :   5.687 Amps  | (ok)
MB_VR_FIVRA_CURR_A           (0x32) :   2.875 Amps  | (ok)
MB_VR_EHV_CURR_A             (0x33) :   0.000 Amps  | (ok)
MB_VR_VCCD_CURR_A            (0x34) :   0.312 Amps  | (ok)
MB_VR_FAON_CURR_A            (0x35) :   6.500 Amps  | (ok)
MB_SOC_PACKAGE_PWR_W         (0x38) :  25.000 Watts | (ok)
MB_HSC_INPUT_PWR_W           (0x39) :  42.000 Watts | (ok)
MB_VR_VCCIN_PWR_W            (0x3A) :   9.250 Watts | (ok)
MB_VR_FIVRA_PWR_W            (0x3C) :   5.000 Watts | (ok)
MB_VR_EHV_PWR_W              (0x3D) :   0.000 Watts | (ok)
MB_VR_VCCD_PWR_W             (0x3E) :   0.125 Watts | (ok)
MB_VR_FAON_PWR_W             (0x3F) :   7.000 Watts | (ok)
MB_VR_DIMMA0_PMIC_PWR_W      (0x1E) : NA | (na)
MB_VR_DIMMA2_PMIC_PWR_W      (0x1F) :   0.375 Watts | (ok)
MB_VR_DIMMA3_PMIC_PWR_W      (0x36) :   0.375 Watts | (ok)
MB_VR_DIMMA4_PMIC_PWR_W      (0x37) : NA | (na)
MB_VR_DIMMA6_PMIC_PWR_W      (0x42) :   0.500 Watts | (ok)
MB_VR_DIMMA7_PMIC_PWR_W      (0x47) :   0.750 Watts | (ok)
VF_E1S_OUTLET_TEMP_C         (0x50) :  33.000 C     | (ok)
VF_E1S_P12V_AUX_VOLT_V       (0x51) :  12.094 Volts | (ok)
VF_E1S_P12V_EDGE_VOLT_V      (0x52) :  12.151 Volts | (ok)
VF_E1S_P3V3_AUX_VOLT_V       (0x53) :   3.279 Volts | (ok)
VF_E1S_P1V2_STBY_VOLT_V      (0x58) :   1.206 Volts | (ok)
VF_E1S_SSD0_PWR_WATT_W       (0x60) :   3.075 Watts | (ok)
VF_E1S_SSD0_VOLT_V           (0x61) :  12.123 Volts | (ok)
VF_E1S_SSD0_TEMP_C           (0x62) :  35.000 C     | (ok)
VF_E1S_SSD0_3V3_ADC_VOLT_V   (0x64) :   3.279 Volts | (ok)
VF_E1S_SSD0_12V_ADC_VOLT_V   (0x63) :  12.151 Volts | (ok)
VF_E1S_SSD1_PWR_WATT_W       (0x68) :   2.975 Watts | (ok)
VF_E1S_SSD1_VOLT_V           (0x69) :  12.123 Volts | (ok)
VF_E1S_SSD1_TEMP_C           (0x6A) :  34.000 C     | (ok)
VF_E1S_SSD1_3V3_ADC_VOLT_V   (0x6C) :   3.287 Volts | (ok)
VF_E1S_SSD1_12V_ADC_VOLT_V   (0x6B) :  12.179 Volts | (ok)
VF_E1S_SSD2_PWR_WATT_W       (0x70) : NA | (na)
VF_E1S_SSD2_VOLT_V           (0x71) : NA | (na)
VF_E1S_SSD2_TEMP_C           (0x72) : NA | (na)
VF_E1S_SSD2_3V3_ADC_VOLT_V   (0x74) : NA | (na)
VF_E1S_SSD2_12V_ADC_VOLT_V   (0x73) : NA | (na)
VF_E1S_SSD3_PWR_WATT_W       (0x78) :   3.275 Watts | (ok)
VF_E1S_SSD3_VOLT_V           (0x79) :  12.123 Volts | (ok)
VF_E1S_SSD3_TEMP_C           (0x7A) :  36.000 C     | (ok)
VF_E1S_SSD3_3V3_ADC_VOLT_V   (0x7C) :   3.275 Volts | (ok)
VF_E1S_SSD3_12V_ADC_VOLT_V   (0x7B) :  12.151 Volts | (ok)