### PR TITLE
sb: rb: add svs functions and fix some issue

### DIFF
--- a/meta-facebook/sb-rb/src/platform/plat_hook.c
+++ b/meta-facebook/sb-rb/src/platform/plat_hook.c
@@ -911,11 +911,14 @@ bool set_ioexp_val_to_bootstrap_table(void)
 			LOG_ERR("Can't find bootstrap direction from pca6416a");
 			return false;
 		}
-		// set when output only
+		uint8_t old_e =
+			bootstrap_table[STRAP_INDEX_OWL_E_BOOT_SOURCE_0_7].change_setting_value;
+		uint8_t old_w =
+			bootstrap_table[STRAP_INDEX_OWL_W_BOOT_SOURCE_0_7].change_setting_value;
 		bootstrap_table[STRAP_INDEX_OWL_E_BOOT_SOURCE_0_7].change_setting_value =
-			(data[0] & (~direction[0]));
+			(old_e & direction[0]) | (data[0] & (~direction[0]));
 		bootstrap_table[STRAP_INDEX_OWL_W_BOOT_SOURCE_0_7].change_setting_value =
-			(data[1] & (~direction[1]));
+			(old_w & direction[1]) | (data[1] & (~direction[1]));
 	}
 
 	// tca6424a only in EVB

--- a/meta-facebook/sb-rb/src/platform/plat_init.c
+++ b/meta-facebook/sb-rb/src/platform/plat_init.c
@@ -107,6 +107,7 @@ void pal_post_init()
 		asic_thermtrip_error_log(LOG_ASSERT);
 	// check clk 312.5Mhz init
 	check_312_5MHz_init_status();
+	vr_vout_offset_get_init();
 }
 
 #define DEF_PROJ_GPIO_PRIORITY 78

--- a/meta-facebook/sb-rb/src/platform/plat_isr.c
+++ b/meta-facebook/sb-rb/src/platform/plat_isr.c
@@ -302,6 +302,7 @@ void ISR_GPIO_RST_IRIS_PWR_ON_PLD_R1_N()
 		reset_error_log_states(err_type);
 		// re-init adc
 		set_is_adc_init(0);
+		vr_vout_offset_get_init();
 	} else {
 		plat_switch_pin_a12(true); /* LOW -> A12 = GPIO73 output low */
 		gpio_conf(SPI_ADC_CS1_N, GPIO_OUTPUT);

--- a/meta-facebook/sb-rb/src/platform/plat_user_setting.c
+++ b/meta-facebook/sb-rb/src/platform/plat_user_setting.c
@@ -1446,7 +1446,6 @@ void user_settings_init(void)
 {
 	bootstrap_default_settings_init();
 	vr_vout_default_settings_init();
-	vr_vout_offset_get_init();
 	bootstrap_user_settings_init();
 	vr_vout_range_user_settings_init();
 	thermaltrip_user_settings_init();

--- a/meta-facebook/sb-rb/src/shell/shell_clock.c
+++ b/meta-facebook/sb-rb/src/shell/shell_clock.c
@@ -23,6 +23,7 @@
 #include "libutil.h"
 #include "plat_i2c.h"
 #include <shell/shell.h>
+#include "plat_log.h"
 
 LOG_MODULE_REGISTER(clock_shell);
 bool clock_name_get(uint8_t index, uint8_t **name);
@@ -386,7 +387,15 @@ void cmd_get_clock_status(const struct shell *shell, size_t argc, char **argv)
 
 			handle_single_clock_status(shell, (enum CLOCK_COMPONENT)i);
 		}
-
+		shell_print(shell, "\n=== %s ===", "GEN_312_5MHz_CLK");
+		uint8_t lock_status = clk_312_5mhz_get_lock_status();
+		if (lock_status == 0xFF) {
+			shell_print(shell, "Failed to get GEN_312_5MHz_CLK APLL lock status");
+		} else if (lock_status == 0) {
+			shell_print(shell, "APLL lock status,  value = %d (unlock)", lock_status);
+		} else {
+			shell_print(shell, "APLL lock status,  value = %d (lock)", lock_status);
+		}
 		return;
 	}
 

