### PR TITLE
Add missing platforms from CI

### DIFF
--- a/.github/workflows/build_and_lint_pr.yml
+++ b/.github/workflows/build_and_lint_pr.yml
@@ -17,12 +17,16 @@ jobs:
         # This job matrix will generate a separate job for all platforms listed.
         # Add platforms in alphabetical order.
         platform: [
+          aalc-rpu,
           at-cb,
           at-mc,
           gt-cc,
+          op2-op,
           wc-mb,
           yv3-dl,
           yv3-vf,
+          yv35-hda1,
+          yv35-nf,
           yv35-bb, 
           yv35-cl, 
           yv35-gl, 
@@ -32,6 +36,7 @@ jobs:
           yv4-sd,
           yv4-ff,
           yv4-wf,
+          nuvoton-minerva-ag,
           nuvoton-sb-rb,
         ]
         # Need to set this to false otherwise it will cancel all platform builds if one fails.


### PR DESCRIPTION
This adds the missing platforms to CI.
This includes adding minerva-ag now that the CI
supports switch based on SOC vendor.