### PR TITLE
minerva-ag: Modify blackbox print real timestamps

### DIFF
--- a/meta-facebook/minerva-ag/src/platform/plat_datetime.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_datetime.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <zephyr.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <logging/log.h>
+#include <sys/timeutil.h>
+#include "plat_datetime.h"
+#include "pldm_firmware_update.h"
+#include "mctp.h"
+#include "pldm.h"
+
+LOG_MODULE_REGISTER(plat_datetime);
+
+static struct tm base_tm;
+static int64_t base_uptime_ms;
+static bool rtc_synced;
+
+static void rtc_sync_work_handler(struct k_work *work);
+K_WORK_DEFINE(rtc_sync_work, rtc_sync_work_handler);
+
+static uint8_t bcd_to_dec(uint8_t bcd)
+{
+	return ((bcd >> 4) & 0x0F) * 10 + (bcd & 0x0F);
+}
+
+int get_datetime_from_bmc(struct tm *tm_now)
+{
+	if (!tm_now)
+		return -1;
+
+	const uint8_t eid = 0x08;
+	uint8_t resp_buf[PLDM_MAX_DATA_SIZE] = { 0 };
+	pldm_msg pmsg = {
+		.hdr = {
+			.msg_type = MCTP_MSG_TYPE_PLDM,
+			.pldm_type = 0x03,
+			.cmd = 0x0C,
+			.rq = PLDM_REQUEST,
+		},
+		.len = 0,
+		.buf = NULL,
+	};
+
+	mctp *mctp_inst;
+	if (!get_mctp_info_by_eid(eid, &mctp_inst, &pmsg.ext_params)) {
+		LOG_ERR("Failed to get mctp info by eid 0x%x", eid);
+		return -1;
+	}
+
+	uint16_t resp_len = mctp_pldm_read(mctp_inst, &pmsg, resp_buf, sizeof(resp_buf));
+	if (!resp_len || resp_buf[0] != 0) {
+		LOG_WRN("Failed to get valid MCTP-PLDM response");
+		return -1;
+	}
+
+	tm_now->tm_sec = bcd_to_dec(resp_buf[1]);
+	tm_now->tm_min = bcd_to_dec(resp_buf[2]);
+	tm_now->tm_hour = bcd_to_dec(resp_buf[3]);
+	tm_now->tm_mday = bcd_to_dec(resp_buf[4]);
+	tm_now->tm_mon = bcd_to_dec(resp_buf[5]) - 1;
+	tm_now->tm_year = bcd_to_dec(resp_buf[6]) + bcd_to_dec(resp_buf[7]) * 100 - 1900;
+	tm_now->tm_isdst = 0;
+
+	return 0;
+}
+
+static void rtc_sync_from_bmc(void)
+{
+	struct tm tm_now;
+	if (get_datetime_from_bmc(&tm_now) == 0) {
+		base_tm = tm_now;
+		base_uptime_ms = k_uptime_get();
+		rtc_synced = true;
+
+		LOG_DBG("RTC sync: %04d-%02d-%02d %02d:%02d:%02d", base_tm.tm_year + 1900,
+			base_tm.tm_mon + 1, base_tm.tm_mday, base_tm.tm_hour, base_tm.tm_min,
+			base_tm.tm_sec);
+	} else {
+		LOG_DBG("RTC sync failed, keep last base time");
+	}
+}
+
+static void rtc_sync_timer_handler(struct k_timer *timer_id)
+{
+	if (is_update_state_idle() == false) {
+		return;
+	}
+	k_work_submit(&rtc_sync_work);
+}
+
+K_TIMER_DEFINE(rtc_sync_timer, rtc_sync_timer_handler, NULL);
+
+static void rtc_sync_work_handler(struct k_work *work)
+{
+	rtc_sync_from_bmc();
+}
+
+void rtc_init_once(void)
+{
+	rtc_sync_from_bmc();
+	k_timer_start(&rtc_sync_timer, K_SECONDS(10), K_SECONDS(10));
+}
+
+time_t rtc_time(time_t *tloc)
+{
+	time_t now;
+
+	if (!rtc_synced) {
+		now = (time_t)(k_uptime_get() / 1000);
+	} else {
+		int64_t elapsed_s = (k_uptime_get() - base_uptime_ms) / 1000;
+		now = timeutil_timegm(&base_tm) + elapsed_s;
+	}
+
+	if (tloc)
+		*tloc = now;
+
+	return now;
+}
+
+void rtc_get_tm(struct tm *tm_now)
+{
+	time_t now = rtc_time(NULL);
+	if (tm_now)
+		*tm_now = *gmtime(&now);
+}

