### PR TITLE
fby4: wf: Modify power control retry times

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
@@ -399,7 +399,7 @@ int check_powers_enabled(int cxl_id, int pwr_stage)
 
 bool is_power_controlled(int cxl_id, int power_pin, uint8_t check_power_status, char *power_name)
 {
-	int retry_times = 5, i = 0;
+	int retry_times = 50, i = 0;
 	for (i = 0; i < retry_times; i++) {
 		k_msleep(CHK_PWR_DELAY_MSEC);
 		// Get power good pin to check power


### PR DESCRIPTION
# [Issue Description]
- JIRA-2104
- Per EE requirement, the WF-controlled power sequence must account for the 12V eFuse’s ~30 ms startup time; insufficient wait may cause premature Power Good checks, leading to false failures or sequence errors.

# [Root Cause]
- According to the EE assessment, components have different power-up times, with the 12V eFuse being the longest (~30 ms). The current flow lacked a sufficient buffer and did not fully meet EE timing requirements.

# [Solution]
- Based on the EE team's request, in the WF-controlled power sequence, the longest component is the 12V eFuse, which takes 30 ms. Considering a small buffer, we have set the maximum time from Power Enable to Power Good check to 50 ms.