### PR TITLE
Common: fix zero-value decimal conversion and add NULL guard in libutil

### DIFF
--- a/common/lib/libutil.c
+++ b/common/lib/libutil.c
@@ -69,7 +69,9 @@ I2C_MSG construct_i2c_message(uint8_t bus_id, uint8_t address, uint8_t tx_len, u
 	i2c_msg.bus = bus_id;
 	i2c_msg.target_addr = address;
 	i2c_msg.tx_len = tx_len;
-	memcpy(i2c_msg.data, data, tx_len);
+	if ((tx_len != 0) && (data != NULL)) {
+		memcpy(i2c_msg.data, data, tx_len);
+	}
 	i2c_msg.rx_len = rx_len;
 	return i2c_msg;
 }
@@ -169,7 +171,8 @@ int uint8_t_to_dec_ascii_pointer(uint8_t val, uint8_t *result, uint8_t len)
 	uint8_t divisor = 100;
 
 	while ((divisor > 0) && (idx < len)) {
-		if ((val / divisor) == 0 && (idx == 0)) {
+		// always write the ones digit so that val = 0 outputs "0"
+		if ((val / divisor) == 0 && (idx == 0) && (divisor != 1)) {
 		} else {
 			digit = val / divisor;
 			result[idx] = 0x30 + digit;


### PR DESCRIPTION
Summary:
This PR includes two common-layer fixes in `common/lib/libutil.c`:

- Fix `uint8_t_to_dec_ascii_pointer()` producing no output for `val = 0`
  - The skip-leading-zeros condition skipped every digit, so the function returned 0 and wrote nothing
  - Callers such as the at-cb VR firmware-version string showed `"Remaining Write: "` with no number once the remaining write count reached 0
  - Always emit the ones digit so that 0 converts to `"0"`

- Add NULL/length guard in `construct_i2c_message()`
  - `memcpy()` was called on the caller-supplied `data` pointer unconditionally
  - Guard the copy the same way as its sibling `construct_ipmi_message()` already does, so a NULL `data` pointer with a non-zero `tx_len` cannot fault

Test Plan:
- Verified the decimal conversion is correct for all 256 possible `uint8_t` inputs (previously `0` produced an empty string)
- `construct_i2c_message()` behavior is unchanged for all existing call sites (every current caller passes a valid buffer; `tx_len` is `uint8_t`, max 255, within `I2C_BUFF_SIZE` 256)