--- a/meta-facebook/sb-rb/src/shell/shell_plat_average_power.c
+++ b/meta-facebook/sb-rb/src/shell/shell_plat_average_power.c
@@ -97,7 +97,8 @@ static int cmd_power_get(const struct shell *shell, size_t argc, char **argv)
 
 static void ubc_vr_rname_get_for_get_power(size_t idx, struct shell_static_entry *entry)
 {
-	if ((get_asic_board_id() != ASIC_BOARD_ID_EVB) && (idx == 2))
+	if (((get_asic_board_id() != ASIC_BOARD_ID_EVB)) &&
+		    (idx == VR_RAIL_E_P3V3_OSFP_VOLT_V))
 		idx++;
 
 	uint8_t *name = NULL;

--- a/meta-facebook/sb-rb/src/shell/shell_plat_average_power.c
+++ b/meta-facebook/sb-rb/src/shell/shell_plat_average_power.c
@@ -97,8 +97,7 @@ static int cmd_power_get(const struct shell *shell, size_t argc, char **argv)
 
 static void ubc_vr_rname_get_for_get_power(size_t idx, struct shell_static_entry *entry)
 {
-	if (((get_asic_board_id() != ASIC_BOARD_ID_EVB)) &&
-		    (idx == VR_RAIL_E_P3V3_OSFP_VOLT_V))
+	if (((get_asic_board_id() != ASIC_BOARD_ID_EVB)) && (idx == VR_RAIL_E_P3V3_OSFP_VOLT_V))
 		idx++;
 
 	uint8_t *name = NULL;

--- a/meta-facebook/sb-rb/src/shell/shell_plat_voltage.c
+++ b/meta-facebook/sb-rb/src/shell/shell_plat_voltage.c
@@ -56,6 +56,15 @@ static int cmd_voltage_get_all(const struct shell *shell, size_t argc, char **ar
 			continue;
 		}
 
+		if (get_svs_flag() == 1) {
+			if(i == VR_RAIL_E_ASIC_P0V85_MEDHA0_VDD || i == VR_RAIL_E_ASIC_P0V85_MEDHA1_VDD) {
+				// if svs is enable, vout need to - vout ofset
+				uint16_t offset = 0;
+				voltage_offset_get(i, &offset);
+				vout -= offset;
+			}
+		}
+
 		shell_print(shell, "%4d|%-40s|%4d", i, rail_name, vout);
 	}
 

--- a/meta-facebook/sb-rb/src/shell/shell_plat_voltage.c
+++ b/meta-facebook/sb-rb/src/shell/shell_plat_voltage.c
@@ -154,6 +154,23 @@ static void cmd_svs_flag_set(const struct shell *shell, size_t argc, char **argv
 	shell_print(shell, "Current SVS flag: %d", svs_flag);
 }
 
+void cmd_get_medha_vout_offset(const struct shell *shell, size_t argc, char **argv)
+{
+	uint16_t vout_offset_value = 0;
+	if (!voltage_offset_get(VR_RAIL_E_ASIC_P0V85_MEDHA0_VDD, &vout_offset_value)) {
+		shell_error(shell, "Failed to get medha0 vout offset");
+		return;
+	}
+	shell_print(shell, "Medha0 vout offset: %d mV", vout_offset_value);
+
+	vout_offset_value = 0;
+	if (!voltage_offset_get(VR_RAIL_E_ASIC_P0V85_MEDHA1_VDD, &vout_offset_value)) {
+		shell_error(shell, "Failed to get medha1 vout offset");
+		return;
+	}
+	shell_print(shell, "Medha1 vout offset: %d mV", vout_offset_value);
+}
+
 SHELL_DYNAMIC_CMD_CREATE(voltage_rname, voltage_rname_get);
 
 /* level 2 */
@@ -165,6 +182,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_voltage_get_cmds,
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_svs_cmds, SHELL_CMD(get, NULL, "get svs flag", cmd_svs_flag_get),
 			       SHELL_CMD(set, NULL, "set svs flag <0/1>", cmd_svs_flag_set),
 			       SHELL_SUBCMD_SET_END);
