### PR TITLE
gc2: es: Enhance VR device ID reading flow

### DIFF
--- a/meta-facebook/gc2-es/src/platform/plat_class.c
+++ b/meta-facebook/gc2-es/src/platform/plat_class.c
@@ -408,7 +408,29 @@ uint8_t detect_vr_module_via_pmbus(void)
 		msg.bus = I2C_BUS5;
 		msg.target_addr = PVCCD_HV_ADDR;
 		msg.tx_len = 1;
-		msg.rx_len = 7;
+		msg.rx_len = 1;
+		msg.data[0] = PMBUS_IC_DEVICE_ID;
+
+		if (i2c_master_read(&msg, retry) != 0) {
+			LOG_ERR("Failed to read VR IC_DEVICE_ID, attempt %d", attempt);
+			k_sleep(K_MSEC(50));
+			continue;
+		}
+
+		uint8_t block_count = msg.data[0];
+
+		if ((block_count < VR_DEVID_LEN_MIN) || (block_count > VR_DEVID_LEN_MAX)) {
+			LOG_ERR("Invalid VR IC_DEVICE_ID length: 0x%x, attempt %d", block_count,
+				attempt);
+			k_sleep(K_MSEC(50));
+			continue;
+		}
+
+		memset(&msg, 0, sizeof(msg));
+		msg.bus = I2C_BUS5;
+		msg.target_addr = PVCCD_HV_ADDR;
+		msg.tx_len = 1;
+		msg.rx_len = block_count + 1;
 		msg.data[0] = PMBUS_IC_DEVICE_ID;
 
 		if (i2c_master_read(&msg, retry) != 0) {

--- a/meta-facebook/gc2-es/src/platform/plat_sensor_table.c
+++ b/meta-facebook/gc2-es/src/platform/plat_sensor_table.c
@@ -686,7 +686,26 @@ void check_vr_type(uint8_t index)
 	msg.bus = sensor_config[index].port;
 	msg.target_addr = sensor_config[index].target_addr;
 	msg.tx_len = 1;
-	msg.rx_len = 7;
+	msg.rx_len = 1;
+	msg.data[0] = PMBUS_IC_DEVICE_ID;
+
+	if (i2c_master_read(&msg, retry)) {
+		printf("Failed to read VR IC_DEVICE_ID: register(0x%x)\n", PMBUS_IC_DEVICE_ID);
+		return;
+	}
+
+	uint8_t block_count = msg.data[0];
+
+	if ((block_count < VR_DEVID_LEN_MIN) || (block_count > VR_DEVID_LEN_MAX)) {
+		printf("Invalid VR IC_DEVICE_ID length: 0x%x\n", block_count);
+		return;
+	}
+
+	memset(&msg, 0, sizeof(msg));
+	msg.bus = sensor_config[index].port;
+	msg.target_addr = sensor_config[index].target_addr;
+	msg.tx_len = 1;
+	msg.rx_len = block_count + 1;
 	msg.data[0] = PMBUS_IC_DEVICE_ID;
 
 	if (i2c_master_read(&msg, retry)) {

--- a/meta-facebook/gc2-es/src/platform/plat_sensor_table.h
+++ b/meta-facebook/gc2-es/src/platform/plat_sensor_table.h
@@ -44,6 +44,9 @@
 #define VR_CUR_CMD 0x8C
 #define VR_TEMP_CMD 0x8D
 #define VR_PWR_CMD 0x96
+/* VR IC_DEVICE_ID block read length, 2 for XDPE15284 and 6 for TPS53689 */
+#define VR_DEVID_LEN_MIN 0x2
+#define VR_DEVID_LEN_MAX 0x6
 #define SSD0_MUX_ADDR (0xE2 >> 1)
 #define SSD0_CHANNEL 2
 #define CPU_PECI_ADDR 0x30


### PR DESCRIPTION
# [Task Description]
- Related to GC20T5T7-317
- Improve VR IC_DEVICE_ID reading flow to match yv35's approach

# [Motivation]
- Previously, VR IC_DEVICE_ID was always read with a fixed 7 bytes, instead of first checking how many bytes the VR chip actually reports. This happens to work for now, but isn't a correct way to read it.

# [Design]
- Read PMBUS_IC_DEVICE_ID (0xAD) in two steps, matching yv35:
  1. Read 1 byte to get the block-read length reported by the VR chip.
  2. Re-read (length + 1) bytes to get the length byte and the full device ID payload.
- Accept the reported length only when it is between 2 and 6. The range comes from the device ID length of the VR chips in use: 2 for XDPE15284, 4 for ISL69259 and 6 for TPS53689.
- Report an error and stop reading the device ID when the length is out of range. Without this, a VR reporting an abnormal value such as 0xFF would make the read length wrap around to 0, so the device ID is never read back and the VR type ends up being detected wrongly.

# [Test Log]
LA data dump:
<img width="387" height="88" alt="image" src="https://github.com/user-attachments/assets/b884fdb1-3a57-434d-a6fe-4e97d64a1d27" />
