### PR TITLE
fby4: sd: Implement post timeout mechanism

### DIFF
--- a/common/service/pldm/pldm_oem.h
+++ b/common/service/pldm/pldm_oem.h
@@ -101,6 +101,7 @@ enum oem_event_type {
 	OS_LOAD_WDT_PWR_DOWN,
 	OS_LOAD_WDT_PWR_CYCLE,
 	MTIA_VR_FAULT,
+	POST_TIMEOUTED,
 };
 
 enum vr_event_source {

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -104,6 +104,7 @@ void pal_pre_init()
 	init_fastprochot_work_q();
 	init_event_work();
 	init_pmic_event_work();
+	init_post_timeout_event_work();
 	init_plat_worker(K_PRIO_PREEMPT(2)); // work queue for low priority jobs
 
 	plat_init_pldm_sensor_table();

--- a/meta-facebook/yv4-sd/src/platform/plat_isr.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.h
@@ -72,6 +72,9 @@ typedef struct {
 	struct pldm_addsel_data sel_data;
 } sel_work_wrapper;
 
+void add_post_timeout_sel_work_handler(struct k_work *work);
+void init_post_timeout_event_work(void);
+void post_timeout_handler(struct k_timer *timer_id);
 void ISR_DC_ON();
 void ISR_POST_COMPLETE();
 void ISR_BMC_READY();


### PR DESCRIPTION
# [Task Description]
- Related to YV4T1M-1993
- Implement SEL to record events when system fails to complete POST within 20 minutes after DC power on or platform reset

# [Motivation]
- To notify users when POST does not complete in time

# [Design]
- Add new event type "Post-Timeouted"