### PR TITLE
fby4: sd: Increase PLDM message retry to fix missing SEL during AC cycle

### DIFF
--- a/common/service/pldm/pldm.c
+++ b/common/service/pldm/pldm.c
@@ -248,7 +248,7 @@ uint16_t mctp_pldm_read(void *mctp_p, pldm_msg *msg, uint8_t *rbuf, uint16_t rbu
 	}
 	SAFE_FREE(event_msgq_p);
 	SAFE_FREE(recv_arg_p);
-	LOG_WRN("Retry reach max!");
+	LOG_ERR("Retry reach max!, pldm msg max retry: %d", PLDM_MSG_MAX_RETRY);
 	return 0;
 }
 

--- a/meta-facebook/yv4-sd/src/platform/plat_def.h
+++ b/meta-facebook/yv4-sd/src/platform/plat_def.h
@@ -76,6 +76,6 @@
 #define WORKER_STACK_SIZE 2048
 
 #define PLDM_MSG_TIMEOUT_MS 20000
-#define PLDM_MSG_MAX_RETRY 5
+#define PLDM_MSG_MAX_RETRY 20
 
 #endif


### PR DESCRIPTION
### Related JIRA ticket:
https://metainfra.atlassian.net/browse/YV4T1M-2254

# Description:
Increase PLDM_MSG_MAX_RETRY from 5 to 20 to ensure BIC can successfully deliver PLDM event messages when BMC is under load during simultaneous blade AC power cycling. Upgrade retry exhaustion log from LOG_WRN to LOG_ERR with retry count for better error visibility.

# Motivation:
During blade AC power cycling, multiple blades power on simultaneously causing BMC to be busy. The previous 5 retries were insufficient, resulting in BIC dropping PLDM platform event messages (BIOS certificate failure 0xFB) before BMC could respond, causing missing SEL entries.

Test Plan:
- Build code: pass