### PR TITLE
Fix IPMB response routing and two MCTP protocol bugs

### DIFF
--- a/common/service/ipmb/ipmb.c
+++ b/common/service/ipmb/ipmb.c
@@ -394,8 +394,11 @@ void IPMB_TXTask(void *pvParameters, void *arvg0, void *arvg1)
 				goto cleanup;
 			}
 
-			// Fix IPMB target address
-			current_msg_tx->buffer.dest_addr = ipmb_cfg.channel_target_address;
+			/* dest_addr was already resolved to the real requester's
+			 * address in ipmb_send_response() - don't stomp it back
+			 * to the single configured channel peer here, or every
+			 * response loops back to whichever address that is
+			 * instead of the actual requester. */
 			// Encode the IPMB message
 			ipmb_encode(&ipmb_buffer_tx[0], &current_msg_tx->buffer);
 			uint8_t resp_tx_size =
@@ -417,7 +420,7 @@ void IPMB_TXTask(void *pvParameters, void *arvg0, void *arvg1)
 				}
 
 				i2c_msg->bus = ipmb_cfg.bus;
-				i2c_msg->target_addr = ipmb_cfg.channel_target_address;
+				i2c_msg->target_addr = current_msg_tx->buffer.dest_addr;
 				i2c_msg->tx_len = resp_tx_size;
 				memcpy(&i2c_msg->data[0], &ipmb_buffer_tx[1], resp_tx_size);
 
@@ -1012,7 +1015,17 @@ ipmb_error ipmb_send_response(ipmi_msg *resp, uint8_t index)
 	resp_cfg.buffer.InF_source = resp->InF_source;
 	resp_cfg.buffer.InF_target = resp->InF_target;
 	resp_cfg.buffer.completion_code = resp->completion_code;
-	resp_cfg.buffer.dest_addr = IPMB_config_table[index].channel_target_address;
+	/* Route the response back to whoever actually sent the request -
+	 * resp->src_addr still holds the original request's rqSA (8-bit
+	 * wire form) at this point, before it gets overwritten below to
+	 * our own address. A real IPMB channel can have more than one
+	 * legitimate requester, so this can't be a single static peer.
+	 * Falls back to the configured channel peer only if the caller
+	 * never populated src_addr (e.g. a synthetic response not built
+	 * from a decoded wire request). */
+	resp_cfg.buffer.dest_addr = resp->src_addr ?
+					     (resp->src_addr >> 1) :
+					     IPMB_config_table[index].channel_target_address;
 	resp_cfg.buffer.netfn = resp->netfn + 1;
 	resp_cfg.buffer.dest_LUN = resp->src_LUN;
 	resp_cfg.buffer.src_addr = IPMB_config_table[index].self_address << 1;

