### PR TITLE
gc2-es: Add new config table for TI VR

### DIFF
--- a/meta-facebook/gc2-es/src/platform/plat_hook.c
+++ b/meta-facebook/gc2-es/src/platform/plat_hook.c
@@ -131,6 +131,12 @@ isl69259_pre_proc_arg isl69259_pre_read_args[] = {
 	[1] = { 0x1 },
 };
 
+/* TPS53689 page arguments: page 0 and page 1 */
+tps53689_pre_proc_arg tps53689_pre_read_args[] = {
+	[0] = { .vr_page = 0x0 },
+	[1] = { .vr_page = 0x1 },
+};
+
 vr_page_cfg xdpe15284_page[] = {
 	[0] = { .vr_page = PMBUS_PAGE_0 },
 	[1] = { .vr_page = PMBUS_PAGE_1 },
@@ -283,6 +289,43 @@ static inline xdpe_vr_state *get_xdpe_vr_state(uint8_t bus, uint8_t addr)
 	return NULL;
 }
 
+/* TPS53689 pre read function
+ *
+ * Sets the PMBus PAGE register before reading.
+ * TPS53689 uses the same page-switch mechanism as ISL69259:
+ * write register 0x00 with the desired page value.
+ * No mutex or write-protect setup is required.
+ *
+ * @param cfg   pointer to sensor_cfg (must not be NULL)
+ * @param args  pointer to tps53689_pre_proc_arg (must not be NULL)
+ * @retval true  if page is set successfully
+ * @retval false if I2C write fails
+ */
+bool pre_tps53689_read(sensor_cfg *cfg, void *args)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(args, false);
+
+	const tps53689_pre_proc_arg *pre_proc_args = (tps53689_pre_proc_arg *)args;
+	uint8_t retry = 5;
+	I2C_MSG msg;
+
+	/* Set PMBus PAGE (register 0x00) */
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 2;
+	msg.data[0] = 0x00; /* PAGE command */
+	msg.data[1] = pre_proc_args->vr_page;
+
+	if (i2c_master_write(&msg, retry)) {
+		LOG_ERR("pre_tps53689_read: set page 0x%x fail, sensor: 0x%x",
+			pre_proc_args->vr_page, cfg->num);
+		return false;
+	}
+
+	return true;
+}
+
 /* All WP initialization states reset after a 12V cycle (DC power off/on). */
 void xdpe_reset_wp_states_after_power_cycle(void)
 {
@@ -314,7 +357,7 @@ bool pre_xdpe15284_read(sensor_cfg *cfg, void *args)
 	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
 	CHECK_NULL_ARG_WITH_RETURN(args, false);
 
-	vr_page_cfg *xdpe15284_vr_page = (vr_page_cfg *)args;
+	const vr_page_cfg *xdpe15284_vr_page = (const vr_page_cfg *)args;
 	I2C_MSG msg = { 0 };
 	int retry = 3;
 

--- a/meta-facebook/gc2-es/src/platform/plat_hook.h
+++ b/meta-facebook/gc2-es/src/platform/plat_hook.h
@@ -43,6 +43,10 @@ typedef struct _mp5998_init_arg {
 	uint16_t fault_mask;
 	uint16_t protect_en;
 } mp5998_init_arg;
+typedef struct _tps53689_pre_proc_arg {
+	/* vr page to set */
+	uint8_t vr_page;
+} tps53689_pre_proc_arg;
 
 /**************************************************************************************************
  * INIT ARGS
@@ -66,6 +70,7 @@ extern pmic_pre_proc_arg pmic_pre_read_args[];
 extern dimm_pre_proc_arg dimm_pre_proc_args[];
 extern ina233_init_arg ina233_init_args[];
 extern vr_page_cfg xdpe15284_page[];
+extern tps53689_pre_proc_arg tps53689_pre_read_args[];
 
 /**************************************************************************************************
  *  PRE-HOOK/POST-HOOK FUNC
@@ -86,5 +91,6 @@ bool post_ltc4286_read(sensor_cfg *cfg, void *args, int *reading);
 bool post_ltc4282_read(sensor_cfg *cfg, void *args, int *reading);
 bool pre_xdpe15284_read(sensor_cfg *cfg, void *args);
 bool post_xdpe15284_read(sensor_cfg *cfg, void *args, int *reading);
+bool pre_tps53689_read(sensor_cfg *cfg, void *args);
 
 #endif

--- a/meta-facebook/gc2-es/src/platform/plat_sensor_table.c
+++ b/meta-facebook/gc2-es/src/platform/plat_sensor_table.c
@@ -272,6 +272,80 @@ sensor_cfg DPV2_sensor_config_table[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &max16550a_init_args[0] },
 };
 
+sensor_cfg vr_tps53689_sensor_config_table[] = {
+	/* VR voltage */
+	{ SENSOR_NUM_VOL_PVCCD_HV, sensor_dev_tps53689, I2C_BUS5, PVCCD_HV_ADDR, VR_VOL_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_VOL_PVCCINFAON, sensor_dev_tps53689, I2C_BUS5, PVCCINFAON_ADDR, VR_VOL_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_VOL_PVCCFA_EHV, sensor_dev_tps53689, I2C_BUS5, PVCCFA_EHV_ADDR, VR_VOL_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[1], NULL, NULL, NULL },
+	{ SENSOR_NUM_VOL_PVCCIN, sensor_dev_tps53689, I2C_BUS5, PVCCIN_ADDR, VR_VOL_CMD, vr_access,
+	  0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_VOL_PVCCFA_EHV_FIVRA, sensor_dev_tps53689, I2C_BUS5, PVCCFA_EHV_FIVRA_ADDR,
+	  VR_VOL_CMD, vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_tps53689_read,
+	  &tps53689_pre_read_args[1], NULL, NULL, NULL },
+
+	/* VR current */
+	{ SENSOR_NUM_CUR_PVCCD_HV, sensor_dev_tps53689, I2C_BUS5, PVCCD_HV_ADDR, VR_CUR_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_CUR_PVCCINFAON, sensor_dev_tps53689, I2C_BUS5, PVCCINFAON_ADDR, VR_CUR_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_CUR_PVCCFA_EHV, sensor_dev_tps53689, I2C_BUS5, PVCCFA_EHV_ADDR, VR_CUR_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[1], NULL, NULL, NULL },
+	{ SENSOR_NUM_CUR_PVCCIN, sensor_dev_tps53689, I2C_BUS5, PVCCIN_ADDR, VR_CUR_CMD, vr_access,
+	  0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_CUR_PVCCFA_EHV_FIVRA, sensor_dev_tps53689, I2C_BUS5, PVCCFA_EHV_FIVRA_ADDR,
+	  VR_CUR_CMD, vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_tps53689_read,
+	  &tps53689_pre_read_args[1], NULL, NULL, NULL },
+
+	/* VR temperature */
+	{ SENSOR_NUM_TEMP_PVCCD_HV, sensor_dev_tps53689, I2C_BUS5, PVCCD_HV_ADDR, VR_TEMP_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_PVCCINFAON, sensor_dev_tps53689, I2C_BUS5, PVCCINFAON_ADDR, VR_TEMP_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_PVCCFA_EHV, sensor_dev_tps53689, I2C_BUS5, PVCCFA_EHV_ADDR, VR_TEMP_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[1], NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_PVCCIN, sensor_dev_tps53689, I2C_BUS5, PVCCIN_ADDR, VR_TEMP_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_TEMP_PVCCFA_EHV_FIVRA, sensor_dev_tps53689, I2C_BUS5, PVCCFA_EHV_FIVRA_ADDR,
+	  VR_TEMP_CMD, vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_tps53689_read,
+	  &tps53689_pre_read_args[1], NULL, NULL, NULL },
+
+	/* VR power */
+	{ SENSOR_NUM_PWR_PVCCD_HV, sensor_dev_tps53689, I2C_BUS5, PVCCD_HV_ADDR, VR_PWR_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_PWR_PVCCINFAON, sensor_dev_tps53689, I2C_BUS5, PVCCINFAON_ADDR, VR_PWR_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_PWR_PVCCFA_EHV, sensor_dev_tps53689, I2C_BUS5, PVCCFA_EHV_ADDR, VR_PWR_CMD,
+	  vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[1], NULL, NULL, NULL },
+	{ SENSOR_NUM_PWR_PVCCIN, sensor_dev_tps53689, I2C_BUS5, PVCCIN_ADDR, VR_PWR_CMD, vr_access,
+	  0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, pre_tps53689_read, &tps53689_pre_read_args[0], NULL, NULL, NULL },
+	{ SENSOR_NUM_PWR_PVCCFA_EHV_FIVRA, sensor_dev_tps53689, I2C_BUS5, PVCCFA_EHV_FIVRA_ADDR,
+	  VR_PWR_CMD, vr_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, pre_tps53689_read,
+	  &tps53689_pre_read_args[1], NULL, NULL, NULL },
+};
+
 sensor_cfg vr_xdpe15284_sensor_config_table[] = {
 	/* VR voltage */
 	{ SENSOR_NUM_VOL_PVCCD_HV, sensor_dev_xdpe15284, I2C_BUS5, PVCCD_HV_ADDR, VR_VOL_CMD,
@@ -480,8 +554,7 @@ void plat_sensor_clear_vr_fault(uint8_t vr_addr, uint8_t vr_bus)
 	msg.data[0] = PMBUS_CLEAR_FAULTS;
 	ret = i2c_master_write(&msg, retry);
 	if (ret != 0) {
-		LOG_ERR("Clear faults failed, bus: 0x%x, addr: 0x%x", msg.bus,
-			msg.target_addr);
+		LOG_ERR("Clear faults failed, bus: 0x%x, addr: 0x%x", msg.bus, msg.target_addr);
 	}
 }
 
@@ -534,7 +607,7 @@ uint8_t pal_get_extend_sensor_config()
 		break;
 	case VR_MODULE_TPS53689:
 		// If independent tables are not yet supported, temporarily use ISL as a placeholder (or create a separate tps53689 table).
-		extend_sensor_config_size += ARRAY_SIZE(vr_isl69259_sensor_config_table);
+		extend_sensor_config_size += ARRAY_SIZE(vr_tps53689_sensor_config_table);
 		break;
 	default:
 		break;
@@ -738,10 +811,9 @@ void pal_extend_sensor_config()
 		}
 		break;
 	case VR_MODULE_TPS53689:
