### PR TITLE
common: new a queue and thread to handle add sel ipmi command

### DIFF
--- a/common/service/host/kcs.h
+++ b/common/service/host/kcs.h
@@ -22,6 +22,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <zephyr.h>
+#include "mctp.h"
 
 #define KCS_POLL_STACK_SIZE 4096
 #define KCS_POLLING_INTERVAL 100
@@ -31,6 +32,9 @@
 #define CMD_SYS_INFO_FW_VERSION 0x01
 #define CMD_DIMM_LOCATION 0x01
 #define KCS_TASK_NAME_LEN 32
+
+#define ADD_SEL_BUF_LEN 5
+#define ADD_SEL_EVENT_DATA_MAX_LEN 18
 
 typedef struct _kcs_dev {
 	const struct device *dev;
@@ -53,6 +57,14 @@ struct kcs_response {
 	uint8_t cmplt_code;
 	uint8_t data[0];
 };
+
+typedef struct _add_sel_msg_t {
+    mctp_ext_params ext_params;
+    uint8_t event_class;
+    uint8_t event_data[ADD_SEL_EVENT_DATA_MAX_LEN]; // ADD_SEL_EVENT length is 18
+    uint8_t event_data_length;
+    uint8_t bmc_bus;
+} add_sel_msg_t;
 
 void kcs_device_init(char **config, uint8_t size);
 int kcs_write(uint8_t index, uint8_t *buf, uint32_t buf_sz);


### PR DESCRIPTION
# Description
Separate sending ADD_SEL's pldm event data from KCS reading function by a queue and thread.

# Motivation
BIC can not send pldm event to BMC until it timeout when BMC pldm busy, but BIOS still send the ipmi command to BIC.
It lead to BIC will read a lot of data which is including retry data and following ipmi command at next loop and it can not dealwith it then drop it in this cycle time.

# Test Plan
1. Build and test on YV4 system. pass
2. Validate by our QE team with 278 DC cycle times and 300 RESET cycle times. pass