### PR TITLE
fby4: wf: Fix unexpected Non-PMBus VR Fault events during power on

### DIFF
--- a/meta-facebook/yv4-wf/boards/ast1030_evb.overlay
+++ b/meta-facebook/yv4-wf/boards/ast1030_evb.overlay
@@ -202,6 +202,10 @@
 	reg = <0 DT_SIZE_K(708)>, <DT_SIZE_K(708) DT_SIZE_K(60)>;
 };
 
+&gpio0 {
+  aspeed,deb-interval-us = <1>;
+};
+
 &gpio0_a_d {
 	aspeed,persist-maps = <0x555554CF>;
 };

--- a/meta-facebook/yv4-wf/src/platform/plat_gpio.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_gpio.h
@@ -270,6 +270,12 @@ enum IOE_PIN_NUM {
 	IOE_P17 = 7,
 };
 
+typedef struct {
+	const char *port;
+	uint32_t pinOffset;
+	const char *netName;
+} gpio_debounce_cfg_t;
+
 int get_ioe_value(uint8_t ioe_addr, uint8_t ioe_reg, uint8_t *value);
 int set_ioe_value(uint8_t ioe_addr, uint8_t ioe_reg, uint8_t value);
 void init_ioe_config();


### PR DESCRIPTION
# [Description]
- Related to YV4T1M-2081
- Per EE requirement, add debounce to filter ns-level jitters for all Non-PMBus VR Fault signals
- Non-PMBus VR list: PVTT_AB_ASIC1/2, PVTT_CD_ASIC1/2, PVPP_AB_ASIC1/2, PVPP_CD_ASIC1/2, P12V_E1S_0, P3V3_E1S_0

# [Root Cause]
- Non-PMBus VR PWRGD pins were experiencing noise spikes during power ramp-up that caused unexpected SEL records.

# [Motivation]
- Related to YV4T1M-2081
- Ensure Non-PMBus VR signals shorter than 1μs are properly filtered out to prevent false triggers

# [Solution]
- Based on the EE team's request, set Debounce Timer Register to 1μs for all Non-PMBus VR PWRGD pins
- Add gpio_debounce_cfg_t structure for centralized debounce management

# [Test Plan]
- Build code: Pass
- Power cycling validation: Pass
- Signal integrity verification: Pass

# [Test Log]
- GPIO Debounce Control Register verification (44h / 4Ch):
  - bit=1: debounce timer enabled for corresponding GPIO pin
  - bit=0: debounce timer disabled for corresponding GPIO pin
```
uart:~$ md 7e780040 4
[7e780040] 00000000 aa000000 00000000 0008a8a0
```