### PR TITLE
minerva-ag: Stop cpld polling while doing update

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_event.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_event.c
@@ -481,6 +481,10 @@ void poll_cpld_registers()
 		/* Sleep for the polling interval */
 		k_msleep(CPLD_POLLING_INTERVAL_MS);
 
+		if (is_update_state_idle() == false) {
+			continue;
+		}
+
 		LOG_DBG("cpld_polling_alert_status = %d, cpld_polling_enable_flag = %d",
 			cpld_polling_alert_status, cpld_polling_enable_flag);
 


### PR DESCRIPTION
Summary:
- Stop cpld polling while doing update
- Prevent vr access while updating VR
- MPS VR MP29816C PW GD drops during update, causing the event trigger and MMC access VR to get information, leading to the VR FW crush

Test Plan:
- Build code: Pass