### PR TITLE
common: Support flexible pldm sensor polling interval less than 1 sec

### DIFF
--- a/common/service/sensor/pldm_sensor.h
+++ b/common/service/sensor/pldm_sensor.h
@@ -38,31 +38,39 @@ typedef struct pldm_sensor_info {
 	PDR_numeric_sensor pdr_numeric_sensor;
 	uint32_t update_time;
 	sensor_cfg pldm_sensor_cfg;
+	uint32_t update_time_ms;
 } pldm_sensor_info;
 
 typedef struct pldm_sensor_thread {
 	int thread_id;
 	char *thread_name;
+	uint32_t poll_interval_ms;
 } pldm_sensor_thread;
 
 void pldm_sensor_monitor_init();
 void pldm_sensor_poll_thread_init();
 void pldm_sensor_polling_handler(void *arug0, void *arug1, void *arug2);
 void pldm_sensor_get_reading(sensor_cfg *pldm_sensor_cfg, uint32_t *update_time,
-			     int pldm_sensor_count, int thread_id, int sensor_num);
+			     uint32_t *update_time_ms, int pldm_sensor_count, int thread_id,
+			     int sensor_num);
 uint8_t pldm_sensor_get_reading_from_cache(uint16_t sensor_id, int *reading,
 					   uint8_t *sensor_operational_state);
 bool pldm_sensor_is_interval_ready(pldm_sensor_info *pldm_sensor_list);
 int pldm_sensor_get_info_via_sensor_thread_and_sensor_pdr_index(
 	int thread_id, int sensor_pdr_index, uint16_t *sensor_id, real32_t *resolution,
 	real32_t *offset, int8_t *unit_modifier, real32_t *poll_time, uint32_t *update_time,
-	uint8_t *type, int *cache, uint8_t *cache_status, char *check_access);
+	uint32_t *update_time_ms, uint8_t *type, int *cache, uint8_t *cache_status,
+	char *check_access);
 pldm_sensor_thread *plat_pldm_sensor_load_thread();
 pldm_sensor_info *plat_pldm_sensor_load(int thread_id);
 int plat_pldm_sensor_get_sensor_count(int thread_id);
 int pldm_sensor_polling_pre_check(pldm_sensor_info *pldm_snr_list, int sensor_num);
 int pldm_polling_sensor_reading(pldm_sensor_info *pldm_snr_list, int pldm_sensor_count,
 				int thread_id, int sensor_num);
+int pldm_polling_sensor_reading_optional_check(pldm_sensor_info *pldm_snr_list,
+					       int pldm_sensor_count, int thread_id, int sensor_num,
+					       bool interval_ready_check_en);
+pldm_sensor_thread *pldm_sensor_get_thread_info(int thread_id);
 int pldm_sensor_get_info_via_sensor_id(uint16_t sensor_id, float *resolution, float *offset,
 				       int8_t *unit_modifier, int *cache,
 				       uint8_t *sensor_operational_state);


### PR DESCRIPTION
Summary:
- Support flexible pldm sensor polling interval less than 1 sec

Test Plan:
- Build code: Pass

example test on minerva-ag:
```
uart:~$ platform sensor list_all_sensor
[0x1 ] CB_UBC1_P12V_TEMP_C                          : mpc12109           | access[O] | poll 0.06(0.10) sec | sensor_enabled        |     58.000
[0x2 ] CB_UBC1_P50V_INPUT_VOLT_V                    : mpc12109           | access[O] | poll 0.09(0.10) sec | sensor_enabled        |     54.625
[0x3 ] CB_UBC1_P12V_OUTPUT_VOLT_V                   : mpc12109           | access[O] | poll 0.02(0.10) sec | sensor_enabled        |     13.562
[0x4 ] CB_UBC1_P12V_CURR_A                          : mpc12109           | access[O] | poll 0.05(0.10) sec | sensor_enabled        |     13.000
[0x5 ] CB_UBC1_P12V_PWR_W                           : mpc12109           | access[O] | poll 0.08(0.10) sec | sensor_enabled        |    168.000
[0x6 ] CB_UBC2_P12V_TEMP_C                          : mpc12109           | access[O] | poll 0.10(0.10) sec | sensor_enabled        |     59.000
[0x7 ] CB_UBC2_P50V_INPUT_VOLT_V                    : mpc12109           | access[O] | poll 0.03(0.10) sec | sensor_enabled        |     54.625
[0x8 ] CB_UBC2_P12V_OUTPUT_VOLT_V                   : mpc12109           | access[O] | poll 0.06(0.10) sec | sensor_enabled        |     13.625
[0x9 ] CB_UBC2_P12V_CURR_A                          : mpc12109           | access[O] | poll 0.09(0.10) sec | sensor_enabled        |     13.000
[0xa ] CB_UBC2_P12V_PWR_W                           : mpc12109           | access[O] | poll 0.01(0.10) sec | sensor_enabled        |    170.000
[0x17] CB_VR_ASIC_P0V85_PVDD_TEMP_C                 : mp29816a           | access[O] | poll 0.74(   1) sec | sensor_enabled        |     47.000
[0x18] CB_VR_ASIC_P0V85_PVDD_VOLT_V                 : mp29816a           | access[O] | poll 0.76(   1) sec | sensor_enabled        |      0.875
[0x19] CB_VR_ASIC_P0V85_PVDD_CURR_A                 : mp29816a           | access[O] | poll 0.80(   1) sec | sensor_enabled        |      0.000
[0x1a] CB_VR_ASIC_P0V85_PVDD_PWR_W                  : mp29816a           | access[O] | poll 0.82(   1) sec | sensor_enabled        |      0.000
[0x1b] CB_VR_ASIC_P0V75_PVDD_CH_N_TEMP_C            : mp2971             | access[O] | poll 0.85(   1) sec | sensor_enabled        |     45.000
[0x1c] CB_VR_ASIC_P0V75_PVDD_CH_N_VOLT_V            : mp2971             | access[O] | poll 0.88(   1) sec | sensor_enabled        |      0.751
[0x1d] CB_VR_ASIC_P0V75_PVDD_CH_N_CURR_A            : mp2971             | access[O] | poll 0.91(   1) sec | sensor_enabled        |      0.000
[0x1e] CB_VR_ASIC_P0V75_PVDD_CH_N_PWR_W             : mp2971             | access[O] | poll 0.94(   1) sec | sensor_enabled        |      0.000
```