### PR TITLE
aalc: rpu: Update the fan table to version R07

### DIFF
--- a/meta-facebook/aalc-rpu/src/platform/plat_fsc_table.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_fsc_table.c
@@ -23,9 +23,9 @@
 pid_cfg hex_fan_pid_table[] = {
 	{
 		.sensor_num = SENSOR_NUM_BPB_RPU_COOLANT_OUTLET_TEMP_C,
-		.setpoint = 40.0,
+		.setpoint = 40,
 		.kp = -15,
-		.ki = -0.1,
+		.ki = -0.12,
 		.kd = -0.01,
 		.i_limit_min = 0,
 		.i_limit_max = 90,
@@ -51,15 +51,17 @@ stepwise_cfg hex_fan_stepwise_table[] = {
 	{
 		.sensor_num = SENSOR_NUM_BPB_RPU_COOLANT_OUTLET_TEMP_C,
 		.step = {
-			{34.0, 5},
-			{35.0, 8},
-			{36.0, 11},
-			{37.0, 14},
-			{38.0, 17},
-			{41.0, 20},
-			{41.2, 25},
-			{41.5, 35},
-			{42.0, 45},
+			{33.0, 5},
+			{34.0, 11},
+			{35.0, 13},
+			{36.0, 15},
+			{37.0, 17},
+			{38.0, 19},
+			{39.0, 21},
+			{40.0, 23},
+			{41.2, 23},
+			{41.5, 25},
+			{42.0, 27},
 		},
 	},
 };
@@ -67,7 +69,7 @@ stepwise_cfg hex_fan_stepwise_table[] = {
 pid_cfg pump_pid_table[] = {
 	{
 		.sensor_num = SENSOR_NUM_BPB_RPU_COOLANT_FLOW_RATE_LPM,
-		.setpoint = 40.0,
+		.setpoint = 40,
 		.kp = 0.5,
 		.ki = 0.03,
 		.kd = 0.01,

--- a/meta-facebook/aalc-rpu/src/platform/plat_modbus.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_modbus.c
@@ -352,13 +352,15 @@ uint8_t modbus_pump_setting(modbus_command_mapping *cmd)
 
 	if (cmd->data[0] == 9) // enable auto mode, reset p0p1 error flag
 	{
-		set_is_rack_level_abnormal(false);
-		set_is_rpu_level_abnormal(false);
-		set_is_press_abnormal(false);
 		set_is_hsc_hsc_fail(false);
+		//clean boolean status(pump not access)
 		set_is_pump_not_access(0, false);
 		set_is_pump_not_access(1, false);
 		set_is_pump_not_access(2, false);
+		//clean boolean status(fan not access)
+		for (uint8_t i = 0; i < 14; i++) {
+			set_is_fan_not_access(i, false);
+		}
 		// restore leak led
 		led_ctrl(LED_IDX_E_LEAK, LED_STOP_BLINK); // only stop blind behavior
 		led_ctrl(LED_IDX_E_LEAK, LED_TURN_OFF); // default led status(turn off)

--- a/meta-facebook/aalc-rpu/src/platform/plat_threshold.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_threshold.c
@@ -387,6 +387,19 @@ void fan_board_tach_status_handler(uint8_t sensor_num, uint8_t status)
 	}
 }
 
+static bool is_fan_not_access[14];
+;
+
+void set_is_fan_not_access(uint8_t index, bool flag)
+{
+	is_fan_not_access[index] = flag;
+}
+
+bool get_is_fan_not_access(uint8_t index)
+{
+	return is_fan_not_access[index];
+}
+
 void hex_fan_failure_do(uint32_t sensor_num, uint32_t status)
 {
 	fan_board_tach_status_handler(sensor_num, status);
@@ -397,6 +410,15 @@ void hex_fan_failure_do(uint32_t sensor_num, uint32_t status)
 
 	if (status == THRESHOLD_STATUS_LCR)
 		error_log_event(sensor_num, IS_ABNORMAL_VAL);
+
+	uint8_t fan_not_access_idx = sensor_num - SENSOR_NUM_FB_1_FAN_TACH_RPM;
+	if (status == THRESHOLD_STATUS_NOT_ACCESS) {
+		if (!get_is_fan_not_access(fan_not_access_idx)) {
+			error_log_event(sensor_num, IS_ABNORMAL_VAL);
+			set_is_fan_not_access(fan_not_access_idx, true);
+		}
+	} else
+		set_is_fan_not_access(fan_not_access_idx, false);
 }
 
 /* flow_rate_ready_flag is flag to wait flow rate ready*/
@@ -563,26 +585,11 @@ void abnormal_temp_do(uint32_t sensor_num, uint32_t status)
 	}
 }
 
-static bool is_rack_level_abnormal = false;
-
-void set_is_rack_level_abnormal(bool flag)
-{
-	is_rack_level_abnormal = flag;
-}
-
-bool get_is_rack_level_abnormal()
-{
-	return is_rack_level_abnormal;
-}
-
 void level_sensor_do(uint32_t unused, uint32_t status)
 {
 	if (get_threshold_status(SENSOR_NUM_BPB_RACK_LEVEL_2)) {
 		set_status_flag(STATUS_FLAG_FAILURE, PUMP_FAIL_LOW_LEVEL, 1);
-		if (!get_is_rack_level_abnormal()) {
-			set_is_rack_level_abnormal(true);
-			error_log_event(SENSOR_NUM_BPB_RACK_LEVEL_2, IS_ABNORMAL_VAL);
-		}
+		error_log_event(SENSOR_NUM_BPB_RACK_LEVEL_2, IS_ABNORMAL_VAL);
 		if (get_threshold_status(SENSOR_NUM_BPB_RACK_LEVEL_1))
 			led_ctrl(LED_IDX_E_COOLANT, LED_TURN_OFF);
 		else
@@ -596,18 +603,6 @@ void level_sensor_do(uint32_t unused, uint32_t status)
 	}
 }
 
-static bool is_rpu_level_abnormal = false;
-
-void set_is_rpu_level_abnormal(bool flag)
-{
-	is_rpu_level_abnormal = flag;
-}
-
-bool get_is_rpu_level_abnormal()
-{
-	return is_rpu_level_abnormal;
-}
-
 void rpu_level_sensor_do(uint32_t unused, uint32_t status)
 {
 	// EVT board does not have this level sensor
@@ -616,10 +611,7 @@ void rpu_level_sensor_do(uint32_t unused, uint32_t status)
 
 	if (get_threshold_status(SENSOR_NUM_BPB_RPU_LEVEL)) {
 		set_status_flag(STATUS_FLAG_FAILURE, PUMP_FAIL_LOW_RPU_LEVEL, 1);
-		if (!get_is_rpu_level_abnormal()) {
-			set_is_rpu_level_abnormal(true);
-			error_log_event(SENSOR_NUM_BPB_RACK_LEVEL_2, IS_ABNORMAL_VAL);
-		}
+		error_log_event(SENSOR_NUM_BPB_RACK_LEVEL_2, IS_ABNORMAL_VAL);
 	}
 }
 
@@ -764,18 +756,6 @@ sensor_threshold *find_threshold_tbl_entry(uint8_t sensor_num)
 	return NULL;
 }
 
-static bool is_press_abnormal = false;
-
-void set_is_press_abnormal(bool flag)
-{
-	is_press_abnormal = flag;
-}
-
-bool get_is_press_abnormal()
-{
-	return is_press_abnormal;
-}
-
 void abnormal_press_do(uint32_t thres_tbl_idx, uint32_t status)
 {
 	if (thres_tbl_idx >= ARRAY_SIZE(threshold_tbl))
@@ -788,11 +768,7 @@ void abnormal_press_do(uint32_t thres_tbl_idx, uint32_t status)
 					       &flow_rate_val);
 		if (flow_rate_val < 10.0) {
 			set_status_flag(STATUS_FLAG_FAILURE, PUMP_FAIL_ABNORMAL_PRESS, 1);
-			if (!get_is_press_abnormal()) {
-				set_is_press_abnormal(true);
-				error_log_event(SENSOR_NUM_BPB_RPU_COOLANT_OUTLET_P_KPA,
-						IS_ABNORMAL_VAL);
-			}
+			error_log_event(SENSOR_NUM_BPB_RPU_COOLANT_OUTLET_P_KPA, IS_ABNORMAL_VAL);
 		} else
 			thres_p->last_status = THRESHOLD_STATUS_NORMAL;
 	}
