### PR TITLE
yv4: wf: Refactor CXL heartbeat monitoring with PERST state check

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
@@ -124,6 +124,7 @@ void set_cxl2_vr_access_delayed_status();
 bool cxl1_vr_access(uint8_t sensor_num);
 bool cxl2_vr_access(uint8_t sensor_num);
 void create_check_cxl_ready_thread();
+bool get_cxl_heartbeat(char *label);
 void cxl1_heartbeat_monitor_handler();
 void cxl2_heartbeat_monitor_handler();
 void init_cxl_heartbeat_monitor_work();


### PR DESCRIPTION
# [Issue Description]
- Related to YV4T1M-1940
- The total number of BMC SELs "Host$i CXL1/2 HB, ASSERTED/DEASSERTED" is not as expected during BIOS update and ACPI reset

# [Root Cause]
- There is a false heartbeat deassert SEL when PERST signal is low, followed by an assert SEL after the heartbeat recovers

# [Solution]
- Bypass heartbeat TACH fetching and reinitialize the state to HB_STATE_UNKNOWN when PERST signal is low
- Double-check the PERST state to prevent timing race conditions
- Add get_cxl_heartbeat() function to centralize heartbeat sensor reading

# [Test Log]
- Run BIOS update stress test: the total number of CXL heartbeat SELs is as expected
- Run ACPI cycle stress test: the total number of CXL heartbeat SELs is as expected