### PR TITLE
sb: rb: Add svs function in i2c target

### DIFF
--- a/common/dev/include/raa228249.h
+++ b/common/dev/include/raa228249.h
@@ -33,5 +33,5 @@ bool raa228249_set_iout_oc_warn_limit(sensor_cfg *cfg, uint16_t value);
 bool raa228249_get_vr_status(sensor_cfg *cfg, uint8_t rail, uint8_t vr_status_rail,
 			     uint16_t *vr_status);
 bool raa228249_clear_vr_status(sensor_cfg *cfg, uint8_t rail);
-
+bool raa228249_get_vout_offset(sensor_cfg *cfg, uint16_t *offset_return);
 #endif

--- a/common/dev/raa228249.c
+++ b/common/dev/raa228249.c
@@ -103,7 +103,7 @@ bool raa228249_i2c_read(uint8_t bus, uint8_t addr, uint8_t reg, uint8_t *data, u
 	i2c_msg.data[0] = reg;
 
 	if (i2c_master_read(&i2c_msg, retry)) {
-		LOG_ERR("Failed to read mp29816a, bus: %d, addr: 0x%x, reg: 0x%x", bus, addr, reg);
+		LOG_ERR("Failed to read raa228249, bus: %d, addr: 0x%x, reg: 0x%x", bus, addr, reg);
 		return false;
 	}
 
@@ -127,7 +127,8 @@ bool raa228249_i2c_write(uint8_t bus, uint8_t addr, uint8_t reg, uint8_t *data, 
 		memcpy(&i2c_msg.data[1], data, len);
 
 	if (i2c_master_write(&i2c_msg, retry)) {
-		LOG_ERR("Failed to write mp29816a, bus: %d, addr: 0x%x, reg: 0x%x", bus, addr, reg);
+		LOG_ERR("Failed to write raa228249, bus: %d, addr: 0x%x, reg: 0x%x", bus, addr,
+			reg);
 		return false;
 	}
 
@@ -547,6 +548,23 @@ bool raa228249_set_vout_command(sensor_cfg *cfg, uint8_t rail, uint16_t *millivo
 				 sizeof(data))) {
 		return false;
 	}
+
+	return true;
+}
+
+bool raa228249_get_vout_offset(sensor_cfg *cfg, uint16_t *offset_return)
+{
+	CHECK_NULL_ARG_WITH_RETURN(cfg, false);
+	CHECK_NULL_ARG_WITH_RETURN(offset_return, false);
+
+	uint8_t data[2] = { 0 };
+	if (!raa228249_i2c_read(cfg->port, cfg->target_addr, PMBUS_VOUT_CAL_OFFSET, data,
+				sizeof(data))) {
+		return false;
+	}
+
+	uint16_t val_cal_offset = data[0] | (data[1] << 8);
+	*offset_return = val_cal_offset;
 
 	return true;
 }

--- a/meta-facebook/sb-rb/src/platform/plat_hook.c
+++ b/meta-facebook/sb-rb/src/platform/plat_hook.c
@@ -23,8 +23,6 @@
 #include "plat_gpio.h"
 #include "plat_pldm_sensor.h"
 #include "mp2971.h"
-#include "mp29816a.h"
-#include "raa228249.h"
 #include "plat_user_setting.h"
 #include "plat_fru.h"
 #include "plat_class.h"
@@ -676,8 +674,9 @@ err:
 }
 
 struct vr_vout_user_settings voltage_command_get = { 0 };
+struct vr_vout_offset vr_offset_init = { 0 };
 vr_vout_range_user_settings_struct vout_range_user_settings = { 0 };
