### PR TITLE
fby35: cl: init HSM sensor after HSM is ready

### DIFF
--- a/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
+++ b/meta-facebook/yv35-cl/src/ipmi/plat_ipmi.c
@@ -186,6 +186,11 @@ void OEM_1S_SET_CARD_TYPE(ipmi_msg *msg)
 		msg->completion_code = CC_SUCCESS;
 		set_2ou_card_type(msg->data[1]);
 		LOG_INF("Set HSM type to %u", msg->data[1]);
+		if (msg->data[1] == TYPE_2OU_MARVELL_HSM) {
+			if (common_tbl_sen_reinit(SENSOR_NUM_TEMP_DPV2_HSM)) {
+				LOG_ERR("Fail to reinit HSM sensor");
+			}
+		}
 		break;
 	default:
 		msg->completion_code = CC_INVALID_DATA_FIELD;


### PR DESCRIPTION
# Description
Init HSM sensor while BIC detect HSM.

# Motivation
Fix HSM sensor init.

# Test plan
1. Check HSM sensor is ready after 12V-cycle

DPV2_2_HSM_TEMP_C            (0x96) :  38.500 C     | (ok)