### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,10 @@ on:
   schedule:
       - cron: '0 0 * * *' # Once per day at midnight
 
+
+permissions:
+  contents: read
+
 jobs:
   # This will skip the nightly if there are no new commits since the previous nightly.
   # Might as well save some electrons on the weekend.


### PR DESCRIPTION
This PR adds a workflow-level `permissions: contents: read` to 1 workflow(s) that currently have no `permissions:` block (and therefore get the default broad read-write token). Each affected workflow was inspected and only reads repository contents; no publish/release/push/comment paths, so the change is non-functional in steady state and just shrinks the blast radius.

GitHub's documented Actions security recommendation. Happy to split per-file or adjust naming if preferred.