### PR TITLE
gc2: es: Add delay to filter false SYS_THROTTLE SEL

### DIFF
--- a/meta-facebook/gc2-es/src/platform/plat_isr.c
+++ b/meta-facebook/gc2-es/src/platform/plat_isr.c
@@ -388,10 +388,17 @@ void ISR_SOC_THMALTRIP()
 		}
 	}
 }
-
-void ISR_SYS_THROTTLE()
+/* Delay handler to prevent false SYS_THROTTLE SEL during power-off.
+ * FM_CPU_BIC_PROCHOT_LVT3_N may have a short low pulse from CPLD during
+ * power-off, triggering a false falling edge interrupt. By delaying 1ms,
+ * PWRGD_SYS_PWROK will have dropped, and the condition check below will
+ * correctly filter out the false event.
+ */
+static void sys_throttle_handler(struct k_work *work)
 {
 	common_addsel_msg_t sel_msg;
+	memset(&sel_msg, 0, sizeof(common_addsel_msg_t));
+
 	if ((gpio_get(RST_PLTRST_PLD_N) == GPIO_HIGH) && (gpio_get(PWRGD_SYS_PWROK) == GPIO_HIGH)) {
 		if (gpio_get(FM_CPU_BIC_PROCHOT_LVT3_N) == GPIO_HIGH) {
 			sel_msg.event_type = IPMI_OEM_EVENT_TYPE_DEASSERT;
@@ -409,6 +416,19 @@ void ISR_SYS_THROTTLE()
 			printf("System Throttle addsel fail\n");
 		}
 	}
+}
+
+K_WORK_DELAYABLE_DEFINE(sys_throttle_work, sys_throttle_handler);
+#define SYS_THROTTLE_DELAY_MS 1
+
+void ISR_SYS_THROTTLE()
+{
+	/* Cancel any pending work to handle rapid edge toggling,
+	 * then reschedule with delay to filter out glitch during power-off.
+	 */
+	if (k_work_cancel_delayable(&sys_throttle_work) != 0) {
+	}
+	k_work_schedule_for_queue(&plat_work_q, &sys_throttle_work, K_MSEC(SYS_THROTTLE_DELAY_MS));
 }
 
 void ISR_PCH_THMALTRIP()


### PR DESCRIPTION
# [Task Description]

Related to GC20T5T7-182
Add a 1 ms delayed work handler for SYS_THROTTLE interrupt handling.

# [Motivation]

FM_CPU_BIC_PROCHOT_LVT3_N may have a short transient pulse during the power-off transition. This transient pulse could trigger a false SYS_THROTTLE SEL event.

# [Design]

Move SYS_THROTTLE SEL logging to a delayed work handler. Delay 1 ms before rechecking RST_PLTRST_PLD_N, PWRGD_SYS_PWROK, and FM_CPU_BIC_PROCHOT_LVT3_N. Only add the SYS_THROTTLE SEL when the power/reset signals are still in a valid state after the delay.

# [Test Log]
During the power-off transition, the false SYS_THROTTLE SEL event can be filtered by the 1 ms delayed check. Normal SYS_THROTTLE ASSERT/DEASSERT behavior is still reported as expected.

1.Executing 12V-cycle
```
power-util server 12V-cycle
```
2.Verify that throttle-related logs are recorded during the test.
```
root@bmc-oob:~# log-util all --print |grep  SYS_THROTTLE
root@bmc-oob:~#
```