### PR TITLE
fby4: sd: Implement thermal sensor UCR triggered PROCHOT mechanism

### DIFF
--- a/common/service/pldm/pldm_oem.h
+++ b/common/service/pldm/pldm_oem.h
@@ -90,7 +90,8 @@ enum oem_event_type {
 	CXL1_HB,
 	CXL2_HB,
 	POST_STARTED,
-	POST_ENDED
+	POST_ENDED,
+	PROCHOT_TRIGGERED_BY_SENSOR_UCR
 };
 
 enum vr_event_source {

--- a/common/service/sensor/pdr.c
+++ b/common/service/sensor/pdr.c
@@ -386,3 +386,19 @@ int check_supported_threshold_with_sensor_id(uint32_t sensorID)
 
 	return -1;
 }
+
+int get_pdr_with_sensor_id(uint32_t sensorID, PDR_numeric_sensor *numeric_sensor_pdr)
+{
+	uint32_t numeric_sensor_pdr_count = 0;
+	numeric_sensor_pdr_count = plat_get_pdr_size(PLDM_NUMERIC_SENSOR_PDR);
+
+	for (int i = 0; i < numeric_sensor_pdr_count; i++) {
+		if (numeric_sensor_table[i].sensor_id == sensorID) {
+			memcpy(numeric_sensor_pdr, &numeric_sensor_table[i],
+			       sizeof(PDR_numeric_sensor));
+			return 0;
+		}
+	}
+
+	return -1;
+}

--- a/common/service/sensor/pdr.h
+++ b/common/service/sensor/pdr.h
@@ -165,5 +165,6 @@ int change_pdr_table_critical_low_with_sensor_id(uint32_t sensorID, float critic
 int get_pdr_table_critical_high_and_low_with_sensor_id(uint32_t sensorID, float *critical_high,
 						       float *critical_low);
 int check_supported_threshold_with_sensor_id(uint32_t sensorID);
+int get_pdr_with_sensor_id(uint32_t sensorID, PDR_numeric_sensor *numeric_sensor_pdr);
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -153,4 +153,5 @@ void pal_set_sys_status()
 void pal_device_init()
 {
 	start_monitor_pmic_error_thread();
+	start_monitor_prochot_sensor_thread();
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.h
@@ -85,4 +85,16 @@ bool bootdrive_access(uint8_t sensor_num);
 void set_bootdrive_exist_status();
 bool get_bootdrive_exist_status();
 
+#define MONITOR_PROCHOT_SENSOR_STACK_SIZE 1024
+void start_monitor_prochot_sensor_thread();
+
+#define PROCHOT_SENSOR_TABLE_LEN 18
+typedef struct _prochot_sensor_info {
+	uint16_t sensor_id;
+	uint16_t event_bit;
+} prochot_sensor_info;
+
+#define MONITOR_PROCHOT_SENSOR_TIME_MS (1 * 1000) // 1s
+void monitor_prochot_sensor_handler();
+
 #endif


### PR DESCRIPTION
# [Task Description]
- Related to JIRA-1031
- Develop a mechanism to trigger PROCHOT when thermal sensors exceed their upper critical threshold
- Implement event logging for PROCHOT events initiated by thermal sensor readings

# [Motivation]
- Enhance system thermal protection by proactively triggering PROCHOT during thermal overload scenarios

# [Design]
- Create a dedicated thread to monitor specified thermal sensors at 1-second intervals
- Implement UCR threshold detection for listed thermal sensors
- Control GPIO FM_BMC_DEBUG_ENABLE_R_N to notify SD CPLD of thermal events
- Add a new event type PROCHOT_TRIGGERED_BY_SENSOR_UCR for BMC SEL message

# [Test Log]
- Verify SEL message generation for PROCHOT events triggered by thermal sensors
- Validate GPIO state changes when sensors exceed critical temperature thresholds
- Confirm event logging across different sensor reading scenarios