### PR TITLE
gc2: es: Fix false current and power sensor UNR events during power-on

### DIFF
--- a/common/dev/tps53689.c
+++ b/common/dev/tps53689.c
@@ -280,6 +280,10 @@ uint8_t tps53689_read(sensor_cfg *cfg, int *reading)
 		/* SLINEAR11 */
 		uint16_t read_value = (msg.data[1] << 8) | msg.data[0];
 		float actual_value = slinear11_to_float(read_value);
+
+		if (actual_value < 0 && (plat_sensor_clamp_negative_reading(offset) == true)) {
+			actual_value = 0;
+		}
 		sval->integer = actual_value;
 		sval->fraction = (actual_value - sval->integer) * 1000;
 	} else {

--- a/common/service/sensor/sensor.c
+++ b/common/service/sensor/sensor.c
@@ -1586,3 +1586,10 @@ bool get_sensor_init_done_flag()
 {
 	return is_sensor_initial_done;
 }
+
+__weak bool plat_sensor_clamp_negative_reading(uint8_t pmbus_cmd)
+{
+	ARG_UNUSED(pmbus_cmd);
+
+	return false;
+}

--- a/common/service/sensor/sensor.h
+++ b/common/service/sensor/sensor.h
@@ -866,5 +866,5 @@ bool get_sensor_init_done_flag();
 sensor_cfg *get_common_sensor_cfg_info(uint8_t sensor_num);
 uint8_t common_tbl_sen_reinit(uint8_t sen_num);
 void plat_sensor_poll_post();
-
+bool plat_sensor_clamp_negative_reading(uint8_t pmbus_cmd);
 #endif

--- a/meta-facebook/gc2-es/src/platform/plat_sensor_table.c
+++ b/meta-facebook/gc2-es/src/platform/plat_sensor_table.c
@@ -957,3 +957,15 @@ uint8_t get_dimm_status(uint8_t dimm_index)
 
 	return sensor_config[sensor_index].cache_status;
 }
+
+bool plat_sensor_clamp_negative_reading(uint8_t pmbus_cmd)
+{
+	switch (pmbus_cmd) {
+	case PMBUS_READ_IOUT:
+	case PMBUS_READ_POUT:
+		return true;
+
+	default:
+		return false;
+	}
+}


### PR DESCRIPTION
# [Task Description]
- Related to GC20T5T7-288 and GC20T5T7-289
- Prevent expected negative telemetry under no-load conditions from triggering false sensor threshold events

# [Root Cause]
- PMBus captures showed that TPS53689 current and power telemetry may briefly report small negative values during the early power-on stage
- In the logic analyzer capture, READ_IOUT returned raw data 0xA5FD, which was decoded by the TPS53689 driver as -0.1257 A
- The Power Team confirmed that small negative telemetry values are expected under no-load conditions
- The BMC sensor path does not support negative current and power readings
- A negative reading may be converted into a large positive value in the unsigned sensor format, potentially causing a false UNR event

# [Solution]
- Adopt the vendor's recommendation by clamping expected negative current and power telemetry values to zero
- Add a weak `plat_sensor_clamp_negative_reading()` implementation that returns false by default
- Check the platform policy after converting the TPS53689 Linear11 data
- Clamp the converted value to zero when it is negative and the PMBus command is configured for clamping
- Enable clamping for PMBUS_READ_IOUT and PMBUS_READ_POUT on GC2 ES
- Keep the behavior unchanged for other platforms and PMBus commands

# [Test Log]
- Verify no unexpected Current and Power sensor UNR event is triggered