### PR TITLE
minerva-ag: Support reboot cli command and i2c auto recovery

### DIFF
--- a/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0025-drivers-i2c-recovery-in-driver-init.patch
+++ b/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0025-drivers-i2c-recovery-in-driver-init.patch
@@ -1,0 +1,57 @@
+From 5e8a2b5a7a930480c21f2eb82b391f356e9f1cf4 Mon Sep 17 00:00:00 2001
+From: Tyrone Ting <kfting@nuvoton.com>
+Date: Wed, 23 Jul 2025 10:17:15 +0800
+Subject: [PATCH] drivers: i2c: recovery in driver init
+
+1. Do recovery if the bus is busy and at least one of SCL/SDA is not high
+   when the i2c driver is initialized.
+2. Change the driver initialization level to POST_KERNEL.
+
+Signed-off-by: Tyrone Ting <kfting@nuvoton.com>
+---
+ drivers/i2c/i2c_npcm4xx.c | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/i2c_npcm4xx.c b/drivers/i2c/i2c_npcm4xx.c
+index 972dc1b12ff9..b2e71c102dbb 100755
+--- a/drivers/i2c/i2c_npcm4xx.c
++++ b/drivers/i2c/i2c_npcm4xx.c
+@@ -107,6 +107,8 @@ struct i2c_npcm4xx_data {
+ #define I2C_INSTANCE(dev) (struct i2c_reg *)(I2C_DRV_CONFIG(dev)->base)
+ 
+ 
++int i2c_npcm4xx_recover_bus(const struct device *dev);
++
+ /* This macro should be set only when in Master mode or when requesting Master mode.
+  * Set START bit to CTL1 register of I2C module, but exclude STOP bit, ACK bit.
+  */
+@@ -947,6 +949,17 @@ static int i2c_npcm4xx_init(const struct device *dev)
+ 		data->slave_cfg[i] = NULL;
+ 	}
+ 
++	if((inst->SMBnCST & BIT(NPCM4XX_SMBnCST_BB)) &&
++			(!IS_BIT_SET(inst->SMBnCTL3, NPCM4XX_SMBnCTL3_SCL_LVL) ||
++			!IS_BIT_SET(inst->SMBnCTL3, NPCM4XX_SMBnCTL3_SDA_LVL))) {
++		if(i2c_npcm4xx_recover_bus(dev)) {
++			LOG_ERR("lines are low SCL: %d SDA: %d",
++					IS_BIT_SET(inst->SMBnCTL3, NPCM4XX_SMBnCTL3_SCL_LVL),
++					IS_BIT_SET(inst->SMBnCTL3, NPCM4XX_SMBnCTL3_SDA_LVL));
++			return -EIO;
++		}
++	}
++
+ 	return 0;
+ }
+ 
+@@ -1207,7 +1220,7 @@ static const struct i2c_driver_api i2c_npcm4xx_driver_api = {
+ 			      I2C_NPCM4XX_CTRL_INIT_FUNC(inst),			 \
+ 			      NULL,						 \
+ 			      &i2c_npcm4xx_data_##inst, &i2c_npcm4xx_cfg_##inst, \
+-			      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	 \
++			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	 \
+ 			      &i2c_npcm4xx_driver_api);				 \
+ 										 \
+ 	I2C_NPCM4XX_CTRL_INIT_FUNC_IMPL(inst)
+-- 
+2.17.1
+

