### PR TITLE
sb: sitv3: fix PCIe switch access index mismatch

### DIFF
--- a/meta-facebook/sb-si/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/sb-si/src/platform/plat_pldm_sensor.c
@@ -2635,15 +2635,8 @@ bool is_pcie_switch_access(uint8_t cfg_idx)
 {
 	I2C_MSG msg = { 0 };
 	uint8_t retry = 3;
-
-	uint8_t sensor_id = cfg_idx;
-	uint8_t bus = 0, addr = 0;
-	uint8_t sensor_dev = 0;
-
-	if (!get_sensor_info_by_sensor_id(sensor_id, &bus, &addr, &sensor_dev)) {
-		LOG_ERR("Can't find PCIe switch addr and bus by sensor id: %d", sensor_id);
-		return false;
-	}
+	uint8_t bus = plat_pldm_sensor_temp_table[cfg_idx].pldm_sensor_cfg.port;
+	uint8_t addr = plat_pldm_sensor_temp_table[cfg_idx].pldm_sensor_cfg.target_addr;
 
 	msg.bus = bus;
 	msg.target_addr = addr;

--- a/meta-facebook/sb-si/src/platform/plat_version.h
+++ b/meta-facebook/sb-si/src/platform/plat_version.h
@@ -37,7 +37,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x25
-#define BIC_FW_WEEK 0x39
+#define BIC_FW_WEEK 0x40
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x73 // char: s
 #define BIC_FW_platform_1 0x69 // char: i


### PR DESCRIPTION
Summery:
- Use plat_pldm_sensor_temp_table[cfg_idx] directly
- Fix 0-base vs 1-base mismatch in bus/address lookup
- Fixes: edb8cc671e085e3ec3104dfd97a8f552de09bd5c
- Version commit for 2025.40.01

Test Plan:
- Build: Pass
- Verified PEX90144 access check and polling