### PR TITLE
fby35: cl: adjust i2c frequency

### DIFF
--- a/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv35-cl/boards/ast1030_evb.overlay
@@ -99,7 +99,7 @@
 
 &i2c8 {
 	pinctrl-0 = <&pinctrl_i2c8_default>;
-	clock-frequency = <I2C_BITRATE_FAST_PLUS>;
+	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
 
 	ipmb8: ipmb@20 {


### PR DESCRIPTION
# Description
Lower I2C frequency from 1M to 400K.

# Motivation
Lower the frequency for accessing HSM device.

# Test plan:
Verified by EE.