### PR TITLE
gc2: es: Version Commit for 2026.36.01

### DIFF
--- a/meta-facebook/gc2-es/src/platform/plat_version.h
+++ b/meta-facebook/gc2-es/src/platform/plat_version.h
@@ -32,7 +32,7 @@
 #define DEVICE_REVISION 0x80
 
 #define FIRMWARE_REVISION_1 GET_FW_VERSION1(BOARD_ID, PROJECT_STAGE)
-#define FIRMWARE_REVISION_2 0x02
+#define FIRMWARE_REVISION_2 0x03
 
 #define IPMI_VERSION 0x04
 #define ADDITIONAL_DEVICE_SUPPORT 0xBF
@@ -41,7 +41,7 @@
 
 #define BIC_FW_YEAR_MSB 0x20
 #define BIC_FW_YEAR_LSB 0x26
-#define BIC_FW_WEEK 0x34
+#define BIC_FW_WEEK 0x36
 #define BIC_FW_VER 0x01
 #define BIC_FW_platform_0 0x65 // char: e
 #define BIC_FW_platform_1 0x73 // char: s


### PR DESCRIPTION
Summary:
Description
- Version commit for Emerald Springs BIC obgc2-es-v2026.36.01

Motivation
- Version commit for Emerald Springs BIC obgc2-es-v2026.36.01

Test Plan:
- Build code: Pass
- Check BIC version: Pass