### PR TITLE
gc2: es: Modify efuse pmbus timeout enable

### DIFF
--- a/meta-facebook/gc2-es/src/platform/plat_class.c
+++ b/meta-facebook/gc2-es/src/platform/plat_class.c
@@ -258,6 +258,13 @@ void mp5998_plat_init()
 	data[2] = (init_args->fault_mask >> 8) & 0xFF;
 	msg = construct_i2c_message(bus, addr, 3, data, 0);
 	i2c_master_write(&msg, retry);
+
+	/* efuse_cfg */
+	data[0] = 0xC4; // 0xC4
+	data[1] = init_args->efuse_cfg & 0xFF;
+	data[2] = (init_args->efuse_cfg >> 8) & 0xFF;
+	msg = construct_i2c_message(bus, addr, 3, data, 0);
+	i2c_master_write(&msg, retry);
 }
 
 void tps25990_plat_init()

--- a/meta-facebook/gc2-es/src/platform/plat_hook.c
+++ b/meta-facebook/gc2-es/src/platform/plat_hook.c
@@ -74,6 +74,7 @@ mp5998_plat_init_arg mp5998_plat_init_args[] = {
 		.iin_oc_fault_limit = 0x01B7, //5Bh value : 27.4375    lsb : 1/16 A
 		.iin_oc_warn_limit = 0x0195, //5Dh value : 25.3125
 		.fault_mask = 0x0008, //D4h
+		.efuse_cfg = 0x49CC, //C4h
 		.protect_en = 0x3EFF } //CAh
 };
 

--- a/meta-facebook/gc2-es/src/platform/plat_hook.h
+++ b/meta-facebook/gc2-es/src/platform/plat_hook.h
@@ -41,6 +41,7 @@ typedef struct _mp5998_plat_init_arg {
 	uint16_t iin_oc_fault_limit;
 	uint16_t iin_oc_warn_limit;
 	uint16_t fault_mask;
+	uint16_t efuse_cfg;
 	uint16_t protect_en;
 } mp5998_plat_init_arg;
 typedef struct _tps53689_pre_proc_arg {


### PR DESCRIPTION
# [Task Description]
- Related to GC20T5T7-218
- Enable PMBus timeout in MP5998

# [Motivation]
- While investigating GC20T5T7-218, we found that the MP5998 eFuse does not have PMBus timeout enabled. Without this feature, if a race condition occurs on the PMBus and causes the bus to hang, the eFuse has no automatic recovery mechanism to reset the PMBus communication.

# [Design]
- Enable MP5998 PMBus timeout by setting bit 8 of register C4h.

# [Test Log]
Verified on GC2-ES platform, all sensors report correct values.
```
 root@bmc-oob:~# bic-util server 0x18 0x52 3 0x98 2 0xC4 CC 49
```