### PR TITLE
minerva-ag: Disable sensor resp during all fw update state

### DIFF
--- a/common/service/pldm/pldm_firmware_update.c
+++ b/common/service/pldm/pldm_firmware_update.c
@@ -1746,3 +1746,11 @@ bool is_update_state_download_phase()
 	}
 	return false;
 }
+
+bool is_update_state_idle()
+{
+	if (current_state == STATE_IDLE) {
+		return true;
+	}
+	return false;
+}

--- a/common/service/pldm/pldm_firmware_update.h
+++ b/common/service/pldm/pldm_firmware_update.h
@@ -65,7 +65,10 @@ static const char hex_to_ascii[] = { '0', '1', '2', '3', '4', '5', '6', '7',
 
 #define PLDM_COMMON_ERR_STR 'E', 'R', 'R', 'O', 'R', ':'
 #define PLDM_COMMON_ERR_CODE 0
-#define PLDM_CREATE_ERR_STR_ARRAY(code) { PLDM_COMMON_ERR_STR, hex_to_ascii[code] }
+#define PLDM_CREATE_ERR_STR_ARRAY(code)                                                            \
+	{                                                                                          \
+		PLDM_COMMON_ERR_STR, hex_to_ascii[code]                                            \
+	}
 
 #define CHECK_PLDM_FW_UPDATE_RESULT_WITH_RETURN(component_id, offset, length, val, ret_val)                \
 	if (val != 0) {                                                                                    \
@@ -722,6 +725,7 @@ int get_device_descriptor_total_length(struct pldm_descriptor_string *table, uin
 uint8_t fill_descriptor_into_buf(struct pldm_descriptor_string *descriptor, uint8_t *buf,
 				 uint8_t *fill_length, uint16_t current_length);
 bool is_update_state_download_phase();
+bool is_update_state_idle();
 
 #ifdef __cplusplus
 }

--- a/common/service/pldm/pldm_monitor.c
+++ b/common/service/pldm/pldm_monitor.c
@@ -138,7 +138,7 @@ uint8_t pldm_get_sensor_reading(void *mctp_inst, uint8_t *buf, uint16_t len, uin
 	CHECK_NULL_ARG_WITH_RETURN(ext_params, PLDM_ERROR);
 
 #ifdef DISABLE_SENSOR_RESP_DURING_FW_UPDATE
-	if (is_update_state_download_phase()) {
+	if (is_update_state_idle() == false) {
 		return PLDM_LATER_RESP;
 	}
 #endif


### PR DESCRIPTION
Summary:
- Disable sensor resp during all fw update state

Test Plan:
- Build code: Pass