### PR TITLE
fby4: sd: adjust sensor MB_ADC_PVDD18_S5_VOLT_V UCR

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -169,7 +169,7 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00000000, //uint32_t normal_min;
 			0x00000000, //uint32_t warning_high;
 			0x00000000, //uint32_t warning_low;
-			0x000000BC, //uint32_t critical_high;
+			0x000000C0, //uint32_t critical_high;
 			0x000000AC, //uint32_t critical_low;
 			0x00000000, //uint32_t fatal_high;
 			0x00000000, //uint32_t fatal_low;


### PR DESCRIPTION
# Description:
Adjust sensor MB_ADC_PVDD18_S5_VOLT_V UCR from 1.88v to 1.92v

# Motivation:
During the test, MB_ADC_PVDD18_S5_VOLT_V occasionally shows a voltage
reading of 1.88V, exceeding the current UCR setting of 1.88V, so the threshold needs to be adjusted to 1.92V.

# Test Plan:
 - Build code: Pass
 - Use pldmtool platform GetPDR to verify the threshold value: Pass