+SHELL_STATIC_SUBCMD_SET_CREATE(vo_ofst_cmds, SHELL_CMD(get, NULL, "get medha vout offset", cmd_get_medha_vout_offset),
+			       SHELL_SUBCMD_SET_END);
 
 /* level 1 */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_voltage_cmds,
@@ -173,6 +192,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_voltage_cmds,
 					     "set <voltage-rail> <new-voltage>|default [perm]",
 					     cmd_voltage_set, 3, 1),
 			       SHELL_CMD(svs_flag, &sub_svs_cmds, "svs flag commands", NULL),
+				   SHELL_CMD(get_medha_vout_offset, &vo_ofst_cmds, "get medha vout offset", NULL),
 			       SHELL_SUBCMD_SET_END);
 
 /* Root of command test */

--- a/meta-facebook/sb-rb/src/shell/shell_plat_voltage.c
+++ b/meta-facebook/sb-rb/src/shell/shell_plat_voltage.c
@@ -57,7 +57,8 @@ static int cmd_voltage_get_all(const struct shell *shell, size_t argc, char **ar
 		}
 
 		if (get_svs_flag() == 1) {
-			if(i == VR_RAIL_E_ASIC_P0V85_MEDHA0_VDD || i == VR_RAIL_E_ASIC_P0V85_MEDHA1_VDD) {
+			if (i == VR_RAIL_E_ASIC_P0V85_MEDHA0_VDD ||
+			    i == VR_RAIL_E_ASIC_P0V85_MEDHA1_VDD) {
 				// if svs is enable, vout need to - vout ofset
 				uint16_t offset = 0;
 				voltage_offset_get(i, &offset);
@@ -143,24 +144,25 @@ static void voltage_rname_get(size_t idx, struct shell_static_entry *entry)
 static void cmd_svs_flag_get(const struct shell *shell, size_t argc, char **argv)
 {
 	uint8_t svs_flag = get_svs_flag();
-	shell_print(shell, "Current SVS flag: %d", svs_flag);
+	shell_print(shell, "voltage offset(1:enable, 0:disable) : %d", svs_flag);
 }
 
 static void cmd_svs_flag_set(const struct shell *shell, size_t argc, char **argv)
 {
 	if (argc < 2) {
-		shell_error(shell, "Usage: set svs flag <0/1>");
+		shell_error(shell, "Usage: set voltage offset <0/1>");
 		return;
 	}
 
 	uint8_t svs_flag = strtol(argv[1], NULL, 0);
 	//flag only support 0 or 1
 	if (svs_flag > 1) {
-		shell_error(shell, "Invalid SVS flag value: %d. Only 0 or 1 is allowed.", svs_flag);
+		shell_error(shell, "Invalid voltage offset value: %d. Only 0 or 1 is allowed.",
+			    svs_flag);
 		return;
 	}
 	set_svs_flag(svs_flag);
-	shell_print(shell, "Current SVS flag: %d", svs_flag);
+	shell_print(shell, "voltage offset(1:enable, 0:disable): %d", svs_flag);
 }
 
 void cmd_get_medha_vout_offset(const struct shell *shell, size_t argc, char **argv)
@@ -191,18 +193,14 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_voltage_get_cmds,
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_svs_cmds, SHELL_CMD(get, NULL, "get svs flag", cmd_svs_flag_get),
 			       SHELL_CMD(set, NULL, "set svs flag <0/1>", cmd_svs_flag_set),
 			       SHELL_SUBCMD_SET_END);
-SHELL_STATIC_SUBCMD_SET_CREATE(vo_ofst_cmds, SHELL_CMD(get, NULL, "get medha vout offset", cmd_get_medha_vout_offset),
-			       SHELL_SUBCMD_SET_END);
-
 /* level 1 */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_voltage_cmds,
-			       SHELL_CMD(get, &sub_voltage_get_cmds, "get voltage all", NULL),
-			       SHELL_CMD_ARG(set, &voltage_rname,
-					     "set <voltage-rail> <new-voltage>|default [perm]",
-					     cmd_voltage_set, 3, 1),
-			       SHELL_CMD(svs_flag, &sub_svs_cmds, "svs flag commands", NULL),
-				   SHELL_CMD(get_medha_vout_offset, &vo_ofst_cmds, "get medha vout offset", NULL),
-			       SHELL_SUBCMD_SET_END);
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_voltage_cmds, SHELL_CMD(get, &sub_voltage_get_cmds, "get voltage all", NULL),
+	SHELL_CMD_ARG(set, &voltage_rname, "set <voltage-rail> <new-voltage>|default [perm]",
+		      cmd_voltage_set, 3, 1),
+	SHELL_CMD(svs_apply_offset, &sub_svs_cmds, "svs apply commands", NULL),
+	SHELL_CMD(get_medha_vout_offset, NULL, "get medha vout offset", cmd_get_medha_vout_offset),
+	SHELL_SUBCMD_SET_END);
 
 /* Root of command test */
 SHELL_CMD_REGISTER(voltage, &sub_voltage_cmds, "voltage set/get commands", NULL);