--- a/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0026-drivers-i2c-add-i2c-interface-support.patch
+++ b/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0026-drivers-i2c-add-i2c-interface-support.patch
@@ -1,0 +1,95 @@
+From b9be44f6ca6c26d4a9b82508c772223df9ad2b1f Mon Sep 17 00:00:00 2001
+From: Tyrone Ting <kfting@nuvoton.com>
+Date: Thu, 24 Jul 2025 15:26:42 +0800
+Subject: [PATCH] drivers: i2c: add i2c interface support
+
+Signed-off-by: Tyrone Ting <kfting@nuvoton.com>
+---
+ drivers/i2c/i2c_npcm4xx.c     | 42 +++++++++++++++++++++++++++++++++++
+ include/drivers/i2c_npcm4xx.h | 14 ++++++++++++
+ 2 files changed, 56 insertions(+)
+ create mode 100644 include/drivers/i2c_npcm4xx.h
+
+diff --git a/drivers/i2c/i2c_npcm4xx.c b/drivers/i2c/i2c_npcm4xx.c
+index b2e71c102dbb..7ce5967d599c 100755
+--- a/drivers/i2c/i2c_npcm4xx.c
++++ b/drivers/i2c/i2c_npcm4xx.c
+@@ -9,6 +9,7 @@
+ #include <drivers/clock_control.h>
+ #include <dt-bindings/i2c/i2c.h>
+ #include <drivers/i2c.h>
++#include "drivers/i2c_npcm4xx.h"
+ #include <soc.h>
+ 
+ #include <logging/log.h>
+@@ -109,6 +110,47 @@ struct i2c_npcm4xx_data {
+ 
+ int i2c_npcm4xx_recover_bus(const struct device *dev);
+ 
++bool is_i2c_device_master_status_idle(const struct device *dev)
++{
++	if (dev == NULL) {
++		LOG_ERR("%s dev null", __func__);
++		return false;
++	}
++
++	struct i2c_npcm4xx_data *const data = I2C_DRV_DATA(dev);
++
++	return (data->master_oper_state == I2C_NPCM4XX_OPER_STA_IDLE);
++}
++
++int i2c_device_disable(const struct device *dev)
++{
++	int loop, loop_limit = 30;
++
++	if (dev == NULL) {
++		LOG_ERR("%s dev null", __func__);
++		return -EBUSY;
++	}
++
++	struct i2c_npcm4xx_data *const data = I2C_DRV_DATA(dev);
++	struct i2c_reg *const inst = I2C_INSTANCE(dev);
++
++	for (loop = 0; loop < loop_limit; loop ++) {
++		if (data->master_oper_state != I2C_NPCM4XX_OPER_STA_IDLE) {
++			k_busy_wait(1000);
++		} else {
++			inst->SMBnCTL2 &= ~BIT(NPCM4XX_SMBnCTL2_ENABLE);
++			break;
++		}
++	}
++
++	if (loop >= loop_limit) {
++		LOG_ERR("%s dev still busy!", __func__);
++		return -EBUSY;
++	}
++
++	return 0;
++}
++
+ /* This macro should be set only when in Master mode or when requesting Master mode.
+  * Set START bit to CTL1 register of I2C module, but exclude STOP bit, ACK bit.
+  */
+diff --git a/include/drivers/i2c_npcm4xx.h b/include/drivers/i2c_npcm4xx.h
+new file mode 100644
+index 000000000000..5d495374644a
+--- /dev/null
++++ b/include/drivers/i2c_npcm4xx.h
+@@ -0,0 +1,14 @@
++/*
++ * Copyright (c) 2024 Nuvoton Technology Corporation.
++ *
++ * SPDX-License-Identifier: Apache-2.0
++ */
++
++#ifndef ZEPHYR_INCLUDE_DRIVERS_I2C_NPCM4XX_H_
++#define ZEPHYR_INCLUDE_DRIVERS_I2C_NPCM4XX_H_
++
++
++bool is_i2c_device_master_status_idle(const struct device *dev);
++int i2c_device_disable(const struct device *dev);
++
++#endif
+-- 
+2.17.1
+

--- a/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0027-drivers-i2c-auto-recover-when-i2c-single-master-bus-.patch
+++ b/fix_patch/nuvoton_tag_v2.6.0.0_cad6d72381ce408c40867f41a8741dba16e50bdf/0027-drivers-i2c-auto-recover-when-i2c-single-master-bus-.patch
@@ -1,0 +1,82 @@
+From dba7751300759ec46a4569019154f0a5f363cb09 Mon Sep 17 00:00:00 2001
+From: Tyrone Ting <kfting@nuvoton.com>
+Date: Tue, 19 Aug 2025 14:41:17 +0800
+Subject: [PATCH] drivers: i2c: auto recover when i2c single-master bus is busy
+
+To enable multi-master mode, add "multi-master = <1>;" in the i2c node(s)
+of the dts or overlay file.
+
+In multi-master mode, the i2c bus doesn't do auto-recovery when
+the bus is busy.
+
+For example:
+
+&i2c1a {
+       clock-frequency = <I2C_BITRATE_STANDARD>;
+       multi-master = <1>;
+       status = "okay";
+};
+
+Signed-off-by: Tyrone Ting <kfting@nuvoton.com>
+---
+ drivers/i2c/i2c_npcm4xx.c                 | 16 +++++++++++++---
+ dts/bindings/i2c/nuvoton,npcm4xx-i2c.yaml |  5 +++++
+ 2 files changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/i2c/i2c_npcm4xx.c b/drivers/i2c/i2c_npcm4xx.c
+index 575dee1d0b55..2ea58a1ba9b5 100755
+--- a/drivers/i2c/i2c_npcm4xx.c
++++ b/drivers/i2c/i2c_npcm4xx.c
+@@ -76,6 +76,7 @@ struct i2c_npcm4xx_config {
+ 	uint32_t wait_free_time;
+ 	uint32_t scllt;
+ 	uint32_t sclht;
++	uint8_t multi_master;
+ };
+ 
+ /*rx_buf and tx_buf address must 4-align for DMA */
+@@ -1134,9 +1135,17 @@ static int i2c_npcm4xx_transfer(const struct device *dev, struct i2c_msg *msgs,
+ 	}
+ 
+ 	if (bus_busy) {
+-		inst->SMBnCST |= BIT(NPCM4XX_SMBnCST_BB);
+-		i2c_npcm4xx_mutex_unlock(dev);
+-		return -EAGAIN;
++		if (!config->multi_master) {
++			ret = i2c_npcm4xx_recover_bus(dev);
++			if (ret) {
++				i2c_npcm4xx_mutex_unlock(dev);
++				return ret;
++			}
++		} else {
++			inst->SMBnCST |= BIT(NPCM4XX_SMBnCST_BB);
++			i2c_npcm4xx_mutex_unlock(dev);
++			return -EAGAIN;
++		}
+ 	}
+ 
+ 	/* prepare data to transfer */
+@@ -1251,6 +1260,7 @@ static const struct i2c_driver_api i2c_npcm4xx_driver_api = {
+ 				  0),	 		                         \
+ 		.sclht = DT_INST_PROP_OR(inst, sclht,		                 \
+ 				  0),	 		                         \
++		.multi_master = DT_INST_PROP_OR(inst, multi_master, 0),          \
+ 	};									 \
+ 										 \
+ 	static struct i2c_npcm4xx_data i2c_npcm4xx_data_##inst;			 \
+diff --git a/dts/bindings/i2c/nuvoton,npcm4xx-i2c.yaml b/dts/bindings/i2c/nuvoton,npcm4xx-i2c.yaml
+index ba8faac2edcf..680c08cba8f8 100644
+--- a/dts/bindings/i2c/nuvoton,npcm4xx-i2c.yaml
++++ b/dts/bindings/i2c/nuvoton,npcm4xx-i2c.yaml
+@@ -26,3 +26,8 @@ properties:
+         type: int
+         required: false
+         description: value from 5 to 255
++    multi-master:
++        type: int
++        required: false
++        description: |
++            i2c multi-master support. Default value is disabled.
+-- 
+2.17.1
+

