### PR TITLE
Common: fix TMP75/TMP432 threshold conversion and MP2971 OVP1 validation

### DIFF
--- a/common/dev/mp2971.c
+++ b/common/dev/mp2971.c
@@ -1493,6 +1493,11 @@ bool mp2971_set_ovp_1(sensor_cfg *cfg, uint8_t rail, uint16_t *ovp_1_mv)
 		return false;
 	}
 
+	if (*ovp_1_mv < vout_max_mv) {
+		LOG_ERR("ovp_1_mv must be >= vout_max");
+		return false;
+	}
+
 	uint16_t delta_mv = *ovp_1_mv - vout_max_mv;
 	uint8_t code = (uint8_t)((delta_mv / 50U) - 1U);
 

--- a/common/dev/mp2971.c
+++ b/common/dev/mp2971.c
@@ -1499,6 +1499,16 @@ bool mp2971_set_ovp_1(sensor_cfg *cfg, uint8_t rail, uint16_t *ovp_1_mv)
 	}
 
 	uint16_t delta_mv = *ovp_1_mv - vout_max_mv;
+
+	if (delta_mv < 50) {
+		delta_mv = 50;
+	}
+
+	/* optional: upper bound */
+	if (delta_mv > 400) {
+		delta_mv = 400;
+	}
+
 	uint8_t code = (uint8_t)((delta_mv / 50U) - 1U);
 
 	uint8_t data[2] = { 0 };

--- a/common/dev/tmp431.c
+++ b/common/dev/tmp431.c
@@ -80,13 +80,12 @@ bool get_tmp432_two_byte_limit(sensor_cfg *cfg, uint8_t temp_threshold_index,
 	msg.data[0] = register_high;
 
 	if (i2c_master_read(&msg, retry)) {
-		LOG_ERR("Failed to write TMP431 register(0x%x)", temp_threshold_index);
+		LOG_ERR("Failed to read TMP432 register(0x%x)", temp_threshold_index);
 		return false;
 	}
 
-	int32_t limit_high_byte_val = (int8_t)msg.data[0] * 1000;
-	int32_t limit_low_byte_val = (((int8_t)msg.data[1] >> 4) * 625) / 10;
-	*millidegree_celsius = limit_high_byte_val + limit_low_byte_val;
+	int16_t raw = ((int16_t)(int8_t)msg.data[0] << 4) | (msg.data[1] >> 4);
+	*millidegree_celsius = (raw * 1000) / 16;
 
 	return true;
 }
@@ -171,20 +170,21 @@ bool set_tmp432_two_byte_limit(sensor_cfg *cfg, uint8_t temp_threshold_index,
 	CHECK_NULL_ARG_WITH_RETURN(millidegree_celsius, false);
 
 	uint8_t register_high = tmp432_temp_register_map[temp_threshold_index].write_byte;
+
 	uint8_t retry = 5;
 	I2C_MSG msg = { 0 };
 	msg.bus = cfg->port;
 	msg.target_addr = cfg->target_addr;
 	msg.tx_len = 3;
 	msg.data[0] = register_high;
-	msg.data[1] = (int8_t)(*millidegree_celsius / 1000);
 
-	int32_t remainder = *millidegree_celsius % 1000;
-	int8_t low_byte_val = (int8_t)((remainder * 16) / 1000);
-	msg.data[2] = (low_byte_val << 4);
+	int16_t raw = (int16_t)((*millidegree_celsius * 16) / 1000);
+
+	msg.data[1] = (uint8_t)(raw >> 4);
+	msg.data[2] = (uint8_t)(raw << 4);
 
 	if (i2c_master_write(&msg, retry)) {
-		LOG_ERR("Failed to write TMP431 register(0x%x)", temp_threshold_index);
+		LOG_ERR("Failed to write TMP432 register(0x%x)", temp_threshold_index);
 		return false;
 	}
 

--- a/common/dev/tmp75.c
+++ b/common/dev/tmp75.c
@@ -39,14 +39,12 @@ bool get_tmp75_two_byte_limit(sensor_cfg *cfg, uint8_t temp_threshold_index,
 								    TMP75_LOCAL_LOW_LIMIT_REG);
 
 	if (i2c_master_read(&msg, retry)) {
-		LOG_ERR("Failed to write TMP431 register(0x%x)", temp_threshold_index);
+		LOG_ERR("Failed to read TMP75 register(0x%x)", temp_threshold_index);
 		return false;
 	}
 
-	int32_t limit_byte_1_val = (int8_t)msg.data[0] * 1000.0;
-	int32_t limit_byte_2_val = ((int8_t)msg.data[1] >> 4) * 62.5;
-
-	*millidegree_celsius = limit_byte_1_val + limit_byte_2_val;
+	int16_t raw = ((int16_t)(int8_t)msg.data[0] << 4) | (msg.data[1] >> 4);
+	*millidegree_celsius = (raw * 1000) / 16;
 
 	return true;
 }
@@ -83,18 +81,19 @@ bool set_tmp75_two_byte_limit(sensor_cfg *cfg, uint8_t temp_threshold_index,
 
 	uint8_t retry = 5;
 	I2C_MSG msg = { 0 };
+
+	int16_t raw = (int16_t)((*millidegree_celsius * 16) / 1000);
+
 	msg.bus = cfg->port;
 	msg.target_addr = cfg->target_addr;
 	msg.tx_len = 3;
 	msg.data[0] = ((temp_threshold_index == LOCAL_HIGH_LIMIT) ? TMP75_LOCAL_HIGH_LIMIT_REG :
 								    TMP75_LOCAL_LOW_LIMIT_REG);
-	msg.data[1] = (int8_t)(*millidegree_celsius / 1000.0);
-	int32_t remainder = *millidegree_celsius % 1000;
-	int8_t low_byte_val = (int8_t)((remainder * 16) / 1000);
-	msg.data[2] = (low_byte_val << 4);
+	msg.data[1] = (uint8_t)(raw >> 4);
+	msg.data[2] = (uint8_t)(raw << 4);
 
 	if (i2c_master_write(&msg, retry)) {
-		LOG_ERR("Failed to write TMP431 register(0x%x)", temp_threshold_index);
+		LOG_ERR("Failed to write TMP75 register(0x%x)", temp_threshold_index);
 		return false;
 	}
 


### PR DESCRIPTION
## Summary
This PR includes common-layer fixes for TMP75/TMP432 threshold handling and MP2971 voltage protection validation:

- Fix TMP75/TMP432 two-byte threshold get/set conversion
  - Decode threshold registers as signed 1/16°C raw values
  - Fix incorrect low-byte signed extension
  - Fix negative threshold handling

- Improve MP2971 validation and parameter handling
  - Ensure `ovp_1_mv` is greater than or equal to `vout_max_mv`
  - Reject invalid OVP1 settings when the threshold is lower than `vout_max`
  - Add `delta_mv` boundary checks
  - Clamp `delta_mv` to the range `50` to `400`

## Test Plan
- Build code: Pass
- Set and get positive TMP75/TMP432 threshold values: Pass
- Set and get negative TMP75/TMP432 threshold values: Pass