-		/* If the TPS53689 table is not yet available, temporarily use the ISL table for support or supplement it later. */
-		sensor_count = ARRAY_SIZE(vr_isl69259_sensor_config_table);
+		sensor_count = ARRAY_SIZE(vr_tps53689_sensor_config_table);
 		for (int i = 0; i < sensor_count; i++) {
-			add_sensor_config(vr_isl69259_sensor_config_table[i]);
+			add_sensor_config(vr_tps53689_sensor_config_table[i]);
 		}
 		break;
 	default:


### PR DESCRIPTION
[Task Description]
	* Related to GC20T5T7-176
	* Add new config table for TI

[Motivation]
	* TI VR requires a corresponding sensor reading process function

[Design]
	* Add vr_tps53689_sensor_config_table

[Test Plan]
1. Verify that the VR sensor reading within the threshold range $ sensor-util server --threshold | grep -i vr

[Test Log]
```
root@bmc-oob:~# sensor-util server --threshold |grep -i vr| grep -v -i dimm
MB_VR_VCCIN_TEMP_C           (0xF) :  42.000 C     | (ok) | UCR: 100.000 | UNC: NA | UNR: 125.000 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_TEMP_C           (0x10) :  41.000 C     | (ok) | UCR: 100.000 | UNC: NA | UNR: 125.000 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_TEMP_C             (0x11) :  42.000 C     | (ok) | UCR: 100.000 | UNC: NA | UNR: 125.000 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_TEMP_C            (0x12) :  43.000 C     | (ok) | UCR: 100.000 | UNC: NA | UNR: 125.000 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_TEMP_C            (0x13) :  43.000 C     | (ok) | UCR: 100.000 | UNC: NA | UNR: 125.000 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_VOLT_V           (0x2A) :   1.620 Volts | (ok) | UCR: 1.920 | UNC: 1.900 | UNR: 2.200 | LCR: 1.460 | LNC: 1.480 | LNR: 0.400
MB_VR_FIVRA_VOLT_V           (0x2B) :   1.790 Volts | (ok) | UCR: 1.910 | UNC: 1.890 | UNR: 2.200 | LCR: 1.690 | LNC: 1.710 | LNR: 0.400
MB_VR_EHV_VOLT_V             (0x2C) :   1.790 Volts | (ok) | UCR: 1.890 | UNC: 1.870 | UNR: 2.200 | LCR: 1.700 | LNC: 1.720 | LNR: 0.400
MB_VR_VCCD_VOLT_V            (0x2D) :   1.140 Volts | (ok) | UCR: 1.224 | UNC: 1.212 | UNR: 1.500 | LCR: 1.050 | LNC: 1.062 | LNR: 0.402
MB_VR_FAON_VOLT_V            (0x2E) :   1.056 Volts | (ok) | UCR: 1.110 | UNC: 1.098 | UNR: 1.476 | LCR: 0.906 | LNC: 0.912 | LNR: 0.402
MB_VR_VCCIN_CURR_A           (0x31) :   8.140 Amps  | (ok) | UCR: 140.600 | UNC: 118.400 | UNR: 179.820 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_CURR_A           (0x32) :   3.920 Amps  | (ok) | UCR: 52.920 | UNC: 47.880 | UNR: 70.840 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_CURR_A             (0x33) :   0.480 Amps  | (ok) | UCR: 6.240 | UNC: 4.960 | UNR: 18.000 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_CURR_A            (0x34) :   0.900 Amps  | (ok) | UCR: 29.880 | UNC: 27.000 | UNR: 42.840 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_CURR_A            (0x35) :   6.960 Amps  | (ok) | UCR: 45.840 | UNC: 42.000 | UNR: 60.000 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCIN_PWR_W            (0x3A) :  13.300 Watts | (ok) | UCR: 252.700 | UNC: 214.130 | UNR: 323.190 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FIVRA_PWR_W            (0x3C) :   6.360 Watts | (ok) | UCR: 95.400 | UNC: 86.390 | UNR: 127.730 | LCR: NA | LNC: NA | LNR: NA
MB_VR_EHV_PWR_W              (0x3D) :   0.822 Watts | (ok) | UCR: 11.234 | UNC: 8.905 | UNR: 32.332 | LCR: NA | LNC: NA | LNR: NA
MB_VR_VCCD_PWR_W             (0x3E) :   1.200 Watts | (ok) | UCR: 34.200 | UNC: 30.800 | UNR: 49.200 | LCR: NA | LNC: NA | LNR: NA
MB_VR_FAON_PWR_W             (0x3F) :   7.280 Watts | (ok) | UCR: 49.140 | UNC: 44.720 | UNR: 63.960 | LCR: NA | LNC: NA | LNR: NA
```