### PR TITLE
fby4: wf: Add support for WF SKU without ASIC

### DIFF
--- a/meta-facebook/yv4-wf/src/platform/plat_class.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_class.c
@@ -26,6 +26,15 @@ struct adc_info adc[NUMBER_OF_ADC_CHANNEL] = {
 	{ 0x118, 0 }, { 0x118, 16 }, { 0x11C, 0 }, { 0x11C, 16 }
 };
 
+struct blade_config_mapping_table blade_config_table[] = {
+	{ 1.5, BLADE_CONFIG_VOLTAGE_RANGE, BLADE_CONFIG_with_ASIC },
+	{ 1.25, BLADE_CONFIG_VOLTAGE_RANGE, BLADE_CONFIG_UNKNOWN },
+	{ 1.0, BLADE_CONFIG_VOLTAGE_RANGE, BLADE_CONFIG_UNKNOWN },
+	{ 0.75, BLADE_CONFIG_VOLTAGE_RANGE, BLADE_CONFIG_without_ASIC },
+	{ 0.5, BLADE_CONFIG_VOLTAGE_RANGE, BLADE_CONFIG_UNKNOWN },
+	{ 0.0, BLADE_CONFIG_VOLTAGE_RANGE, BLADE_CONFIG_UNKNOWN },
+};
+
 struct board_rev_mappting_table board_rev_table[] = {
 	{ 1.25, 0.05, BOARD_POC }, // range: +-5%
 	{ 0.75, 0.05, BOARD_POC2 }, // range: +-5%
@@ -36,6 +45,20 @@ struct board_rev_mappting_table board_rev_table[] = {
 };
 
 static uint8_t board_revision = UNKNOWN;
+static uint8_t blade_configuration = BLADE_CONFIG_UNKNOWN;
+
+static uint32_t adc_get_sample_period_us(void)
+{
+	uint32_t clk_ctrl = sys_read32(AST1030_ADC_BASE_ADDR + 0x00C); // ADC00C
+	uint32_t divisor = clk_ctrl & 0xFFFF; // [15:0]
+
+	// Period(ADC clock) = PCLK_period * 2 * (divisor+1)
+	// Sample period = Period(ADC clock) * 12
+	uint64_t adc_clk_period_ns = (uint64_t)ADC_PCLK_NS * 2 * (divisor + 1);
+	uint64_t sample_period_ns = adc_clk_period_ns * 12;
+
+	return (uint32_t)(sample_period_ns / 1000) + 1; // convert to us, round up
+}
 
 bool get_adc_voltage(int channel, float *voltage)
 {
@@ -46,7 +69,7 @@ bool get_adc_voltage(int channel, float *voltage)
 		return false;
 	}
 
-	uint32_t raw_value, reg_value;
+	uint32_t reg_value;
 	long unsigned int engine_control = 0x0;
 	float reference_voltage = 0.0f;
 
@@ -68,19 +91,72 @@ bool get_adc_voltage(int channel, float *voltage)
 		return false;
 	}
 
-	// Read ADC raw value
-	reg_value = sys_read32(AST1030_ADC_BASE_ADDR + adc[channel].offset);
-	raw_value = (reg_value >> adc[channel].shift) & 0x3FF; // 10-bit(0x3FF) resolution
+	uint32_t sample_period_us = adc_get_sample_period_us();
 
-	// Real voltage = raw data * reference voltage / 2 ^ resolution(10)
-	*voltage = (raw_value * reference_voltage) / 1024;
+	// Settle: wait at least 2 full sample periods before first read
+	k_usleep(sample_period_us * 2);
+
+	uint32_t sum_raw = 0;
+
+	for (int i = 0; i < ADC_SAMPLE_COUNT; i++) {
+		reg_value = sys_read32(AST1030_ADC_BASE_ADDR + adc[channel].offset);
+		uint32_t raw_value = (reg_value >> adc[channel].shift) & 0x3FF;
+		sum_raw += raw_value;
+
+		// Wait for a genuinely new conversion before next read
+		k_usleep(sample_period_us);
+	}
+
+	float avg_raw = (float)sum_raw / ADC_SAMPLE_COUNT;
+	*voltage = (avg_raw * reference_voltage) / 1024.0f;
 
 	return true;
+}
+
+bool get_blade_config(uint8_t *blade_config)
+{
+	/* Determine blade configuration using ADC0 voltage
+	 * Since the BMC also have FRU acessibility,
+	 * avoid reading FRU to prevent unexpected behavior.
+	 */
+
+	CHECK_NULL_ARG_WITH_RETURN(blade_config, false);
+
+	float voltage = 0.0f;
+
+	if (get_adc_voltage(CHANNEL_0, &voltage) == false) {
+		LOG_ERR("Failed to get blade config");
+		*blade_config = BLADE_CONFIG_UNKNOWN;
+		return false;
+	}
+
+	*blade_config = BLADE_CONFIG_UNKNOWN;
+
+	for (int i = 0; i < ARRAY_SIZE(blade_config_table); i++) {
+		float typical_voltage = blade_config_table[i].voltage;
+		float range_val = blade_config_table[i].range_val;
+
+		if ((voltage <= typical_voltage + range_val) &&
+		    (voltage >= typical_voltage - range_val)) {
+			*blade_config = blade_config_table[i].blade_config;
+			LOG_INF("Blade config: 0x%02x, voltage: %dmV", *blade_config,
+				(int)(voltage * 1000));
+			return true;
+		}
+	}
+
+	LOG_ERR("Unknown blade config voltage: %dmV", (int)(voltage * 1000));
+	return false;
 }
 
 uint8_t get_board_revision()
 {
 	return board_revision;
+}
+
+uint8_t get_blade_configuration()
+{
+	return blade_configuration;
 }
 
 int init_platform_config()
@@ -90,6 +166,12 @@ int init_platform_config()
 	bool ret = get_adc_voltage(CHANNEL_1, &voltage);
 	if (!ret) {
 		LOG_ERR("Failed to get board revision");
+		return -1;
+	}
+
+	ret = get_blade_config(&blade_configuration);
+	if (!ret) {
+		LOG_ERR("Failed to get blade configuration");
 		return -1;
 	}
 

--- a/meta-facebook/yv4-wf/src/platform/plat_class.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_class.h
@@ -19,6 +19,9 @@
 
 #define NUMBER_OF_ADC_CHANNEL 16
 #define AST1030_ADC_BASE_ADDR 0x7e6e9000