--- a/common/service/mctp/mctp.h
+++ b/common/service/mctp/mctp.h
@@ -48,7 +48,18 @@ extern "C" {
 #ifdef PLAT_MCTP_MSG_MAX_SIZE
 #define MCTP_DEFAULT_MSG_MAX_SIZE PLAT_MCTP_MSG_MAX_SIZE
 #else
-#define MCTP_DEFAULT_MSG_MAX_SIZE 244
+/* DSP0236 sec 8.4: 64 bytes is the MCTP baseline transmission unit -
+ * the only per-packet payload size every conformant endpoint is
+ * guaranteed to accept without negotiation. This stack has no
+ * transmission-unit negotiation (Get MCTP Version Support just
+ * reports the versions accepted, it doesn't negotiate a larger MTU),
+ * so unilaterally sending bigger packets isn't something a peer is
+ * spec-obligated to accept. Confirmed in practice: a 244-byte packet
+ * silently truncated on a real I2C/SMBus bridge in the path (a
+ * 251-byte fragment arriving as a clean, complete 128-byte write),
+ * because that bridge - correctly, per spec - wasn't built to assume
+ * anything past the 64-byte baseline. */
+#define MCTP_DEFAULT_MSG_MAX_SIZE 64
 #endif
 #define MCTP_TRANSPORT_HEADER_SIZE 4
 #define MCTP_MEDIUM_META_SIZE_SMBUS 3

--- a/common/service/mctp/mctp_ctrl.c
+++ b/common/service/mctp/mctp_ctrl.c
@@ -141,7 +141,12 @@ uint8_t mctp_ctrl_cmd_get_message_type_support(void *mctp_inst, uint8_t *buf, ui
 	struct _get_message_type_resp *p = (struct _get_message_type_resp *)resp;
 
 	uint8_t type_len = 0;
-	uint8_t *types = malloc(sizeof(TYPE_MAX_SIZE));
+	/* Was malloc(sizeof(TYPE_MAX_SIZE)) - TYPE_MAX_SIZE is an enum
+	 * constant, so sizeof() gave sizeof(int) (4), not the intended
+	 * type-count. Harmless today by luck (4 >= the 2-3 types any
+	 * board hook here reports), but a board hook reporting more than
+	 * that would overflow this buffer. */
+	uint8_t *types = malloc(MCTP_SUPPORTED_MSG_TYPE_MAX);
 	int ret = 0;
 
 	ret = load_mctp_support_types(&type_len, types);

--- a/common/service/mctp/mctp_ctrl.h
+++ b/common/service/mctp/mctp_ctrl.h
@@ -90,6 +90,13 @@ enum message_type {
 	TYPE_MAX_SIZE,
 };
 
+/* Scratch buffer size for mctp_ctrl_cmd_get_message_type_support()'s
+ * load_mctp_support_types() call - a board hook can report any real
+ * DSP0239 message type, not just the two named above, so this isn't
+ * sized off `enum message_type`. Generous headroom over what any
+ * real board hook reports (typically 2-3 types). */
+#define MCTP_SUPPORTED_MSG_TYPE_MAX 8
+
 struct _get_message_type_resp {
 	uint8_t completion_code;
 	uint8_t type_count;


### PR DESCRIPTION
## Summary

Three independent, real bugs found in the shared IPMB/MCTP stack while bringing up a new board port and testing it end-to-end against real external hardware (an I2C master issuing genuine wire-level IPMB/MCTP requests). Each is a self-contained fix; none depends on the new board.

- **`ipmb_send_response()` misroutes every response to a single fixed address.** It hardcodes the response destination to `IPMB_config_table[index].channel_target_address` instead of the original request's actual source address, so on any channel that can see requests from more than one address, every response goes to the same fixed peer regardless of who asked. `IPMB_TXTask()` compounds this by discarding a correctly-resolved `dest_addr` a second time. Fixed by resolving the destination from the request's `src_addr`, falling back to the configured peer only when the caller didn't populate it.

- **`MCTP_DEFAULT_MSG_MAX_SIZE` is hardcoded to 244**, but DSP0236 sec 8.4 defines 64 bytes as the MCTP baseline transmission unit - the only per-packet size every conformant endpoint must accept without an explicit negotiation step, which this stack doesn't implement. Confirmed in practice: a 244-byte packet was silently truncated by a real I2C/SMBus bridge that (correctly, per spec) wasn't built to assume anything past the 64-byte baseline. Dropped the default to 64; `PLAT_MCTP_MSG_MAX_SIZE` still lets a board override it.

- **`mctp_ctrl_cmd_get_message_type_support()` undersizes its scratch buffer.** `malloc(sizeof(TYPE_MAX_SIZE))` takes `sizeof` of an enum *constant*, giving `sizeof(int)` (4 bytes), not the intended type-count. Harmless today by luck (every current board hook reports 2-3 types), but a board hook reporting more of the real DSP0239 message types than that would silently heap-overflow. Replaced with an explicit, documented cap.

## Test plan

- [x] IPMB fix: verified end-to-end against a real external I2C master issuing genuine wire-level IPMB requests - responses now correctly reach the actual requester instead of looping back to the configured peer address, confirmed via checksum-valid decoded responses on the requester's side, across repeated hard resets.
- [x] MTU fix: verified on real hardware - a multi-fragment MCTP message that previously arrived truncated at a real I2C/SMBus bridge now reassembles correctly at 64 bytes/packet, including a case spanning enough fragments to wrap the packet-sequence counter.
- [x] Message Type Support fix: verified the corrected buffer holds 3 real supported types cleanly on hardware after adding a third type to a board's own hook; logic-reviewed for the general case since triggering an actual overflow isn't safely reproducible from this workspace.
- These 3 commits were isolated and hand-verified against a clean checkout of `main` (not cherry-picked wholesale from the board-port branch they were found on, which also carries unrelated, in-progress board-specific work not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARQUbyKTSivw9diGWNjcar