### PR TITLE
minerva-ag: Added and enhanced power_capping CLI command with support for set perm/default options, and auto-reset of HC/LC flags when the switch status changes

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_hook.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_hook.h
@@ -22,6 +22,10 @@
 #define VR_MAX_NUM 11
 #define VR_MUTEX_LOCK_TIMEOUT_MS 1000
 #define POWER_HISTORY_SIZE 10
+#define POWER_CAPPING_HC_DEFAULT 1000
+#define POWER_CAPPING_LC_DEFAULT 800
+#define POWER_CAPPING_ENABLE 1
+#define POWER_CAPPING_DISABLE 0
 
 #include "plat_pldm_sensor.h"
 
@@ -164,12 +168,14 @@ enum POWER_CAPPING_INDEX_E {
 	POWER_CAPPING_INDEX_HC = 0,
 	POWER_CAPPING_INDEX_LC,
 	POWER_CAPPING_INDEX_INTERVAL,
+	POWER_CAPPING_INDEX_SWITCH,
 	POWER_CAPPING_INDEX_MAX,
 };
 
 typedef struct power_capping_mapping_sensor {
 	uint8_t index;
 	uint8_t *sensor_name;
+	uint16_t change_setting_value;
 } power_capping_mapping_sensor;
 
 typedef struct power_capping_user_settings_struct {
@@ -349,6 +355,7 @@ bool get_average_power(uint8_t rail, uint32_t *milliwatt);
 bool voltage_command_setting_get(uint8_t rail, uint16_t *vout);
 bool power_capping_rail_name_get(uint8_t rail, uint8_t **name);
 bool power_capping_rail_enum_get(uint8_t *name, uint8_t *num);
-bool plat_set_power_capping_command(uint8_t rail, uint16_t *set_value);
+bool plat_set_power_capping_command(uint8_t rail, uint16_t *set_value, bool is_perm);
+bool plat_get_power_capping_command(uint8_t rail, uint16_t *set_value);
 
 #endif

--- a/meta-facebook/minerva-ag/src/platform/plat_i2c_target.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_i2c_target.c
@@ -267,8 +267,8 @@ void set_power_capping_handler(struct k_work *work_item)
 
 	uint16_t set_value_HC = sensor_data->set_value_HC;
 	uint16_t set_value_LC = sensor_data->set_value_LC;
-	plat_set_power_capping_command(POWER_CAPPING_INDEX_HC, &set_value_HC);
-	plat_set_power_capping_command(POWER_CAPPING_INDEX_LC, &set_value_LC);
+	plat_set_power_capping_command(POWER_CAPPING_INDEX_HC, &set_value_HC, false);
+	plat_set_power_capping_command(POWER_CAPPING_INDEX_LC, &set_value_LC, false);
 	// LOG_DBG("Power capping set HC: %d, LC: %d", set_value_HC, set_value_LC);
 }
 

--- a/meta-facebook/minerva-ag/src/shell/plat_perm_config_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_perm_config_shell.c
@@ -133,8 +133,16 @@ static int cmd_perm_config_get(const struct shell *shell, size_t argc, char **ar
 				LOG_ERR("Can't find power_capping_rail_name by rail index: %x", i);
 				continue;
 			}
-			shell_print(shell, "[%2d]%-50s val=%d", i, rail_name,
-				    power_capping_user_settings.user_setting_value[i]);
+			if (i == POWER_CAPPING_INDEX_SWITCH) {
+				shell_print(shell, "[%2d]%-50s val=%s", i, rail_name,
+					    power_capping_user_settings.user_setting_value[i] ?
+						    "enable" :
+						    "disable");
+				config_count++;
+			} else {
+				shell_print(shell, "[%2d]%-50s val=%d", i, rail_name,
+					    power_capping_user_settings.user_setting_value[i]);
+			}
 			config_count++;
 		}
 	}

--- a/meta-facebook/minerva-ag/src/shell/plat_power_capping_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_power_capping_shell.c
@@ -24,91 +24,183 @@
 
 LOG_MODULE_REGISTER(plat_power_capping_shell, LOG_LEVEL_DBG);
 
