### PR TITLE
minerva-ag: modify vr_status command

### DIFF
--- a/common/dev/mp2971.c
+++ b/common/dev/mp2971.c
@@ -1178,6 +1178,7 @@ bool mp2971_get_vr_status(sensor_cfg *cfg, uint8_t rail, uint8_t vr_status_rail,
 		val = (uint16_t)data[0];
 	} break;
 	case PMBUS_STATUS_INPUT: {
+		mp2856_set_page(cfg->port, cfg->target_addr, VR_MPS_PAGE_0);
 		uint8_t data[1] = { 0 };
 		if (!mp2971_i2c_read(cfg->port, cfg->target_addr, PMBUS_STATUS_INPUT, data,
 				     sizeof(data))) {
@@ -1194,6 +1195,7 @@ bool mp2971_get_vr_status(sensor_cfg *cfg, uint8_t rail, uint8_t vr_status_rail,
 		val = (uint16_t)data[0];
 	} break;
 	case PMBUS_STATUS_CML: {
+		mp2856_set_page(cfg->port, cfg->target_addr, VR_MPS_PAGE_0);
 		uint8_t data[1] = { 0 };
 		if (!mp2971_i2c_read(cfg->port, cfg->target_addr, PMBUS_STATUS_CML, data,
 				     sizeof(data))) {

--- a/common/dev/mp29816a.c
+++ b/common/dev/mp29816a.c
@@ -659,6 +659,7 @@ bool mp29816a_get_vr_status(sensor_cfg *cfg, uint8_t rail, uint8_t vr_status_rai
 		val = (uint16_t)data[0];
 	} break;
 	case PMBUS_STATUS_INPUT: {
+		mp29816a_set_page(cfg->port, cfg->target_addr, 0);
 		uint8_t data[1] = { 0 };
 		if (!mp29816a_i2c_read(cfg->port, cfg->target_addr, PMBUS_STATUS_INPUT, data,
 				       sizeof(data))) {
@@ -675,6 +676,7 @@ bool mp29816a_get_vr_status(sensor_cfg *cfg, uint8_t rail, uint8_t vr_status_rai
 		val = (uint16_t)data[0];
 	} break;
 	case PMBUS_STATUS_CML: {
+		mp29816a_set_page(cfg->port, cfg->target_addr, 0);
 		uint8_t data[1] = { 0 };
 		if (!mp29816a_i2c_read(cfg->port, cfg->target_addr, PMBUS_STATUS_CML, data,
 				       sizeof(data))) {

--- a/meta-facebook/minerva-ag/src/shell/plat_vr_status_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_vr_status_shell.c
@@ -62,7 +62,7 @@ static int cmd_vr_status_get(const struct shell *shell, size_t argc, char **argv
 						continue;
 					}
 
-					shell_print(shell, "    %-10s:%2x", vr_status_name,
+					shell_print(shell, "    %-10s:0x%02x", vr_status_name,
 						    vr_status);
 				}
 			} else {
@@ -82,8 +82,8 @@ static int cmd_vr_status_get(const struct shell *shell, size_t argc, char **argv
 					return -1;
 				}
 
-				shell_print(shell, "[%-2x]%-50s %-10s:%2x", i, rail_name, argv[2],
-					    vr_status);
+				shell_print(shell, "[%-2x]%-50s %-10s:0x%02x", i, rail_name,
+					    argv[2], vr_status);
 			}
 		}
 		return 0;
@@ -117,7 +117,7 @@ static int cmd_vr_status_get(const struct shell *shell, size_t argc, char **argv
 					continue;
 				}
 
-				shell_print(shell, "[%-2x]%-50s %-10s:%2x", rail, argv[1],
+				shell_print(shell, "[%-2x]%-50s %-10s:0x%02x", rail, argv[1],
 					    vr_status_name, vr_status);
 			}
 			return 0;
@@ -136,9 +136,8 @@ static int cmd_vr_status_get(const struct shell *shell, size_t argc, char **argv
 				return -1;
 			}
 
-			shell_print(shell, "[%-2x]%-50s %-10s:%2x", rail, argv[1], argv[2],
+			shell_print(shell, "[%-2x]%-50s %-10s:0x%02x", rail, argv[1], argv[2],
 				    vr_status);
-
 			return 0;
 		}
 	}


### PR DESCRIPTION
Summary:
- modify vr_status command display
- moddify MP2971, MP29816A get PMBUS_STATUS_INPUT, PMBUS_STATUS_CML

Test Plan:
- Build code: PASS