@@ -887,6 +863,9 @@ void pump_failure_do(uint32_t thres_tbl_idx, uint32_t status)
 		LOG_DBG("Unexpected threshold warning");
 		break;
 	}
+
+	if (status != THRESHOLD_STATUS_NOT_ACCESS)
+		set_is_pump_not_access(pump_not_access_idx, false);
 
 	pump_board_tach_status_handler(sensor_num, status);
 }

--- a/meta-facebook/aalc-rpu/src/platform/plat_threshold.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_threshold.h
@@ -58,14 +58,10 @@ bool hsc_fail_check();
 bool system_failure_recovery();
 bool check_rpu_ready();
 void pump_change_threshold(uint8_t sensor_num, uint8_t duty);
-void set_is_rack_level_abnormal(bool flag);
-bool get_is_rack_level_abnormal();
-void set_is_rpu_level_abnormal(bool flag);
-bool get_is_rpu_level_abnormal();
-void set_is_press_abnormal(bool flag);
-bool get_is_press_abnormal();
 void set_is_pump_not_access(uint8_t index, bool flag);
 bool get_is_pump_not_access(uint8_t index);
+void set_is_fan_not_access(uint8_t index, bool flag);
+bool get_is_fan_not_access(uint8_t index);
 void set_is_hsc_hsc_fail(bool flag);
 bool get_is_hsc_hsc_fail();
 

--- a/meta-facebook/aalc-rpu/src/platform/plat_version.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_version.h
@@ -48,6 +48,6 @@
 #define BIC_FW_platform_1 0x61 // char: a
 #define BIC_FW_platform_2 0x00 // char: '\0'
 
-#define FAN_TABLE_REVISION 6
+#define FAN_TABLE_REVISION 7
 
 #endif


### PR DESCRIPTION
Summary:
1. Update the fan table to version R07.
2. Support repeatedly record event for RPU outlet pressure & level sensors.
3. Support record hex fan event when cannot access RPM value

Test Plan:
Build code: Pass
