### PR TITLE
common: sensor: fix stack overflow

### DIFF
--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -29,7 +29,7 @@
 
 #define sensor_name_to_num(x) #x,
 
-#define SENSOR_POLL_STACK_SIZE 2048
+#define SENSOR_POLL_STACK_SIZE 4096
 #define NONE 0
 
 #define GET_FROM_CACHE 0x00


### PR DESCRIPTION
# Description
Enlarge the stack size of sensor polling thread

# Motivation
Fix stack overflow in sensor polling thread

# Test plan
1. Check the stack usage is enough:

Before:

 0x68608 sensor_poll
        options: 0x0, priority: 0 timeout: 427648
        state: suspended, entry: 0x194f5
        Total execution cycles: 3319087716 (336801155 %)
        stack size 2048, unused 444, usage 1604 / 2048 (78 %)

After:

 0x68608 sensor_poll
        options: 0x0, priority: 0 timeout: 427648
        state: pending, entry: 0x194f9
        Total execution cycles: 35585480 (1 %)
        stack size 4096, unused 2540, usage 1556 / 4096 (37 %)