### PR TITLE
minerva-ag: set EMC1413 therm mode and threshold

### DIFF
--- a/common/dev/include/emc1413.h
+++ b/common/dev/include/emc1413.h
@@ -57,5 +57,7 @@ bool emc1413_get_temp_threshold(sensor_cfg *cfg, uint8_t temp_threshold_index,
 				uint32_t *millidegree_celsius);
 bool emc1413_set_temp_threshold(sensor_cfg *cfg, uint8_t temp_threshold_index,
 				uint32_t *millidegree_celsius);
+bool emc1413_set_comparator_mode(sensor_cfg *cfg);
+bool emc1413_set_therm_hysteresis(sensor_cfg *cfg, uint8_t temp_therm_hysteresis_val);
 
 #endif

--- a/common/dev/include/tmp431.h
+++ b/common/dev/include/tmp431.h
@@ -66,5 +66,7 @@ bool tmp432_get_temp_threshold(sensor_cfg *cfg, uint8_t temp_threshold_index,
 			       uint32_t *millidegree_celsius);
 bool tmp432_set_temp_threshold(sensor_cfg *cfg, uint8_t temp_threshold_index,
 			       uint32_t *millidegree_celsius);
+bool tmp432_set_thermal_mode(sensor_cfg *cfg);
+bool tmp432_set_therm_hysteresis(sensor_cfg *cfg, uint8_t temp_therm_hysteresis_val);
 
 #endif

--- a/common/service/sensor/pldm_sensor.c
+++ b/common/service/sensor/pldm_sensor.c
@@ -51,6 +51,11 @@ __weak int plat_pldm_sensor_get_sensor_count(int thread_id)
 	return -1;
 }
 
+__weak void plat_pldm_sensor_post_load_init(int thread_id)
+{
+	return;
+}
+
 bool pldm_sensor_is_interval_ready(pldm_sensor_info *pldm_sensor_list)
 {
 	CHECK_NULL_ARG_WITH_RETURN(pldm_sensor_list, false);
@@ -411,6 +416,8 @@ void pldm_sensor_polling_handler(void *arug0, void *arug1, void *arug2)
 	if (pldm_sensor_thread_list[thread_id].poll_interval_ms != 0) {
 		poll_interval_ms = pldm_sensor_thread_list[thread_id].poll_interval_ms;
 	}
+
+	plat_pldm_sensor_post_load_init(thread_id);
 
 	while (1) {
 		// Check sensor poll enable

--- a/meta-facebook/minerva-ag/src/platform/plat_init.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_init.c
@@ -58,7 +58,6 @@ void pal_pre_init()
 		plat_clock_init();
 
 	plat_eusb_init();
-	init_temp_alert_mode();
 }
 
 void pal_set_sys_status()
@@ -69,7 +68,6 @@ void pal_set_sys_status()
 void pal_post_init()
 {
 	plat_mctp_init();
-	init_temp_limit(); //should be before temp_threshold_default_settings_init() and after pldm sensor init
 	user_settings_init();
 	pldm_load_state_effecter_table(MAX_STATE_EFFECTER_IDX);
 	pldm_assign_gpio_effecter_id(PLAT_EFFECTER_ID_GPIO_HIGH_BYTE);


### PR DESCRIPTION
Summary:
- set EMC1413 to therm mode and threshold value
- adjust the order of init_temp_alert_mode() and init_temp_limit()
- add plat_pldm_sensor_post_load_init() for temp init setting

Test Plan:
- Build code: PASS