### PR TITLE
Zephyr: Aspeed Update VWIRE event initialization

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,7 +11,7 @@ manifest:
     - name: zephyr
       remote: aspeed
       path: zephyr
-      revision: 632d2fb5d0438040e8dc44da48a2fb0712c1feea
+      revision: 641ac3b4d956f2d237c109526c017fdee4715bfb
       import: 
         name-allowlist:
           - cmsis


### PR DESCRIPTION
# Description:
- Ensures the espi_event structure is properly initialized when invoking the callback.
- The event's evt_data is set using the ESPI interrupt status value read from address 0x7E6E_E008.
- GitHub link: AspeedTech-BMC/zephyr@641ac3b

# Motivation:
- On OP2 platforms that rely on virtual wire GPIO signaling, the ESPI event callback requires valid evt_data to correctly interpret VWIRE changes.
- Without setting evt_data, the callback may operate with incomplete context, leading to POST_COMPLETE failed.

# Test Plan:
- Build code: Pass
- OP2 virtual wire GPIO action: Pass