### PR TITLE
gc2: es: support Efuse 2nd sensor TPS25990

### DIFF
--- a/common/dev/tps25990.c
+++ b/common/dev/tps25990.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "sensor.h"
+#include "hal_i2c.h"
+#include "libutil.h"
+#include "pmbus.h"
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(tps25990);
+
+/* RIMON = 2 kohm*/
+#define TPS25990_RIMON_OHM 2000
+
+uint8_t tps25990_read(sensor_cfg *cfg, int *reading)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(reading, SENSOR_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX) {
+		return SENSOR_UNSPECIFIED_ERROR;
+	}
+
+	uint8_t retry = 5;
+	double val;
+	I2C_MSG msg = { 0 };
+
+	msg.bus = cfg->port;
+	msg.target_addr = cfg->target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = 2;
+	msg.data[0] = cfg->offset;
+
+	if (i2c_master_read(&msg, retry))
+		return SENSOR_FAIL_TO_ACCESS;
+
+	switch (cfg->offset) {
+	case PMBUS_READ_VIN:
+		/* spec: m = 5251, b = 0, R = -2 */
+		val = (float)((msg.data[1] << 8) | msg.data[0]) * 100 / 5251;
+		break;
+	case PMBUS_READ_IIN:
+		/* spec: m = 9.538 x RIMON, b = 0, R = -3 */
+		val = (float)((msg.data[1] << 8) | msg.data[0]) * 1000 /
+		      (9.538 * TPS25990_RIMON_OHM);
+		break;
+	case PMBUS_READ_PIN:
+		/* spec: m = 4.901 x RIMON, b = 0, R = -4 */
+		val = (float)((msg.data[1] << 8) | msg.data[0]) * 10000 /
+		      (4.901 * TPS25990_RIMON_OHM);
+		break;
+	case PMBUS_READ_TEMPERATURE_1:
+		/* spec: m = 140, b = 32100, R = -2 */
+		val = (((msg.data[1] << 8) | msg.data[0]) * 100 - 32100) / 140;
+		break;
+	default:
+		return SENSOR_NOT_FOUND;
+	}
+
+	sensor_val *sval = (sensor_val *)reading;
+	memset(sval, 0, sizeof(*sval));
+
+	sval->integer = (int32_t)val;
+	sval->fraction = (int32_t)(val * 1000) % 1000;
+
+	return SENSOR_READ_SUCCESS;
+}
+
+uint8_t tps25990_init(sensor_cfg *cfg)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, SENSOR_INIT_UNSPECIFIED_ERROR);
+	CHECK_NULL_ARG_WITH_RETURN(cfg->init_args, SENSOR_INIT_UNSPECIFIED_ERROR);
+
+	if (cfg->num > SENSOR_NUM_MAX)
+		return SENSOR_INIT_UNSPECIFIED_ERROR;
+
+	tps25990_init_arg *init_args = (tps25990_init_arg *)cfg->init_args;
+
+	if (init_args->is_init)
+		goto skip_init;
+
+	init_args->is_init = true;
+
+skip_init:
+	cfg->read = tps25990_read;
+	return SENSOR_INIT_SUCCESS;
+}

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -39,9 +39,15 @@ LOG_MODULE_REGISTER(sensor);
 
 #define SENSOR_DRIVE_INIT_DECLARE(name) uint8_t name##_init(sensor_cfg *cfg)
 
-#define SENSOR_DRIVE_TYPE_INIT_MAP(name) { sensor_dev_##name, name##_init }
+#define SENSOR_DRIVE_TYPE_INIT_MAP(name)                                                           \
+	{                                                                                          \
+		sensor_dev_##name, name##_init                                                     \
+	}
 
-#define SENSOR_DRIVE_TYPE_UNUSE(name) { sensor_dev_##name, NULL }
+#define SENSOR_DRIVE_TYPE_UNUSE(name)                                                              \
+	{                                                                                          \
+		sensor_dev_##name, NULL                                                            \
+	}
 
 #define SENSOR_READ_RETRY_MAX 3
 