+static bool validate_power_capping_cmd(int argc, char **argv)
+{
+	if (argc < 3)
+		return false;
+
+	if (strcmp(argv[0], "set") != 0)
+		return false;
+
+	if (strcmp(argv[1], "HC_LC") == 0) {
+		// set HC_LC <HC_value|default> <LC_value|default> [perm]
+		if (argc != 4 && argc != 5)
+			return false;
+		if (argc == 5 && strcmp(argv[4], "perm") != 0)
+			return false;
+		return true;
+
+	} else if (strcmp(argv[1], "interval_ms") == 0) {
+		// set interval_ms <value|default> [perm]
+		if (argc != 3 && argc != 4)
+			return false;
+		if (argc == 4 && strcmp(argv[3], "perm") != 0)
+			return false;
+		return true;
+
+	} else if (strcmp(argv[1], "switch") == 0) {
+		// set switch <enable|disable|default> [perm]
+		if (argc != 3 && argc != 4)
+			return false;
+		if (strcmp(argv[2], "enable") != 0 && strcmp(argv[2], "disable") != 0 &&
+		    strcmp(argv[2], "default") != 0)
+			return false;
+		if (argc == 4 && strcmp(argv[3], "perm") != 0)
+			return false;
+		return true;
+	}
+
+	return false;
+}
+
 void cmd_power_capping_get(const struct shell *shell, size_t argc, char **argv)
 {
 	for (int i = 0; i < POWER_CAPPING_INDEX_MAX; i++) {
 		uint8_t *rail_name = NULL;
+		uint16_t value = 0;
 		if (!power_capping_rail_name_get((uint8_t)i, &rail_name)) {
 			shell_print(shell, "Can't find power_capping_rail_name by rail index: %d",
 				    i);
 			continue;
 		}
 
-		if (power_capping_user_settings.user_setting_value[i] == 0xffff) {
-			shell_print(shell, "%4d|%-50s|not set", i, rail_name);
+		if (!plat_get_power_capping_command((uint8_t)i, &value)) {
+			shell_print(shell, "Can't get value by rail index: %d", i);
+			continue;
+		}
+
+		if (i == POWER_CAPPING_INDEX_SWITCH) {
+			shell_print(shell, "%4d|%-50s|%s", i, rail_name,
+				    value ? "enable" : "disable");
 		} else {
-			shell_print(shell, "%4d|%-50s|%4d", i, rail_name,
-				    power_capping_user_settings.user_setting_value[i]);
+			shell_print(shell, "%4d|%-50s|%4d", i, rail_name, value);
 		}
 	}
 }
 
 int cmd_power_capping_set(const struct shell *shell, size_t argc, char **argv)
 {
-	if (argc == 4) {
-		if (!strcmp(argv[1], "HC_LC")) {
-			uint16_t set_value_HC = strtol(argv[2], NULL, 10);
-			uint16_t set_value_LC = strtol(argv[3], NULL, 10);
-			if (!plat_set_power_capping_command(POWER_CAPPING_INDEX_HC,
-							    &set_value_HC)) {
-				shell_error(shell, "Can't set value by rail index: %d",
-					    POWER_CAPPING_INDEX_HC);
-				return -1;
-			}
-			if (!plat_set_power_capping_command(POWER_CAPPING_INDEX_LC,
-							    &set_value_LC)) {
-				shell_error(shell, "Can't set value by rail index: %d",
-					    POWER_CAPPING_INDEX_LC);
-				return -1;
-			}
-			shell_print(shell, "set HC value: %d, LC value: %d successfully",
-				    set_value_HC, set_value_LC);
-		} else {
-			shell_error(shell, "only support HC_LC");
-			return -1;
-		}
-	} else if (argc == 3) {
-		if (!strcmp(argv[1], "interval_ms")) {
-			long interval_val = strtol(argv[2], NULL, 10);
-			if (interval_val < ATH_VDD_INTERVAL_MS) {
-				shell_error(
-					shell,
-					"The interval_ms value is smaller than the ATH_VDD polling interval_ms, which is %d ms",
-					ATH_VDD_INTERVAL_MS);
-				return -1;
-			}
-			if (interval_val > 0xFFFF) {
-				shell_error(shell, "The interval_ms value is too large (max %d)",
-					    0xFFFF);
-				return -1;
-			}
+	if (!validate_power_capping_cmd(argc, argv)) {
+		shell_error(shell, "Invalid command format. Allowed formats:\n"
+				   "  set HC_LC <HC_value|default> <LC_value|default> [perm]\n"
+				   "  set interval_ms <value|default> [perm]\n"
+				   "  set switch <enable|disable|default> [perm]");
+		return -EINVAL;
+	}
 
-			uint16_t set_value = (uint16_t)interval_val;
-			if (!plat_set_power_capping_command(POWER_CAPPING_INDEX_INTERVAL,
-							    &set_value)) {
-				shell_error(shell, "Can't set value by rail index: %d",
-					    POWER_CAPPING_INDEX_INTERVAL);
-				return -1;
-			}
-			shell_print(shell, "set interval_ms value: %d successfully", set_value);
-		} else {
-			shell_error(shell, "only support interval_ms");
+	bool is_perm = false;
+
+	if (strcmp(argv[1], "HC_LC") == 0) {
+		uint16_t set_value_HC = strtol(argv[2], NULL, 10);
+		uint16_t set_value_LC = strtol(argv[3], NULL, 10);
+		if (!strcmp(argv[4], "perm")) {
+			is_perm = true;
+		}
+		if (!strcmp(argv[2], "default")) {
+			set_value_HC = POWER_CAPPING_HC_DEFAULT;
+		}
+		if (!strcmp(argv[3], "default")) {
+			set_value_LC = POWER_CAPPING_LC_DEFAULT;
+		}
+		if (!plat_set_power_capping_command(POWER_CAPPING_INDEX_HC, &set_value_HC,
+						    is_perm)) {
+			shell_error(shell, "Can't set value by rail index: %d",
+				    POWER_CAPPING_INDEX_HC);
 			return -1;
 		}
+		if (!plat_set_power_capping_command(POWER_CAPPING_INDEX_LC, &set_value_LC,
+						    is_perm)) {
+			shell_error(shell, "Can't set value by rail index: %d",
+				    POWER_CAPPING_INDEX_LC);
+			return -1;
+		}
+		shell_info(shell, "Set %s HC:%d, LC:%d ,%svolatile\n", argv[1], set_value_HC,
+			   set_value_LC, (argc == 5) ? "non-" : "");
+	} else if (strcmp(argv[1], "interval_ms") == 0) {
+		long interval_val = strtol(argv[2], NULL, 10);
+		if (!strcmp(argv[3], "perm")) {
+			is_perm = true;
+		}
+		if (!strcmp(argv[2], "default")) {
+			interval_val = ATH_VDD_INTERVAL_MS;
+		}
+		if (interval_val < ATH_VDD_INTERVAL_MS) {
+			shell_error(
+				shell,
+				"The interval_ms value is smaller than the ATH_VDD polling interval_ms, which is %d ms",
+				ATH_VDD_INTERVAL_MS);
+			return -1;
+		}
+		if (interval_val > 0xFFFF) {
+			shell_error(shell, "The interval_ms value is too large (max %d)", 0xFFFF);
+			return -1;
+		}
+
+		uint16_t set_value = (uint16_t)interval_val;
+		if (!plat_set_power_capping_command(POWER_CAPPING_INDEX_INTERVAL, &set_value,
+						    is_perm)) {
+			shell_error(shell, "Can't set value by rail index: %d",
+				    POWER_CAPPING_INDEX_INTERVAL);
+			return -1;
+		}
+		shell_info(shell, "Set %s:%d, %svolatile\n", argv[1], interval_val,
+			   (argc == 4) ? "non-" : "");
+	} else if (strcmp(argv[1], "switch") == 0) {
+		bool enable = strcmp(argv[2], "enable") == 0;
+		if (!strcmp(argv[3], "perm")) {
+			is_perm = true;
+		}
+		if (!strcmp(argv[2], "default")) {
+			enable = POWER_CAPPING_DISABLE;
+		}
+		if (enable) {
+			uint16_t set_value = POWER_CAPPING_ENABLE;
+			if (!plat_set_power_capping_command(POWER_CAPPING_INDEX_SWITCH, &set_value,
+							    is_perm)) {
+				shell_error(shell, "Can't set value by rail index: %d",
+					    POWER_CAPPING_INDEX_SWITCH);
+				return -1;
+			}
+		} else {
+			uint16_t set_value = POWER_CAPPING_DISABLE;
+			if (!plat_set_power_capping_command(POWER_CAPPING_INDEX_SWITCH, &set_value,
+							    is_perm)) {
+				shell_error(shell, "Can't set value by rail index: %d",
+					    POWER_CAPPING_INDEX_SWITCH);
+				return -1;
+			}
+		}
+		shell_info(shell, "Set %s:%s, %svolatile\n", argv[1],
+			   (enable ? "enable" : "disable"), (argc == 4) ? "non-" : "");
 	}
 
 	return 0;
 }
 
 static const struct shell_static_entry power_capping_name_entries[] = {
-	{ .syntax = "interval_ms",
-	  .handler = NULL,
-	  .subcmd = NULL,
-	  .help = "set interval_ms <interval_value>" },
 	{ .syntax = "HC_LC",
 	  .handler = NULL,
 	  .subcmd = NULL,
-	  .help = "set HC_LC <HC_value> <LC_value>" },
+	  .help = "set HC_LC <HC_value|default> <LC_value|default> [perm]" },
+	{ .syntax = "interval_ms",
+	  .handler = NULL,
+	  .subcmd = NULL,
+	  .help = "set interval_ms <interval_value|default> [perm]" },
+	{ .syntax = "switch",
+	  .handler = NULL,
+	  .subcmd = NULL,
+	  .help = "set switch <enable|disable|default> [perm]" },
+
 };
 
 static void power_capping_rname_get(size_t idx, struct shell_static_entry *entry)
@@ -122,17 +214,20 @@ static void power_capping_rname_get(size_t idx, struct shell_static_entry *entry
 
 SHELL_DYNAMIC_CMD_CREATE(power_capping_rname, power_capping_rname_get);
 
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_voltage_get_cmds,
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_power_capping_get_cmds,
 			       SHELL_CMD(all, NULL, "get power capping all setting",
 					 cmd_power_capping_get),
 			       SHELL_SUBCMD_SET_END);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_power_capping_cmds,
-	SHELL_CMD(get, &sub_voltage_get_cmds, "get power capping all ", NULL),
-	SHELL_CMD_ARG(set, &power_capping_rname,
-		      "set <interval_ms|HC_LC> <interval_value|HC_value> <LC_value>",
-		      cmd_power_capping_set, 3, 1),
+	SHELL_CMD(get, &sub_power_capping_get_cmds, "get power capping all ", NULL),
+	SHELL_CMD(set, &power_capping_rname,
+		  "Power capping control\n"
+		  "  set HC_LC <HC_value|default> <LC_value|default> [perm]\n"
+		  "  set interval_ms <value|default> [perm]\n"
+		  "  set switch <enable|disable|default> [perm]",
+		  cmd_power_capping_set),
 	SHELL_SUBCMD_SET_END);
 
 /* Root of command test */


### PR DESCRIPTION
Summary:
- Add power_capping CLI command to set/get switch
- Modify power_capping CLI command to set perm and default
- Add default values: HC = 1000, LC = 800, switch = disable
- Changed default behavior: comparison switch is disabled by default
- If change switch status, reset HC and LC enable flag

Test Plan:
- Build: PASS