### PR TITLE
Artemis: cb: Disable unused device drivers

### DIFF
--- a/meta-facebook/at-cb/src/platform/plat_def.h
+++ b/meta-facebook/at-cb/src/platform/plat_def.h
@@ -23,6 +23,42 @@
 #define FW_UPDATE_RETRY_MAX_COUNT 4
 #define MORE_THAN_ONE_ADM1272
 
+#define DISABLE_ISL69259
+#define DISABLE_MP5990
+#define DISABLE_ISL28022
+#define DISABLE_PCH
+#define DISABLE_ADM1278
+#define ISABLE_TPS53689
+#define DISABLE_LTC4282
+#define DISABLE_TMP431
+#define DISABLE_PMIC
+#define DISABLE_ISL69254IRAZ_T
+#define DISABLE_MAX16550A
+#define DISABLE_XDP12284C
+#define DISABLE_RAA229621
+#define DISABLE_NCT7718W
+#define DISABLE_XDPE19283B
+#define DISABLE_G788P81U
+#define DISABLE_DDR5_POWER
+#define DISABLE_DDR5_TEMP
+#define DISABLE_MP2971
+#define DISABLE_LTC2991
+#define DISABLE_EMC1412
+#define DISABLE_LM75BD118
+#define DISABLE_TMP461
+#define DISABLE_M88RT51632
+#define DISABLE_CX7
+#define DISABLE_MAX11617
+#define DISABLE_NCT7363
+#define DISABLE_ADS112C
+#define DISABLE_HDC1080
+#define DISABLE_INA238
+#define DISABLE_NCT214
+#define DISABLE_AST_TACH
+#define DISABLE_ADC128D818
+#define DISABLE_I3C_DIMM
+#define DISABLE_PT5161L
+
 #define PLDM_SEND_FAIL_DELAY_MS                                                                    \
 	20 // Workaround to avoid responding too frequently and being unable to reply
 


### PR DESCRIPTION
# Description:
- The at-cb build failed because out of memory.

# Motivation:
- Disable unused device drivers to free upmemory

# Test Plan:
- Build code: Pass
- Get sensor reading: Pass