--- a/meta-facebook/minerva-ag/src/platform/plat_datetime.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_datetime.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_DATETIME_H
+#define PLAT_DATETIME_H
+
+#include <time.h>
+
+void rtc_init_once(void);
+void rtc_get_tm(struct tm *tm_now);
+
+#endif

--- a/meta-facebook/minerva-ag/src/platform/plat_init.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_init.c
@@ -37,6 +37,7 @@
 #include "plat_event.h"
 #include "plat_log.h"
 #include "plat_fru.h"
+#include "plat_datetime.h"
 
 LOG_MODULE_REGISTER(plat_init);
 
@@ -72,6 +73,7 @@ void pal_post_init()
 	pldm_load_state_effecter_table(MAX_STATE_EFFECTER_IDX);
 	pldm_assign_gpio_effecter_id(PLAT_EFFECTER_ID_GPIO_HIGH_BYTE);
 	init_fru_info();
+	rtc_init_once();
 	init_load_eeprom_log();
 	plat_set_ac_on_log();
 	init_cpld_polling();

--- a/meta-facebook/minerva-ag/src/platform/plat_log.c
+++ b/meta-facebook/minerva-ag/src/platform/plat_log.c
@@ -27,6 +27,7 @@
 #include "plat_hook.h"
 #include "plat_class.h"
 #include <pmbus.h>
+#include "plat_datetime.h"
 
 LOG_MODULE_REGISTER(plat_log);
 
@@ -383,7 +384,15 @@ void error_log_event(uint16_t error_code, bool log_status)
 
 	// Update log error code and timestamp
 	err_log_data[fru_count].err_code = error_code;
-	err_log_data[fru_count].sys_time = k_uptime_get();
+	struct tm tm_now;
+	rtc_get_tm(&tm_now);
+
+	err_log_data[fru_count].sys_datetime.year = tm_now.tm_year + 1900;
+	err_log_data[fru_count].sys_datetime.month = tm_now.tm_mon + 1;
+	err_log_data[fru_count].sys_datetime.day = tm_now.tm_mday;
+	err_log_data[fru_count].sys_datetime.hour = tm_now.tm_hour;
+	err_log_data[fru_count].sys_datetime.min = tm_now.tm_min;
+	err_log_data[fru_count].sys_datetime.sec = tm_now.tm_sec;
 
 	if (!get_error_data(error_code, err_log_data[fru_count].error_data)) {
 		// Clear error data if no valid data is found

--- a/meta-facebook/minerva-ag/src/platform/plat_log.h
+++ b/meta-facebook/minerva-ag/src/platform/plat_log.h
@@ -41,10 +41,20 @@ uint8_t plat_log_get_num(void);
 void reset_error_log_event(uint8_t err_type);
 bool vr_fault_get_error_data(uint8_t sensor_id, uint8_t device_id, uint8_t *data);
 
+struct rtc_datetime {
+	uint16_t year;
+	uint8_t month;
+	uint8_t day;
+	uint8_t hour;
+	uint8_t min;
+	uint8_t sec;
+	uint8_t _padding;
+};
+
 typedef struct __attribute__((packed)) _plat_err_log_mapping {
 	uint16_t index;
 	uint16_t err_code;
-	uint64_t sys_time;
+	struct rtc_datetime sys_datetime;
 	uint8_t error_data[20];
 	uint8_t cpld_dump[AEGIS_CPLD_REGISTER_MAX_NUM];
 } plat_err_log_mapping;

--- a/meta-facebook/minerva-ag/src/shell/log_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/log_shell.c
@@ -84,7 +84,9 @@ void cmd_log_dump(const struct shell *shell, size_t argc, char **argv)
 			break;
 		}
 
