### PR TITLE
gc2: es: Fix Efuse show NA after 12V cycle

### DIFF
--- a/meta-facebook/gc2-es/src/platform/plat_class.c
+++ b/meta-facebook/gc2-es/src/platform/plat_class.c
@@ -372,7 +372,13 @@ static uint8_t detect_hsc_module_via_pmbus()
 
 void init_hsc_module()
 {
-	hsc_module = detect_hsc_module_via_pmbus();
+	for (int retry = 0; retry < 5; retry++) {
+		hsc_module = detect_hsc_module_via_pmbus();
+		if (hsc_module != HSC_MODULE_UNKNOWN) {
+			return;
+		}
+		k_sleep(K_SECONDS(1));
+	}
 }
 
 static uint8_t detect_vr_module_via_pmbus(void)


### PR DESCRIPTION
# [Task Description]
- Related to GC20T5T7-181
- Fix efuse sensor showing NA after 12V-cycle

# [Motivation]
- After performing a 12V-cycle, HSC module detection may occasionally fail due to a timing issue, which prevents the correct eFuse configuration from being loaded properly.

# [Design]
- Added a retry mechanism with up to 5 attempts and a 1-second delay between each retry to ensure reliable HSC module detection after 12V-cycle.

# [Test Result]
Verified on GC2-ES platform by running multiple 12V-cycle tests using a script. All iterations completed successfully with sensor status showing OK.

root@bmc-oob:~# sensor-util server | grep EFUSE
MB_EFUSE_TEMP_C              (0xE) :  37.000 C     | (ok)
MB_EFUSE_INPUT_VOLT_V        (0x29) :  12.250 Volts | (ok)
MB_EFUSE_OUTPUT_CURR_A       (0x30) :   2.600 Amps  | (ok)
MB_EFUSE_INPUT_PWR_W         (0x39) :  62.350 Watts | (ok)