-bool plat_set_vout_command(uint8_t rail, uint16_t *millivolt, bool is_perm)
+bool plat_set_vout_command(uint8_t rail, uint16_t *millivolt, bool is_default)
 {
 	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
 
@@ -1912,4 +1911,104 @@ bool get_pre_read_bootstrap_setting_value()
 uint8_t get_error_bootstrap_index_list(uint8_t index)
 {
 	return error_bootstrap_setting_value_index[index];
+}
+
+static uint8_t svs_flag = 0;
+uint8_t get_svs_flag()
+{
+	return svs_flag;
+}
+
+void set_svs_flag(uint8_t flag)
+{
+	svs_flag = flag;
+}
+bool vr_vout_default_settings_init(void)
+{
+	for (int i = 0; i < VR_RAIL_E_MAX; i++) {
+		if ((get_asic_board_id() == ASIC_BOARD_ID_EVB) &&
+		    (i == VR_RAIL_E_P3V3_OSFP_VOLT_V)) {
+			voltage_command_get.vout[i] = 0xffff;
+			continue; // skip osfp p3v3 on AEGIS BD
+		}
+		uint16_t vout = 0;
+		if (!plat_get_vout_command(i, &vout)) {
+			LOG_ERR("Can't find vout default by rail index: %d", i);
+			return false;
+		}
+		voltage_command_get.vout[i] = vout;
+	}
+	return true;
+}
+
+bool plat_get_get_vout_offset(uint8_t rail, uint16_t *vout_offset)
+{
+	CHECK_NULL_ARG_WITH_RETURN(vout_offset, false);
+
+	bool ret = false;
+	uint8_t sensor_id = vr_rail_table[rail].sensor_id;
+	sensor_cfg *cfg = get_sensor_cfg_by_sensor_id(sensor_id);
+	if (cfg == NULL) {
+		LOG_ERR("Failed to get sensor config for sensor 0x%x", sensor_id);
+		return false;
+	}
+
+	if (cfg->pre_sensor_read_hook) {
+		if (!cfg->pre_sensor_read_hook(cfg, cfg->pre_sensor_read_args)) {
+			LOG_ERR("sensor id: 0x%x pre-read fail", sensor_id);
+			goto err;
+		}
+	}
+
+	switch (cfg->type) {
+	case sensor_dev_mp29816a:
+		if (!mp29816a_get_vout_offset(cfg, vout_offset)) {
+			LOG_ERR("The VR MPS29816a vout setting failed");
+			goto err;
+		}
+		break;
+	case sensor_dev_raa228249:
+		if (!raa228249_get_vout_offset(cfg, vout_offset)) {
+			LOG_ERR("The VR RAA228249 vout setting failed");
+			goto err;
+		}
+		break;
+	default:
+		LOG_ERR("Unsupport VR type(%x)", cfg->type);
+		goto err;
+	}
+
+	ret = true;
+err:
+	if (cfg->post_sensor_read_hook) {
+		if (cfg->post_sensor_read_hook(cfg, cfg->post_sensor_read_args, NULL) == false) {
+			LOG_ERR("sensor id: 0x%x post-read fail", sensor_id);
+		}
+	}
+	return ret;
+}
+bool vr_vout_offset_get_init(void)
+{
+	for (int i = 0; i < VR_RAIL_E_ASIC_P0V9_OWL_E_TRVDD; i++) {
+		uint16_t vout_offset = 0;
+		if (!plat_get_get_vout_offset(i, &vout_offset)) {
+			LOG_ERR("Can't find vout default by rail index: %d", i);
+			return false;
+		}
+		vr_offset_init.vout_offset[i] = vout_offset;
+		LOG_INF("init rail %d, vout_offset = 0x%04x", i, vout_offset);
+	}
+	return true;
+}
+bool voltage_offset_get(uint8_t rail, uint16_t *vout_offset)
+{
+	CHECK_NULL_ARG_WITH_RETURN(vout_offset, false);
+
+	if (rail >= VR_RAIL_E_ASIC_P0V9_OWL_E_TRVDD) {
+		LOG_ERR("invalid rail %d", rail);
+		return false;
+	}
+
+	*vout_offset = vr_offset_init.vout_offset[rail];
+	return true;
 }

--- a/meta-facebook/sb-rb/src/platform/plat_hook.c
+++ b/meta-facebook/sb-rb/src/platform/plat_hook.c
@@ -676,7 +676,7 @@ err:
 struct vr_vout_user_settings voltage_command_get = { 0 };
 struct vr_vout_offset vr_offset_init = { 0 };
 vr_vout_range_user_settings_struct vout_range_user_settings = { 0 };
-bool plat_set_vout_command(uint8_t rail, uint16_t *millivolt, bool is_default)
+bool plat_set_vout_command(uint8_t rail, uint16_t *millivolt, bool is_perm)
 {
 	CHECK_NULL_ARG_WITH_RETURN(millivolt, false);
 

--- a/meta-facebook/sb-rb/src/platform/plat_hook.h
+++ b/meta-facebook/sb-rb/src/platform/plat_hook.h
@@ -19,6 +19,8 @@
 
 #include "sensor.h"
 #include "plat_pldm_sensor.h"
+#include "mp29816a.h"
+#include "raa228249.h"
 
 #define VR_MUTEX_LOCK_TIMEOUT_MS 1000
 
@@ -220,6 +222,9 @@ typedef struct vr_vout_range_user_settings_struct {
 typedef struct vr_vout_user_settings {
 	uint16_t vout[VR_RAIL_E_MAX];
 } vr_vout_user_settings;
+typedef struct vr_vout_offset {
+	uint16_t vout_offset[2]; // onlt medha0/1
+} vr_vout_offset;
 typedef struct bootstrap_mapping_register {
 	uint8_t index;
 	uint8_t type;
@@ -297,4 +302,10 @@ uint8_t get_emc1413_cache_status(uint8_t idx);
 bool get_pre_read_bootstrap_setting_value();
 void add_error_bootstrap_index_to_list(uint8_t index);
 uint8_t get_error_bootstrap_index_list(uint8_t index);
+uint8_t get_svs_flag();
+void set_svs_flag(uint8_t flag);
+bool vr_vout_default_settings_init(void);
+bool plat_get_get_vout_offset(uint8_t rail, uint16_t *vout_offset);
+bool vr_vout_offset_get_init(void);
+bool voltage_offset_get(uint8_t rail, uint16_t *vout_offset);
 #endif

--- a/meta-facebook/sb-rb/src/platform/plat_i2c_target.c
+++ b/meta-facebook/sb-rb/src/platform/plat_i2c_target.c
@@ -726,6 +726,8 @@ telemetry_info telemetry_info_table[] = {
 static bool command_reply_data_handle(void *arg)
 {
 	struct i2c_target_data *data = (struct i2c_target_data *)arg;
+	uint8_t svs_flag = get_svs_flag();
+	uint16_t vout_offset_value = 0;
 	if (data->wr_buffer_idx >= 1) {
 		if (data->wr_buffer_idx == 1) {
 			uint8_t reg_offset = data->target_wr_msg.msg[0];
@@ -847,6 +849,20 @@ static bool command_reply_data_handle(void *arg)
 				if (!voltage_command_setting_get(rail, &vout)) {
 					LOG_ERR("Can't voltage_command setting_get by rail: 0x%02x",
 						rail);
+				}
+				if (svs_flag) {
+					if (reg_offset ==
+						    CONTROL_VOL_VR_ASIC_P0V85_MEDHA0_VDD_REG ||
+					    reg_offset ==
+						    CONTROL_VOL_VR_ASIC_P0V85_MEDHA1_VDD_REG) {
+						if (!voltage_offset_get(rail, &vout_offset_value)) {
+							LOG_ERR("Failed to get vout offset for reg_offset 0x%02x",
+								reg_offset);
+							break;
+						}
+						// need to minus vout offset(read back from VR)
+						vout -= vout_offset_value;
+					}
 				}
 				memcpy(data->target_rd_msg.msg, &vout, sizeof(vout));
 				data->target_rd_msg.msg_length = 2;
@@ -1155,6 +1171,8 @@ void plat_master_write_thread_handler()
 	while (1) {
 		uint8_t rdata[MAX_I2C_TARGET_BUFF] = { 0 };
 		uint16_t rlen = 0;
+		uint16_t vout_offset_value = 0;
+		uint8_t svs_flag = get_svs_flag();
 		for (int i = 0; i < ASIC_I2C_BUS_IDX_MAX; i++) {
 			rc = multi_bus_i2c_target_read(target_bus_list[i].i2c_bus, rdata,
 						       sizeof(rdata), &rlen, K_MSEC(5));
@@ -1229,8 +1247,35 @@ void plat_master_write_thread_handler()
 					LOG_ERR("Memory allocation failed!");
 					break;
 				}
+				uint8_t rail = get_vr_rail_by_control_vol_reg(reg_offset);
+				if (svs_flag) {
+					if (reg_offset ==
+						    CONTROL_VOL_VR_ASIC_P0V85_MEDHA0_VDD_REG ||
+					    reg_offset ==
+						    CONTROL_VOL_VR_ASIC_P0V85_MEDHA1_VDD_REG) {
+						if (!voltage_offset_get(rail, &vout_offset_value)) {
+							LOG_ERR("Failed to get vout offset for reg_offset 0x%02x",
+								reg_offset);
+							free(sensor_data);
+							break;
+						}
+					}
+				}
+
 				sensor_data->rail = get_vr_rail_by_control_vol_reg(reg_offset);
 				sensor_data->set_value = rdata[1] | (rdata[2] << 8);
+				// check set_value in range 750mv~850mv, if out of range, print error and end
+				if (sensor_data->set_value < 750 || sensor_data->set_value > 850) {
+					LOG_ERR("Set voltage out of range: %d mV(750~850)",
+						sensor_data->set_value);
+					free(sensor_data);
+					break;
+				}
+
+				// if svs flag = enable, add vout_offset
+				if (svs_flag) {
+					sensor_data->set_value += vout_offset_value;
+				}
 				k_work_init(&sensor_data->work, set_control_voltage_handler);
 				k_work_submit(&sensor_data->work);
 			} break;

--- a/meta-facebook/sb-rb/src/platform/plat_log.c
+++ b/meta-facebook/sb-rb/src/platform/plat_log.c
@@ -33,6 +33,7 @@
 #include "plat_gpio.h"
 #include "plat_thermal.h"
 #include "shell_plat_power_sequence.h"
+#include "pmbus.h"
 
 LOG_MODULE_REGISTER(plat_log);
 
@@ -266,8 +267,43 @@ bool vr_fault_get_error_data(uint8_t sensor_id, uint8_t *data)
 {
 	CHECK_NULL_ARG_WITH_RETURN(data, false);
 
-	// vr status word
-	return get_raw_data_from_sensor_id(sensor_id, 0x79, data, 2);
+	bool ret = true;
+	uint8_t vr_status_buf[7] = { 0 };
+
+	if (!get_raw_data_from_sensor_id(sensor_id, PMBUS_STATUS_WORD, &vr_status_buf[0], 2)) {
+		LOG_ERR("Failed to read VR status word, sensor_id %d", sensor_id);
+		ret = false;
+	}
+
+	if (!get_raw_data_from_sensor_id(sensor_id, PMBUS_STATUS_VOUT, &vr_status_buf[2], 1)) {
+		LOG_ERR("Failed to read VR status vout, sensor_id %d", sensor_id);
+		ret = false;
+	}
+
+	if (!get_raw_data_from_sensor_id(sensor_id, PMBUS_STATUS_IOUT, &vr_status_buf[3], 1)) {
+		LOG_ERR("Failed to read VR status iout, sensor_id %d", sensor_id);
+		ret = false;
+	}
+
+	if (!get_raw_data_from_sensor_id(sensor_id, PMBUS_STATUS_INPUT, &vr_status_buf[4], 1)) {
+		LOG_ERR("Failed to read VR status input, sensor_id %d", sensor_id);
+		ret = false;
+	}
+
+	if (!get_raw_data_from_sensor_id(sensor_id, PMBUS_STATUS_TEMPERATURE, &vr_status_buf[5],
+					 1)) {
+		LOG_ERR("Failed to read VR status temperature, sensor_id %d", sensor_id);
+		ret = false;
+	}
+
+	if (!get_raw_data_from_sensor_id(sensor_id, PMBUS_STATUS_CML, &vr_status_buf[6], 1)) {
+		LOG_ERR("Failed to read VR status CML, sensor_id %d", sensor_id);
+		ret = false;
+	}
+
+	memcpy(data, vr_status_buf, sizeof(vr_status_buf));
+
+	return ret;
 }
 
 bool get_multi_vr_status(uint8_t alrt_index, uint8_t *data)

--- a/meta-facebook/sb-rb/src/platform/plat_user_setting.c
+++ b/meta-facebook/sb-rb/src/platform/plat_user_setting.c
@@ -1445,6 +1445,8 @@ void set_clock_u87_u88_lphcsl_amp_ctrl_to_1v()
 void user_settings_init(void)
 {
 	bootstrap_default_settings_init();
+	vr_vout_default_settings_init();
+	vr_vout_offset_get_init();
 	bootstrap_user_settings_init();
 	vr_vout_range_user_settings_init();
 	thermaltrip_user_settings_init();

--- a/meta-facebook/sb-rb/src/platform/plat_user_setting.h
+++ b/meta-facebook/sb-rb/src/platform/plat_user_setting.h
@@ -163,4 +163,5 @@ bool set_user_settings_delay_pcie_perst_to_eeprom(void *user_settings, uint8_t d
 bool set_user_settings_delay_asic_rst_to_eeprom(void *user_settings, uint8_t data_length);
 bool set_user_settings_delay_module_pg_to_eeprom(void *user_settings, uint8_t data_length);
 void set_clock_u87_u88_lphcsl_amp_ctrl_to_1v();
+bool vr_vout_user_settings_init(void);
 #endif

--- a/meta-facebook/sb-rb/src/shell/shell_log.c
+++ b/meta-facebook/sb-rb/src/shell/shell_log.c
@@ -339,6 +339,7 @@ void cmd_log_dump(const struct shell *shell, size_t argc, char **argv)
 				shell_print(shell, "read vr sensor status word(0x79):");
 				shell_print(shell, "\tlow  byte: 0x%02x", log.error_data[0]);
 				shell_print(shell, "\thigh byte: 0x%02x", log.error_data[1]);
+				err_data_len = 7;
 			}
 			break;
 		case POWER_ON_SEQUENCE_TRIGGER_CAUSE:

--- a/meta-facebook/sb-rb/src/shell/shell_plat_voltage.c
+++ b/meta-facebook/sb-rb/src/shell/shell_plat_voltage.c
@@ -132,6 +132,29 @@ static void voltage_rname_get(size_t idx, struct shell_static_entry *entry)
 	entry->subcmd = NULL;
 }
 
+static void cmd_svs_flag_get(const struct shell *shell, size_t argc, char **argv)
+{
+	uint8_t svs_flag = get_svs_flag();
+	shell_print(shell, "Current SVS flag: %d", svs_flag);
+}
+
+static void cmd_svs_flag_set(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc < 2) {
+		shell_error(shell, "Usage: set svs flag <0/1>");
+		return;
+	}
+
+	uint8_t svs_flag = strtol(argv[1], NULL, 0);
+	//flag only support 0 or 1
+	if (svs_flag > 1) {
+		shell_error(shell, "Invalid SVS flag value: %d. Only 0 or 1 is allowed.", svs_flag);
+		return;
+	}
+	set_svs_flag(svs_flag);
+	shell_print(shell, "Current SVS flag: %d", svs_flag);
+}
+
 SHELL_DYNAMIC_CMD_CREATE(voltage_rname, voltage_rname_get);
 
 /* level 2 */
@@ -140,12 +163,17 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_voltage_get_cmds,
 					 cmd_voltage_get_all),
 			       SHELL_SUBCMD_SET_END);
 
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_svs_cmds, SHELL_CMD(get, NULL, "get svs flag", cmd_svs_flag_get),
+			       SHELL_CMD(set, NULL, "set svs flag <0/1>", cmd_svs_flag_set),
+			       SHELL_SUBCMD_SET_END);
+
 /* level 1 */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_voltage_cmds,
 			       SHELL_CMD(get, &sub_voltage_get_cmds, "get voltage all", NULL),
 			       SHELL_CMD_ARG(set, &voltage_rname,
 					     "set <voltage-rail> <new-voltage>|default [perm]",
 					     cmd_voltage_set, 3, 1),
+			       SHELL_CMD(svs_flag, &sub_svs_cmds, "svs flag commands", NULL),
 			       SHELL_SUBCMD_SET_END);
 
 /* Root of command test */


### PR DESCRIPTION
Summary:
    - svs flag will set/get vout command with offset(0:disable) or without offset(1:enable)
    - add shell command for set/get SVS_FLAG
    - add raa228249_get_vout_offset function
    - Add more vr_status in blackbox error_data
   
Test Plan:
    - Build code: Pass