@@ -152,6 +158,8 @@ const char *const sensor_type_name[] = {
 	sensor_name_to_num(ads7830)
 	sensor_name_to_num(s54ss4p180pmdafc)
 	sensor_name_to_num(pex90144)
+	sensor_name_to_num(octeon)
+	sensor_name_to_num(tps25990)
 };
 // clang-format on
 
@@ -390,6 +398,9 @@ SENSOR_DRIVE_INIT_DECLARE(pex90144);
 #endif
 #ifdef ENABLE_OCTEON
 SENSOR_DRIVE_INIT_DECLARE(octeon);
+#endif
+#ifndef DISABLE_TPS25990
+SENSOR_DRIVE_INIT_DECLARE(tps25990);
 #endif
 
 // The sequence needs to same with SENSOR_DEV ID
@@ -792,6 +803,11 @@ sensor_drive_api sensor_drive_tbl[] = {
 	SENSOR_DRIVE_TYPE_INIT_MAP(octeon),
 #else
 	SENSOR_DRIVE_TYPE_UNUSE(octeon),
+#endif
+#ifndef DISABLE_TPS25990
+	SENSOR_DRIVE_TYPE_INIT_MAP(tps25990),
+#else
+	SENSOR_DRIVE_TYPE_UNUSE(tps25990),
 #endif
 
 };

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -196,6 +196,7 @@ enum SENSOR_DEV {
 	sensor_dev_s54ss4p180pmdafc = 0x4E,
 	sensor_dev_pex90144 = 0x4F,
 	sensor_dev_octeon = 0x50,
+	sensor_dev_tps25990 = 0x51,
 	sensor_dev_max
 };
 
@@ -474,6 +475,10 @@ typedef struct _mp5990_init_arg {
 	bool is_init;
 
 } mp5990_init_arg;
+
+typedef struct _tps25990_init_arg {
+	bool is_init;
+} tps25990_init_arg;
 
 typedef struct _rs31380r_init_arg {
 	/* value to sets the gain for output current reporting */

--- a/meta-facebook/gc2-es/src/platform/plat_class.c
+++ b/meta-facebook/gc2-es/src/platform/plat_class.c
@@ -29,6 +29,8 @@
 #include "plat_sensor_table.h"
 #include "plat_hook.h"
 
+LOG_MODULE_REGISTER(plat_class);
+
 static uint8_t system_class = SYS_CLASS_1;
 static uint8_t system_sku = 0;
 static uint8_t board_revision = 0x0F;
@@ -199,12 +201,178 @@ void init_e1s_boot_drive_module()
 	e1s_boot_drive_module = detect_e1s_boot_drive_module_via_pmbus();
 }
 
