### PR TITLE
fby4: wf: Add support for reading QSPI flash to collect CXL coredump data

### DIFF
--- a/common/service/pldm/pldm_oem.c
+++ b/common/service/pldm/pldm_oem.c
@@ -43,6 +43,23 @@ static uint8_t oem_wf_read_spd_chunk(void *mctp_inst, uint8_t *buf, uint16_t len
 				     void *ext_params);
 #endif
 
+__weak uint8_t read_flash_data_cmd(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t instance_id,
+				   uint8_t *resp, uint16_t *resp_len, void *ext_params)
+{
+	CHECK_NULL_ARG_WITH_RETURN(mctp_inst, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(buf, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(resp_len, PLDM_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(ext_params, PLDM_ERROR);
+
+	uint8_t *completion_code_p = resp;
+
+	*completion_code_p = PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+	*resp_len = 1;
+
+	return PLDM_ERROR_UNSUPPORTED_PLDM_CMD;
+}
+
 __weak uint8_t force_update_flag_set_cmd(void *mctp_inst, uint8_t *buf, uint16_t len,
 					 uint8_t instance_id, uint8_t *resp, uint16_t *resp_len,
 					 void *ext_params)
@@ -127,7 +144,7 @@ static uint8_t cmd_echo(void *mctp_inst, uint8_t *buf, uint16_t len, uint8_t ins
 	CHECK_NULL_ARG_WITH_RETURN(resp_len, PLDM_ERROR);
 	CHECK_NULL_ARG_WITH_RETURN(ext_params, PLDM_ERROR);
 
-	struct _cmd_echo_req *req_p = (struct _cmd_echo_req *)buf;
+	const struct _cmd_echo_req *req_p = (const struct _cmd_echo_req *)buf;
 	struct _cmd_echo_resp *resp_p = (struct _cmd_echo_resp *)resp;
 
 	if (check_iana(req_p->iana) == PLDM_ERROR) {
@@ -289,6 +306,7 @@ static pldm_cmd_handler pldm_oem_cmd_tbl[] = {
 #endif
 	{ PLDM_OEM_FORCE_UPDATE_SETTING_CMD, force_update_flag_set_cmd },
 	{ PLDM_OEM_FORCE_UPDATE_GETTING_CMD, force_update_flag_get_cmd },
+	{ PLDM_OEM_READ_FLASH_DATA_CMD, read_flash_data_cmd },
 };
 
 uint8_t pldm_oem_handler_query(uint8_t code, void **ret_fn)
@@ -333,7 +351,7 @@ static uint8_t oem_wf_read_spd_chunk(void *mctp_inst, uint8_t *buf, uint16_t len
 		return PLDM_SUCCESS;
 	}
 
-	uint8_t *iana = &buf[0];
+	const uint8_t *iana = &buf[0];
 	uint8_t cxl_id = buf[3];
 	uint8_t dimm_idx = buf[4];
 	uint16_t offset = (uint16_t)buf[5] | ((uint16_t)buf[6] << 8);

--- a/common/service/pldm/pldm_oem.h
+++ b/common/service/pldm/pldm_oem.h
@@ -39,6 +39,7 @@ extern "C" {
 #define PLDM_OEM_WF_READ_SPD_CHUNK 0x05
 #define PLDM_OEM_FORCE_UPDATE_SETTING_CMD 0x06
 #define PLDM_OEM_FORCE_UPDATE_GETTING_CMD 0x07
+#define PLDM_OEM_READ_FLASH_DATA_CMD 0x08
 
 #define POWER_CONTROL_LEN 0x01
 
@@ -438,7 +439,7 @@ struct _force_update_flag_get_cmd_resp {
 
 uint8_t check_iana(const uint8_t *iana);
 uint8_t set_iana(uint8_t *buf, uint8_t buf_len);
-uint8_t send_event_log_to_bmc(struct pldm_addsel_data msg);
+uint8_t send_event_log_to_bmc(struct pldm_addsel_data sel_msg);
 
 uint8_t pldm_oem_handler_query(uint8_t code, void **ret_fn);
 

--- a/meta-facebook/yv4-wf/src/lib/plat_spi.c
+++ b/meta-facebook/yv4-wf/src/lib/plat_spi.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <drivers/flash.h>
+#include <logging/log.h>
+#include <device.h>
+#include "util_spi.h"
+#include "plat_spi.h"
+// CXL flash JEDEC ID
+#define IS25WP256D_ID 0x9D7019
+
+LOG_MODULE_REGISTER(plat_spi);
+
+uint8_t pal_init_cxl_flash_device(uint8_t cxl_comp_id, const struct device **flash_dev)
+{
+	if (flash_dev == NULL) {
+		LOG_ERR("Invalid parameter");
+		return 1;
+	}
+	int flash_position = pal_get_cxl_flash_position_by_id(cxl_comp_id);
+	if (flash_position == 0xFF) {
+		LOG_ERR("Invalid flash position for CXL component ID %d", cxl_comp_id);
+		return 1;
+	}
+	*flash_dev = device_get_binding(get_flash_device_string_by_index(flash_position));
+	if (!(*flash_dev)) {
+		LOG_ERR("device_get_binding() failed");
+		return 1;
+	}
+
+	int ret = ckeck_flash_device_isinit(*flash_dev, flash_position);
+	if (ret != 0) {
+		LOG_ERR("Failed to re-init flash");
+		return ret;
+	}
+	//IS25WP256D need to set 4byte address mode to read  flash
+	uint8_t jedec_id[3] = { 0 };
+	flash_read_jedec_id(*flash_dev, jedec_id);
+	if ((jedec_id[0] << 16 | jedec_id[1] << 8 | jedec_id[2]) == IS25WP256D_ID) {
+		spi_nor_config_4byte_mode(*flash_dev, true);
+	}
+
+	return 0;
+}
+
+int pal_get_cxl_flash_position_by_id(uint8_t cxl_comp_id)
+{
+	int flash_position = 0xFF;
+	switch (cxl_comp_id) {
+	case WF_COMPNT_CXL1:
+		flash_position = DEVSPI_SPI1_CS0;
+		break;
+	case WF_COMPNT_CXL2:
+		flash_position = DEVSPI_SPI2_CS0;
+		break;
+	default:
+		LOG_ERR("Unknown CXL component ID %d", cxl_comp_id);
+		return 0xFF;
+	}
+	return flash_position;
+}
+
+int pal_dump_cxl_flash_data(uint8_t *read_buf, uint32_t offset, size_t length,
+			    const struct device *flash_dev, uint8_t cxl_comp_id)
+{
+	if (read_buf == NULL || flash_dev == NULL) {
+		LOG_ERR("Invalid parameter");
+		return 1;
+	}
+	uint8_t ret = 0;
+
+	ret = flash_read(flash_dev, offset, read_buf, length);
+	if (ret != 0) {
+		LOG_ERR("Failed to read CXL flash at offset 0x%x (ret = %d)", offset, ret);
+		return 1;
+	}
+	return 0;
+}

--- a/meta-facebook/yv4-wf/src/lib/plat_spi.h
+++ b/meta-facebook/yv4-wf/src/lib/plat_spi.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_SPI_H
+#define PLAT_SPI_H
+
+enum wf_cxl_component {
+	WF_COMPNT_CXL1 = 0x05,
+	WF_COMPNT_CXL2 = 0x06,
+};
+
+int pal_dump_cxl_flash_data(uint8_t *read_buf, uint32_t offset, size_t length,
+			    const struct device *flash_dev, uint8_t cxl_comp_id);
+int pal_get_cxl_flash_position_by_id(uint8_t cxl_comp_id);
+uint8_t pal_init_cxl_flash_device(uint8_t cxl_comp_id, const struct device **flash_dev);
+
+#endif

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_oem.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_oem.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <zephyr.h>
+#include <sys/printk.h>
+#include <logging/log.h>
+#include <logging/log_ctrl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "libutil.h"
+
+#include "pldm_oem.h"
+
+#include "plat_isr.h"
+#include "plat_mctp.h"
+#include "plat_spi.h"
+#include "plat_pldm_oem.h"
+#include "plat_gpio.h"
+#include "ioexp_tca9555.h"
+#include "util_spi.h"
+
+LOG_MODULE_REGISTER(plat_pldm_oem);
+
+static uint8_t plat_switch_flash_mux_wf(uint8_t cxl_id)
+{
+	uint8_t value = 0;
+	if (get_ioe_value(ADDR_IOE1, TCA9555_OUTPUT_PORT_REG_0, &value) != 0) {
+		return 1;
+	}
+	switch (cxl_id) {
+	case WF_COMPNT_CXL1:
+		// Switch SPI1 MUX to BIC
+		value = SETBIT(value, IOE_P05);
+		break;
+	case WF_COMPNT_CXL2:
+		// Switch SPI2 MUX to BIC
+		value = SETBIT(value, IOE_P06);
+		break;
+	default:
+		LOG_ERR("Unknown CXL component ID %d", cxl_id);
+		return 1;
+	}
+
+	set_ioe_value(ADDR_IOE1, TCA9555_OUTPUT_PORT_REG_0, value);
+
+	return 0;
+}
+
+static uint8_t plat_switch_flash_mux_cxl(uint8_t cxl_id)
+{
+	uint8_t value = 0;
+	if (get_ioe_value(ADDR_IOE1, TCA9555_OUTPUT_PORT_REG_0, &value) != 0) {
+		return 1;
+	}
+	switch (cxl_id) {
+	case WF_COMPNT_CXL1:
+		// Switch SPI1 MUX to CXL
+		value = CLEARBIT(value, IOE_P05);
+		break;
+	case WF_COMPNT_CXL2:
+		// Switch SPI2 MUX to CXL
+		value = CLEARBIT(value, IOE_P06);
+		break;
+	default:
+		LOG_ERR("Unknown CXL component ID %d", cxl_id);
+		return 1;
+	}
+
+	set_ioe_value(ADDR_IOE1, TCA9555_OUTPUT_PORT_REG_0, value);
+	return 0;
+}
+
+uint8_t read_flash_data_cmd(void *mctp_inst, uint8_t *req_buf, uint16_t req_len,
+			    uint8_t instance_id, uint8_t *resp_buf, uint16_t *resp_len,
+			    void *ext_params)
+{
+	ARG_UNUSED(mctp_inst);
+	ARG_UNUSED(instance_id);
+	ARG_UNUSED(ext_params);
+	struct _cxl_read_flash_req *req = (struct _cxl_read_flash_req *)req_buf;
+	struct _cxl_read_flash_resp *resp = (struct _cxl_read_flash_resp *)resp_buf;
+	//check request length
+	if (req_len < sizeof(struct _cxl_read_flash_req)) {
+		resp->completion_code = PLDM_ERROR_INVALID_LENGTH;
+		*resp_len = sizeof(struct _cxl_read_flash_resp);
+		return PLDM_SUCCESS;
+	}
+	//check iana
+	if (check_iana(req->iana) == PLDM_ERROR) {
+		resp->completion_code = PLDM_ERROR_INVALID_DATA;
+		*resp_len = 1;
+		return PLDM_SUCCESS;
+	}
+
+	set_iana(resp->iana, sizeof(resp->iana));
+	resp->completion_code = PLDM_SUCCESS;
+	resp->data_len = req->data_len;
+	static bool is_init = false;
+	static const struct device *flash_dev = NULL;
+	uint8_t ret = 0;
+	// check request to switch MUX or read flash data
+	switch (req->transfer_flag) {
+	case READ_CXL_FLASH_START:
+		ret = plat_switch_flash_mux_wf(req->cxl_comp_id);
+		if (ret) {
+			LOG_ERR("Failed to switch SPI MUX to WF BIC");
+			resp->completion_code = PLDM_ERROR;
+			break;
+		}
+		ret = pal_init_cxl_flash_device(req->cxl_comp_id, &flash_dev);
+		if (ret) {
+			LOG_ERR("Failed to init CXL flash");
+			resp->completion_code = PLDM_ERROR;
+			break;
+		}
+		is_init = true;
+		break;
+	case READ_CXL_FLASH_DATA:
+		if (is_init == true && flash_dev != NULL) {
+			ret = pal_dump_cxl_flash_data(resp->data, req->data_offset, req->data_len,
+						      flash_dev, req->cxl_comp_id);
+			if (ret) {
+				resp->completion_code = PLDM_ERROR;
+			}
+		} else {
+			LOG_ERR("Flash device and MUX is not ready");
+			resp->completion_code = PLDM_ERROR;
+		}
+		break;
+	case READ_CXL_FLASH_END:
+		ret = plat_switch_flash_mux_cxl(req->cxl_comp_id);
+		if (ret) {
+			LOG_ERR("Failed to switch SPI MUX to CXL");
+			resp->completion_code = PLDM_ERROR;
+			break;
+		}
+		is_init = false;
+		flash_dev = NULL;
+		break;
+	default:
+		LOG_ERR("Unknown transfer_flag: 0x%x", req->transfer_flag);
+		resp->completion_code = PLDM_ERROR_INVALID_DATA;
+		break;
+	}
+
+	if (resp->completion_code != PLDM_SUCCESS) {
+		resp->data_len = 0;
+	}
+
+	*resp_len = sizeof(struct _cxl_read_flash_resp) + resp->data_len;
+	LOG_INF("resp len: %d", *resp_len);
+	return PLDM_SUCCESS;
+}

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_oem.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_oem.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PLAT_PLDM_OEM_H
+#define PLAT_PLDM_OEM_H
+
+#include "pldm_oem.h"
+
+enum CXL_COREDUMP_CMD_TYPE {
+	READ_CXL_FLASH_START = 0x00,
+	READ_CXL_FLASH_DATA = 0x01,
+	READ_CXL_FLASH_END = 0x02
+};
+
+struct _cxl_read_flash_req {
+	uint8_t iana[IANA_LEN];
+	uint8_t transfer_flag;
+	uint8_t cxl_comp_id;
+	uint32_t data_offset;
+	uint16_t data_len;
+} __attribute__((packed));
+
+struct _cxl_read_flash_resp {
+	uint8_t completion_code;
+	uint8_t iana[IANA_LEN];
+	uint16_t data_len;
+	uint8_t data[];
+} __attribute__((packed));
+
+uint8_t read_flash_data_cmd(void *mctp_inst, uint8_t *req_buf, uint16_t req_len,
+			    uint8_t instance_id, uint8_t *resp_buf, uint16_t *resp_len,
+			    void *ext_params);
+
+#endif


### PR DESCRIPTION
# [Task Description]:
- Related to JIRA YV4T1M-2294.
- Implement a function to read coredump data via the SPI interface and return the coredump data to the BMC via the PLDM interface.

# [Motivation]:
The current coredump collection relies on the UART interface. The Meta CXL team requests a new method to get coredump data directly through the BMC without accessing the CXL console, using the  existing BMC -> WF BIC -> QSPI flash path.

# [Design]:
- Add PLDM OEM command 0x08 and override the platform handler to switch the QSPI flash MUX  and read CXL flash data
- Add a platform SPI read function to allow WF BIC to read QSPI flash data.

# [Test Log]:
In BMC test pldmtool:
root@bmc-WX84433002GN01:~# pldmtool raw -m 52 -d 0x80 0x3f 0x08 0x15 0xA0 0x00 0x00 0x05 0x00 0x00 0x00 0x00 0x00 0x00 pldmtool: Tx: 80 3f 08 15 a0 00 00 05 00 00 00 00 00 00 pldmtool: Rx: 00 3f 08 00 15 a0 00 00 00

root@bmc-WX84433002GN01:~# pldmtool raw -m 52 -d 0x80 0x3f 0x08  0x15 0xA0 0x00 0x01 0x05  0x00 0x00 0xF8 0x01  0x14 0x00 pldmtool: Tx: 80 3f 08 15 a0 00 01 05 00 00 f8 01 14 00 pldmtool: Rx: 00 3f 08 00 15 a0 00 14 00 00 01 cd cd 03 71 00 00 6c 7a 05 00 00 00 00 00 5a 45 01 00

root@bmc-WX84433002GN01:~# pldmtool raw -m 52 -d 0x80 0x3f 0x08 0x15 0xA0 0x00 0x02 0x05 0x00 0x00 0x00 0x00 0x00 0x00 pldmtool: Tx: 80 3f 08 15 a0 00 02 05 00 00 00 00 00 00 pldmtool: Rx: 00 3f 08 00 15 a0 00 00 00