### PR TITLE
fby4: wf: Fix CXL VR access during DC-off

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_isr.c
@@ -434,6 +434,7 @@ void ISR_MB_DC_STAGUS_CHAGNE()
 		k_work_schedule_for_queue(&plat_work_q, &set_clk_buf_bypass_work,
 					  K_MSEC(SET_CLK_BUF_DELAY_MS));
 	} else {
+		set_cxl_vr_access(MAX_CXL_ID, false);
 		k_work_submit(&cxl_power_off_work);
 	}
 }

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
@@ -559,6 +559,12 @@ static bool plat_get_vr_fw_version(void *info_p, uint8_t *buf, uint8_t *len)
 	uint8_t value = 0x0;
 	uint8_t vr_comp_id = p->comp_identifier;
 
+	if (get_cxl_vr_access_status(CXL_ID_1) == false ||
+	    get_cxl_vr_access_status(CXL_ID_2) == false) {
+		LOG_WRN("CXL VR access is not allowed");
+		return false;
+	}
+
 	get_ioe_value(ADDR_IOE2, TCA9555_OUTPUT_PORT_REG_0, &value);
 	switch (vr_comp_id) {
 	case WF_COMPNT_VR_PVDDQ_AB_ASIC1:

--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
@@ -485,6 +485,7 @@ void execute_power_off_sequence()
 		LOG_INF("CXL 1 power off success");
 	} else {
 		is_cxl_power_on[CXL_ID_1] = true;
+		set_cxl_vr_access(CXL_ID_1, true);
 		LOG_ERR("CXL 1 power off fail");
 	}
 
@@ -494,6 +495,7 @@ void execute_power_off_sequence()
 		LOG_INF("CXL 2 power off success");
 	} else {
 		is_cxl_power_on[CXL_ID_2] = true;
+		set_cxl_vr_access(CXL_ID_2, true);
 		LOG_ERR("CXL 2 power off fail");
 	}
 
@@ -1026,6 +1028,11 @@ bool cxl1_vr_access(uint8_t sensor_num)
 bool cxl2_vr_access(uint8_t sensor_num)
 {
 	return is_cxl_vr_accessible[CXL_ID_2];
+}
+
+bool get_cxl_vr_access_status(uint8_t cxl_id)
+{
+	return is_cxl_vr_accessible[cxl_id];
 }
 
 void set_cxl_ready_status(uint8_t cxl_id, bool value)

--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.h
@@ -130,4 +130,5 @@ void cxl2_heartbeat_monitor_handler();
 void init_cxl_heartbeat_monitor_work();
 void plat_pldm_sensor_clear_vr_fault(uint8_t vr_addr, uint8_t vr_bus, uint8_t page_cnt);
 void switch_mux_to_bic(uint8_t value_to_write);
+bool get_cxl_vr_access_status(uint8_t cxl_id);
 #endif


### PR DESCRIPTION
# [Task Description]:
- Related to YV4T1M-1992
- This task addresses the issue where SEL events were generated when the DC was off. From analysis, it was observed that all the SEL events occurred during the DC-off state, likely due to unstable sensor readings in this condition. The improvement aims to set CXL VR access to false when DC is off.

# [Task Description]:
When DC is off, sensor readings become unstable, which can lead to false or unexpected SEL events.

# [Design]:
- In `ISR_MB_DC_STAGUS_CHAGNE()`, when DC is turned off, set set_cxl_vr_access to false to ensure VR is disabled.
- In plat_get_vr_fw_version(), add a check for CXL VR access status and prevent further actions if access is not allowed, avoiding VR sensor polling in DC-off state.
- Add get_cxl_vr_access_status() API for checking CXL VR access.

# [Test Log]:
- Verified that SEL events are no longer generated spuriously during DC-off.

```
    "1": {
        "additional_data": {
            "NUMBER_OF_LOGS": "11",
            "_CODE_FILE": "/usr/src/debug/phosphor-logging/1.0+git/log_manager.hpp",
            "_CODE_FUNC": "virtual void phosphor::logging::Manager::deleteAll()",
            "_CODE_LINE": "361",
            "_PID": "635"
        },
        "event_id": "",
        "message": "xyz.openbmc_project.Logging.Cleared",
        "redfish": {
            "args": [],
            "id": "OpenBMC_Logging.Cleared",
            "message": "Event log cleared by user."
        },
        "resolution": "",
        "resolved": false,
        "severity": "xyz.openbmc_project.Logging.Entry.Level.Informational",
        "timestamp": "2025-08-01T18:21:36.715000000Z",
        "updated_timestamp": "2025-08-01T18:21:36.715000000Z"
    },
    "2": {
        "additional_data": {},
        "event_id": "",
        "message": "Execute host8 DC power off",
        "resolution": "",
        "resolved": false,
        "severity": "xyz.openbmc_project.Logging.Entry.Level.Informational",
        "timestamp": "2025-08-01T18:21:39.168000000Z",
        "updated_timestamp": "2025-08-01T18:21:39.168000000Z"
    },
    "3": {
        "additional_data": {
            "HOST_PATH": "/xyz/openbmc_project/state/host8"
        },
        "event_id": "",
        "message": "Host8 state is off",
        "resolution": "",
        "resolved": false,
        "severity": "xyz.openbmc_project.Logging.Entry.Level.Informational",
        "timestamp": "2025-08-01T18:21:39.746000000Z",
        "updated_timestamp": "2025-08-01T18:21:39.746000000Z"
    },
    "4": {
        "additional_data": {},
        "event_id": "",
        "message": "Event: Host8 PLTRST Assertion, ASSERTED",
        "resolution": "",
        "resolved": false,
        "severity": "xyz.openbmc_project.Logging.Entry.Level.Error",
        "timestamp": "2025-08-01T18:21:44.773000000Z",
        "updated_timestamp": "2025-08-01T18:21:44.773000000Z"
    },
    "5": {
        "additional_data": {},
        "event_id": "",
        "message": "Host8 system DC power is off",
        "resolution": "",
        "resolved": false,
        "severity": "xyz.openbmc_project.Logging.Entry.Level.Informational",
        "timestamp": "2025-08-01T18:21:49.509000000Z",
        "updated_timestamp": "2025-08-01T18:21:49.509000000Z"
    }
}
```