### PR TITLE
fby4: wf: Avoid CXL DIMM polling during Set EID and DIMM init

### DIFF
--- a/common/dev/include/vistara.h
+++ b/common/dev/include/vistara.h
@@ -99,7 +99,7 @@ typedef struct {
 extern ddr_slot_info_cache_t g_ddr_slot_cache;
 
 uint8_t plat_get_cxl_eid(uint8_t cxl_id);
-void plat_set_dimm_cache(uint8_t *resp_buf, uint8_t cxl_id, uint8_t status);
+void plat_set_dimm_cache(const uint8_t *resp_buf, uint8_t cxl_id, uint8_t status);
 float plat_get_dimm_cache(uint8_t cxl_id, uint8_t dimm_id);
 bool vistara_cci_command(uint8_t cxl_eid, mctp_cci_msg cci_msg, uint8_t *resp, uint8_t resp_len);
 bool vistara_read_ddr_temp(uint8_t cxl_eid, uint8_t *resp);

--- a/common/dev/vistara.c
+++ b/common/dev/vistara.c
@@ -32,7 +32,7 @@ __weak uint8_t plat_get_cxl_eid(uint8_t cxl_id)
 	return 0;
 }
 
-__weak void plat_set_dimm_cache(uint8_t *resp_buf, uint8_t cxl_id, uint8_t status)
+__weak void plat_set_dimm_cache(const uint8_t *resp_buf, uint8_t cxl_id, uint8_t status)
 {
 	return;
 }
@@ -40,6 +40,16 @@ __weak void plat_set_dimm_cache(uint8_t *resp_buf, uint8_t cxl_id, uint8_t statu
 __weak float plat_get_dimm_cache(uint8_t cxl_id, uint8_t dimm_id)
 {
 	return 0;
+}
+
+__weak bool plat_is_cxl_set_eid_in_progress(uint8_t cxl_id)
+{
+	return false;
+}
+
+__weak bool plat_is_dimm_present_check_in_progress(uint8_t cxl_id)
+{
+	return false;
 }
 
 bool vistara_read_ddr_temp(uint8_t cxl_eid, uint8_t *resp)
@@ -127,13 +137,13 @@ int vistara_init_ddr_slot_info(uint8_t cxl_id)
 		}
 
 		// 4 byte(slot count) + 16 byte(per DIMM) * 4