--- a/meta-facebook/minerva-ag/boards/npcm400f_evb.overlay
+++ b/meta-facebook/minerva-ag/boards/npcm400f_evb.overlay
@@ -38,6 +38,7 @@
 	clock-frequency = <I2C_BITRATE_STANDARD>;
     wait_free_time = <1000>;
 	status = "okay";
+    multi-master = <1>;
 };
 
 &i2c5a {

--- a/meta-facebook/minerva-ag/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_pldm_fw_update.c
@@ -38,6 +38,7 @@
 #include "mp29816a.h"
 #include "plat_hook.h"
 #include "plat_event.h"
+#include "drivers/i2c_npcm4xx.h"
 
 LOG_MODULE_REGISTER(plat_fwupdate);
 
@@ -667,4 +668,31 @@ int get_aegis_vr_compnt_mapping_sensor_table_count(void)
 	int count = 0;
 	count = ARRAY_SIZE(aegis_vr_compnt_mapping_sensor_table);
 	return count;
+}
+
+void plat_reset_prepare()
+{
+	const char *i2c_labels[] = { "I2C_0", "I2C_1", "I2C_2", "I2C_3",
+				     "I2C_4", "I2C_5", "I2C_6", "I2C_11" };
+
+	for (int i = 0; i < ARRAY_SIZE(i2c_labels); i++) {
+		const struct device *i2c_dev = device_get_binding(i2c_labels[i]);
+		if (!i2c_dev) {
+			LOG_ERR("Failed to get binding for %s", i2c_labels[i]);
+			continue;
+		}
+
+		int ret = i2c_device_disable(i2c_dev);
+		if (ret) {
+			LOG_ERR("Failed to disable %s (ret=%d)", i2c_labels[i], ret);
+		} else {
+			LOG_INF("%s disabled", i2c_labels[i]);
+		}
+	}
+}
+
+void pal_warm_reset_prepare()
+{
+	LOG_INF("cmd platform warm reset prepare");
+	plat_reset_prepare();
 }

--- a/meta-facebook/minerva-ag/src/shell/plat_reboot.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_reboot.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <shell/shell.h>
+#include <zephyr.h>
+#include <stdio.h>
+#include <zephyr.h>
+#include "util_sys.h"
+#include "plat_pldm_sensor.h"
+
+#define PLAT_WAIT_SENSOR_POLLING_END_DELAY_MS 1000 
+
+void cmd_plat_reboot(struct shell *shell, size_t argc, char **argv)
+{
+	set_plat_sensor_polling_enable_flag(false);
+	k_msleep(PLAT_WAIT_SENSOR_POLLING_END_DELAY_MS);
+	submit_bic_warm_reset();
+}
+
+SHELL_CMD_REGISTER(reboot, NULL, "reboot command", cmd_plat_reboot);


### PR DESCRIPTION
Summary:
- Support reboot cli command and support i2c disable before reset
- Set I2C_3 mult-master
- patch: drivers: i2c: recovery in driver init
- patch: drivers: i2c: add i2c interface support
- patch: drivers: i2c: auto recover when i2c single-master bus is busy

Test Plan:
- Build code: PASS