### PR TITLE
fby4: sd: Remove redundant SEL

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -361,15 +361,6 @@ void ISR_POST_COMPLETE()
 		read_cpuid();
 		LOG_INF("Post complete event assert");
 		hw_event_register[12]++;
-
-		add_sel_info *event_item = find_event_work_items(FM_BIOS_POST_CMPLT_BIC_N);
-		if (event_item == NULL) {
-			LOG_ERR("Fail to find event items, gpio num: 0x%x",
-				FM_BIOS_POST_CMPLT_BIC_N);
-			return;
-		}
-
-		k_work_schedule_for_queue(&plat_work_q, &event_item->add_sel_work, K_NO_WAIT);
 	} else {
 		if (get_DC_status()) { // Host is reset
 			k_work_submit(&switch_i3c_dimm_work);


### PR DESCRIPTION
# Description
To save SEL space, it is recommended to remove redundant events such as "Post-Completed".

# Motivation
For YV4T1M-1918. Remove the SEL for sending "Post-Completed"

# Test Plan:
- Build code - pass

- In BMC Execute these commands: 

root@bmc:~ mfg-tool power-control -p 8 -a off -s runtime 
root@bmc:~ mfg-tool power-control -p 8 -a on -s runtime 
root@bmc:~ mfg-tool power-control -p 7 -a cycle -s runtime 
root@bmc:~ mfg-tool power-control -p 6 -a off -s standby 
root@bmc:~ mfg-tool power-control -p 6 -a on -s standby 
root@bmc:~ mfg-tool power-control -p 5 -a cycle -s standby 
root@bmc:~ mfg-tool power-control -p 4 -a cycle -s acpi 
root@bmc:~ mfg-tool log-display | grep "Post-Completed"

You will not find the "Post-Completed" in these logs.