+void mp5998_plat_init()
+{
+	const mp5998_plat_init_arg *init_args = &mp5998_plat_init_args[0];
+	uint8_t retry = 5;
+	I2C_MSG msg;
+	uint8_t data[I2C_DATA_SIZE];
+	uint8_t bus = I2C_BUS2;
+	uint8_t addr = MPS_MP5990_ADDR;
+
+	/* protect_en */
+	data[0] = 0xCA; // 0xCA
+	data[1] = init_args->protect_en & 0xFF;
+	data[2] = (init_args->protect_en >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+
+	/* vin_ov_fault_limit */
+	data[0] = PMBUS_VIN_OV_FAULT_LIMIT; // 0x55
+	data[1] = init_args->vin_ov_fault_limit & 0xFF;
+	data[2] = (init_args->vin_ov_fault_limit >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+
+	/* vin_ov_warn_limit */
+	data[0] = PMBUS_VIN_OV_WARN_LIMIT; // 0x57
+	data[1] = init_args->vin_ov_warn_limit & 0xFF;
+	data[2] = (init_args->vin_ov_warn_limit >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+
+	/* vin_uv_warn_limit */
+	data[0] = PMBUS_VIN_UV_WARN_LIMIT; // 0x58
+	data[1] = init_args->vin_uv_warn_limit & 0xFF;
+	data[2] = (init_args->vin_uv_warn_limit >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+
+	/* iin_oc_fault_limit */
+	data[0] = PMBUS_IIN_OC_FAULT_LIMIT; // 0x5B
+	data[1] = init_args->iin_oc_fault_limit & 0xFF;
+	data[2] = (init_args->iin_oc_fault_limit >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+
+	/* iin_oc_warn_limit */
+	data[0] = PMBUS_IIN_OC_WARN_LIMIT; // 0x5D
+	data[1] = init_args->iin_oc_warn_limit & 0xFF;
+	data[2] = (init_args->iin_oc_warn_limit >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+
+	/* fault_mask */
+	data[0] = 0xD4; // 0xD4
+	data[1] = init_args->fault_mask & 0xFF;
+	data[2] = (init_args->fault_mask >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+}
+
+void tps25990_plat_init()
+{
+	const tps25990_plat_init_arg *init_args = &tps25990_plat_init_args[0];
+	uint8_t retry = 5;
+	I2C_MSG msg;
+	uint8_t data[I2C_DATA_SIZE];
+	uint8_t bus = I2C_BUS2;
+	uint8_t addr = TI_TPS25990_ADDR;
+
+	/* vin_ov_fault_limit */
+	data[0] = PMBUS_VIN_OV_FAULT_LIMIT; // 0x55
+	data[1] = init_args->vin_ov_fault_limit & 0xFF;
+	data[2] = (init_args->vin_ov_fault_limit >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+
+	/* vin_ov_warn_limit */
+	data[0] = PMBUS_VIN_OV_WARN_LIMIT; // 0x57
+	data[1] = init_args->vin_ov_warn_limit & 0xFF;
+	data[2] = (init_args->vin_ov_warn_limit >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+
+	/* vin_uv_warn_limit */
+	data[0] = PMBUS_VIN_UV_WARN_LIMIT; // 0x58
+	data[1] = init_args->vin_uv_warn_limit & 0xFF;
+	data[2] = (init_args->vin_uv_warn_limit >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+
+	/* vin_uv_fault_limit */
+	data[0] = PMBUS_VIN_UV_FAULT_LIMIT; // 0x59
+	data[1] = init_args->vin_uv_fault_limit & 0xFF;
+	data[2] = (init_args->vin_uv_fault_limit >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+
+	/* iin_oc_warn_limit */
+	data[0] = PMBUS_IIN_OC_WARN_LIMIT; // 0x5D
+	data[1] = init_args->iin_oc_warn_limit & 0xFF;
+	data[2] = (init_args->iin_oc_warn_limit >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
+
+	/* protect_en */
+	data[0] = 0xF8; // 0xF8
+	data[1] = init_args->protect_en & 0xFF;
+	msg = construct_i2c_message(bus, addr, 2, data, 0);
+	i2c_master_write(&msg, retry);
+}
+
+static uint8_t detect_hsc_module_via_pmbus()
+{
+	uint8_t retry = 5;
+	I2C_MSG msg;
+	memset(&msg, 0, sizeof(msg));
+
+	msg.bus = I2C_BUS2;
+	msg.target_addr = ADI_ADM1278_ADDR;
+	msg.tx_len = 1;
+	msg.rx_len = 8;
+	msg.data[0] = PMBUS_MFR_MODEL;
+
+	if (i2c_master_read(&msg, retry) == 0) {
+		char model_str[8] = { 0 };
+		memcpy(model_str, &msg.data[1], 7);
+
+		if (strncmp(model_str, "ADM1278", 7) == 0 ||
+		    strncmp(model_str, "ADM1281", 7) == 0) {
+			return HSC_MODULE_ADM1278;
+		}
+	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = I2C_BUS2;
+	msg.target_addr = MPS_MP5990_ADDR;
+	msg.tx_len = 1;
+	msg.rx_len = 6;
+	msg.data[0] = PMBUS_MFR_MODEL;
+
+	if (i2c_master_read(&msg, retry) == 0) {
+		char model_str[6] = { 0 };
+		memcpy(model_str, &msg.data[2], 4);
+
+		if (strncmp(model_str, "8995", 4) == 0) {
+			mp5998_plat_init();
+			return HSC_MODULE_MP5990;
+		}
+	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = I2C_BUS2;
+	msg.target_addr = TI_TPS25990_ADDR;
+	msg.tx_len = 1;
+	msg.rx_len = 9;
+	msg.data[0] = PMBUS_MFR_MODEL;
+
+	if (i2c_master_read(&msg, retry) == 0) {
+		char model_str[9] = { 0 };
+		memcpy(model_str, &msg.data[1], 8);
+
+		if (strncmp(model_str, "TPS25990", 8) == 0) {
+			tps25990_plat_init();
+			return HSC_MODULE_TPS25990;
+		}
+	}
+
+	return HSC_MODULE_UNKNOWN;
+}
+
 void init_hsc_module()
 {
-	read_adm1278_model();
-	if (hsc_module == HSC_MODULE_UNKNOWN) {
-		read_mp5990_model();
-	}
+	hsc_module = detect_hsc_module_via_pmbus();
 }
 
 static uint8_t detect_vr_module_via_pmbus(void)
@@ -261,114 +429,6 @@ void init_platform_config()
 	// Initialize VR module (for use by pal_extend_sensor_config)
 	init_vr_module();
 	init_e1s_boot_drive_module();
-}
-
-void read_adm1278_model()
-{
-	uint8_t retry = 5;
-	I2C_MSG msg = { 0 };
-
-	msg.bus = I2C_BUS2;
-	msg.target_addr = ADI_ADM1278_ADDR;
-	msg.tx_len = 1;
-	msg.rx_len = 8;
-	msg.data[0] = PMBUS_MFR_MODEL;
-
-	int ret = i2c_master_read(&msg, retry);
-	if (ret != 0) {
-		return;
-	}
-
-	char model_str[8] = { 0 };
-	memcpy(model_str, &msg.data[1], 7);
-	if (strncmp(model_str, "ADM1278", 7) == 0 || strncmp(model_str, "ADM1281", 7) == 0) {
-		hsc_module = HSC_MODULE_ADM1278;
-	} else {
-		return;
-	}
-}
-
-void read_mp5990_model()
-{
-	uint8_t retry = 5;
-	I2C_MSG msg = { 0 };
-
-	msg.bus = I2C_BUS2;
-	msg.target_addr = MPS_MP5990_ADDR;
-	msg.tx_len = 1;
-	msg.rx_len = 6;
-	msg.data[0] = PMBUS_MFR_MODEL;
-
-	int ret = i2c_master_read(&msg, retry);
-	if (ret != 0) {
-		return;
-	}
-
-	char model_str[6] = { 0 };
-	memcpy(model_str, &msg.data[2], 4);
-	if (strncmp(model_str, "8995", 4) == 0) {
-		hsc_module = HSC_MODULE_MP5990;
-		mp5998_init();
-	}
-}
-
-void mp5998_init()
-{
-	mp5998_init_arg *init_args = &mp5998_init_args[0];
-	uint8_t retry = 5;
-	I2C_MSG msg;
-	uint8_t data[I2C_DATA_SIZE];
-	uint8_t bus = I2C_BUS2;
-	uint8_t addr = MPS_MP5990_ADDR;
-
-	/* vin_ov_fault_limit */
-	data[0] = PMBUS_VIN_OV_FAULT_LIMIT; // 0x55
-	data[1] = init_args->vin_ov_fault_limit & 0xFF;
-	data[2] = (init_args->vin_ov_fault_limit >> 8) & 0xFF;
-	msg = construct_i2c_message(bus, addr, 3, data, 0);
-	i2c_master_write(&msg, retry);
-
-	/* vin_ov_warn_limit */
-	data[0] = PMBUS_VIN_OV_WARN_LIMIT; // 0x57
-	data[1] = init_args->vin_ov_warn_limit & 0xFF;
-	data[2] = (init_args->vin_ov_warn_limit >> 8) & 0xFF;
-	msg = construct_i2c_message(bus, addr, 3, data, 0);
-	i2c_master_write(&msg, retry);
-
-	/* vin_uv_warn_limit */
-	data[0] = PMBUS_VIN_UV_WARN_LIMIT; // 0x58
-	data[1] = init_args->vin_uv_warn_limit & 0xFF;
-	data[2] = (init_args->vin_uv_warn_limit >> 8) & 0xFF;
-	msg = construct_i2c_message(bus, addr, 3, data, 0);
-	i2c_master_write(&msg, retry);
-
-	/* iin_oc_fault_limit */
-	data[0] = PMBUS_IIN_OC_FAULT_LIMIT; // 0x5B
-	data[1] = init_args->iin_oc_fault_limit & 0xFF;
-	data[2] = (init_args->iin_oc_fault_limit >> 8) & 0xFF;
-	msg = construct_i2c_message(bus, addr, 3, data, 0);
-	i2c_master_write(&msg, retry);
-
-	/* iin_oc_warn_limit */
-	data[0] = PMBUS_IIN_OC_WARN_LIMIT; // 0x5D
-	data[1] = init_args->iin_oc_warn_limit & 0xFF;
-	data[2] = (init_args->iin_oc_warn_limit >> 8) & 0xFF;
-	msg = construct_i2c_message(bus, addr, 3, data, 0);
-	i2c_master_write(&msg, retry);
-
-	/* fault_mask */
-	data[0] = 0xD4; // 0xD4
-	data[1] = init_args->fault_mask & 0xFF;
-	data[2] = (init_args->fault_mask >> 8) & 0xFF;
-	msg = construct_i2c_message(bus, addr, 3, data, 0);
-	i2c_master_write(&msg, retry);
-
-	/* protect_en */
-	data[0] = 0xCA; // 0xCA
-	data[1] = init_args->protect_en & 0xFF;
-	data[2] = (init_args->protect_en >> 8) & 0xFF;
-	msg = construct_i2c_message(bus, addr, 3, data, 0);
-	i2c_master_write(&msg, retry);
 }
 
 void set_bootdrive_exist_status()

--- a/meta-facebook/gc2-es/src/platform/plat_class.h
+++ b/meta-facebook/gc2-es/src/platform/plat_class.h
@@ -87,6 +87,7 @@ enum HSC_MODULE {
 	HSC_MODULE_MP5990,
 	HSC_MODULE_LTC4282,
 	HSC_MODULE_LTC4286,
+	HSC_MODULE_TPS25990,
 	HSC_MODULE_UNKNOWN,
 };
 
@@ -124,9 +125,8 @@ bool get_adc_voltage(int channel, float *voltage);
 void init_hsc_module();
 void init_e1s_boot_drive_module();
 void init_platform_config();
-void read_adm1278_model();
-void read_mp5990_model();
-void mp5998_init();
+void mp5998_plat_init();
+void tps25990_plat_init();
 void set_bootdrive_exist_status();
 bool get_bootdrive_exist_status();
 #endif

--- a/meta-facebook/gc2-es/src/platform/plat_hook.c
+++ b/meta-facebook/gc2-es/src/platform/plat_hook.c
@@ -67,15 +67,27 @@ mp5990_init_arg mp5990_init_args[] = { [0] = { .is_init = false,
 					       .iout_cal_gain = 0x01BF,
 					       .iout_oc_fault_limit = 0x0046,
 					       .ocw_sc_ref = 0xFFFF } };
-mp5998_init_arg mp5998_init_args[] = {
+mp5998_plat_init_arg mp5998_plat_init_args[] = {
 	[0] = { .vin_ov_fault_limit = 0x0370, //55h value : 13.75      lsb : 1/64 V
 		.vin_ov_warn_limit = 0x0360, //57h value : 13.5
 		.vin_uv_warn_limit = 0x028D, //58h value : 10.203125
 		.iin_oc_fault_limit = 0x01B7, //5Bh value : 27.4375    lsb : 1/16 A
 		.iin_oc_warn_limit = 0x0195, //5Dh value : 25.3125
 		.fault_mask = 0x0008, //D4h
-		.protect_en = 0x3EFF }
-}; //CAh
+		.protect_en = 0x3EFF } //CAh
+};
+
+tps25990_init_arg tps25990_init_args[] = { [0] = { .is_init = false }, [1] = { .is_init = false } };
+
+tps25990_plat_init_arg tps25990_plat_init_args[] = {
+	[0] = { .vin_ov_fault_limit = 0x000B, //55h value : 13.79
+		.vin_ov_warn_limit = 0x00B1, //57h value : 13.482
+		.vin_uv_warn_limit = 0x0086, //58h value : 10.207
+		.vin_uv_fault_limit = 0x0077, //59h value : 9.064
+		.iin_oc_warn_limit = 0x0078, //5Dh value : 25.210
+		.protect_en = 0xA2 } //F8h
+};
+
 ltc4286_init_arg ltc4286_init_args[] = {
 	[0] = { .is_init = false, .r_sense_mohm = 0.25, .mfr_config_1 = { 0x1570 } },
 	[1] = { .is_init = false, .r_sense_mohm = 0.25, .mfr_config_1 = { 0x3570 } }

--- a/meta-facebook/gc2-es/src/platform/plat_hook.h
+++ b/meta-facebook/gc2-es/src/platform/plat_hook.h
@@ -34,7 +34,7 @@ typedef struct _dimm_pre_proc_arg {
 	bool is_present_checked;
 } dimm_pre_proc_arg;
 
-typedef struct _mp5998_init_arg {
+typedef struct _mp5998_plat_init_arg {
 	uint16_t vin_ov_fault_limit;
 	uint16_t vin_ov_warn_limit;
 	uint16_t vin_uv_warn_limit;
@@ -42,11 +42,20 @@ typedef struct _mp5998_init_arg {
 	uint16_t iin_oc_warn_limit;
 	uint16_t fault_mask;
 	uint16_t protect_en;
-} mp5998_init_arg;
+} mp5998_plat_init_arg;
 typedef struct _tps53689_pre_proc_arg {
 	/* vr page to set */
 	uint8_t vr_page;
 } tps53689_pre_proc_arg;
+
+typedef struct _tps25990_plat_init_arg {
+	uint16_t vin_ov_fault_limit;
+	uint16_t vin_ov_warn_limit;
+	uint16_t vin_uv_warn_limit;
+	uint16_t vin_uv_fault_limit;
+	uint16_t iin_oc_warn_limit;
+	uint16_t protect_en;
+} tps25990_plat_init_arg;
 
 /**************************************************************************************************
  * INIT ARGS
@@ -54,7 +63,9 @@ typedef struct _tps53689_pre_proc_arg {
 extern adc_asd_init_arg adc_asd_init_args[];
 extern adm1278_init_arg adm1278_init_args[];
 extern mp5990_init_arg mp5990_init_args[];
-extern mp5998_init_arg mp5998_init_args[];
+extern mp5998_plat_init_arg mp5998_plat_init_args[];
+extern tps25990_init_arg tps25990_init_args[];
+extern tps25990_plat_init_arg tps25990_plat_init_args[];
 extern pmic_init_arg pmic_init_args[];
 extern max16550a_init_arg max16550a_init_args[];
 extern ltc4286_init_arg ltc4286_init_args[];

--- a/meta-facebook/gc2-es/src/platform/plat_sdr_table.c
+++ b/meta-facebook/gc2-es/src/platform/plat_sdr_table.c
@@ -3677,6 +3677,7 @@ uint8_t pal_get_extend_sdr()
 		extend_sdr_size += ARRAY_SIZE(hotswap_sdr_table);
 		break;
 	case HSC_MODULE_MP5990:
+	case HSC_MODULE_TPS25990:
 		extend_sdr_size += ARRAY_SIZE(efuse_sdr_table);
 		break;
 	default:
@@ -3701,6 +3702,7 @@ void pal_extend_full_sdr_table()
 		}
 		break;
 	case HSC_MODULE_MP5990:
+	case HSC_MODULE_TPS25990:
 		extend_array_num = ARRAY_SIZE(efuse_sdr_table);
 		for (int index = 0; index < extend_array_num; index++) {
 			add_full_sdr_table(efuse_sdr_table[index]);

--- a/meta-facebook/gc2-es/src/platform/plat_sensor_table.c
+++ b/meta-facebook/gc2-es/src/platform/plat_sensor_table.c
@@ -203,6 +203,25 @@ sensor_cfg adm1278_sensor_config_table[] = {
 	  SENSOR_INIT_STATUS, NULL, NULL, post_adm1278_power_read, NULL, &adm1278_init_args[0] },
 };
 
+sensor_cfg tps25990_sensor_config_table[] = {
+	/* number,                  type,       port,      address,      offset,
+	   access check arg0, arg1, sample_count, cache, cache_status, mux_address, mux_offset,
+	   pre_sensor_read_fn, pre_sensor_read_args, post_sensor_read_fn, post_sensor_read_fn  */
+	{ SENSOR_NUM_TEMP_EFUSE, sensor_dev_tps25990, I2C_BUS2, TI_TPS25990_ADDR,
+	  PMBUS_READ_TEMPERATURE_1, stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT,
+	  ENABLE_SENSOR_POLLING, 0, SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL,
+	  &tps25990_init_args[0] },
+	{ SENSOR_NUM_VOL_EFUSE_IN, sensor_dev_tps25990, I2C_BUS2, TI_TPS25990_ADDR, PMBUS_READ_VIN,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &tps25990_init_args[0] },
+	{ SENSOR_NUM_CUR_EFUSE_OUT, sensor_dev_tps25990, I2C_BUS2, TI_TPS25990_ADDR, PMBUS_READ_IIN,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &tps25990_init_args[0] },
+	{ SENSOR_NUM_PWR_EFUSE_IN, sensor_dev_tps25990, I2C_BUS2, TI_TPS25990_ADDR, PMBUS_READ_PIN,
+	  stby_access, 0, 0, SAMPLE_COUNT_DEFAULT, POLL_TIME_DEFAULT, ENABLE_SENSOR_POLLING, 0,
+	  SENSOR_INIT_STATUS, NULL, NULL, NULL, NULL, &tps25990_init_args[0] },
+};
+
 sensor_cfg ltc4286_sensor_config_table[] = {
 	/* number,                  type,       port,      address,      offset,
 	   access check arg0, arg1, sample_count, cache, cache_status, mux_address, mux_offset,
@@ -587,6 +606,13 @@ uint8_t pal_get_extend_sensor_config()
 			plat_sensor_clear_vr_fault(MPS_MP5990_ADDR, I2C_BUS2);
 		}
 		break;
+	case HSC_MODULE_TPS25990:
+		extend_sensor_config_size += ARRAY_SIZE(tps25990_sensor_config_table);
+		if (is_ac_lost()) {
+			// Clear VR fault bit
+			plat_sensor_clear_vr_fault(TI_TPS25990_ADDR, I2C_BUS2);
+		}
+		break;
 	case HSC_MODULE_LTC4286:
 		extend_sensor_config_size += ARRAY_SIZE(ltc4286_sensor_config_table);
 		break;
@@ -773,6 +799,14 @@ void pal_extend_sensor_config()
 		for (int index = 0; index < sensor_count; index++) {
 			mp5990_sensor_config_table[index].init_args = &mp5990_init_args[arg_index];
 			add_sensor_config(mp5990_sensor_config_table[index]);
+		}
+		break;
+	case HSC_MODULE_TPS25990:
+		sensor_count = ARRAY_SIZE(tps25990_sensor_config_table);
+		for (int index = 0; index < sensor_count; index++) {
+			tps25990_sensor_config_table[index].init_args =
+				&tps25990_init_args[arg_index];
+			add_sensor_config(tps25990_sensor_config_table[index]);
 		}
 		break;
 	case HSC_MODULE_LTC4286:

--- a/meta-facebook/gc2-es/src/platform/plat_sensor_table.h
+++ b/meta-facebook/gc2-es/src/platform/plat_sensor_table.h
@@ -31,6 +31,7 @@
 #define ADI_ADM1278_ADDR (0x20 >> 1)
 #define ADI_LTC4286_ADDR (0x84 >> 1)
 #define MPS_MP5990_ADDR (0x98 >> 1)
+#define TI_TPS25990_ADDR (0x96 >> 1)
 #define ADI_LTC4282_ADDR (0x88 >> 1)
 #define PCH_ADDR (0x2C >> 1)
 #define ME_SENSOR_NUM_TEMP_PCH 0x08


### PR DESCRIPTION
# [Motivation]
- Related to GC20T5T7-210
- DVT platform uses TPS25990 as Efuse sensor in addition to existing HSC modules
- Need to support ADM1278, MP5998, and TPS25990 for different hardware revisions
- Enable runtime Efuse module detection and proper sensor monitoring

# [Design]
1. HSC Module Auto-Detection:
   - Add detect_hsc_module_via_pmbus() to detect HSC/Efuse chip via PMBUS_MFR_MODEL
   - Add TPS25990 detection logic: match model string "TPS25990" (8 bytes)
   - Implement fallback detection order: ADM1278 → MP5998 → TPS25990
   - Call tps25990_plat_init() upon successful TPS25990 identification

2. TPS25990 Sensor Configuration:
   - I2C Bus: I2C_BUS2
   - I2C Address: 0x4B (0x96 >> 1)
   - Supported Sensors:
     * SENSOR_NUM_TEMP_EFUSE  (0x0E): On-die temperature monitoring
     * SENSOR_NUM_VOL_EFUSE_IN (0x29): Input voltage monitoring * SENSOR_NUM_CUR_EFUSE_OUT (0x30): Input current monitoring * SENSOR_NUM_PWR_EFUSE_IN  (0x39): Input power monitoring

3. TPS25990 Initialization Parameters:
   - vin_ov_fault_limit: 0x000B (55h, 13.79V)
   - vin_ov_warn_limit:  0x00B1 (57h, 13.482V)
   - vin_uv_warn_limit:  0x0086 (58h, 10.207V)
   - vin_uv_fault_limit: 0x0077 (59h, 9.064V)
   - iin_oc_warn_limit:  0x0078 (5Dh, 25.210A)
   - protect_en:         0xA2   (F8h)

# [Test Result]
Verified on GC2-ES DVT platform with TPS25990 Efuse module. All sensors report correctly:

root@bmc-oob:~# sensor-util server --force | grep EFUSE
MB_EFUSE_TEMP_C              (0xE) :  37.000 C     | (ok)
MB_EFUSE_INPUT_VOLT_V        (0x29) :  12.110 Volts | (ok)
MB_EFUSE_OUTPUT_CURR_A       (0x30) :   3.300 Amps  | (ok)
MB_EFUSE_INPUT_PWR_W         (0x39) :  37.700 Watts | (ok)

Then, verified that all TPS25990 initialization parameters are correctly written to the chip registers and match the expected values: root@bmc-oob:~ # bic-util server 0x18 0x52 3 0x96 2 0x55 0B 00
root@bmc-oob:~ # bic-util server 0x18 0x52 3 0x96 2 0x57 B1 00
root@bmc-oob:~ # bic-util server 0x18 0x52 3 0x96 2 0x58 86 00
root@bmc-oob:~ # bic-util server 0x18 0x52 3 0x96 2 0x59 77 00
root@bmc-oob:~ # bic-util server 0x18 0x52 3 0x96 2 0x5D 78 00
root@bmc-oob:~ # bic-util server 0x18 0x52 3 0x96 1 0xF8 A2