--- a/meta-facebook/sb-rb/src/shell/shell_plat_voltage.c
+++ b/meta-facebook/sb-rb/src/shell/shell_plat_voltage.c
@@ -120,9 +120,8 @@ static int cmd_voltage_set(const struct shell *shell, size_t argc, char **argv)
 
 static void voltage_rname_get(size_t idx, struct shell_static_entry *entry)
 {
-	if ((get_asic_board_id() == ASIC_BOARD_ID_EVB))
+	if (((get_asic_board_id() != ASIC_BOARD_ID_EVB)) && (idx == VR_RAIL_E_P3V3_OSFP_VOLT_V))
 		idx++;
-
 	uint8_t *name = NULL;
 	vr_rail_name_get((uint8_t)idx, &name);
 

--- a/meta-facebook/sb-rb/src/shell/shell_plat_voltage_peak.c
+++ b/meta-facebook/sb-rb/src/shell/shell_plat_voltage_peak.c
@@ -164,7 +164,8 @@ static int cmd_clear_voltage_peak(const struct shell *shell, size_t argc, char *
 
 static void voltage_rname_get(size_t idx, struct shell_static_entry *entry)
 {
-	if ((get_asic_board_id() == ASIC_BOARD_ID_EVB))
+	if (((get_asic_board_id() != ASIC_BOARD_ID_EVB)) &&
+		    (idx == VR_RAIL_E_P3V3_OSFP_VOLT_V))
 		idx++;
 
 	uint8_t *name = NULL;

--- a/meta-facebook/sb-rb/src/shell/shell_plat_voltage_peak.c
+++ b/meta-facebook/sb-rb/src/shell/shell_plat_voltage_peak.c
@@ -164,8 +164,7 @@ static int cmd_clear_voltage_peak(const struct shell *shell, size_t argc, char *
 
 static void voltage_rname_get(size_t idx, struct shell_static_entry *entry)
 {
-	if (((get_asic_board_id() != ASIC_BOARD_ID_EVB)) &&
-		    (idx == VR_RAIL_E_P3V3_OSFP_VOLT_V))
+	if (((get_asic_board_id() != ASIC_BOARD_ID_EVB)) && (idx == VR_RAIL_E_P3V3_OSFP_VOLT_V))
 		idx++;
 
 	uint8_t *name = NULL;

--- a/meta-facebook/sb-rb/src/shell/shell_rainbow_asic.c
+++ b/meta-facebook/sb-rb/src/shell/shell_rainbow_asic.c
@@ -31,11 +31,13 @@
 #define ASIC_MONITOR_HBM_TEMP_REG 0x8F // Max of 8 HBM temperature sensors in history
 #define ASIC_MONITOR_TEMP_REG 0x70
 #define ASIC_VERSION_REG 0x68
+#define ASIC_SVS_CORE_VOLT_REG 0x9B
 //asic reg len
 #define ASIC_STATUS_REG_LEN 8
 #define ASIC_VERSION_REG_LEN 10
 #define ASIC_MONITOR_TEMP_REG_LEN 10
 #define ASIC_MONITOR_HBM_TEMP_REG_LEN 10
+#define ASIC_SVS_CORE_VOLT_REG_LEN 6
 
 int asic_read_cmd(const struct shell *shell, uint8_t reg, uint8_t *data, uint8_t len)
 {
@@ -189,7 +191,32 @@ void asic_read_all_cmd(const struct shell *shell, size_t argc, char **argv)
 
 	shell_print(shell, "\n=== Asic Dump Complete ===");
 }
-
+void asic_read_svs_core_voltage_cmd(const struct shell *shell, size_t argc, char **argv)
+{
+	if (argc > 1) {
+		shell_error(shell, "Usage: svs_core_voltage_get");
+		return;
+	}
+	// read 0x9B
+	/*
+	0:length
+	1-2: cip0 mv
+	3-4: cip1 mv
+	5: pec
+	*/
+	uint8_t data[ASIC_SVS_CORE_VOLT_REG_LEN] = { 0 };
+	if (asic_read_cmd(shell, ASIC_SVS_CORE_VOLT_REG, (uint8_t *)data,
+			  ASIC_SVS_CORE_VOLT_REG_LEN) != 0) {
+		shell_warn(shell, "Can't get SVS core voltage data from ASIC, reg: 0x%02x",
+			   ASIC_SVS_CORE_VOLT_REG);
+		return;
+	}
+	uint16_t cip0_mv = (data[2] << 8) | data[1];
+	uint16_t cip1_mv = (data[4] << 8) | data[3];
+	shell_print(shell, "SVS Core Voltage:");
+	shell_print(shell, "  cip0: raw: 0x%02X%02X -> %d mV", data[2], data[1], cip0_mv);
+	shell_print(shell, "  cip1: raw: 0x%02X%02X -> %d mV", data[4], data[3], cip1_mv);
+}
 /**
  * @brief Display help information for all Asic commands
  * @param shell Shell instance
@@ -200,11 +227,14 @@ void asic_help_cmd(const struct shell *shell, size_t argc, char **argv)
 {
 	shell_info(shell, "Usage: Asic help");
 	shell_info(shell, "       Asic read_all");
+	shell_info(shell, "       svs_core_voltage_get");
 }
 
 /* Sub-command Level 1 of  commands */
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_asic_cmds, SHELL_CMD(read_all, NULL, "read all Asic system data", asic_read_all_cmd),
+	SHELL_CMD(svs_core_voltage_get, NULL, "get SVS core voltage from asic",
+		  asic_read_svs_core_voltage_cmd),
 	SHELL_CMD(help, NULL, "display help information for Asic commands", asic_help_cmd),
 	SHELL_SUBCMD_SET_END);
 


### PR DESCRIPTION
Summary:
-  add 312.5Mhz APLL lock status can get from shell cmd: "clock_status get all"
-  add read svs_core_voltage from shell cmd: "rb_asic svs_core_voltage_get"
-  fix ioe set bootstrap table issue
-  fix shell voltage set rail name error
- add shell cmd to read medha0/1 vout offset value
- add vout set/get will follow svs_flag to set/get same as i2c target 0x88 0x89
- modify some issue and add read vout offset when power on

Test Plan:
- Build code: Pass