### PR TITLE
fby4: sd: Support NXP I3C Hub

### DIFF
--- a/meta-facebook/yv4-sd/src/platform/plat_class.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_class.c
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "rg3mxxb12.h"
+#include "p3h284x.h"
 #include "hal_gpio.h"
 #include "hal_i2c.h"
 #include "libutil.h"
@@ -11,12 +13,15 @@
 #include "plat_i2c.h"
 #include "plat_sensor_table.h"
 #include "hal_i3c.h"
+#include "plat_mctp.h"
 
 #include <logging/log.h>
 
 #define BOARD_REVISION_PRSNT_BITS 0x07
 
 LOG_MODULE_REGISTER(plat_class);
+
+static uint16_t i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
 
 /* ADC information for each channel
  * offset: register offset
@@ -78,6 +83,11 @@ uint8_t get_slot_eid()
 uint8_t get_slot_id()
 {
 	return slot_id;
+}
+
+uint16_t get_i3c_hub_type()
+{
+	return i3c_hub_type;
 }
 
 bool pal_get_slot_pid(uint16_t *pid)
@@ -297,4 +307,17 @@ void init_retimer_type()
 	}
 
 	return;
+}
+
+void init_i3c_hub_type(void)
+{
+	if (rg3mxxb12_get_device_info_i3c(I3C_BUS_HUB, &i3c_hub_type) &&
+	    (i3c_hub_type == RG3M87B12_DEVICE_INFO)) {
+		LOG_INF("I3C hub type: rg3mxxb12");
+	} else if (p3h284x_get_device_info_i3c(I3C_BUS_HUB, &i3c_hub_type) &&
+		   (i3c_hub_type == P3H2840_DEVICE_INFO)) {
+		LOG_INF("I3C hub type: p3h284x");
+	} else {
+		LOG_ERR("I3C hub get device type fail");
+	}
 }

--- a/meta-facebook/yv4-sd/src/platform/plat_class.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_class.h
@@ -56,6 +56,12 @@ enum RETIMER_TYPE {
 	RETIMER_TYPE_BROADCOM,
 };
 
+enum I3C_HUB_TYPE {
+	I3C_HUB_TYPE_RNS,
+	I3C_HUB_TYPE_NXP,
+	I3C_HUB_TYPE_UNKNOWN,
+};
+
 bool get_adc_voltage(int channel, float *voltage);
 bool get_board_rev(uint8_t *board_rev);
 uint8_t get_slot_eid();
@@ -64,5 +70,7 @@ bool get_blade_config(uint8_t *blade_config);
 void init_platform_config();
 uint8_t get_retimer_type();
 void init_retimer_type();
+uint16_t get_i3c_hub_type();
+void init_i3c_hub_type();
 
 #endif

--- a/meta-facebook/yv4-sd/src/platform/plat_i3c.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_i3c.c
@@ -25,6 +25,33 @@ k_tid_t tid;
 K_THREAD_STACK_DEFINE(send_setaasa_stack, SEND_SETAASA_STACK_SIZE);
 struct k_thread send_setaasa_thread;
 
+const uint8_t rg3mxxb12_cmd_initial[][2] = {
+	{ RG3MXXB12_SLAVE_PORT_ENABLE, 0x0 },
+	{ RG3MXXB12_VOLT_LDO_SETTING, LDO_VOLT },
+	{ RG3MXXB12_SSPORTS_AGENT_ENABLE, 0x0 },
+	{ RG3MXXB12_SSPORTS_GPIO_ENABLE, 0x0 },
+	{ RG3MXXB12_SSPORTS_PULLUP_SETTING, 0xF0 },
+	{ RG3MXXB12_SSPORTS_PULLUP_ENABLE, 0xFF },
+	{ RG3MXXB12_SSPORTS_OD_ONLY, 0x0 },
+	{ RG3MXXB12_SSPORTS_HUB_NETWORK_CONNECTION, 0x01 },
+	{ RG3MXXB12_SLAVE_PORT_ENABLE, 0x01 },
+};
+
+const uint8_t p3h284x_cmd_initial[][2] = {
+	// Target Port Enable
+	{ P3H284X_TARGET_PORT_ENABLE, 0x0 },
+	// VCCIO LDO Setting
+	{ P3H284X_VOLT_LDO_SETTING, LDO_VOLT },
+	// On-die LDO Enable and Pull up Resistor Value Setting
+	{ P3H284X_TARGET_PORTS_PULLUP_SETTING, 0xF0 },
+	// Target Port Pull Up Enable
+	{ P3H284X_TARGET_PORTS_PULLUP_ENABLE, 0xFF },
+	// Target Port Hub Network Connection Enable
+	{ P3H284X_TARGET_PORTSHUB_NETWORK_CONNECTION, 0x01 },
+	// Target Port Enable
+	{ P3H284X_TARGET_PORT_ENABLE, 0x01 },
+};
+
 void start_setaasa()
 {
 	LOG_INF("Start a thread to send setaasa");

--- a/meta-facebook/yv4-sd/src/platform/plat_i3c.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_i3c.h
@@ -18,15 +18,22 @@
 #define PLAT_I3C_H
 
 #include "rg3mxxb12.h"
+#include "p3h284x.h"
 
 #define I3C_BUS3 2
 
 #define SEND_SETAASA_STACK_SIZE 1024
 #define SEND_SETAASA_TIME_MS 5000
 
+#define RG3MXXB12_CMD_INITIAL_SIZE 9
+#define P3H284X_CMD_INITIAL_SIZE 6
+
 #define LDO_VOLT                                                                                   \
 	V_LDO_SETTING(rg3mxxb12_ldo_1_2_volt, rg3mxxb12_ldo_1_2_volt, rg3mxxb12_ldo_1_2_volt,      \
 		      rg3mxxb12_ldo_1_2_volt)
+
+extern const uint8_t rg3mxxb12_cmd_initial[][2];
+extern const uint8_t p3h284x_cmd_initial[][2];
 
 void start_setaasa();
 void send_setaasa();

--- a/meta-facebook/yv4-sd/src/platform/plat_init.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_init.c
@@ -92,11 +92,20 @@ void pal_pre_init()
 		printf("Error to set daa\n");
 	}
 
+	uint16_t i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
 	i3c_attach(&i3c_msg);
+	init_i3c_hub_type();
+	i3c_hub_type = get_i3c_hub_type();
 
 	// Initialize I3C HUB
-	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT, 0xF0)) {
-		printk("failed to initialize 1ou rg3mxxb12\n");
+	if(i3c_hub_type == P3H2840_DEVICE_INFO) {
+		if (!p3h284x_i3c_mode_only_init(&i3c_msg, p3h284x_cmd_initial, P3H284X_CMD_INITIAL_SIZE)) {
+			printk("failed to initialize 1ou p3h284x\n");
+		}
+	} else {
+		if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, rg3mxxb12_cmd_initial, RG3MXXB12_CMD_INITIAL_SIZE)) {
+			printk("failed to initialize 1ou rg3mxxb12\n");
+		}
 	}
 
 	init_vr_event_work();

--- a/meta-facebook/yv4-sd/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-sd/src/platform/plat_isr.c
@@ -21,6 +21,7 @@
 #include "app_handler.h"
 #include "kcs.h"
 #include "rg3mxxb12.h"
+#include "p3h284x.h"
 #include "power_status.h"
 #include "sensor.h"
 #include "snoop.h"
@@ -165,59 +166,6 @@ static add_sel_info *find_event_work_items(uint8_t gpio_num)
 	return NULL;
 }
 
-bool rg3mxxb12_i3c_mode_only_init(I3C_MSG *i3c_msg, uint8_t ldo_volt, uint8_t pullup_val)
-{
-	bool ret = false;
-
-	const uint8_t cmd_unprotect[2] = { RG3MXXB12_PROTECTION_REG, 0x69 };
-	uint8_t cmd_protect[2] = { RG3MXXB12_PROTECTION_REG, 0x00 };
-	uint8_t cmd_initial[][2] = {
-		/* 
-		 * Refer to RG3MxxB12 datasheet page 13, LDO voltage depends
-		 * on each project's hard design
-		 */
-		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0x0 },
-		{ RG3MXXB12_VOLT_LDO_SETTING, ldo_volt },
-		{ RG3MXXB12_SSPORTS_AGENT_ENABLE, 0x0 },
-		{ RG3MXXB12_SSPORTS_GPIO_ENABLE, 0x0 },
-		{ RG3MXXB12_SSPORTS_PULLUP_SETTING, pullup_val },
-		{ RG3MXXB12_SSPORTS_PULLUP_ENABLE, 0xFF },
-		{ RG3MXXB12_SSPORTS_OD_ONLY, 0x0 },
-		{ RG3MXXB12_SSPORTS_HUB_NETWORK_CONNECTION, 0x01 },
-		{ RG3MXXB12_SLAVE_PORT_ENABLE, 0x01 },
-	};
-
-	i3c_msg->tx_len = 2;
-	memcpy(i3c_msg->data, cmd_unprotect, 2);
-	int initial_cmd_size = sizeof(cmd_initial) / sizeof(cmd_initial[0]);
-
-	// Unlock protected regsiter
-	if (i3c_controller_write(i3c_msg) != 0) {
-		goto out;
-	}
-
-	for (int cmd = 0; cmd < initial_cmd_size; cmd++) {
-		i3c_msg->tx_len = 2;
-		memcpy(i3c_msg->data, cmd_initial[cmd], 2);
-		if (i3c_controller_write(i3c_msg) != 0) {
-			LOG_ERR("Failed to initial i3c mode. offset = 0x%02x, value = 0x%02x",
-				cmd_initial[cmd][0], cmd_initial[cmd][1]);
-			goto out;
-		}
-		k_msleep(10);
-	}
-
-	ret = true;
-out:
-	memcpy(i3c_msg->data, cmd_protect, 2);
-	if (i3c_controller_write(i3c_msg) != 0) {
-		LOG_ERR("Failed to set protect. offset = 0x%02x, value = 0x%02x", cmd_protect[0],
-			cmd_protect[1]);
-	}
-
-	return ret;
-}
-
 /*
  *	TODO: I3C hub is supplied by DC power currently. When DC off, it can't be initialized.
  *  	  Therefore, BIC needs to implement a workaround to reinitialize the I3C hub during DC on.
@@ -225,6 +173,7 @@ out:
  */
 void reinit_i3c_hub()
 {
+	uint16_t i3c_hub_type = I3C_HUB_TYPE_UNKNOWN;
 	// i3c master initial
 	I3C_MSG i3c_msg = { 0 };
 	i3c_msg.bus = I3C_BUS_HUB;
@@ -246,10 +195,18 @@ void reinit_i3c_hub()
 	}
 
 	i3c_attach(&i3c_msg);
+	init_i3c_hub_type();
+	i3c_hub_type = get_i3c_hub_type();
 
 	// Initialize I3C HUB
-	if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, LDO_VOLT, 0xF0)) {
-		printk("failed to initialize 1ou rg3mxxb12\n");
+	if(i3c_hub_type == P3H2840_DEVICE_INFO) {
+		if (!p3h284x_i3c_mode_only_init(&i3c_msg, p3h284x_cmd_initial, P3H284X_CMD_INITIAL_SIZE)) {
+			printk("failed to initialize 1ou p3h284x\n");
+		}
+	} else {
+		if (!rg3mxxb12_i3c_mode_only_init(&i3c_msg, rg3mxxb12_cmd_initial, RG3MXXB12_CMD_INITIAL_SIZE)) {
+			printk("failed to initialize 1ou rg3mxxb12\n");
+		}
 	}
 
 	// Set FF/WF's EID


### PR DESCRIPTION
# Description:
- Add NXP I3C hub init setting.
- Add get hub type function for detect Hub type.
- Modify Renesas Hub driver settings for driver revise.

# Motivation:
- Support NXP I3C Hub for YV4 Sentinel Done.

# Test Plan:
- Build code: pass
- EE test I3C Hub waveform: pass

* Need to related commit
#2494