-		uint8_t *dimm_data = resp_buf + 4; // skip 4 byte(slot count)
+		const uint8_t *dimm_data = resp_buf + 4; // skip 4 byte(slot count)
 
 		for (int dimm_idx = 0; dimm_idx < MAX_DIMM_PER_CXL && dimm_idx < num_slots;
 		     dimm_idx++) {
 			dimm_slot_info_t *dimm_info =
 				&g_ddr_slot_cache.slot_info[cxl_id].dimm_info[dimm_idx];
-			uint8_t *current_dimm = dimm_data + (dimm_idx * 16);
+			const uint8_t *current_dimm = dimm_data + (dimm_idx * 16);
 
 			dimm_info->spd_i2c_addr = current_dimm[0];
 			dimm_info->channel_id = current_dimm[1];
@@ -236,7 +246,7 @@ uint8_t vistara_read(sensor_cfg *cfg, int *reading)
 	uint8_t dimm_id = cfg->target_addr;
 	uint8_t sensor_type = cfg->arg0;
 	uint8_t dimm_idx = dimm_id % MAX_DIMM_PER_CXL;
-	vistara_init_arg *init_arg = (vistara_init_arg *)cfg->init_args;
+	const vistara_init_arg *init_arg = (const vistara_init_arg *)cfg->init_args;
 
 	sensor_val *sval = (sensor_val *)reading;
 	float f_val = 0;
@@ -244,6 +254,19 @@ uint8_t vistara_read(sensor_cfg *cfg, int *reading)
 	switch (sensor_type) {
 	case DDR_TEMP: {
 		uint8_t resp_buf[READ_DDR_TEMP_RESP_LEN];
+
+		if (plat_is_cxl_set_eid_in_progress(cxl_id)) {
+			LOG_WRN("Skip CXL%d DIMM temp query because set EID is in progress",
+				cxl_id + 1);
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+
+		if (plat_is_dimm_present_check_in_progress(cxl_id)) {
+			LOG_WRN("Skip CXL%d DIMM temp query because DIMM present check is in progress",
+				cxl_id + 1);
+			return SENSOR_FAIL_TO_ACCESS;
+		}
+
 		if (init_arg->is_cached) {
 			k_mutex_lock(&g_ddr_slot_cache.mutex[cxl_id], K_FOREVER);
 			// Get master dimm id from slot info cache
@@ -278,8 +301,11 @@ uint8_t vistara_read(sensor_cfg *cfg, int *reading)
 				return SENSOR_FAIL_TO_ACCESS;
 			} else {
 				read_ddr_temp_resp *ddr_temp =
-					(read_ddr_temp_resp *)(resp_buf + dimm_idx * 8);
-				f_val = *((float *)&ddr_temp->dimm_temp);
+					(read_ddr_temp_resp *)(resp_buf +
+							       dimm_idx *
+								       sizeof(read_ddr_temp_resp));
+
+				memcpy(&f_val, ddr_temp->dimm_temp, sizeof(float));
 				LOG_HEXDUMP_INF(ddr_temp->dimm_temp, sizeof(float), "ddr temp");
 			}
 		}
@@ -304,7 +330,7 @@ uint8_t vistara_init(sensor_cfg *cfg)
 	return SENSOR_INIT_SUCCESS;
 }
 
-static inline int validate_spd_read_params(uint8_t *out, uint8_t dimm_idx, uint16_t offset,
+static inline int validate_spd_read_params(const uint8_t *out, uint8_t dimm_idx, uint16_t offset,
 					   uint8_t length)
 {
 	if (!out || length == 0 || length > VISTARA_SPD_CHUNK_DEFAULT || dimm_idx > 3 ||

--- a/meta-facebook/yv4-wf/src/platform/plat_dimm.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_dimm.c
@@ -39,8 +39,19 @@ K_THREAD_STACK_DEFINE(dimm_cxl2_init_stack, 2048);
 struct k_thread dimm_cxl2_init_thread;
 static k_tid_t dimm_cxl2_init_tid = NULL;
 
+static bool dimm_present_check_in_progress[MAX_CXL_ID] = { false, false };
+
+bool plat_is_dimm_present_check_in_progress(uint8_t cxl_id)
+{
+	if (cxl_id >= MAX_CXL_ID)
+		return false;
+
+	return dimm_present_check_in_progress[cxl_id];
+}
+
 void dimm_cxl1_slot_info_init_handler()
 {
+	dimm_present_check_in_progress[CXL_ID_1] = true;
 	LOG_INF("DIMM slot info initialization for CXL1 started");
 
 	int retry = 0;
@@ -48,6 +59,7 @@ void dimm_cxl1_slot_info_init_handler()
 		int result = vistara_init_ddr_slot_info(CXL_ID_1);
 		if (result > 0) {
 			LOG_INF("CXL1 DIMM slot info initialized successfully");
+			dimm_present_check_in_progress[CXL_ID_1] = false;
 			return;
 		} else {
 			LOG_ERR("Failed to initialize CXL1 DIMM slot info, retry: %d", retry);
@@ -57,10 +69,12 @@ void dimm_cxl1_slot_info_init_handler()
 	}
 
 	LOG_ERR("Failed to initialize CXL1 DIMM slot info after all retries");
+	dimm_present_check_in_progress[CXL_ID_1] = false;
 }
 
 void dimm_cxl2_slot_info_init_handler()
 {
+	dimm_present_check_in_progress[CXL_ID_2] = true;
 	LOG_INF("DIMM slot info initialization for CXL2 started");
 
 	int retry = 0;
@@ -68,6 +82,7 @@ void dimm_cxl2_slot_info_init_handler()
 		int result = vistara_init_ddr_slot_info(CXL_ID_2);
 		if (result > 0) {
 			LOG_INF("CXL2 DIMM slot info initialized successfully");
+			dimm_present_check_in_progress[CXL_ID_2] = false;
 			return;
 		} else {
 			LOG_ERR("Failed to initialize CXL2 DIMM slot info, retry: %d", retry);
@@ -77,6 +92,7 @@ void dimm_cxl2_slot_info_init_handler()
 	}
 
 	LOG_ERR("Failed to initialize CXL2 DIMM slot info after all retries");
+	dimm_present_check_in_progress[CXL_ID_2] = false;
 }
 
 void create_init_ddr_slot_info_thread(uint8_t cxl_id)

--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.c
@@ -48,6 +48,8 @@ K_THREAD_STACK_DEFINE(set_dev_endpoint_stack, SET_DEV_ENDPOINT_STACK_SIZE);
 struct k_thread set_dev_endpoint_thread_data;
 static k_tid_t set_dev_endpoint_tid = NULL;
 
+static bool cxl_set_eid_in_progress[MAX_CXL_ID] = { false, false };
+
 static mctp_port plat_mctp_port[] = {
 	{ .conf.smbus_conf.addr = I3C_ADDR_SD_BIC,
 	  .conf.i3c_conf.bus = I3C_BUS_SD_BIC,
@@ -180,9 +182,20 @@ bool set_cxl_eid(uint8_t cxl_id)
 	return false;
 }
 
+bool plat_is_cxl_set_eid_in_progress(uint8_t cxl_id)
+{
+	if (cxl_id >= MAX_CXL_ID) {
+		return false;
+	}
+
+	return cxl_set_eid_in_progress[cxl_id];
+}
+
 static void set_dev_endpoint(void)
 {
 	bool set_eid[MAX_CXL_ID] = { false, false };
+	cxl_set_eid_in_progress[CXL_ID_1] = true;
+	cxl_set_eid_in_progress[CXL_ID_2] = true;
 	// The CXL FW is unstable and its booting up time is random now.
 	// Temporary add retry mechanism for it.
 	for (int attempt = 0; attempt < 60; attempt++) {
@@ -238,13 +251,11 @@ static void set_dev_endpoint(void)
 					case I2C_BUS_CXL1: {
 						LOG_INF("Send set EID command to CXL1");
 						set_eid[CXL_ID_1] = true;
-						create_init_ddr_slot_info_thread(CXL_ID_1);
 						break;
 					}
 					case I2C_BUS_CXL2: {
 						LOG_INF("Send set EID command to CXL2");
 						set_eid[CXL_ID_2] = true;
-						create_init_ddr_slot_info_thread(CXL_ID_2);
 						break;
 					}
 					}
@@ -259,6 +270,13 @@ static void set_dev_endpoint(void)
 		// Delay for 10 seconds before the next attempt
 		k_sleep(K_SECONDS(10));
 	}
+	k_sleep(K_SECONDS(3));
+
+	create_init_ddr_slot_info_thread(CXL_ID_1);
+	create_init_ddr_slot_info_thread(CXL_ID_2);
+
+	cxl_set_eid_in_progress[CXL_ID_1] = false;
+	cxl_set_eid_in_progress[CXL_ID_2] = false;
 }
 
 static uint8_t mctp_msg_recv(void *mctp_p, uint8_t *buf, uint32_t len, mctp_ext_params ext_params)

--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.h
@@ -66,5 +66,6 @@ mctp *find_mctp_by_bus(uint8_t bus);
 bool check_cxl_eid(uint8_t cxl_id);
 bool set_cxl_eid(uint8_t cxl_id);
 uint8_t plat_get_cxl_eid(uint8_t cxl_id);
+bool plat_is_cxl_set_eid_in_progress(uint8_t cxl_id);
 
 #endif /* _PLAT_MCTP_h */

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
@@ -6761,7 +6761,7 @@ float plat_get_dimm_cache(uint8_t cxl_id, uint8_t dimm_id)
 	return result;
 }
 
-void plat_set_dimm_cache(uint8_t *resp_buf, uint8_t cxl_id, uint8_t status)
+void plat_set_dimm_cache(const uint8_t *resp_buf, uint8_t cxl_id, uint8_t status)
 {
 	if (k_mutex_lock(&cxl_dimm_mutex, K_MSEC(CXL_DIMM_MUTEX_WAITING_TIME_MS))) {
 		cxl_dimm_temp[cxl_id][DIMMA_ID] = -1;


### PR DESCRIPTION
 # [Issue Description]
- Related to YV4T1M-2265
- BMC recorded "CXL DEASSERTED" SEL after conducting SD BIC update with CXL 3.2.2.

 # [Root Cause]
WF may perform CXL Set EID, DIMM present initialization, and DIMM temperature sensor polling at overlapping timing. During these timing windows, CXL may not receive the expected response from WF BIC. Based on the CXL team's previous explanation, when WF BIC does not respond as expected, the Vistara I2C Master may hang indefinitely and eventually trigger the watchdog, resulting in a CXL crash. Since the CXL team believes that improving CXL's I2C timeout handling may impact the underlying I2C driver code, this scenario has been treated as a CXL limitation.

 # [Solution]
- This change is mainly a workaround for the CXL limitation previously raised by the CXL team.
- This change can only reduce the failure rate, but cannot fully resolve the CXL limitation.
- Added a per-CXL flag while WF is performing Set EID to CXL.
- Adjusted the execution timing between DIMM presence checking and sensor polling.
- Avoid performing DIMM temperature polling to CXL while the corresponding CXL is under Set EID or DIMM present initialization.