-		shell_print(shell, "sys_time: %lld ms", log.sys_time);
+		shell_print(shell, "sys_datetime: %04d-%02d-%02d %02d:%02d:%02d",
+			    log.sys_datetime.year, log.sys_datetime.month, log.sys_datetime.day,
+			    log.sys_datetime.hour, log.sys_datetime.min, log.sys_datetime.sec);
 		shell_print(shell, "error_data:");
 		shell_hexdump(shell, log.error_data, sizeof(log.error_data));
 		shell_print(shell, "cpld register: start offset 0x%02x",

--- a/meta-facebook/minerva-ag/src/shell/plat_shell.c
+++ b/meta-facebook/minerva-ag/src/shell/plat_shell.c
@@ -22,6 +22,8 @@
 #include "mctp.h"
 #include "pldm.h"
 #include "plat_aegis_power_control_shell.h"
+#include <time.h>
+#include "plat_datetime.h"
 
 void pldm_cmd(const struct shell *shell, size_t argc, char **argv)
 {
@@ -63,18 +65,27 @@ void pldm_cmd(const struct shell *shell, size_t argc, char **argv)
 	return;
 }
 
+void cmd_plat_get_datetime(const struct shell *shell, size_t argc, char **argv)
+{
+	struct tm tm_now;
+	rtc_get_tm(&tm_now);
+
+	shell_print(shell, "datetime: %04d-%02d-%02d %02d:%02d:%02d, epoch: %ld",
+		    tm_now.tm_year + 1900, tm_now.tm_mon + 1, tm_now.tm_mday, tm_now.tm_hour,
+		    tm_now.tm_min, tm_now.tm_sec);
+}
+
 /* Sub-command Level 1 of command test */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_test_cmds,
-			       SHELL_CMD(sensor, &sub_plat_sensor_polling_cmd,
-					 "set/get platform sensor polling command", NULL),
-			       SHELL_CMD(log, &sub_plat_log_cmd, "platform log command", NULL),
-			       SHELL_CMD(cpld, &sub_cpld_cmd, "cpld command", NULL),
-			       SHELL_CMD(get_fw_version, &sub_get_fw_version_cmd,
-					 "get fw version command", NULL),
-			       SHELL_CMD(pldm, NULL, "send pldm to bmc", pldm_cmd),
-			       SHELL_CMD(aegis_power, &sub_aegis_power_cmds, "aegis power commands",
-					 NULL),
-			       SHELL_SUBCMD_SET_END);
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_test_cmds,
+	SHELL_CMD(sensor, &sub_plat_sensor_polling_cmd, "set/get platform sensor polling command",
+		  NULL),
+	SHELL_CMD(log, &sub_plat_log_cmd, "platform log command", NULL),
+	SHELL_CMD(cpld, &sub_cpld_cmd, "cpld command", NULL),
+	SHELL_CMD(get_fw_version, &sub_get_fw_version_cmd, "get fw version command", NULL),
+	SHELL_CMD(pldm, NULL, "send pldm to bmc", pldm_cmd),
+	SHELL_CMD(aegis_power, &sub_aegis_power_cmds, "aegis power commands", NULL),
+	SHELL_CMD(get_datetime, NULL, "get datetime", cmd_plat_get_datetime), SHELL_SUBCMD_SET_END);
 
 /* Root of command test */
 SHELL_CMD_REGISTER(test, &sub_test_cmds, "Test commands for AG", NULL);


### PR DESCRIPTION
Summary:
- Modify blackbox print real timestamps
- every 10s sync from BMC
- if sync failed, keep last base time
- test get_datetime cli command

Test Plan:
- Build code: Pass