### PR TITLE
fby4: sd: Modify supported_thresholds for MB_ADC_P1V2_STBY_VOLT_V

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_pldm_sensor.c
@@ -634,7 +634,7 @@ pldm_sensor_info plat_pldm_sensor_adc_table[] = {
 			0x00, //uint8_t plus_tolerance;
 			0x00, //uint8_t minus_tolerance;
 			0x00000000, //uint32_t hysteresis;
-			0xDB, //uint8_t supported_thresholds;
+			0xFB, //uint8_t supported_thresholds;
 			0x00, //uint8_t threshold_and_hysteresis_volatility;
 			0, //real32_t state_transition_interval;
 			UPDATE_INTERVAL_1S, //real32_t update_interval;


### PR DESCRIPTION
# Description
- Related to YV4T1M-2059.
- Modify the bit to enable LNR threshold support for MB_ADC_P1V2_STBY_VOLT_V.

# Motivation
- To align with the threshold settings required by the thermal team.