+#define ADC_PCLK_NS 42 // ~24MHz APB clock, adjust if your board differs
+#define ADC_SAMPLE_COUNT 8
+#define BLADE_CONFIG_VOLTAGE_RANGE 0.1 // range: +-0.1V, half of 0.25V spacing
 
 enum ADC_REF_VOL_SELECTION {
 	REF_VOL_2_5V = 0x0, // 2.5V reference voltage selection
@@ -26,7 +29,14 @@ enum ADC_REF_VOL_SELECTION {
 };
 
 enum ADC_CHANNEL_NUM {
+	CHANNEL_0 = 0,
 	CHANNEL_1 = 1,
+};
+
+enum BLADE_CONFIG {
+	BLADE_CONFIG_with_ASIC = 0x00,
+	BLADE_CONFIG_without_ASIC = 0x10,
+	BLADE_CONFIG_UNKNOWN = 0xff,
 };
 
 enum BOARD_REV_ID {
@@ -44,6 +54,12 @@ struct adc_info {
 	int shift;
 };
 
+struct blade_config_mapping_table {
+	float voltage;
+	float range_val;
+	uint8_t blade_config;
+};
+
 struct board_rev_mappting_table {
 	float voltage;
 	float range_val;
@@ -51,7 +67,9 @@ struct board_rev_mappting_table {
 };
 
 bool get_adc_voltage(int channel, float *voltage);
+bool get_blade_config(uint8_t *blade_config);
 uint8_t get_board_revision();
+uint8_t get_blade_configuration();
 int init_platform_config();
 
 #endif

--- a/meta-facebook/yv4-wf/src/platform/plat_init.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_init.c
@@ -62,18 +62,29 @@ void pal_set_sys_status()
 	set_DC_on_delayed_status();
 	init_ioe_config();
 
-	if (gpio_get(PG_CARD_OK) == POWER_ON) {
+	uint8_t blade_conf = get_blade_configuration();
+	if (blade_conf == BLADE_CONFIG_without_ASIC) {
 		if (get_board_revision() == BOARD_POC) {
 			set_P3V3_E1S_power_status(POC_PWRGD_P3V3_E1S_0_R);
 		} else {
 			set_P3V3_E1S_power_status(PWRGD_P3V3_E1S_0_R);
 		}
 		set_P12V_E1S_power_status(PWRGD_P12V_E1S_0_R);
-		create_check_cxl_ready_thread();
-	} else {
-		LOG_ERR("PG_CARD_OK not ready, skip set_sys_status");
+		set_sys_ready_pin(BIC_READY_R);
+	} else { //default: BLADE_CONFIG_with_ASIC
+		if (gpio_get(PG_CARD_OK) == POWER_ON) {
+			if (get_board_revision() == BOARD_POC) {
+				set_P3V3_E1S_power_status(POC_PWRGD_P3V3_E1S_0_R);
+			} else {
+				set_P3V3_E1S_power_status(PWRGD_P3V3_E1S_0_R);
+			}
+			set_P12V_E1S_power_status(PWRGD_P12V_E1S_0_R);
+			create_check_cxl_ready_thread();
+		} else {
+			LOG_ERR("PG_CARD_OK not ready, skip set_sys_status");
+		}
+		set_sys_ready_pin(BIC_READY_R);
 	}
-	set_sys_ready_pin(BIC_READY_R);
 }
 
 static const gpio_debounce_cfg_t debounce_cfg[] = {
@@ -138,6 +149,8 @@ void pal_pre_init()
 
 	init_vr_event_work();
 	init_plat_worker(CONFIG_MAIN_THREAD_PRIORITY + 1); // work queue for low priority jobs
+
+	plat_init_pldm_sensor_table();
 }
 
 void pal_post_init()

--- a/meta-facebook/yv4-wf/src/platform/plat_isr.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_isr.c
@@ -153,11 +153,21 @@ void process_pmbus_vr_event_handler(struct k_work *work_item)
 	uint8_t retry = 5;
 	uint8_t ioe1_reg_data = 0;
 	uint8_t ioe2_reg_data = 0;
+	uint8_t blade_conf = get_blade_configuration();
 
 	get_ioe_value(ADDR_IOE1, TCA9555_INPUT_PORT_REG_0, &ioe1_reg_data);
-	get_ioe_value(ADDR_IOE2, TCA9555_OUTPUT_PORT_REG_0, &ioe2_reg_data);
+	if (blade_conf != BLADE_CONFIG_without_ASIC) {
+		get_ioe_value(ADDR_IOE2, TCA9555_OUTPUT_PORT_REG_0, &ioe2_reg_data);
+	} else {
+		LOG_INF("Blade config without ASIC: Skip ASIC VR chips");
+	}
 
 	for (int i = 0; i < ARRAY_SIZE(vr_fault_table); ++i) {
+		// Skip ASIC VR chips entirely if blade has no ASIC populated
+		if (blade_conf == BLADE_CONFIG_without_ASIC) {
+			continue;
+		}
+
 		bool is_vr_alert =
 			(GETBIT(ioe1_reg_data, vr_fault_table[i].ioe_pin_num) == GPIO_LOW) ? true :
 											     false;
@@ -443,26 +453,34 @@ K_WORK_DEFINE(set_e1s_pe_reset_work, set_e1s_pe_reset);
 
 void ISR_MB_PCIE_RST()
 {
-	gpio_set(PERST_ASIC1_N_R, gpio_get(RST_PCIE_MB_EXP_N));
-	gpio_set(PERST_ASIC2_N_R, gpio_get(RST_PCIE_MB_EXP_N));
+	uint8_t blade_conf = get_blade_configuration();
 
-	k_work_submit(&set_e1s_pe_reset_work);
-
-	// Monitor CXL ready and set CXL EID again
-	if (gpio_get(RST_PCIE_MB_EXP_N) == GPIO_HIGH) {
-		LOG_INF("PERST+");
-		// If CXL didn't ready, check again
-		if ((!get_cxl_ready_status(CXL_ID_1)) || (!get_cxl_ready_status(CXL_ID_2))) {
-			create_check_cxl_ready_thread();
-			create_set_dev_endpoint_thread();
-		}
+	if (blade_conf == BLADE_CONFIG_without_ASIC) {
+		k_work_submit(&set_e1s_pe_reset_work);
 	} else {
-		LOG_INF("PERST-");
-		// host reset, cxl also reset
-		set_cxl_ready_status(CXL_ID_1, false);
-		set_cxl_ready_status(CXL_ID_2, false);
-		set_cxl_vr_access(CXL_ID_1, false);
-		set_cxl_vr_access(CXL_ID_2, false);
+		gpio_set(PERST_ASIC1_N_R, gpio_get(RST_PCIE_MB_EXP_N));
+		gpio_set(PERST_ASIC2_N_R, gpio_get(RST_PCIE_MB_EXP_N));
+
+		k_work_submit(&set_e1s_pe_reset_work);
+
+		// Monitor CXL ready and set CXL EID again
+		if (gpio_get(RST_PCIE_MB_EXP_N) == GPIO_HIGH) {
+			LOG_INF("PERST+");
+
+			// If CXL didn't ready, check again
+			if ((!get_cxl_ready_status(CXL_ID_1)) ||
+			    (!get_cxl_ready_status(CXL_ID_2))) {
+				create_check_cxl_ready_thread();
+				create_set_dev_endpoint_thread();
+			}
+		} else {
+			LOG_INF("PERST-");
+			// host reset, cxl also reset
+			set_cxl_ready_status(CXL_ID_1, false);
+			set_cxl_ready_status(CXL_ID_2, false);
+			set_cxl_vr_access(CXL_ID_1, false);
+			set_cxl_vr_access(CXL_ID_2, false);
+		}
 	}
 }
 

--- a/meta-facebook/yv4-wf/src/platform/plat_mctp.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_mctp.c
@@ -37,6 +37,7 @@
 #include "plat_power_seq.h"
 #include "plat_pldm_sensor.h"
 #include "plat_dimm.h"
+#include "plat_class.h"
 
 #include "hal_i2c.h"
 
@@ -369,8 +370,13 @@ void set_dev_endpoint_thread(void *arg1, void *arg2, void *arg3)
 	ARG_UNUSED(arg2);
 	ARG_UNUSED(arg3);
 
-	/* init the device endpoint */
-	set_dev_endpoint();
+	uint8_t blade_conf = get_blade_configuration();
+	if (blade_conf == BLADE_CONFIG_without_ASIC) {
+		return;
+	} else { //default: BLADE_CONFIG_with_ASIC
+		/* init the device endpoint */
+		set_dev_endpoint();
+	}
 }
 
 void create_set_dev_endpoint_thread()

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_device_identifier.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_device_identifier.c
@@ -207,4 +207,4 @@ struct pldm_downstream_identifier_table downstream_table[] = {
 	  .descriptor_count = ARRAY_SIZE(PLDM_CXL2_DESCRIPTORS) },
 };
 
-const uint8_t downstream_devices_count = ARRAY_SIZE(downstream_table);
+uint8_t downstream_devices_count = ARRAY_SIZE(downstream_table);

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_device_identifier.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_device_identifier.h
@@ -19,7 +19,7 @@
 
 #include "pldm_firmware_update.h"
 
-extern const uint8_t downstream_devices_count;
+extern uint8_t downstream_devices_count;
 
 extern struct pldm_downstream_identifier_table downstream_table[];
 

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.c
@@ -35,6 +35,7 @@
 #include "cci.h"
 #include "util_spi.h"
 #include "plat_pldm_device_identifier.h"
+#include "plat_class.h"
 
 LOG_MODULE_REGISTER(plat_fwupdate);
 
@@ -267,8 +268,8 @@ uint8_t plat_pldm_query_downstream_devices(const uint8_t *buf, uint16_t len, uin
 
 	resp_p->completion_code = PLDM_SUCCESS;
 	resp_p->downstream_device_update_supported = PLDM_FW_UPDATE_SUPPORT_DOWNSTREAM_DEVICES;
-	resp_p->number_of_downstream_devices = 6;
-	resp_p->max_number_of_downstream_devices = 6;
+	resp_p->number_of_downstream_devices = downstream_devices_count;
+	resp_p->max_number_of_downstream_devices = downstream_devices_count;
 
 	resp_p->capabilities.dynamically_attached = 0;
 	resp_p->capabilities.dynamically_removed = 0;
@@ -432,6 +433,15 @@ uint8_t plat_pldm_query_downstream_identifiers(const uint8_t *buf, uint16_t len,
 	return PLDM_SUCCESS;
 }
 
+void plat_pldm_init_downstream_devices(void)
+{
+	if (get_blade_configuration() == BLADE_CONFIG_without_ASIC) {
+		downstream_devices_count = 0;
+	} else {
+		downstream_devices_count = DOWNSTREAM_DEVICES_MAX;
+	}
+}
+
 void load_pldmupdate_comp_config(void)
 {
 	if (comp_config) {
@@ -439,14 +449,40 @@ void load_pldmupdate_comp_config(void)
 		return;
 	}
 
-	comp_config_count = ARRAY_SIZE(PLDMUPDATE_FW_CONFIG_TABLE);
-	comp_config = malloc(sizeof(pldm_fw_update_info_t) * comp_config_count);
+	uint8_t total_count = ARRAY_SIZE(PLDMUPDATE_FW_CONFIG_TABLE);
+
+	comp_config = malloc(sizeof(pldm_fw_update_info_t) * total_count);
 	if (!comp_config) {
 		LOG_ERR("comp_config malloc failed");
 		return;
 	}
 
-	memcpy(comp_config, PLDMUPDATE_FW_CONFIG_TABLE, sizeof(PLDMUPDATE_FW_CONFIG_TABLE));
+	if (get_blade_configuration() != BLADE_CONFIG_without_ASIC) {
+		memcpy(comp_config, PLDMUPDATE_FW_CONFIG_TABLE, sizeof(PLDMUPDATE_FW_CONFIG_TABLE));
+		comp_config_count = total_count;
+	} else {
+		// Without-ASIC: filter out ASIC-related components
+		comp_config_count = 0;
+		for (int i = 0; i < total_count; i++) {
+			switch (PLDMUPDATE_FW_CONFIG_TABLE[i].comp_identifier) {
+			case WF_COMPNT_VR_PVDDQ_AB_ASIC1:
+			case WF_COMPNT_VR_PVDDQ_CD_ASIC1:
+			case WF_COMPNT_VR_PVDDQ_AB_ASIC2:
+			case WF_COMPNT_VR_PVDDQ_CD_ASIC2:
+			case WF_COMPNT_CXL1:
+			case WF_COMPNT_CXL2:
+				continue;
+			default:
+				break;
+			}
+
+			memcpy(&comp_config[comp_config_count], &PLDMUPDATE_FW_CONFIG_TABLE[i],
+			       sizeof(pldm_fw_update_info_t));
+			comp_config_count++;
+		}
+	}
+
+	plat_pldm_init_downstream_devices();
 }
 
 static bool plat_pldm_vr_i2c_info_get(int comp_identifier, uint8_t *bus, uint8_t *addr)

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_fw_update.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include "pldm_firmware_update.h"
 
+#define DOWNSTREAM_DEVICES_MAX 6
 #define INF_CRC_PREFIX "Infineon "
 
 void load_pldmupdate_comp_config(void);

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_monitor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_monitor.c
@@ -184,7 +184,7 @@ uint8_t plat_pldm_set_state_effecter_state_handler(const uint8_t *buf, uint16_t 
 }
 
 static void plat_get_cxl_ready_state(const uint8_t *buf, uint16_t len, uint8_t *resp,
-					      uint16_t *resp_len)
+				     uint16_t *resp_len)
 {
 	CHECK_NULL_ARG(buf);
 	CHECK_NULL_ARG(resp);
@@ -197,9 +197,11 @@ static void plat_get_cxl_ready_state(const uint8_t *buf, uint16_t len, uint8_t *
 	get_effecter_state_field_t *cxl2_state = &res_p->field[1];
 
 	cxl1_state->effecter_op_state = PLDM_EFFECTER_ENABLED_NOUPDATEPENDING;
-	cxl1_state->present_state = cxl1_state->pending_state = (get_cxl_ready_status(CXL_ID_1) ? 1 : 0);
+	cxl1_state->present_state = cxl1_state->pending_state =
+		(get_cxl_ready_status(CXL_ID_1) ? 1 : 0);
 	cxl2_state->effecter_op_state = PLDM_EFFECTER_ENABLED_NOUPDATEPENDING;
-	cxl2_state->present_state = cxl2_state->pending_state = (get_cxl_ready_status(CXL_ID_2) ? 1 : 0);
+	cxl2_state->present_state = cxl2_state->pending_state =
+		(get_cxl_ready_status(CXL_ID_2) ? 1 : 0);
 
 	*resp_len = PLDM_GET_STATE_EFFECTER_RESP_NO_STATE_FIELD_BYTES +
 		    (sizeof(get_effecter_state_field_t) * 2);

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.c
@@ -40,6 +40,7 @@ void plat_pldm_sensor_change_vr_dev();
 void plat_pldm_sensor_change_adc_monitor_dev();
 void plat_pldm_sensor_change_asic_tmp_dev();
 void plat_pldm_sensor_change_ina233_dev();
+void plat_pldm_sensor_change_asic_dev();
 
 float cxl_dimm_temp[MAX_CXL_ID][MAX_DIMM_ID] = { { -1, -1, -1, -1 }, { -1, -1, -1, -1 } };
 
@@ -6354,6 +6355,99 @@ PDR_entity_auxiliary_names plat_pdr_entity_aux_names_table[] = { {
 	.nameLanguageTag = "en",
 } };
 
+uint16_t total_disable_sensors_count = 0;
+uint16_t total_disable_aux_names_count = 0;
+
+uint16_t *disable_sensors_id_table = NULL;
+
+void plat_init_pldm_sensor_table()
+{
+        // Disable/Change sensors according to different config
+        plat_pldm_sensor_change_asic_dev();
+
+        // Initialize sensors that needs to be disabled
+        plat_init_pldm_disabled_sensors();
+}
+
+void plat_pldm_disable_sensor(sensor_cfg *cfg)
+{
+        CHECK_NULL_ARG(cfg);
+
+        cfg->cache_status = PLDM_SENSOR_DISABLED;
+        total_disable_sensors_count++;
+}
+
+void plat_init_pldm_disabled_sensors()
+{
+        int count = 0;
+        uint16_t thread_id = 0;
+        uint16_t sensor_id = 0;
+        uint16_t current_sensor_count = 0;
+        pldm_sensor_info *pldm_sensor_table = NULL;
+
+        if (total_disable_sensors_count == 0) {
+                return;
+        }
+
+        disable_sensors_id_table =
+                (uint16_t *)malloc(total_disable_sensors_count * sizeof(uint16_t));
+        if (disable_sensors_id_table == NULL) {
+                total_disable_sensors_count = 0;
+                LOG_ERR("Failed to allocate disable_sensors_id_table, revise sensors count to 0");
+                return;
+        }
+
+        for (thread_id = 0; thread_id < MAX_SENSOR_THREAD_ID; ++thread_id) {
+                pldm_sensor_table = plat_pldm_sensor_load(thread_id);
+                if (pldm_sensor_table == NULL) {
+                        LOG_ERR("Failed to get pldm sensor table, thread id: 0x%x", thread_id);
+                        continue;
+                }
+
+                count = plat_pldm_sensor_get_sensor_count(thread_id);
+                if (count < 0) {
+                        LOG_ERR("Failed to get pldm sensor table count, thread id: 0x%x",
+                                thread_id);
+                        continue;
+                }
+
+                for (sensor_id = 0; sensor_id < count; ++sensor_id) {
+                        if (pldm_sensor_table[sensor_id].pldm_sensor_cfg.cache_status ==
+                            PLDM_SENSOR_DISABLED) {
+                                if (current_sensor_count >= total_disable_sensors_count) {
+                                        LOG_ERR("Record disabled sensor id exceeded table size, total size: 0x%x, current thread id: 0x%x, sensor id: 0x%x",
+                                                total_disable_sensors_count, thread_id,
+                                                pldm_sensor_table[sensor_id]
+                                                        .pdr_numeric_sensor.sensor_id);
+                                        continue;
+                                }
+				
+				uint16_t disabled_sid =
+                                        pldm_sensor_table[sensor_id].pdr_numeric_sensor.sensor_id;
+
+                                disable_sensors_id_table[current_sensor_count] = disabled_sid;
+                                current_sensor_count++;
+
+                                // NEW: check if this disabled sensor has an aux name entry
+                                for (int aux_idx = 0;
+                                     aux_idx < ARRAY_SIZE(plat_pdr_sensor_aux_names_table);
+                                     aux_idx++) {
+                                        if (plat_pdr_sensor_aux_names_table[aux_idx].sensor_id ==
+                                            disabled_sid) {
+                                                total_disable_aux_names_count++;
+                                                break;
+                                        }
+                                }
+                        }
+                }
+        }
+}
+
+uint16_t plat_get_disabled_sensor_count()
+{
+        return total_disable_sensors_count;
+}
+
 // clang-format on
 uint32_t plat_get_pdr_size(uint8_t pdr_type)
 {
@@ -6364,9 +6458,16 @@ uint32_t plat_get_pdr_size(uint8_t pdr_type)
 		for (i = 0; i < MAX_SENSOR_THREAD_ID; i++) {
 			total_size += plat_pldm_sensor_get_sensor_count(i);
 		}
+		total_size -= total_disable_sensors_count;
 		break;
 	case PLDM_SENSOR_AUXILIARY_NAMES_PDR:
 		total_size = ARRAY_SIZE(plat_pdr_sensor_aux_names_table);
+		total_size -= total_disable_aux_names_count;
+		if (total_size < 0) {
+			LOG_ERR("Aux names PDR size underflow (disabled=%d), clamping to 0",
+				total_disable_aux_names_count);
+			total_size = 0;
+		}
 		break;
 	case PLDM_ENTITY_AUXILIARY_NAMES_PDR:
 		total_size = ARRAY_SIZE(plat_pdr_entity_aux_names_table);
@@ -6484,21 +6585,72 @@ void plat_load_numeric_sensor_pdr_table(PDR_numeric_sensor *numeric_sensor_table
 {
 	int thread_id = 0, sensor_num = 0;
 	int max_sensor_num = 0, current_sensor_size = 0;
+	uint32_t total_size = plat_get_pdr_size(PLDM_NUMERIC_SENSOR_PDR);
+	pldm_sensor_info *pdr_table = NULL;
 
 	for (thread_id = 0; thread_id < MAX_SENSOR_THREAD_ID; thread_id++) {
+		pdr_table = plat_pldm_sensor_load(thread_id);
+		if (pdr_table == NULL) {
+			LOG_ERR("Failed to get pdr table, thread id: 0x%x", thread_id);
+			continue;
+		}
+
 		max_sensor_num = plat_pldm_sensor_get_sensor_count(thread_id);
+		if (max_sensor_num < 0) {
+			LOG_ERR("Failed to get sensor count, thread id: 0x%x", thread_id);
+			continue;
+		}
+
 		for (sensor_num = 0; sensor_num < max_sensor_num; sensor_num++) {
-			plat_pldm_sensor_get_pdr_numeric_sensor(
-				thread_id, sensor_num, &numeric_sensor_table[current_sensor_size]);
-			current_sensor_size++;
+			if (pdr_table[sensor_num].pldm_sensor_cfg.cache_status !=
+			    PLDM_SENSOR_DISABLED) {
+				if (current_sensor_size >= total_size) {
+					LOG_ERR("Load numeric sensor pdr exceeded table size, total size: 0x%x, current thread: 0x%x, sensor id: 0x%x",
+						total_size, thread_id,
+						pdr_table[sensor_num].pdr_numeric_sensor.sensor_id);
+					continue;
+				}
+
+				memcpy(&numeric_sensor_table[current_sensor_size],
+				       &pdr_table[sensor_num].pdr_numeric_sensor,
+				       sizeof(PDR_numeric_sensor));
+				current_sensor_size++;
+			}
 		}
 	}
 }
 
 void plat_load_aux_sensor_names_pdr_table(PDR_sensor_auxiliary_names *aux_sensor_name_table)
 {
-	memcpy(aux_sensor_name_table, &plat_pdr_sensor_aux_names_table,
-	       sizeof(plat_pdr_sensor_aux_names_table));
+	int index = 0;
+	int disable_sensor_id = 0;
+	int current_sensor_size = 0;
+	uint32_t total_size = plat_get_pdr_size(PLDM_SENSOR_AUXILIARY_NAMES_PDR);
+
+	for (index = 0; index < ARRAY_SIZE(plat_pdr_sensor_aux_names_table); ++index) {
+		for (disable_sensor_id = 0; disable_sensor_id < total_disable_sensors_count;
+		     ++disable_sensor_id) {
+			if (plat_pdr_sensor_aux_names_table[index].sensor_id ==
+			    disable_sensors_id_table[disable_sensor_id]) {
+				break;
+			}
+		}
+
+		if (disable_sensor_id >= total_disable_sensors_count) {
+			// AUX sensor name isn't a disabled sensor
+			if (current_sensor_size >= total_size) {
+				LOG_ERR("Load aux sensor names exceeded table size, current sensors size: 0x%x, sensor id: 0x%x",
+					current_sensor_size,
+					plat_pdr_sensor_aux_names_table[index].sensor_id);
+				continue;
+			}
+
+			memcpy(&aux_sensor_name_table[current_sensor_size],
+			       &plat_pdr_sensor_aux_names_table[index],
+			       sizeof(PDR_sensor_auxiliary_names));
+			current_sensor_size++;
+		}
+	}
 }
 
 uint16_t plat_pdr_entity_aux_names_table_size = 0;
@@ -6663,6 +6815,54 @@ void plat_pldm_sensor_change_asic_tmp_dev()
 					ADDR_TMP461_CXL2;
 				break;
 			}
+		}
+	}
+}
+
+void plat_pldm_sensor_change_asic_dev()
+{
+	uint8_t blade_conf = get_blade_configuration();
+
+	if (blade_conf == BLADE_CONFIG_without_ASIC) {
+		// Disable ASIC1 ADC sensors (ports ADC_PORT3 ~ ADC_PORT9)
+		for (int index = 0; index < plat_pldm_sensor_get_sensor_count(ADC_SENSOR_THREAD_ID);
+		     index++) {
+			if (plat_pldm_sensor_adc_table[index].pldm_sensor_cfg.port >= ADC_PORT3 &&
+			    plat_pldm_sensor_adc_table[index].pldm_sensor_cfg.port <= ADC_PORT9) {
+				plat_pldm_disable_sensor(
+					&plat_pldm_sensor_adc_table[index].pldm_sensor_cfg);
+			}
+		}
+
+		// Disable all ASIC2 ADC monitor sensors
+		for (int index = 0;
+		     index < plat_pldm_sensor_get_sensor_count(ADC_MONITOR_SENSOR_THREAD_ID);
+		     index++) {
+			plat_pldm_disable_sensor(
+				&plat_pldm_sensor_adc_monitor_table[index].pldm_sensor_cfg);
+		}
+
+		// Disable CXL temperature sensors
+		for (int index = 0; index < plat_pldm_sensor_get_sensor_count(TMP_SENSOR_THREAD_ID);
+		     index++) {
+			if (plat_pldm_sensor_tmp_table[index].pldm_sensor_cfg.type ==
+			    sensor_dev_tmp461) {
+				plat_pldm_disable_sensor(
+					&plat_pldm_sensor_tmp_table[index].pldm_sensor_cfg);
+			}
+		}
+
+		// Disable all VR sensors
+		for (int index = 0; index < plat_pldm_sensor_get_sensor_count(VR_SENSOR_THREAD_ID);
+		     index++) {
+			plat_pldm_disable_sensor(&plat_pldm_sensor_vr_table[index].pldm_sensor_cfg);
+		}
+
+		// Disable all DIMM sensors
+		for (int index = 0;
+		     index < plat_pldm_sensor_get_sensor_count(DIMM_SENSOR_THREAD_ID); index++) {
+			plat_pldm_disable_sensor(
+				&plat_pldm_sensor_dimm_table[index].pldm_sensor_cfg);
 		}
 	}
 }

--- a/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.h
+++ b/meta-facebook/yv4-wf/src/platform/plat_pldm_sensor.h
@@ -72,6 +72,8 @@ enum GET_VR_DEV_STATUS {
 };
 
 int plat_pldm_sensor_get_sensor_count(int thread_id);
+void plat_init_pldm_sensor_table();
+void plat_init_pldm_disabled_sensors();
 void plat_pldm_sensor_get_pdr_numeric_sensor(int thread_id, int sensor_num,
 					     PDR_numeric_sensor *numeric_sensor_table);
 uint8_t plat_pldm_sensor_get_vr_dev(uint8_t *vr_dev);

--- a/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
+++ b/meta-facebook/yv4-wf/src/platform/plat_power_seq.c
@@ -168,54 +168,30 @@ uint32_t get_uptime_secs(void)
 
 void execute_power_on_sequence()
 {
-	int ret = 0;
+	uint8_t blade_conf = get_blade_configuration();
 
-	// If CXL is on, doesn't need to power on again
-	if (gpio_get(PG_CARD_OK) == POWER_ON) {
-		LOG_INF("CXL DC status is ON");
-		return;
-	}
+	if (blade_conf == BLADE_CONFIG_without_ASIC) {
+		// If DC is on, doesn't need to power on again
+		if (gpio_get(PG_CARD_OK) == POWER_ON) {
+			LOG_INF("DC status is ON");
+			return;
+		}
 
-	// TODO: check E1S present
-	if (get_board_revision() == BOARD_POC) {
-		gpio_set(POC_EN_P3V3_E1S_0_R, POWER_ON);
-		set_P3V3_E1S_power_status(POC_PWRGD_P3V3_E1S_0_R);
-	} else {
-		gpio_set(EN_P3V3_E1S_0_R, POWER_ON);
-		set_P3V3_E1S_power_status(PWRGD_P3V3_E1S_0_R);
-	}
-	gpio_set(EN_P12V_E1S_0_R, POWER_ON);
-	set_P12V_E1S_power_status(PWRGD_P12V_E1S_0_R);
+		// TODO: check E1S present
+		if (get_board_revision() == BOARD_POC) {
+			gpio_set(POC_EN_P3V3_E1S_0_R, POWER_ON);
+			set_P3V3_E1S_power_status(POC_PWRGD_P3V3_E1S_0_R);
+		} else {
+			gpio_set(EN_P3V3_E1S_0_R, POWER_ON);
+			set_P3V3_E1S_power_status(PWRGD_P3V3_E1S_0_R);
+		}
+		gpio_set(EN_P12V_E1S_0_R, POWER_ON);
+		set_P12V_E1S_power_status(PWRGD_P12V_E1S_0_R);
 
-	ret = power_on_handler(CXL_ID_1, ASIC_POWER_ON_STAGE_1);
-	if (ret == 0) {
-		is_cxl_power_on[CXL_ID_1] = true;
-		LOG_INF("CXL 1 power on success");
-	} else {
-		is_cxl_power_on[CXL_ID_1] = false;
-		LOG_ERR("CXL 1 power on fail");
-	}
-
-	ret = power_on_handler(CXL_ID_2, ASIC_POWER_ON_STAGE_1);
-	if (ret == 0) {
-		is_cxl_power_on[CXL_ID_2] = true;
-		LOG_INF("CXL 2 power on success");
-	} else {
-		is_cxl_power_on[CXL_ID_2] = false;
-		LOG_ERR("CXL 2 power on fail");
-	}
-
-	if (is_cxl_power_on[CXL_ID_1] && is_cxl_power_on[CXL_ID_2]) {
-		is_cxl_power_on_success = true;
 		gpio_set(PG_CARD_OK, POWER_ON);
 		set_DC_status(PG_CARD_OK);
 		k_work_schedule(&set_dc_on_5s_work, K_SECONDS(DC_ON_DELAY5_SEC));
 
-		create_check_cxl_ready_thread();
-	} else {
-		LOG_INF("CXL power on failed, switch IOE mux to BIC");
-		switch_mux_to_bic(IOE_SWITCH_CXL1_VR_TO_BIC);
-		switch_mux_to_bic(IOE_SWITCH_CXL2_VR_TO_BIC);
 		uint32_t uptime = get_uptime_secs();
 		uint32_t delay_ms = VR_EVENT_DELAY_MS;
 
@@ -225,9 +201,74 @@ void execute_power_on_sequence()
 				(delay_ms / 1000U));
 		}
 
+		init_vr_event_work();
 		k_work_schedule_for_queue(&plat_work_q,
 					  &vr_event_work_items[PMBUS_VR_IOE1_INT].add_sel_work,
 					  K_MSEC(delay_ms));
+
+	} else { // default: BLADE_CONFIG_with_ASIC
+
+		int ret = 0;
+
+		// If CXL is on, doesn't need to power on again
+		if (gpio_get(PG_CARD_OK) == POWER_ON) {
+			LOG_INF("CXL DC status is ON");
+			return;
+		}
+
+		// TODO: check E1S present
+		if (get_board_revision() == BOARD_POC) {
+			gpio_set(POC_EN_P3V3_E1S_0_R, POWER_ON);
+			set_P3V3_E1S_power_status(POC_PWRGD_P3V3_E1S_0_R);
+		} else {
+			gpio_set(EN_P3V3_E1S_0_R, POWER_ON);
+			set_P3V3_E1S_power_status(PWRGD_P3V3_E1S_0_R);
+		}
+		gpio_set(EN_P12V_E1S_0_R, POWER_ON);
+		set_P12V_E1S_power_status(PWRGD_P12V_E1S_0_R);
+
+		ret = power_on_handler(CXL_ID_1, ASIC_POWER_ON_STAGE_1);
+		if (ret == 0) {
+			is_cxl_power_on[CXL_ID_1] = true;
+			LOG_INF("CXL 1 power on success");
+		} else {
+			is_cxl_power_on[CXL_ID_1] = false;
+			LOG_ERR("CXL 1 power on fail");
+		}
+
+		ret = power_on_handler(CXL_ID_2, ASIC_POWER_ON_STAGE_1);
+		if (ret == 0) {
+			is_cxl_power_on[CXL_ID_2] = true;
+			LOG_INF("CXL 2 power on success");
+		} else {
+			is_cxl_power_on[CXL_ID_2] = false;
+			LOG_ERR("CXL 2 power on fail");
+		}
+
+		if (is_cxl_power_on[CXL_ID_1] && is_cxl_power_on[CXL_ID_2]) {
+			is_cxl_power_on_success = true;
+			gpio_set(PG_CARD_OK, POWER_ON);
+			set_DC_status(PG_CARD_OK);
+			k_work_schedule(&set_dc_on_5s_work, K_SECONDS(DC_ON_DELAY5_SEC));
+
+			create_check_cxl_ready_thread();
+		} else {
+			LOG_INF("CXL power on failed, switch IOE mux to BIC");
+			switch_mux_to_bic(IOE_SWITCH_CXL1_VR_TO_BIC);
+			switch_mux_to_bic(IOE_SWITCH_CXL2_VR_TO_BIC);
+			uint32_t uptime = get_uptime_secs();
+			uint32_t delay_ms = VR_EVENT_DELAY_MS;
+
+			if (uptime < 30) { //wait longer for BIC reset
+				delay_ms = VR_EVENT_WAIT_BIC_RESET_DELAY_MS;
+				LOG_INF("pldm not ready yet, wait for %u seconds before checking VR",
+					(delay_ms / 1000U));
+			}
+
+			k_work_schedule_for_queue(
+				&plat_work_q, &vr_event_work_items[PMBUS_VR_IOE1_INT].add_sel_work,
+				K_MSEC(delay_ms));
+		}
 	}
 }
 
@@ -420,92 +461,118 @@ bool is_power_controlled(int cxl_id, int power_pin, uint8_t check_power_status, 
 
 void execute_power_off_sequence()
 {
-	int ret = 0;
+	uint8_t blade_conf = get_blade_configuration();
 
-	// If CXL is off, doesn't need to power off again
-	if (gpio_get(PG_CARD_OK) == POWER_OFF) {
-		LOG_INF("CXL DC status is OFF");
-		return;
-	}
+	if (blade_conf == BLADE_CONFIG_without_ASIC) {
+		// If DC is off, doesn't need to power off again
+		if (gpio_get(PG_CARD_OK) == POWER_OFF) {
+			LOG_INF("DC status is OFF");
+			return;
+		}
 
-	// TODO: check E1S present
-	if (get_board_revision() == BOARD_POC) {
-		gpio_set(POC_EN_P3V3_E1S_0_R, POWER_OFF);
-		set_P3V3_E1S_power_status(POC_PWRGD_P3V3_E1S_0_R);
-	} else {
-		gpio_set(EN_P3V3_E1S_0_R, POWER_OFF);
-		set_P3V3_E1S_power_status(PWRGD_P3V3_E1S_0_R);
-	}
-	gpio_set(EN_P12V_E1S_0_R, POWER_OFF);
-	set_P12V_E1S_power_status(PWRGD_P12V_E1S_0_R);
+		// TODO: check E1S present
+		if (get_board_revision() == BOARD_POC) {
+			gpio_set(POC_EN_P3V3_E1S_0_R, POWER_OFF);
+			set_P3V3_E1S_power_status(POC_PWRGD_P3V3_E1S_0_R);
+		} else {
+			gpio_set(EN_P3V3_E1S_0_R, POWER_OFF);
+			set_P3V3_E1S_power_status(PWRGD_P3V3_E1S_0_R);
+		}
+		gpio_set(EN_P12V_E1S_0_R, POWER_OFF);
+		set_P12V_E1S_power_status(PWRGD_P12V_E1S_0_R);
 
-	is_cxl_ready[CXL_ID_1] = false;
-	is_cxl_ready[CXL_ID_2] = false;
+		gpio_set(PG_CARD_OK, POWER_OFF);
+		set_DC_status(PG_CARD_OK);
 
-	gpio_set(PG_CARD_OK, POWER_OFF);
-	set_DC_status(PG_CARD_OK);
+	} else { // default: BLADE_CONFIG_with_ASIC
 
-	if (k_work_cancel_delayable(&set_dc_on_5s_work) != 0) {
-		LOG_ERR("Cancel set dc off delay work fail");
-	}
+		int ret = 0;
 
-	if (k_work_cancel_delayable(&cxl1_ready_thread) != 0) {
-		LOG_ERR("Failed to cancel cxl1_ready_thread");
-	}
+		// If CXL is off, doesn't need to power off again
+		if (gpio_get(PG_CARD_OK) == POWER_OFF) {
+			LOG_INF("CXL DC status is OFF");
+			return;
+		}
 
-	if (k_work_cancel_delayable(&cxl2_ready_thread) != 0) {
-		LOG_ERR("Failed to cancel cxl2_ready_thread");
-	}
+		// TODO: check E1S present
+		if (get_board_revision() == BOARD_POC) {
+			gpio_set(POC_EN_P3V3_E1S_0_R, POWER_OFF);
+			set_P3V3_E1S_power_status(POC_PWRGD_P3V3_E1S_0_R);
+		} else {
+			gpio_set(EN_P3V3_E1S_0_R, POWER_OFF);
+			set_P3V3_E1S_power_status(PWRGD_P3V3_E1S_0_R);
+		}
+		gpio_set(EN_P12V_E1S_0_R, POWER_OFF);
+		set_P12V_E1S_power_status(PWRGD_P12V_E1S_0_R);
 
-	if (k_work_cancel_delayable(&set_cxl1_vr_ready_work) != 0) {
-		LOG_WRN("Failed to cancel set_cxl1_vr_ready_work");
-	}
+		is_cxl_ready[CXL_ID_1] = false;
+		is_cxl_ready[CXL_ID_2] = false;
 
-	if (k_work_cancel_delayable(&set_cxl2_vr_ready_work) != 0) {
-		LOG_WRN("Failed to cancel set_cxl2_vr_ready_work");
-	}
+		gpio_set(PG_CARD_OK, POWER_OFF);
+		set_DC_status(PG_CARD_OK);
 
-	if (k_work_cancel_delayable(&cxl1_hb_monitor_work) != 0) {
-		LOG_ERR("Failed to cancel cxl1_hb_monitor_work");
-	}
+		if (k_work_cancel_delayable(&set_dc_on_5s_work) != 0) {
+			LOG_ERR("Cancel set dc off delay work fail");
+		}
 
-	cxl1_hb_state = HB_STATE_UNKNOWN;
+		if (k_work_cancel_delayable(&cxl1_ready_thread) != 0) {
+			LOG_ERR("Failed to cancel cxl1_ready_thread");
+		}
 
-	if (k_work_cancel_delayable(&cxl2_hb_monitor_work) != 0) {
-		LOG_ERR("Failed to cancel cxl2_hb_monitor_work");
-	}
+		if (k_work_cancel_delayable(&cxl2_ready_thread) != 0) {
+			LOG_ERR("Failed to cancel cxl2_ready_thread");
+		}
 
-	cxl2_hb_state = HB_STATE_UNKNOWN;
+		if (k_work_cancel_delayable(&set_cxl1_vr_ready_work) != 0) {
+			LOG_WRN("Failed to cancel set_cxl1_vr_ready_work");
+		}
 
-	set_DC_on_delayed_status_with_value(false);
+		if (k_work_cancel_delayable(&set_cxl2_vr_ready_work) != 0) {
+			LOG_WRN("Failed to cancel set_cxl2_vr_ready_work");
+		}
 
-	ret = power_off_handler(CXL_ID_1, DIMM_POWER_OFF_STAGE_1);
-	if (ret == 0) {
-		is_cxl_power_on[CXL_ID_1] = false;
-		LOG_INF("CXL 1 power off success");
-	} else {
-		is_cxl_power_on[CXL_ID_1] = true;
-		set_cxl_vr_access(CXL_ID_1, true);
-		LOG_ERR("CXL 1 power off fail");
-	}
+		if (k_work_cancel_delayable(&cxl1_hb_monitor_work) != 0) {
+			LOG_ERR("Failed to cancel cxl1_hb_monitor_work");
+		}
 
-	ret = power_off_handler(CXL_ID_2, DIMM_POWER_OFF_STAGE_1);
-	if (ret == 0) {
-		is_cxl_power_on[CXL_ID_2] = false;
-		LOG_INF("CXL 2 power off success");
-	} else {
-		is_cxl_power_on[CXL_ID_2] = true;
-		set_cxl_vr_access(CXL_ID_2, true);
-		LOG_ERR("CXL 2 power off fail");
-	}
+		cxl1_hb_state = HB_STATE_UNKNOWN;
 
-	uint8_t ioe2_output_value = 0;
+		if (k_work_cancel_delayable(&cxl2_hb_monitor_work) != 0) {
+			LOG_ERR("Failed to cancel cxl2_hb_monitor_work");
+		}
 
-	if (get_ioe_value(ADDR_IOE2, TCA9555_OUTPUT_PORT_REG_0, &ioe2_output_value) == 0) {
-		CLEARBITS(ioe2_output_value, IOE_P00,
-			  IOE_P03) // Disable P0~P3 to switch mux to CXL.
-		set_ioe_value(ADDR_IOE2, TCA9555_OUTPUT_PORT_REG_0, ioe2_output_value);
-		set_cxl_vr_access(MAX_CXL_ID, false);
+		cxl2_hb_state = HB_STATE_UNKNOWN;
+
+		set_DC_on_delayed_status_with_value(false);
+
+		ret = power_off_handler(CXL_ID_1, DIMM_POWER_OFF_STAGE_1);
+		if (ret == 0) {
+			is_cxl_power_on[CXL_ID_1] = false;
+			LOG_INF("CXL 1 power off success");
+		} else {
+			is_cxl_power_on[CXL_ID_1] = true;
+			set_cxl_vr_access(CXL_ID_1, true);
+			LOG_ERR("CXL 1 power off fail");
+		}
+
+		ret = power_off_handler(CXL_ID_2, DIMM_POWER_OFF_STAGE_1);
+		if (ret == 0) {
+			is_cxl_power_on[CXL_ID_2] = false;
+			LOG_INF("CXL 2 power off success");
+		} else {
+			is_cxl_power_on[CXL_ID_2] = true;
+			set_cxl_vr_access(CXL_ID_2, true);
+			LOG_ERR("CXL 2 power off fail");
+		}
+
+		uint8_t ioe2_output_value = 0;
+
+		if (get_ioe_value(ADDR_IOE2, TCA9555_OUTPUT_PORT_REG_0, &ioe2_output_value) == 0) {
+			CLEARBITS(ioe2_output_value, IOE_P00,
+				  IOE_P03); // Disable P0~P3 to switch mux to CXL.
+			set_ioe_value(ADDR_IOE2, TCA9555_OUTPUT_PORT_REG_0, ioe2_output_value);
+			set_cxl_vr_access(MAX_CXL_ID, false);
+		}
 	}
 }
 


### PR DESCRIPTION
### Related JIRA ticket: 
YV4T1M-2363

# [Description]
- Implement code to support WF SKU variant without ASIC

# [Motivation]
- New WF board variant requires special handling to operate without ASIC components

# [Design]
- Detect the specific WF SKU by measuring voltage on ADC0 channel:
  * Original WF: 1.5V
  * New WF (no ASIC): 0.75V
- Query blade configuration during initialization to determine appropriate power sequence
- Execute power sequence while bypassing ASICs
- Modify FW behavior when specific WF configuration is detected:
  * Disable ASIC-related sensors in BIC FW
  * Disable ASIC-related VR fault reporting in ISR
  * Disable downstream devices for PLDM FW updates
  
# [Test Plan]
(1) Build: pass
(2) Test on Yv4: pass