### PR TITLE
minerva-ag: Replace float with uint32_t in PDR threshold functions to avoid precision errors

### DIFF
--- a/common/service/sensor/pdr.c
+++ b/common/service/sensor/pdr.c
@@ -316,16 +316,18 @@ PDR_entity_auxiliary_names *get_entity_auxiliary_names_table()
 	return entity_auxiliary_names_table;
 }
 
-int change_pdr_table_critical_high_with_sensor_id(uint32_t sensorID, float critical_high)
+int change_pdr_table_critical_high_with_sensor_id(uint32_t sensorID, uint32_t critical_high)
 {
 	uint32_t numeric_sensor_pdr_count = 0;
 	numeric_sensor_pdr_count = plat_get_pdr_size(PLDM_NUMERIC_SENSOR_PDR);
 
 	for (int i = 0; i < numeric_sensor_pdr_count; i++) {
 		if (numeric_sensor_table[i].sensor_id == sensorID) {
-			critical_high =
-				critical_high * power(10, -numeric_sensor_table[i].unit_modifier);
 			numeric_sensor_table[i].critical_high = (int32_t)critical_high;
+
+			LOG_DBG("SET critical_high - sensorID: 0x%x, unit_modifier: %d, critical_high stored: %d",
+				sensorID, numeric_sensor_table[i].unit_modifier,
+				numeric_sensor_table[i].critical_high);
 			return 0;
 		}
 	}
@@ -333,16 +335,18 @@ int change_pdr_table_critical_high_with_sensor_id(uint32_t sensorID, float criti
 	return -1;
 }
 
-int change_pdr_table_critical_low_with_sensor_id(uint32_t sensorID, float critical_low)
+int change_pdr_table_critical_low_with_sensor_id(uint32_t sensorID, uint32_t critical_low)
 {
 	uint32_t numeric_sensor_pdr_count = 0;
 	numeric_sensor_pdr_count = plat_get_pdr_size(PLDM_NUMERIC_SENSOR_PDR);
 
 	for (int i = 0; i < numeric_sensor_pdr_count; i++) {
 		if (numeric_sensor_table[i].sensor_id == sensorID) {
-			critical_low =
-				critical_low * power(10, -numeric_sensor_table[i].unit_modifier);
 			numeric_sensor_table[i].critical_low = (int32_t)critical_low;
+
+			LOG_DBG("SET critical_low - sensorID: 0x%x, unit_modifier: %d, critical_low stored: %d",
+				sensorID, numeric_sensor_table[i].unit_modifier,
+				numeric_sensor_table[i].critical_low);
 			return 0;
 		}
 	}
@@ -356,12 +360,21 @@ int get_pdr_table_critical_high_and_low_with_sensor_id(uint32_t sensorID, float 
 	uint32_t numeric_sensor_pdr_count = 0;
 	numeric_sensor_pdr_count = plat_get_pdr_size(PLDM_NUMERIC_SENSOR_PDR);
 
+	int32_t data_high = 0, data_low = 0;
+
 	for (int i = 0; i < numeric_sensor_pdr_count; i++) {
 		if (numeric_sensor_table[i].sensor_id == sensorID) {
 			*critical_high = numeric_sensor_table[i].critical_high *
 					 power(10, numeric_sensor_table[i].unit_modifier);
 			*critical_low = numeric_sensor_table[i].critical_low *
 					power(10, numeric_sensor_table[i].unit_modifier);
+
+			data_high = numeric_sensor_table[i].critical_high;
+			data_low = numeric_sensor_table[i].critical_low;
+
+			LOG_DBG("sensorID: 0x%x, data_high: %d, data_low: %d", sensorID, data_high,
+				data_low);
+
 			return 0;
 		}
 	}

--- a/common/service/sensor/pdr.h
+++ b/common/service/sensor/pdr.h
@@ -160,8 +160,8 @@ void plat_init_entity_aux_names_pdr_table();
 uint16_t plat_get_pdr_entity_aux_names_size();
 uint16_t plat_get_disabled_sensor_count();
 PDR_entity_auxiliary_names *get_entity_auxiliary_names_table();
-int change_pdr_table_critical_high_with_sensor_id(uint32_t sensorID, float critical_high);
-int change_pdr_table_critical_low_with_sensor_id(uint32_t sensorID, float critical_low);
+int change_pdr_table_critical_high_with_sensor_id(uint32_t sensorID, uint32_t critical_high);
+int change_pdr_table_critical_low_with_sensor_id(uint32_t sensorID, uint32_t critical_low);
 int get_pdr_table_critical_high_and_low_with_sensor_id(uint32_t sensorID, float *critical_high,
 						       float *critical_low);
 int check_supported_threshold_with_sensor_id(uint32_t sensorID);

--- a/meta-facebook/minerva-ag/src/shell/sensor_threshold_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/sensor_threshold_shell.c
@@ -50,12 +50,11 @@ void cmd_set_sensor_threshold(const struct shell *shell, size_t argc, char **arg
 
 	char threshold_type[4] = { 0 };
 	int value = 0;
-	float threshold_value = 0;
+	uint32_t threshold_value = 0;
 
 	snprintf(threshold_type, sizeof(threshold_type), "%s", argv[2]);
 	value = strtol(argv[3], NULL, 10);
-	threshold_value = (float)value *
-			  MINERVA_THRESHOLD_UNIT; // If user want to send 3.3V, "value" will be 3300
+	threshold_value = (uint32_t)value; // Direct integer value
 
 	if (strcmp(threshold_type, "UCT") == 0) {
 		result = change_pdr_table_critical_high_with_sensor_id(sensorID, threshold_value);


### PR DESCRIPTION
Summary:
- Replace float with uint32_t in PDR threshold functions to avoid precision errors

Test Plan:
- Build code: Pass